### PR TITLE
net/haproxy: add "default certificate" parameter, fixes #51

### DIFF
--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogFrontend.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogFrontend.xml
@@ -65,6 +65,13 @@
         <hint>Type certificate name or choose from list.</hint>
     </field>
     <field>
+        <id>frontend.ssl_default_certificate</id>
+        <label>Default certificate</label>
+        <type>dropdown</type>
+        <help><![CDATA[This certificate will be presented if no SNI is provided by the client or if the client provides an SNI hostname which does not match any certificate.<div class="text-info"><b>NOTE:</b> This parameter is optional to enforce a certain sort order for certificates. The certificate itself must still be listed under "Certificates".</div>]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
         <id>frontend.ssl_customOptions</id>
         <label>Advanced SSL options</label>
         <type>text</type>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -282,6 +282,11 @@
                     <Multiple>Y</Multiple>
                     <ValidationMessage>Please select a valid certificate from the list.</ValidationMessage>
                 </ssl_certificates>
+                <ssl_default_certificate type="CertificateField">
+                    <Required>N</Required>
+                    <Multiple>N</Multiple>
+                    <ValidationMessage>Please select a valid certificate from the list.</ValidationMessage>
+                </ssl_default_certificate>
                 <ssl_customOptions type="TextField">
                     <Required>N</Required>
                 </ssl_customOptions>

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -551,8 +551,17 @@ frontend {{frontend.name}}
 {%       if frontend.ssl_enabled == '1' %}
 {#         # collect ssl certs (if configured) #}
 {%         if frontend.ssl_certificates|default("") != "" %}
+{#           # check if a default certificate is configured #}
+{%           if frontend.ssl_default_certificate|default("") != "" %}
+{%             do ssl_certs.append('crt /var/etc/haproxy/ssl/' ~ frontend.ssl_default_certificate ~ '.pem') %}
+{%           endif %}
 {%           for cert in frontend.ssl_certificates.split(",") %}
-{%             do ssl_certs.append('crt /var/etc/haproxy/ssl/' ~ cert ~ '.pem') %}
+{#             # skip default certificate, it was already added to the list #}
+{%             if frontend.ssl_default_certificate|default("") != "" and cert == frontend.ssl_default_certificate %}
+{#               # do nothing  #}
+{%             else %}
+{%               do ssl_certs.append('crt /var/etc/haproxy/ssl/' ~ cert ~ '.pem') %}
+{%             endif %}
 {%           endfor %}
 {%         endif %}
 {#         # advanced ssl options #}


### PR DESCRIPTION
This introduces a new frontend parameter: "Default certificate". The only purpose is to enforce a certain sort order for certificates. This makes it possible to choose the "default" certificate which will be used by HAProxy if no SNI is provided by the client or if the client provides an SNI hostname which does not match any certificate.

Previously this was possibly too by adding the certificates to the "Certificates" parameter in the required order, but this turned out to be a hassle and not user-friendly. The new parameter is an advanced parameter and thus hidden to most users as only a few will ever make use of it.

Side note: While it would be possible to just add the "default certificate" as the first certificate to the "bind" option (which is OK for HAProxy, it can handle multiple occurence of the same cert), I chose to add some extra lines to the template code to avoid duplicate certs.

This fixes #51.