### PR TITLE
net/haproxy: make more timeout values configurable

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		haproxy
-PLUGIN_VERSION=		1.7
+PLUGIN_VERSION=		1.8
 PLUGIN_COMMENT=		Reliable, high performance TCP/HTTP load balancer
 PLUGIN_DEPENDS=		haproxy
 PLUGIN_MAINTAINER=	opnsense@moov.de

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogBackend.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogBackend.xml
@@ -118,6 +118,13 @@
         <advanced>true</advanced>
     </field>
     <field>
+        <id>backend.tuning_timeoutCheck</id>
+        <label>Check Timeout</label>
+        <type>text</type>
+        <help><![CDATA[Sets an additional read timeout for running health checks on a server. Defaults to milliseconds. Optionally the unit may be specified as either "d", "h", "m", "s", "ms" or "us".]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
         <id>backend.tuning_timeoutServer</id>
         <label>Server Timeout</label>
         <type>text</type>

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogServer.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogServer.xml
@@ -81,6 +81,13 @@
         <advanced>true</advanced>
     </field>
     <field>
+        <id>server.checkDownInterval</id>
+        <label>Down Interval</label>
+        <type>text</type>
+        <help><![CDATA[Sets the interval (in milliseconds) for running health checks on the server when the server state is DOWN. If it is not set HAProxy uses the check interval.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
         <id>server.checkport</id>
         <label>Port to check</label>
         <type>text</type>

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/main.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/main.xml
@@ -109,6 +109,12 @@
                 <help><![CDATA[Set the maximum time to wait for a connection attempt to a server to succeed. Defaults to milliseconds. Optionally the unit may be specified as either "d", "h", "m", "s", "ms" or "us".]]></help>
             </field>
             <field>
+                <id>haproxy.general.defaults.timeoutCheck</id>
+                <label>Check Timeout</label>
+                <type>text</type>
+                <help><![CDATA[Sets an additional read timeout for running health checks on a server. Defaults to milliseconds. Optionally the unit may be specified as either "d", "h", "m", "s", "ms" or "us".]]></help>
+            </field>
+            <field>
                 <id>haproxy.general.defaults.timeoutServer</id>
                 <label>Server Timeout</label>
                 <type>text</type>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -94,6 +94,11 @@
                     <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
                     <Required>N</Required>
                 </timeoutConnect>
+                <timeoutCheck type="TextField">
+                    <mask>/^([0-9]{1,8}(?:us|ms|s|m|h|d)?)/u</mask>
+                    <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
+                    <Required>N</Required>
+                </timeoutCheck>
                 <timeoutServer type="TextField">
                     <default>30s</default>
                     <mask>/^([0-9]{1,8}(?:us|ms|s|m|h|d)?)/u</mask>
@@ -484,6 +489,11 @@
                     <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
                     <Required>N</Required>
                 </tuning_timeoutConnect>
+                <tuning_timeoutCheck type="TextField">
+                    <mask>/^([0-9]{1,8}(?:us|ms|s|m|h|d)?)/u</mask>
+                    <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
+                    <Required>N</Required>
+                </tuning_timeoutCheck>
                 <tuning_timeoutServer type="TextField">
                     <mask>/^([0-9]{1,8}(?:us|ms|s|m|h|d)?)/u</mask>
                     <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
@@ -607,6 +617,12 @@
                     <ValidationMessage>Please specify a value between 500 and 100000.</ValidationMessage>
                     <Required>Y</Required>
                 </checkInterval>
+                <checkDownInterval type="IntegerField">
+                    <MinimumValue>500</MinimumValue>
+                    <MaximumValue>100000</MaximumValue>
+                    <ValidationMessage>Please specify a value between 500 and 100000.</ValidationMessage>
+                    <Required>N</Required>
+                </checkDownInterval>
                 <source type="TextField">
                     <mask>/^((([0-9a-zA-Z._\-\*]+:[0-9]+(-[0-9]+)?)([,]){0,1}))*/u</mask>
                     <ValidationMessage>Please specify a valid source address, i.e. 10.0.0.1 or loadbalancer.example.com:50000. Port range as start-end, i.e. 10.0.0.1:50000-60000.</ValidationMessage>

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -524,6 +524,9 @@ defaults
 {%   if OPNsense.HAProxy.general.defaults.timeoutConnect|default("") != "" %}
     timeout connect {{OPNsense.HAProxy.general.defaults.timeoutConnect}}
 {%   endif %}
+{%   if OPNsense.HAProxy.general.defaults.timeoutCheck|default("") != "" %}
+    timeout check {{OPNsense.HAProxy.general.defaults.timeoutCheck}}
+{%   endif %}
 {%   if OPNsense.HAProxy.general.defaults.timeoutServer|default("") != "" %}
     timeout server {{OPNsense.HAProxy.general.defaults.timeoutServer}}
 {%   endif %}
@@ -749,6 +752,11 @@ backend {{backend.name}}
 {%       elif OPNsense.HAProxy.general.defaults.timeoutConnect is defined %}
     timeout connect {{OPNsense.HAProxy.general.defaults.timeoutConnect}}
 {%       endif %}
+{%       if backend.tuning_timeoutCheck|default("") != "" %}
+    timeout check {{backend.tuning_timeoutCheck}}
+{%       elif OPNsense.HAProxy.general.defaults.timeoutCheck is defined %}
+    timeout check {{OPNsense.HAProxy.general.defaults.timeoutCheck}}
+{%       endif %}
 {%       if backend.tuning_timeoutServer|default("") != "" %}
     timeout server {{backend.tuning_timeoutServer}}
 {%       elif OPNsense.HAProxy.general.defaults.timeoutServer is defined %}
@@ -784,6 +792,10 @@ backend {{backend.name}}
 {%         if healthcheck_enabled == '1' %}
 {%           do server_options.append('check') %}
 {%           do server_options.append('inter ' ~ server_data.checkInterval) %}
+{#           # use a different interval when server is in DOWN state #}
+{%           if server_data.checkDownInterval|default("") != "" %}
+{%             do server_options.append('downinter ' ~ server_data.checkDownInterval) %}
+{%           endif %}
 {#           # use a different port for health check #}
 {%           if healthcheck_data.checkport|default("") != "" %}
 {#             # prefer port from health check template #}


### PR DESCRIPTION
This adds the following new configuration options:

* Default Parameters:  Check Timeout (HAProxy's `timeout check`)
* Backends:  Check Timeout (HAProxy's `timeout check`)
* Servers: Down Interval (HAProxy's `downinter`)

Tested on OPNsense 16.7.11 with HAProxy 1.6.10.