### PR TITLE
net/haproxy: fix ACL option for "Host matches"

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		haproxy
-PLUGIN_VERSION=		1.10
+PLUGIN_VERSION=		1.11
 PLUGIN_COMMENT=		Reliable, high performance TCP/HTTP load balancer
 PLUGIN_DEPENDS=		haproxy
 PLUGIN_MAINTAINER=	opnsense@moov.de

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -86,7 +86,7 @@
 {%             endif %}
 {%           elif acl_data.expression == 'host_contains' %}
 {%             if acl_data.value|default("") != "" %}
-{%               do acl_options.append('hdr_dir(host) -i ' ~ acl_data.value) %}
+{%               do acl_options.append('hdr_sub(host) -i ' ~ acl_data.value) %}
 {%             else %}
 {%               set acl_enabled = '0' %}
     # ERROR: missing parameters


### PR DESCRIPTION
I've just discovered today that we're using the wrong HAProxy directive in our ACL option "Host matches". According to the HAProxy manual:

```
ACL derivatives :
  hdr_dir([<name>[,<occ>]]) : subdir match
  hdr_sub([<name>[,<occ>]]) : substring match

  - "dir"   : subdir match : check that a slash-delimited portion of the
              contents exactly matches one of the provided string patterns.
              This may be used with binary or string samples.

  - "sub"   : substring match : check that the contents contain at least one of
              the provided string patterns. This may be used with binary or
              string samples.
```

This patch replaces the wrong `hdr_dir` directive with the more appropiate `hdr_sub` directive. This may be a breaking change for some users, because it's unlikely that `hdr_dir` did what users were expecting.

Apparently we've inherited this from the pfSense plugin, because I haven't double-checked all the options back then. The author of this plugin [fixed this issue some time ago](https://github.com/pfsense/FreeBSD-ports/commit/8eb530c9f428d15d5a3e9fa1f60861f672eadc63).