### PR TITLE
security/acme-client: adopt official LE wording

### DIFF
--- a/security/acme-client/Makefile
+++ b/security/acme-client/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		acme-client
-PLUGIN_VERSION=		1.4
+PLUGIN_VERSION=		1.5
 PLUGIN_COMMENT=		Let's Encrypt client
 PLUGIN_MAINTAINER=	opnsense@moov.de
 

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -19,9 +19,9 @@
     </field>
     <field>
         <id>validation.method</id>
-        <label>Validation Method</label>
+        <label>Challenge Type</label>
         <type>dropdown</type>
-        <help><![CDATA[Set the Let's Encrypt validation method. You'll have to add configuration for the selected method below.]]></help>
+        <help><![CDATA[Set the Let's Encrypt challenge type. You'll have to add configuration for the selected challenge type below.]]></help>
     </field>
     <field>
         <label>HTTP-01</label>


### PR DESCRIPTION
This renames the option field "Validation Method" to "Challenge Type" to better comply with official Let's Encrypt wording.

The menu item "Validation Method" remains unchanged, because IMHO it defines a configured (unique) method to handle the selected challenge type.