### PR TITLE
net/haproxy: enable xmlrpc sync

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		haproxy
-PLUGIN_VERSION=		1.8
+PLUGIN_VERSION=		1.9
 PLUGIN_COMMENT=		Reliable, high performance TCP/HTTP load balancer
 PLUGIN_DEPENDS=		haproxy
 PLUGIN_MAINTAINER=	opnsense@moov.de

--- a/net/haproxy/src/etc/inc/plugins.inc.d/haproxy.inc
+++ b/net/haproxy/src/etc/inc/plugins.inc.d/haproxy.inc
@@ -68,3 +68,16 @@ function haproxy_services()
 
     return $services;
 }
+
+/**
+ *  sync configuration via xmlrpc
+ * @return array
+ */
+function haproxy_xmlrpc_sync()
+{
+    $result = array();
+    $result['id'] = 'haproxy';
+    $result['section'] = 'OPNsense.HAProxy';
+    $result['description'] = 'HAProxy load balancer';
+    return array($result);
+}


### PR DESCRIPTION
Thanks to the friendly reminder in opnsense/core/issues/1224 this finally enables XMLRPC sync for HAProxy configuration. 