### PR TITLE
net/haproxy: chroot fixes

### DIFF
--- a/net/haproxy/src/etc/inc/plugins.inc.d/haproxy.inc
+++ b/net/haproxy/src/etc/inc/plugins.inc.d/haproxy.inc
@@ -37,7 +37,7 @@ function haproxy_syslog()
     $syslogconf = array();
 
     $syslogconf['haproxy'] = array(
-        'local' => '/var/run/haproxy/var/run/log',
+        'local' => '/var/haproxy/var/run/log',
         'facility' => array('haproxy'),
         'remote' => 'relayd',
     );

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/main.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/main.xml
@@ -25,12 +25,6 @@
                 <advanced>true</advanced>
             </field>
             <field>
-                <id>haproxy.general.tuning.chroot</id>
-                <label>Secure mode (chroot)</label>
-                <type>checkbox</type>
-                <help><![CDATA[Enable or disable HAProxy's chroot feature.]]></help>
-            </field>
-            <field>
                 <id>haproxy.general.tuning.nbproc</id>
                 <label>HAProxy processes</label>
                 <type>text</type>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -14,10 +14,6 @@
                     <default>0</default>
                     <Required>Y</Required>
                 </root>
-                <chroot type="BooleanField">
-                    <default>1</default>
-                    <Required>Y</Required>
-                </chroot>
                 <maxConnections type="IntegerField">
                     <MinimumValue>1</MinimumValue>
                     <MaximumValue>500000</MaximumValue>

--- a/net/haproxy/src/opnsense/scripts/OPNsense/HAProxy/setup.sh
+++ b/net/haproxy/src/opnsense/scripts/OPNsense/HAProxy/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-HAPROXY_DIRS="/var/run/haproxy /var/etc/haproxy/ssl /var/etc/haproxy/lua /var/etc/haproxy/errorfiles"
+HAPROXY_DIRS="/var/haproxy/var/run /var/etc/haproxy/ssl /var/etc/haproxy/lua /var/etc/haproxy/errorfiles"
 
 for directory in ${HAPROXY_DIRS}; do
     mkdir -p ${directory}
@@ -9,7 +9,7 @@ for directory in ${HAPROXY_DIRS}; do
 done
 
 # chroot dir must not be writable
-chmod 550 /var/run/haproxy
+find /var/haproxy -type d -exec chmod 550 {} \;
 
 # export required data to filesystem
 /usr/local/opnsense/scripts/OPNsense/HAProxy/exportCerts.php > /dev/null 2>&1

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -446,9 +446,7 @@ global
     uid                         80
 {% endif %}
     gid                         80
-{% if OPNsense.HAProxy.general.tuning.chroot == "1" %}
     chroot                      /var/run/haproxy
-{% endif %}
     daemon
     stats                       socket /var/run/haproxy.socket level admin
     nbproc                      {{OPNsense.HAProxy.general.tuning.nbproc}}

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -446,7 +446,7 @@ global
     uid                         80
 {% endif %}
     gid                         80
-    chroot                      /var/run/haproxy
+    chroot                      /var/haproxy
     daemon
     stats                       socket /var/run/haproxy.socket level admin
     nbproc                      {{OPNsense.HAProxy.general.tuning.nbproc}}


### PR DESCRIPTION
* remove chroot GUI option, because there's no point in running HAProxy in insecure mode anymore (see 5a7459707fd2e5eb703b32fd4715b1818f9ca49e)
* change chroot directory to `/var/haproxy`