### PR TITLE
net/haproxy hotfixes

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		haproxy
-PLUGIN_VERSION=		1.0.1
+PLUGIN_VERSION=		1.1
 PLUGIN_COMMENT=		Reliable, high performance TCP/HTTP load balancer
 PLUGIN_DEPENDS=		haproxy
 PLUGIN_MAINTAINER=	opnsense@moov.de

--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		haproxy
-PLUGIN_VERSION=		1.0
+PLUGIN_VERSION=		1.0.1
 PLUGIN_COMMENT=		Reliable, high performance TCP/HTTP load balancer
 PLUGIN_DEPENDS=		haproxy
 PLUGIN_MAINTAINER=	opnsense@moov.de

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/ACL/ACL.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/ACL/ACL.xml
@@ -6,6 +6,7 @@
         <patterns>
             <pattern>ui/haproxy/*</pattern>
             <pattern>api/haproxy/*</pattern>
+            <pattern>diag_logs_haproxy.php</pattern>
         </patterns>
     </page-services-haproxy>
 </acl>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -118,7 +118,7 @@
             <logging>
                 <host type="TextField">
                     <default>127.0.0.1</default>
-                    <mask>/^((([0-9a-zA-Z._\-\*]+:[0-9]+)([,]){0,1}))*/u</mask>
+                    <mask>/^([0-9a-zA-Z\.,_\-:]){0,1024}$/u</mask>
                     <ChangeCase>lower</ChangeCase>
                     <ValidationMessage>Please provide a valid host, i.e. 127.0.0.1 or 10.0.0.1:514.</ValidationMessage>
                     <Required>Y</Required>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -120,7 +120,7 @@
                     <default>127.0.0.1</default>
                     <mask>/^([0-9a-zA-Z\.,_\-:]){0,1024}$/u</mask>
                     <ChangeCase>lower</ChangeCase>
-                    <ValidationMessage>Please provide a valid host, i.e. 127.0.0.1 or 10.0.0.1:514.</ValidationMessage>
+                    <ValidationMessage>Please specify a valid servername or IP address.</ValidationMessage>
                     <Required>Y</Required>
                 </host>
                 <facility type="OptionField">

--- a/net/haproxy/src/opnsense/scripts/OPNsense/HAProxy/exportCerts.php
+++ b/net/haproxy/src/opnsense/scripts/OPNsense/HAProxy/exportCerts.php
@@ -41,11 +41,11 @@ global $config;
 $configObj = Config::getInstance()->object();
 if (isset($configObj->OPNsense->HAProxy->frontends)) {
     foreach ($configObj->OPNsense->HAProxy->frontends->children() as $frontend) {
-        if (!isset($frontend->ssl)) {
+        if (!isset($frontend->ssl_enabled)) {
             continue;
         }
         // multiple comma-separated values are possible
-        $certs = explode(',', $frontend->ssl->certificates);
+        $certs = explode(',', $frontend->ssl_certificates);
         foreach ($certs as $cert_refid) {
             // if the frontend has a cert attached, search for its contents
             if ($cert_refid != "") {
@@ -53,7 +53,7 @@ if (isset($configObj->OPNsense->HAProxy->frontends)) {
                     if ($cert_refid == (string)$cert->refid) {
                         // generate cert pem file
                         $pem_content = str_replace("\n\n", "\n", str_replace("\r", "", base64_decode((string)$cert->crt)));
-                        $pem_content .= str_replace("\n\n", "\n", str_replace("\r", "", base64_decode((string)$cert->prv)));
+                        $pem_content .= "\n" . str_replace("\n\n", "\n", str_replace("\r", "", base64_decode((string)$cert->prv)));
                         $output_pem_filename = "/var/etc/haproxy/ssl/" . $cert_refid . ".pem" ;
                         file_put_contents($output_pem_filename, $pem_content);
                         chmod($output_pem_filename, 0600);

--- a/net/haproxy/src/opnsense/scripts/OPNsense/HAProxy/queryStats.php
+++ b/net/haproxy/src/opnsense/scripts/OPNsense/HAProxy/queryStats.php
@@ -35,11 +35,11 @@ function socketCmd($command) {
     global $haproxy_socket;
     $data = array();
     if (!file_exists($haproxy_socket)) {
-        throw new UnexpectedValueException("HAProxy socket does not exist, service may be stopped");
+        exit("HAProxy socket does not exist, service may be stopped");
     } else {
         $socket = @stream_socket_client("unix://$haproxy_socket", $errorNumber, $errorMessage);
         if (!$socket) {
-            throw new UnexpectedValueException("Unable to open socket: $errorMessage");
+            exit("Unable to open socket: $errorMessage");
         } else {
             fwrite($socket, "$command\n");
             while (!feof($socket)) {

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/+MANIFEST
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/+MANIFEST
@@ -1,5 +1,5 @@
 name: opnsense-haproxy
-version: 1.0.1
+version: 1.1
 origin: opnsense/haproxy
 comment: load balancer
 desc: Reliable, high performance TCP/HTTP load balancer

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/+MANIFEST
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/+MANIFEST
@@ -1,5 +1,5 @@
 name: opnsense-haproxy
-version: 1.0
+version: 1.0.1
 origin: opnsense/haproxy
 comment: load balancer
 desc: Reliable, high performance TCP/HTTP load balancer

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -482,7 +482,7 @@ global
 {% do logging.append(OPNsense.HAProxy.general.logging.facility) %}
 {% do logging.append(OPNsense.HAProxy.general.logging.level) if OPNsense.HAProxy.general.logging.level|default("") != "" %}
     log {{logging|join(' ')}}
-{% if OPNsense.HAProxy.luas.lua is defined %}
+{% if helpers.exists('OPNsense.HAProxy.luas.lua') %}
     # lua scripts
 {%   for lua in helpers.toList('OPNsense.HAProxy.luas.lua') %}
 {%     if lua.enabled == '1' %}
@@ -497,25 +497,27 @@ global
 {#             DEFAULTS            #}
 {# ############################### #}
 
+{% if helpers.exists('OPNsense.HAProxy.general.defaults') %}
 defaults
     log     global
-{% if OPNsense.HAProxy.general.defaults.redispatch|default("") != "" %}
+{%   if OPNsense.HAProxy.general.defaults.redispatch|default("") != "" %}
     option redispatch {{OPNsense.HAProxy.general.defaults.redispatch|replace("x", "")}}
-{% endif %}
-{% if OPNsense.HAProxy.general.defaults.maxConnections|default("") != "" %}
+{%   endif %}
+{%   if OPNsense.HAProxy.general.defaults.maxConnections|default("") != "" %}
     maxconn {{OPNsense.HAProxy.general.defaults.maxConnections}}
-{% endif %}
-{% if OPNsense.HAProxy.general.defaults.timeoutClient|default("") != "" %}
+{%   endif %}
+{%   if OPNsense.HAProxy.general.defaults.timeoutClient|default("") != "" %}
     timeout client {{OPNsense.HAProxy.general.defaults.timeoutClient}}
-{% endif %}
-{% if OPNsense.HAProxy.general.defaults.timeoutConnect|default("") != "" %}
+{%   endif %}
+{%   if OPNsense.HAProxy.general.defaults.timeoutConnect|default("") != "" %}
     timeout connect {{OPNsense.HAProxy.general.defaults.timeoutConnect}}
-{% endif %}
-{% if OPNsense.HAProxy.general.defaults.timeoutServer|default("") != "" %}
+{%   endif %}
+{%   if OPNsense.HAProxy.general.defaults.timeoutServer|default("") != "" %}
     timeout server {{OPNsense.HAProxy.general.defaults.timeoutServer}}
-{% endif %}
-{% if OPNsense.HAProxy.general.defaults.retries|default("") != "" %}
+{%   endif %}
+{%   if OPNsense.HAProxy.general.defaults.retries|default("") != "" %}
     retries {{OPNsense.HAProxy.general.defaults.retries}}
+{%   endif %}
 {% endif %}
 
 {# ############################### #}
@@ -766,7 +768,7 @@ backend {{backend.name}}
 {#             STATISTICS          #}
 {# ############################### #}
 
-{% if OPNsense.HAProxy.general.stats.enabled|default("") == "1" %}
+{% if helpers.exists('OPNsense.HAProxy.general.stats') and OPNsense.HAProxy.general.stats.enabled|default("") == "1" %}
 {# # enable local stats #}
 listen local_statistics
     bind            127.0.0.1:{{OPNsense.HAProxy.general.stats.port}}
@@ -801,5 +803,4 @@ listen  remote_statistics
 {% else %}
 # statistics are DISABLED
 {% endif %}
-
 


### PR DESCRIPTION
The wrong validation mask for "Log Host" turns out to be a show stopper. It kills validation and thus prevents the "Apply" button from working. To make it worse the user has no glue what field is invalid. :-(

Everyhing else are small fixes, mostly to prevent unnecessary crash reports.