### PR TITLE
security/acme-client: bugfix release

### DIFF
--- a/security/acme-client/Makefile
+++ b/security/acme-client/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		acme-client
-PLUGIN_VERSION=		1.1
+PLUGIN_VERSION=		1.2
 PLUGIN_COMMENT=		Let's Encrypt client
 PLUGIN_MAINTAINER=	opnsense@moov.de
 

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/Api/CertificatesController.php
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/Api/CertificatesController.php
@@ -203,7 +203,7 @@ class CertificatesController extends ApiControllerBase
         $grid = new UIModelGrid($mdlAcme->certificates->certificate);
         return $grid->fetchBindRequest(
             $this->request,
-            array("enabled", "name", "altNames", "description"),
+            array("enabled", "name", "altNames", "description", "lastUpdate", "statusCode", "statusLastUpdate"),
             "name"
         );
     }

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/Api/SettingsController.php
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/Api/SettingsController.php
@@ -322,6 +322,11 @@ class SettingsController extends ApiMutableModelControllerBase
                         (string)$validation->method == "http01" and
                         (string)$validation->http_service == "haproxy") {
                         //$this->getLogger()->error("LE HAProxy DEBUG: checking validation method: " . (string)$validation->name);
+                        // Check if HAProxy frontends were specified.
+                        if (empty((string)$validation->http_haproxyFrontends)) {
+                            // Skip item, no HAProxy frontends were specified.
+                            continue;
+                        }
                         $_frontends = explode(',', $validation->http_haproxyFrontends);
                         // Walk through all linked frontends.
                         foreach ($_frontends as $_frontend) {

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogCertificate.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogCertificate.xml
@@ -28,9 +28,9 @@
     </field>
     <field>
         <id>certificate.account</id>
-        <label>CA Account</label>
+        <label>LE Account</label>
         <type>dropdown</type>
-        <help><![CDATA[Set the CA account to use for this certificate.]]></help>
+        <help><![CDATA[Set the Let's Encrypt account to use for this certificate.]]></help>
     </field>
     <field>
         <id>certificate.validationMethod</id>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -224,6 +224,18 @@
                 <lastUpdate type="IntegerField">
                     <Required>N</Required>
                 </lastUpdate>
+                <!-- hidden field; status of last operation -->
+                <statusCode type="IntegerField">
+                    <Required>N</Required>
+                    <!-- XXX: enable once data migration is working -->
+                    <!-- <default>100</default> -->
+                    <MinimumValue>100</MinimumValue>
+                    <MaximumValue>1000</MaximumValue>
+                </statusCode>
+                <!-- hidden field; timestamp for statusCode -->
+                <statusLastUpdate type="IntegerField">
+                    <Required>N</Required>
+                </statusLastUpdate>
             </certificate>
         </certificates>
         <validations>

--- a/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/certificates.volt
+++ b/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/certificates.volt
@@ -69,6 +69,50 @@ POSSIBILITY OF SUCH DAMAGE.
                     } else {
                         return "<span style=\"cursor: pointer;\" class=\"fa fa-square-o command-toggle\" data-value=\"0\" data-row-id=\"" + row.uuid + "\"></span>";
                     }
+                },
+                "certdate": function (column, row) {
+                    if (row.lastUpdate == "" || row.lastUpdate == undefined) {
+                        return "pending";
+                    } else {
+                        var certdate = new Date(row.lastUpdate*1000);
+                        return certdate.toLocaleString();
+                    }
+                },
+                "certstatus": function (column, row) {
+                    if (row.statusCode == "" || row.statusCode == undefined) {
+                        // fallback to lastUpdate value (unset if cert was never issued/imported)
+                        if (row.lastUpdate == "" || row.lastUpdate == undefined) {
+                            return "never";
+                        } else {
+                            return "OK";
+                        }
+                    } else if (row.statusCode == "100") {
+                        return "never";
+                    } else if (row.statusCode == "200") {
+                        return "OK";
+                    } else if (row.statusCode == "250") {
+                        return "OK (renewed)";
+                    } else if (row.statusCode == "400") {
+                        return "failed";
+                    } else if (row.statusCode == "500") {
+                        return "internal error";
+                    } else {
+                        return "unknown";
+                    }
+                },
+                "certstatusdate": function (column, row) {
+                    if (row.statusLastUpdate == "" || row.statusCode == undefined) {
+                        // fallback to lastUpdate value
+                        if (row.lastUpdate == "" || row.lastUpdate == undefined) {
+                            return "unknown";
+                        } else {
+                            var legacydate = new Date(row.lastUpdate*1000);
+                            return legacydate.toLocaleString();
+                        }
+                    } else {
+                        var statusdate = new Date(row.statusLastUpdate*1000);
+                        return statusdate.toLocaleString();
+                    }
                 }
             },
         };
@@ -339,6 +383,9 @@ POSSIBILITY OF SUCH DAMAGE.
                 <th data-column-id="name" data-type="string">{{ lang._('Certificate Name') }}</th>
                 <th data-column-id="altNames" data-type="string">{{ lang._('Multi-Domain (SAN)') }}</th>
                 <th data-column-id="description" data-type="string">{{ lang._('Description') }}</th>
+                <th data-column-id="lastUpdate" data-type="string" data-formatter="certdate">{{ lang._('Issue/Renewal Date') }}</th>
+                <th data-column-id="statusCode" data-type="string" data-formatter="certstatus">{{ lang._('Last Acme Status') }}</th>
+                <th data-column-id="statusLastUpdate" data-type="string" data-formatter="certstatusdate">{{ lang._('Last Acme Run') }}</th>
                 <th data-column-id="commands" data-width="11em" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
                 <th data-column-id="uuid" data-type="string" data-identifier="true"  data-visible="false">{{ lang._('ID') }}</th>
             </tr>

--- a/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/certificates.volt
+++ b/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/certificates.volt
@@ -91,9 +91,11 @@ POSSIBILITY OF SUCH DAMAGE.
                     } else if (row.statusCode == "200") {
                         return "OK";
                     } else if (row.statusCode == "250") {
-                        return "OK (renewed)";
+                        return "cert revoked";
+                    } else if (row.statusCode == "300") {
+                        return "configuration error";
                     } else if (row.statusCode == "400") {
-                        return "failed";
+                        return "validation failed";
                     } else if (row.statusCode == "500") {
                         return "internal error";
                     } else {

--- a/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/certificates.volt
+++ b/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/certificates.volt
@@ -72,7 +72,7 @@ POSSIBILITY OF SUCH DAMAGE.
                 },
                 "certdate": function (column, row) {
                     if (row.lastUpdate == "" || row.lastUpdate == undefined) {
-                        return "pending";
+                        return "{{ lang._('pending') }}";
                     } else {
                         var certdate = new Date(row.lastUpdate*1000);
                         return certdate.toLocaleString();
@@ -82,31 +82,31 @@ POSSIBILITY OF SUCH DAMAGE.
                     if (row.statusCode == "" || row.statusCode == undefined) {
                         // fallback to lastUpdate value (unset if cert was never issued/imported)
                         if (row.lastUpdate == "" || row.lastUpdate == undefined) {
-                            return "never";
+                            return "{{ lang._('unknown') }}";
                         } else {
-                            return "OK";
+                            return "{{ lang._('OK') }}";
                         }
                     } else if (row.statusCode == "100") {
-                        return "never";
+                        return "{{ lang._('unknown') }}";
                     } else if (row.statusCode == "200") {
-                        return "OK";
+                        return "{{ lang._('OK') }}";
                     } else if (row.statusCode == "250") {
-                        return "cert revoked";
+                        return "{{ lang._('cert revoked') }}";
                     } else if (row.statusCode == "300") {
-                        return "configuration error";
+                        return "{{ lang._('configuration error') }}";
                     } else if (row.statusCode == "400") {
-                        return "validation failed";
+                        return "{{ lang._('validation failed') }}";
                     } else if (row.statusCode == "500") {
-                        return "internal error";
+                        return "{{ lang._('internal error') }}";
                     } else {
-                        return "unknown";
+                        return "{{ lang._('unknown') }}";
                     }
                 },
                 "certstatusdate": function (column, row) {
                     if (row.statusLastUpdate == "" || row.statusCode == undefined) {
                         // fallback to lastUpdate value
                         if (row.lastUpdate == "" || row.lastUpdate == undefined) {
-                            return "unknown";
+                            return "{{ lang._('unknown') }}";
                         } else {
                             var legacydate = new Date(row.lastUpdate*1000);
                             return legacydate.toLocaleString();

--- a/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/certificates.volt
+++ b/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/certificates.volt
@@ -78,7 +78,7 @@ POSSIBILITY OF SUCH DAMAGE.
                         return certdate.toLocaleString();
                     }
                 },
-                "certstatus": function (column, row) {
+                "acmestatus": function (column, row) {
                     if (row.statusCode == "" || row.statusCode == undefined) {
                         // fallback to lastUpdate value (unset if cert was never issued/imported)
                         if (row.lastUpdate == "" || row.lastUpdate == undefined) {
@@ -102,7 +102,7 @@ POSSIBILITY OF SUCH DAMAGE.
                         return "{{ lang._('unknown') }}";
                     }
                 },
-                "certstatusdate": function (column, row) {
+                "acmestatusdate": function (column, row) {
                     if (row.statusLastUpdate == "" || row.statusCode == undefined) {
                         // fallback to lastUpdate value
                         if (row.lastUpdate == "" || row.lastUpdate == undefined) {
@@ -386,8 +386,8 @@ POSSIBILITY OF SUCH DAMAGE.
                 <th data-column-id="altNames" data-type="string">{{ lang._('Multi-Domain (SAN)') }}</th>
                 <th data-column-id="description" data-type="string">{{ lang._('Description') }}</th>
                 <th data-column-id="lastUpdate" data-type="string" data-formatter="certdate">{{ lang._('Issue/Renewal Date') }}</th>
-                <th data-column-id="statusCode" data-type="string" data-formatter="certstatus">{{ lang._('Last Acme Status') }}</th>
-                <th data-column-id="statusLastUpdate" data-type="string" data-formatter="certstatusdate">{{ lang._('Last Acme Run') }}</th>
+                <th data-column-id="statusCode" data-type="string" data-formatter="acmestatus">{{ lang._('Last Acme Status') }}</th>
+                <th data-column-id="statusLastUpdate" data-type="string" data-formatter="acmestatusdate">{{ lang._('Last Acme Run') }}</th>
                 <th data-column-id="commands" data-width="11em" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
                 <th data-column-id="uuid" data-type="string" data-identifier="true"  data-visible="false">{{ lang._('ID') }}</th>
             </tr>

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -887,8 +887,11 @@ function run_restart_actions($certlist, $modelObj)
             }
             // Extract restart actions
             $_actions = explode(',', $certObj->restartActions);
+            if (empty($_actions)) {
+                // No restart actions configured.
+                continue;
+            }
             // Walk through all linked restart actions.
-            $_actions = explode(',', $certObj->restartActions);
             foreach ($_actions as $_action) {
                 // Extract restart action
                 $action = $modelObj->getByActionID($_action);


### PR DESCRIPTION
## New features
- Show acme status for each certificate in GUI
## Bugfixes
- Avoid API exception by skipping HAProxy integration if validation method is not configured
- Don't log an error if no restart action was specified
- Rename field "CA Account" to "LE Account" to avoid confusion

### Example: certificate status in GUI

![certstatus2](https://cloud.githubusercontent.com/assets/909706/23760475/10cb5136-04f0-11e7-80ac-aa38adc5e9e5.png)


