### PR TITLE
net/haproxy: bugfix release 1.13

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		haproxy
-PLUGIN_VERSION=		1.12
+PLUGIN_VERSION=		1.13
 PLUGIN_COMMENT=		Reliable, high performance TCP/HTTP load balancer
 PLUGIN_DEPENDS=		haproxy
 PLUGIN_MAINTAINER=	opnsense@moov.de

--- a/net/haproxy/src/opnsense/scripts/OPNsense/HAProxy/exportCerts.php
+++ b/net/haproxy/src/opnsense/scripts/OPNsense/HAProxy/exportCerts.php
@@ -73,6 +73,12 @@ foreach ($configNodes as $key => $value) {
                                         } else {
                                             $pem_content = str_replace("\n\n", "\n", str_replace("\r", "", base64_decode((string)$cert->crt)));
                                             $pem_content .= "\n" . str_replace("\n\n", "\n", str_replace("\r", "", base64_decode((string)$cert->prv)));
+                                            // check if a CA is linked
+                                            if (!empty((string)$cert->caref)) {
+                                                $cert = (array)$cert;
+                                                $ca = ca_chain($cert);
+                                                $pem_content .= $ca;
+                                            }
                                         }
                                         // generate pem file
                                         $output_pem_filename = "/var/etc/haproxy/ssl/" . $cert_refid . ".pem";


### PR DESCRIPTION
In light of #84 it became clear that the HAProxy plugin is lacking with this regard too.

## New features
- none

## Bugfixes
- fix CA/intermediate certificate handling if a certificate (chain) was (properly) imported into OPNsense
