### PR TITLE
fix strings in quagga

### DIFF
--- a/net/quagga/src/opnsense/service/conf/actions.d/actions_quagga.conf
+++ b/net/quagga/src/opnsense/service/conf/actions.d/actions_quagga.conf
@@ -2,28 +2,28 @@
 command:/usr/local/etc/rc.d/quagga start
 parameters:
 type:script
-message:starting proxy
+message:starting quagga
 
 [stop]
 command:/usr/local/etc/rc.d/quagga; exit 0
 parameters:
 type:script
-message:stopping proxy
+message:stopping quagga
 
 [restart]
 command:/usr/local/etc/rc.d/quagga restart
 parameters:
 type:script
-message:restarting proxy
+message:restarting quagga
 
 [reconfigure]
 command:/usr/local/etc/rc.d/quagga reload
 parameters:
 type:script
-message:reconfigure proxy
+message:reconfigure quagga
 
 [status]
 command:/usr/local/etc/rc.d/quagga status;exit 0
 parameters:
 type:script_output
-message:request proxy status
+message:request quagga


### PR DESCRIPTION
This can happen if you copy a configuration file for configd...