### PR TITLE
change places of scripts-auto and scripts-manual

### DIFF
--- a/Mk/plugins.mk
+++ b/Mk/plugins.mk
@@ -93,12 +93,12 @@ manifest: check
 	@echo "}"
 .endif
 
-scripts: check scripts-manual scripts-auto
+scripts: check scripts-auto scripts-manual
 
 scripts-manual:
 	@for SCRIPT in ${PLUGIN_SCRIPTS}; do \
 		if [ -f $${SCRIPT} ]; then \
-			cp $${SCRIPT} ${DESTDIR}/; \
+			cat $${SCRIPT} >> ${DESTDIR}/$${SCRIPT}; \
 		fi; \
 	done
 


### PR DESCRIPTION
In my cases I need to reload some services after the plugin was installed and templates regenerated. For example, I generate pluggable config part for syslog-ng and need to restart syslog-ng. If scripts-manual executed first, then syslog-ng restarts before templates regeneration. Right way, I think, first execute template regeneration, then make some additional tasks as services restarts and other.