### PR TITLE
net/haproxy: enhance "checkport" option & more fixes

### DIFF
--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogHealthcheck.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogHealthcheck.xml
@@ -24,6 +24,13 @@
         <help><![CDATA[Select interval (in milliseconds) between two consecutive health checks.]]></help>
     </field>
     <field>
+        <id>healthcheck.checkport</id>
+        <label>Port to check</label>
+        <type>text</type>
+        <help><![CDATA[Provide the TCP communication port to use during check, i.e. 80 or 443.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
         <label>HTTP check options</label>
         <type>header</type>
     </field>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -549,7 +549,7 @@
                     <Required>Y</Required>
                 </port>
                 <checkport type="IntegerField">
-                    <default>80</default>
+                    <default></default>
                     <MinimumValue>1</MinimumValue>
                     <MaximumValue>65535</MaximumValue>
                     <ValidationMessage>Please specify a value between 1 and 65535.</ValidationMessage>
@@ -624,6 +624,13 @@
                     <ValidationMessage>Please specify a value between 250 and 1000000.</ValidationMessage>
                     <Required>N</Required>
                 </interval>
+                <checkport type="IntegerField">
+                    <default></default>
+                    <MinimumValue>1</MinimumValue>
+                    <MaximumValue>65535</MaximumValue>
+                    <ValidationMessage>Please specify a value between 1 and 65535.</ValidationMessage>
+                    <Required>N</Required>
+                </checkport>
                 <!-- XXX: add tag <http> once nesting is supported by our framework -->
                 <http_method type="OptionField">
                     <Required>N</Required>

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -652,7 +652,7 @@ backend {{backend.name}}
 {#         # health check option #}
 {%         set healthcheck_options = [] %}
 {%         if healthcheck_data.type|default("") == "" %}
-{%           set healthcheck_enabled = '1' %}
+{%           set healthcheck_enabled = '0' %}
 {%         elif healthcheck_data.type == 'tcp' %}
 {#           # TCP check does not require additional options #}
 {%         elif healthcheck_data.type == 'http' %}
@@ -768,7 +768,7 @@ backend {{backend.name}}
 {%         set server_data = helpers.getUUID(server) %}
 {#         # collect optional server parameters #}
 {%         set server_options = [] %}
-{#       if# check if health check is enabled #}("") != "" %}
+{#         # check if health check is enabled # %}
 {%         if healthcheck_enabled == '1' %}
 {%           do server_options.append('check') %}
 {%           do server_options.append('inter ' ~ server_data.checkInterval) %}

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -763,15 +763,21 @@ backend {{backend.name}}
 {%       if backend.tuning_defaultserver|default("") != "" %}
     default-server {{backend.tuning_defaultserver}}
 {%       endif %}
-
 {%       for server in backend.linkedServers.split(",") %}
 {%         set server_data = helpers.getUUID(server) %}
 {#         # collect optional server parameters #}
 {%         set server_options = [] %}
-{#         # check if health check is enabled # %}
+{#         # check if health check is enabled #}
 {%         if healthcheck_enabled == '1' %}
 {%           do server_options.append('check') %}
 {%           do server_options.append('inter ' ~ server_data.checkInterval) %}
+{#           # use a different port for health check #}
+{%           if healthcheck_data.checkport|default("") != "" %}
+{#             # prefer port from health check template #}
+{%             do server_options.append('port ' ~ healthcheck_data.checkport) %}
+{%           elif server_data.checkport|default("") != "" %}
+{%             do server_options.append('port ' ~ server_data.checkport) %}
+{%           endif %}
 {#           # add all additions from healthchecks here #}
 {%           do server_options.append(healthcheck_additions|join(' ')) if healthcheck_additions.length != '0' %}
 {%         endif %}


### PR DESCRIPTION
- remove default value for `server.checkport` (setting a default value would silently enable this advanced feature everywhere)
- add "checkport" option to health checks (so that health checks can be used as a template to set it for every server)
- disable health check if type is missing (it can't be empty in the current release, but now this old check actually does what it was intended for)
- fix template comment that broke in 991b85651500c9a69f6975027ffb175c1def5395

@manusfreedom: FYI, now you can configure the "checkport" in health checks instead of setting it for every single server.