### PR TITLE
net/haproxy new feature "source address"

### DIFF
--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogBackend.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogBackend.xml
@@ -41,6 +41,13 @@
         <hint>Type server name or choose from list.</hint>
     </field>
     <field>
+        <id>backend.source</id>
+        <label>Source address</label>
+        <type>text</type>
+        <help><![CDATA[Sets the source address which will be used when connecting to the server(s).]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
         <label>Health Checking</label>
         <type>header</type>
     </field>

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogServer.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogServer.xml
@@ -58,4 +58,11 @@
         <help><![CDATA[Provide the TCP communication port to use during check, i.e. 80 or 443.]]></help>
         <advanced>true</advanced>
     </field>
+    <field>
+        <id>server.source</id>
+        <label>Source address</label>
+        <type>text</type>
+        <help><![CDATA[Sets the source address which will be used when connecting to the server.]]></help>
+        <advanced>true</advanced>
+    </field>
 </form>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -408,6 +408,11 @@
                     <Multiple>Y</Multiple>
                     <Required>N</Required>
                 </linkedServers>
+                <source type="TextField">
+                    <mask>/^((([0-9a-zA-Z._\-\*]+:[0-9]+(-[0-9]+)?)([,]){0,1}))*/u</mask>
+                    <ValidationMessage>Please specify a valid source address, i.e. 10.0.0.1 or loadbalancer.example.com:50000. Port range as start-end, i.e. 10.0.0.1:50000-60000.</ValidationMessage>
+                    <Required>N</Required>
+                </source>
                 <healthCheckEnabled type="BooleanField">
                     <default>1</default>
                     <Required>Y</Required>
@@ -577,6 +582,11 @@
                     <ValidationMessage>Please specify a value between 500 and 100000.</ValidationMessage>
                     <Required>Y</Required>
                 </checkInterval>
+                <source type="TextField">
+                    <mask>/^((([0-9a-zA-Z._\-\*]+:[0-9]+(-[0-9]+)?)([,]){0,1}))*/u</mask>
+                    <ValidationMessage>Please specify a valid source address, i.e. 10.0.0.1 or loadbalancer.example.com:50000. Port range as start-end, i.e. 10.0.0.1:50000-60000.</ValidationMessage>
+                    <Required>N</Required>
+                </source>
             </server>
         </servers>
         <healthchecks>

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -779,6 +779,13 @@ backend {{backend.name}}
 {%         do server_options.append('weight ' ~ server_data.weight) if server_data.weight|default("") != "" %}
 {#         # server role/mode #}
 {%         do server_options.append(server_data.mode) if server_data.mode|default("") != "active" %}
+{#         # source address #}
+{%         if backend.source|default("") != "" %}
+{#           # prefer backend configuration #}
+{%           do server_options.append('source ' ~ backend.source) %}
+{%         elif server_data.source|default("") != "" %}
+{%           do server_options.append('source ' ~ server_data.source) %}
+{%         endif %}
     server {{server_data.name}} {{server_data.address}}:{% if backend.tuning_noport != '1' %}{{server_data.port}}{% endif %}{% if server_data.checkport|default("") != "" %} port {{server_data.checkport}}{% endif %} {{server_options|join(' ')}}
 {%       endfor %}
 

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -624,7 +624,7 @@ frontend {{frontend.name}}
 {%       endif %}
 
 {%     else %}
-# Frontend (DISABLED): {{frontend.description}}
+# Frontend (DISABLED): {{frontend.name}} ({{frontend.description}})
 
 {%     endif %}
 {%   endfor %}
@@ -783,7 +783,7 @@ backend {{backend.name}}
 {%       endfor %}
 
 {%     else %}
-# Backend (DISABLED): {{backend.description}}
+# Backend (DISABLED): {{backend.name}} ({{backend.description}})
 
 {%     endif %}
 {%   endfor %}


### PR DESCRIPTION
This allows to specify the source address which HAProxy will use when connecting to servers. And it fixes a small text bug in `haproxy.conf`.