### PR TITLE
net/haproxy: add support for advanced server options

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		haproxy
-PLUGIN_VERSION=		1.6
+PLUGIN_VERSION=		1.7
 PLUGIN_COMMENT=		Reliable, high performance TCP/HTTP load balancer
 PLUGIN_DEPENDS=		haproxy
 PLUGIN_MAINTAINER=	opnsense@moov.de

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogServer.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogServer.xml
@@ -94,4 +94,11 @@
         <help><![CDATA[Sets the source address which will be used when connecting to the server.]]></help>
         <advanced>true</advanced>
     </field>
+    <field>
+        <id>server.advanced</id>
+        <label>Advanced options</label>
+        <type>text</type>
+        <help><![CDATA[A list of parameters that will be appended to the server line in every backend where this is will be used.<br/>Example: send-proxy<br/><div class="text-info"><b>NOTE:</b> The syntax will not be checked, use at your own risk!</div>.]]></help>
+        <advanced>true</advanced>
+    </field>
 </form>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -607,6 +607,9 @@
                     <ValidationMessage>Please specify a valid source address, i.e. 10.0.0.1 or loadbalancer.example.com:50000. Port range as start-end, i.e. 10.0.0.1:50000-60000.</ValidationMessage>
                     <Required>N</Required>
                 </source>
+                <advanced type="TextField">
+                    <Required>N</Required>
+                </advanced>
             </server>
         </servers>
         <healthchecks>

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -829,6 +829,10 @@ backend {{backend.name}}
 {%         elif server_data.source|default("") != "" %}
 {%           do server_options.append('source ' ~ server_data.source) %}
 {%         endif %}
+{#         # server advanced options #}
+{%         if server_data.advanced|default("") != "" %}
+{%           do server_options.append(server_data.advanced) %}
+{%         endif %}
     server {{server_data.name}} {{server_data.address}}:{% if backend.tuning_noport != '1' %}{{server_data.port}}{% endif %} {{server_options|join(' ')}}
 {%       endfor %}
 


### PR DESCRIPTION
Several use-cases for advanced options, because some options may not be used in `default-server` context; I think this will help to solve #51 in particular.