### PR TITLE
net/haproxy: syslog & security enhancements

### DIFF
--- a/net/haproxy/src/etc/inc/plugins.inc.d/haproxy.inc
+++ b/net/haproxy/src/etc/inc/plugins.inc.d/haproxy.inc
@@ -35,7 +35,7 @@
 function haproxy_syslog()
 {
     $syslogconf = array();
-    $syslogconf['haproxy'] = array("facility" => array('haproxy'), "remote" => "haproxy");
+    $syslogconf['haproxy'] = array("facility" => array('haproxy'), "local" => "/var/run/haproxy/var/run/log");
     return $syslogconf;
 }
 

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/main.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/main.xml
@@ -28,7 +28,7 @@
                 <id>haproxy.general.tuning.chroot</id>
                 <label>Secure mode (chroot)</label>
                 <type>checkbox</type>
-                <help><![CDATA[Enable or disable HAProxy's chroot feature.<br/><div class="text-info"><b>NOTE:</b> Enabling chroot will deactivate logging to localhost, because the local syslogd is running in secure mode and does not accept network connections (and it's log socket is not accessible from the chroot directory). You'll need to log to a remote host when enabling the chroot feature.</div>]]></help>
+                <help><![CDATA[Enable or disable HAProxy's chroot feature.]]></help>
             </field>
             <field>
                 <id>haproxy.general.tuning.nbproc</id>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -15,7 +15,7 @@
                     <Required>Y</Required>
                 </root>
                 <chroot type="BooleanField">
-                    <default>0</default>
+                    <default>1</default>
                     <Required>Y</Required>
                 </chroot>
                 <maxConnections type="IntegerField">

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -447,8 +447,6 @@ global
 {% endif %}
     gid                         80
 {% if OPNsense.HAProxy.general.tuning.chroot == "1" %}
-    # NOTE: chroot prevents (most) local logging, you need to enable remote
-    #       logging when using it (because syslogd is running in secure mode).
     chroot                      /var/run/haproxy
 {% endif %}
     daemon
@@ -477,8 +475,6 @@ global
 {% if OPNsense.HAProxy.general.logging.host != '127.0.0.1' %}
 {%   do logging.append(OPNsense.HAProxy.general.logging.host) %}
 {% else %}
-{#   # NOTE: syslogd is running is secure mode and thus does not accept network #}
-{#   #       connections. That's why we need to use the log socket instead. #}
 {%   do logging.append('/var/run/log') %}
 {% endif %}
 {% do logging.append('len ' ~ OPNsense.HAProxy.general.logging.length) if OPNsense.HAProxy.general.logging.length|default("") != "" %}


### PR DESCRIPTION
* fixes #18  
* changes "chroot" to "enabled", now it's safe to do so; it will only affect new installations, on old installations it will remain "disabled"