### PR TITLE
net/haproxy: add support for custom TCP health checks

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		haproxy
-PLUGIN_VERSION=		1.9
+PLUGIN_VERSION=		1.10
 PLUGIN_COMMENT=		Reliable, high performance TCP/HTTP load balancer
 PLUGIN_DEPENDS=		haproxy
 PLUGIN_MAINTAINER=	opnsense@moov.de

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogHealthcheck.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogHealthcheck.xml
@@ -84,9 +84,6 @@
         <label>Value</label>
         <type>text</type>
         <help><![CDATA[Specify a value to match with the expression. <br/><div class="text-info"><b>NOTE:</b> It is important to note that the responses will be limited to a certain size defined by the global "tune.chksize" option, which defaults to 16384 bytes.</div>]]></help>
-
-        <help><![CDATA[Specify additional SSL parameters such as force-sslv3, force-tlsv10, force-tlsv11, force-tlsv12, no-sslv3, no-tlsv10, no-tlsv11, no-tlsv12, no-tls-tickets or customize the list of SSL ciphers.<br/>Example: no-sslv3 ciphers HIGH:!DSS:!aNULL@STRENGTH<br/><div class="text-info"><b>NOTE:</b> The syntax will not be checked, use at your own risk!</div>]]></help>
-
     </field>
     <field>
         <label>Custom TCP check</label>

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogHealthcheck.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogHealthcheck.xml
@@ -89,7 +89,40 @@
 
     </field>
     <field>
-        <label>Non-HTTP check options</label>
+        <label>Custom TCP check</label>
+        <type>header</type>
+    </field>
+    <field>
+        <id>healthcheck.tcp_enabled</id>
+        <label>Enabled</label>
+        <type>checkbox</type>
+    </field>
+    <field>
+        <id>healthcheck.tcp_sendValue</id>
+        <label>Send data</label>
+        <type>text</type>
+        <help><![CDATA[Specify a value to match with the expression. <br/><div class="text-info"><b>NOTE:</b> It is important to note that the responses will be limited to a certain size defined by the global "tune.chksize" option, which defaults to 16384 bytes.</div>]]></help>
+    </field>
+    <field>
+        <id>healthcheck.tcp_matchType</id>
+        <label>Match response</label>
+        <type>dropdown</type>
+        <help><![CDATA[Select how to look for a specific pattern in the response.]]></help>
+    </field>
+    <field>
+        <id>healthcheck.tcp_negate</id>
+        <label>Negate condition</label>
+        <type>checkbox</type>
+        <help><![CDATA[Use this to invert the meaning of the expression.]]></help>
+    </field>
+    <field>
+        <id>healthcheck.tcp_matchValue</id>
+        <label>Match pattern</label>
+        <type>text</type>
+        <help><![CDATA[Specify the pattern to look for in the response buffer. If the match is set to binary, then the pattern must be passed as a serie of hexadecimal digits in an even number.]]></help>
+    </field>
+    <field>
+        <label>Other check options</label>
         <type>header</type>
     </field>
     <field>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -729,6 +729,29 @@
                 <http_value type="TextField">
                     <Required>N</Required>
                 </http_value>
+                <tcp_enabled type="BooleanField">
+                    <default>0</default>
+                    <Required>N</Required>
+                </tcp_enabled>
+                <tcp_sendValue type="TextField">
+                    <Required>N</Required>
+                </tcp_sendValue>
+                <tcp_matchType type="OptionField">
+                    <Required>N</Required>
+                    <default>string</default>
+                    <OptionValues>
+                        <string>test the exact string match in the response buffer [default]</string>
+                        <rstring>test a regular expression on the response buffer</rstring>
+                        <binary>test the exact string in its hexadecimal form matches in the response buffer</binary>
+                    </OptionValues>
+                </tcp_matchType>
+                <tcp_negate type="BooleanField">
+                    <default>0</default>
+                    <Required>N</Required>
+                </tcp_negate>
+                <tcp_matchValue type="TextField">
+                    <Required>N</Required>
+                </tcp_matchValue>
                 <agentPort type="IntegerField">
                     <MinimumValue>1</MinimumValue>
                     <MaximumValue>65535</MaximumValue>

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -670,7 +670,28 @@ backend {{backend.name}}
 {%         if healthcheck_data.type|default("") == "" %}
 {%           set healthcheck_enabled = '0' %}
 {%         elif healthcheck_data.type == 'tcp' %}
-{#           # TCP check does not require additional options #}
+{#           # custom TCP health check option #}
+{%           if healthcheck_data.tcp_enabled|default("") == '1' %}
+{#             # validate options: both must not be disabled at the same time #}
+{%             if healthcheck_data.tcp_sendValue|default("") == "" and healthcheck_data.tcp_matchValue|default("") == "" %}
+    # ERROR: invalid custom TCP health check, missing "sendValue" or "matchValue"
+{%             else %}
+{%               set healthcheck_customtcp = [] %}
+{%               do healthcheck_customtcp.append('send ' ~ healthcheck_data.tcp_sendValue) if healthcheck_data.tcp_sendValue|default("") != "" %}
+{%               if healthcheck_data.tcp_matchValue|default("") != "" %}
+{%                 do healthcheck_customtcp.append('expect ' ~ healthcheck_data.tcp_matchType) %}
+{%                 if healthcheck_data.tcp_negate == '1' and healthcheck_data.tcp_matchType|default("") != 'binary' %}
+{%                   do healthcheck_customtcp.append('!') %}
+{%                 endif %}
+{%                 do healthcheck_customtcp.append(healthcheck_data.tcp_matchValue) %}
+{%               endif %}
+{#               # XXX: some values (send/match) must be properly escaped (whitespace) #}
+{#               # TODO: add support for multiple send/expect steps #}
+    option tcp-check
+    tcp-check connect
+    tcp-check {{healthcheck_customtcp|join(' ')}}
+{%             endif %}
+{%           endif %}
 {%         elif healthcheck_data.type == 'http' %}
 {%           do healthcheck_options.append('httpchk') %}
 {#           # HTTP method must be uppercase #}

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -580,8 +580,12 @@ frontend {{frontend.name}}
 
 {%         endfor %}
 {%       endif %}
+{%       if frontend.mode == "ssl" %}
+    mode tcp
+{%       else %}
     mode {{frontend.mode}}
-{%       if frontend.mode != "tcp" %}
+{%       endif %}
+{%       if frontend.mode != "tcp" and frontend.mode != "ssl" %}
     option {{frontend.connectionBehaviour}}
 {%       endif %}
 {#       # select backend #}


### PR DESCRIPTION
This patch add support for custom TCP health checks. It may be used to check for a proper response from SMTP and IMAP servers (or any other TCP service).

Below is an example for a simple SMTP health check:

![tcp_check](https://cloud.githubusercontent.com/assets/909706/21546654/7ebe13f0-cde0-11e6-9820-d3e6e669ecf4.png)

Which will result in the following HAProxy configuration:

```
    option tcp-check
    tcp-check connect
    tcp-check expect string "220 mail.example.com ESMTP"
```
Currently this is limited to only _one_ send/expect step.

While here, this fixes a help text in HTTP health check options.