### PR TITLE
net/haproxy: add support for time format

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		haproxy
-PLUGIN_VERSION=		1.5
+PLUGIN_VERSION=		1.6
 PLUGIN_COMMENT=		Reliable, high performance TCP/HTTP load balancer
 PLUGIN_DEPENDS=		haproxy
 PLUGIN_MAINTAINER=	opnsense@moov.de

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogBackend.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogBackend.xml
@@ -114,14 +114,14 @@
         <id>backend.tuning_timeoutConnect</id>
         <label>Connection Timeout</label>
         <type>text</type>
-        <help><![CDATA[Set the maximum time (in milliseconds) to wait for a connection attempt to a server to succeed.]]></help>
+        <help><![CDATA[Set the maximum time to wait for a connection attempt to a server to succeed. Defaults to milliseconds. Optionally the unit may be specified as either "d", "h", "m", "s", "ms" or "us".]]></help>
         <advanced>true</advanced>
     </field>
     <field>
         <id>backend.tuning_timeoutServer</id>
         <label>Server Timeout</label>
         <type>text</type>
-        <help><![CDATA[Set the maximum inactivity time (in milliseconds) on the server side.]]></help>
+        <help><![CDATA[Set the maximum inactivity time on the server side. Defaults to milliseconds. Optionally the unit may be specified as either "d", "h", "m", "s", "ms" or "us".]]></help>
         <advanced>true</advanced>
     </field>
     <field>

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogFrontend.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogFrontend.xml
@@ -85,7 +85,7 @@
         <id>frontend.tuning_timeoutClient</id>
         <label>Client Timeout</label>
         <type>text</type>
-        <help><![CDATA[Set the maximum inactivity time (in milliseconds) on the client side.]]></help>
+        <help><![CDATA[Set the maximum inactivity time on the client side. Defaults to milliseconds. Optionally the unit may be specified as either "d", "h", "m", "s", "ms" or "us".]]></help>
         <advanced>true</advanced>
     </field>
     <field>

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/main.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/main.xml
@@ -100,19 +100,19 @@
                 <id>haproxy.general.defaults.timeoutClient</id>
                 <label>Client Timeout</label>
                 <type>text</type>
-                <help><![CDATA[Set the maximum inactivity time (in milliseconds) on the client side.]]></help>
+                <help><![CDATA[Set the maximum inactivity time on the client side. Defaults to milliseconds. Optionally the unit may be specified as either "d", "h", "m", "s", "ms" or "us".]]></help>
             </field>
             <field>
                 <id>haproxy.general.defaults.timeoutConnect</id>
                 <label>Connection Timeout</label>
                 <type>text</type>
-                <help><![CDATA[Set the maximum time (in milliseconds) to wait for a connection attempt to a server to succeed.]]></help>
+                <help><![CDATA[Set the maximum time to wait for a connection attempt to a server to succeed. Defaults to milliseconds. Optionally the unit may be specified as either "d", "h", "m", "s", "ms" or "us".]]></help>
             </field>
             <field>
                 <id>haproxy.general.defaults.timeoutServer</id>
                 <label>Server Timeout</label>
                 <type>text</type>
-                <help><![CDATA[Set the maximum inactivity time (in milliseconds) on the server side.]]></help>
+                <help><![CDATA[Set the maximum inactivity time on the server side. Defaults to milliseconds. Optionally the unit may be specified as either "d", "h", "m", "s", "ms" or "us".]]></help>
             </field>
             <field>
                 <id>haproxy.general.defaults.retries</id>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -84,19 +84,19 @@
                 </maxConnections>
                 <timeoutClient type="TextField">
                     <default>30s</default>
-                    <mask>/^([0-9]{1,8}[d|h|m|s|ms|us]{0,1})*/u</mask>
+                    <mask>/^([0-9]{1,8}[d|h|m|s|ms|us]{0,1})/u</mask>
                     <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
                     <Required>N</Required>
                 </timeoutClient>
                 <timeoutConnect type="TextField">
                     <default>30s</default>
-                    <mask>/^([0-9]{1,8}[d|h|m|s|ms|us]{0,1})*/u</mask>
+                    <mask>/^([0-9]{1,8}[d|h|m|s|ms|us]{0,1})/u</mask>
                     <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
                     <Required>N</Required>
                 </timeoutConnect>
                 <timeoutServer type="TextField">
                     <default>30s</default>
-                    <mask>/^([0-9]{1,8}[d|h|m|s|ms|us]{0,1})*/u</mask>
+                    <mask>/^([0-9]{1,8}[d|h|m|s|ms|us]{0,1})/u</mask>
                     <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
                     <Required>N</Required>
                 </timeoutServer>
@@ -293,7 +293,7 @@
                     <Required>N</Required>
                 </tuning_maxConnections>
                 <tuning_timeoutClient type="TextField">
-                    <mask>/^([0-9]{1,8}[d|h|m|s|ms|us]{0,1})*/u</mask>
+                    <mask>/^([0-9]{1,8}[d|h|m|s|ms|us]{0,1})/u</mask>
                     <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
                     <Required>N</Required>
                 </tuning_timeoutClient>
@@ -475,12 +475,12 @@
                 </stickiness_cookielength>
                 <!-- XXX: add tag <tuning> once nesting is supported by our framework -->
                 <tuning_timeoutConnect type="TextField">
-                    <mask>/^([0-9]{1,8}[d|h|m|s|ms|us]{0,1})*/u</mask>
+                    <mask>/^([0-9]{1,8}[d|h|m|s|ms|us]{0,1})/u</mask>
                     <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
                     <Required>N</Required>
                 </tuning_timeoutConnect>
                 <tuning_timeoutServer type="TextField">
-                    <mask>/^([0-9]{1,8}[d|h|m|s|ms|us]{0,1})*/u</mask>
+                    <mask>/^([0-9]{1,8}[d|h|m|s|ms|us]{0,1})/u</mask>
                     <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
                     <Required>N</Required>
                 </tuning_timeoutServer>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -83,19 +83,19 @@
                     <Required>N</Required>
                 </maxConnections>
                 <timeoutClient type="TextField">
-                    <default>30000</default>
+                    <default>30s</default>
                     <mask>/^([0-9]{1,8}[d|h|m|s|ms|us]{0,1})*/u</mask>
                     <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
                     <Required>N</Required>
                 </timeoutClient>
                 <timeoutConnect type="TextField">
-                    <default>30000</default>
+                    <default>30s</default>
                     <mask>/^([0-9]{1,8}[d|h|m|s|ms|us]{0,1})*/u</mask>
                     <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
                     <Required>N</Required>
                 </timeoutConnect>
                 <timeoutServer type="TextField">
-                    <default>30000</default>
+                    <default>30s</default>
                     <mask>/^([0-9]{1,8}[d|h|m|s|ms|us]{0,1})*/u</mask>
                     <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
                     <Required>N</Required>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -84,19 +84,19 @@
                 </maxConnections>
                 <timeoutClient type="TextField">
                     <default>30s</default>
-                    <mask>/^([0-9]{1,8}[d|h|m|s|ms|us]{0,1})/u</mask>
+                    <mask>/^([0-9]{1,8}(?:us|ms|s|m|h|d)?)/u</mask>
                     <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
                     <Required>N</Required>
                 </timeoutClient>
                 <timeoutConnect type="TextField">
                     <default>30s</default>
-                    <mask>/^([0-9]{1,8}[d|h|m|s|ms|us]{0,1})/u</mask>
+                    <mask>/^([0-9]{1,8}(?:us|ms|s|m|h|d)?)/u</mask>
                     <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
                     <Required>N</Required>
                 </timeoutConnect>
                 <timeoutServer type="TextField">
                     <default>30s</default>
-                    <mask>/^([0-9]{1,8}[d|h|m|s|ms|us]{0,1})/u</mask>
+                    <mask>/^([0-9]{1,8}(?:us|ms|s|m|h|d)?)/u</mask>
                     <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
                     <Required>N</Required>
                 </timeoutServer>
@@ -293,7 +293,7 @@
                     <Required>N</Required>
                 </tuning_maxConnections>
                 <tuning_timeoutClient type="TextField">
-                    <mask>/^([0-9]{1,8}[d|h|m|s|ms|us]{0,1})/u</mask>
+                    <mask>/^([0-9]{1,8}(?:us|ms|s|m|h|d)?)/u</mask>
                     <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
                     <Required>N</Required>
                 </tuning_timeoutClient>
@@ -451,7 +451,7 @@
                 <stickiness_expire type="TextField">
                     <Required>Y</Required>
                     <default>30m</default>
-                    <mask>/^([0-9]{1,5}[d|h|m|s|ms]{1})*/u</mask>
+                    <mask>/^([0-9]{1,5}(?:ms|s|m|h|d)?)/u</mask>
                     <ChangeCase>lower</ChangeCase>
                     <ValidationMessage>Should be a number between 1 and 5 characters followed by either "d", "h", "m", "s" or "ms".</ValidationMessage>
                 </stickiness_expire>
@@ -475,12 +475,12 @@
                 </stickiness_cookielength>
                 <!-- XXX: add tag <tuning> once nesting is supported by our framework -->
                 <tuning_timeoutConnect type="TextField">
-                    <mask>/^([0-9]{1,8}[d|h|m|s|ms|us]{0,1})/u</mask>
+                    <mask>/^([0-9]{1,8}(?:us|ms|s|m|h|d)?)/u</mask>
                     <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
                     <Required>N</Required>
                 </tuning_timeoutConnect>
                 <tuning_timeoutServer type="TextField">
-                    <mask>/^([0-9]{1,8}[d|h|m|s|ms|us]{0,1})/u</mask>
+                    <mask>/^([0-9]{1,8}(?:us|ms|s|m|h|d)?)/u</mask>
                     <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
                     <Required>N</Required>
                 </tuning_timeoutServer>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -82,25 +82,22 @@
                     <ValidationMessage>Please specify a value between 1 and 500000.</ValidationMessage>
                     <Required>N</Required>
                 </maxConnections>
-                <timeoutClient type="IntegerField">
-                    <MinimumValue>1</MinimumValue>
-                    <MaximumValue>1000000</MaximumValue>
+                <timeoutClient type="TextField">
                     <default>30000</default>
-                    <ValidationMessage>Please specify a value between 1 and 1000000.</ValidationMessage>
+                    <mask>/^([0-9]{1,8}[d|h|m|s|ms|us]{0,1})*/u</mask>
+                    <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
                     <Required>N</Required>
                 </timeoutClient>
-                <timeoutConnect type="IntegerField">
-                    <MinimumValue>100</MinimumValue>
-                    <MaximumValue>1000000</MaximumValue>
+                <timeoutConnect type="TextField">
                     <default>30000</default>
-                    <ValidationMessage>Please specify a value between 100 and 1000000.</ValidationMessage>
+                    <mask>/^([0-9]{1,8}[d|h|m|s|ms|us]{0,1})*/u</mask>
+                    <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
                     <Required>N</Required>
                 </timeoutConnect>
-                <timeoutServer type="IntegerField">
-                    <MinimumValue>100</MinimumValue>
-                    <MaximumValue>1000000</MaximumValue>
+                <timeoutServer type="TextField">
                     <default>30000</default>
-                    <ValidationMessage>Please specify a value between 100 and 1000000.</ValidationMessage>
+                    <mask>/^([0-9]{1,8}[d|h|m|s|ms|us]{0,1})*/u</mask>
+                    <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
                     <Required>N</Required>
                 </timeoutServer>
                 <retries type="IntegerField">
@@ -295,10 +292,9 @@
                     <ValidationMessage>Please specify a value between 1 and 500000.</ValidationMessage>
                     <Required>N</Required>
                 </tuning_maxConnections>
-                <tuning_timeoutClient type="IntegerField">
-                    <MinimumValue>1</MinimumValue>
-                    <MaximumValue>1000000</MaximumValue>
-                    <ValidationMessage>Please specify a value between 1 and 1000000.</ValidationMessage>
+                <tuning_timeoutClient type="TextField">
+                    <mask>/^([0-9]{1,8}[d|h|m|s|ms|us]{0,1})*/u</mask>
+                    <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
                     <Required>N</Required>
                 </tuning_timeoutClient>
                 <!-- XXX: add tag <logging> once nesting is supported by our framework -->
@@ -478,16 +474,14 @@
                     <Required>N</Required>
                 </stickiness_cookielength>
                 <!-- XXX: add tag <tuning> once nesting is supported by our framework -->
-                <tuning_timeoutConnect type="IntegerField">
-                    <MinimumValue>100</MinimumValue>
-                    <MaximumValue>1000000</MaximumValue>
-                    <ValidationMessage>Please specify a value between 100 and 1000000.</ValidationMessage>
+                <tuning_timeoutConnect type="TextField">
+                    <mask>/^([0-9]{1,8}[d|h|m|s|ms|us]{0,1})*/u</mask>
+                    <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
                     <Required>N</Required>
                 </tuning_timeoutConnect>
-                <tuning_timeoutServer type="IntegerField">
-                    <MinimumValue>100</MinimumValue>
-                    <MaximumValue>1000000</MaximumValue>
-                    <ValidationMessage>Please specify a value between 100 and 1000000.</ValidationMessage>
+                <tuning_timeoutServer type="TextField">
+                    <mask>/^([0-9]{1,8}[d|h|m|s|ms|us]{0,1})*/u</mask>
+                    <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
                     <Required>N</Required>
                 </tuning_timeoutServer>
                 <tuning_retries type="IntegerField">


### PR DESCRIPTION
From the HAProxy documentation:

> Some parameters involve values representing time, such as timeouts. These
> values are generally expressed in milliseconds (unless explicitly stated
> otherwise) but may be expressed in any other unit by suffixing the unit to the
> numeric value.

This obviously improves readability of these values and supports lower and higher values. Previously some values were limited to a value between 100-1000000ms, which was an unnecessary limitation.