### PR TITLE
net/haproxy: bugfix release 1.14

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		haproxy
-PLUGIN_VERSION=		1.13
+PLUGIN_VERSION=		1.14
 PLUGIN_COMMENT=		Reliable, high performance TCP/HTTP load balancer
 PLUGIN_DEPENDS=		haproxy
 PLUGIN_MAINTAINER=	opnsense@moov.de

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -797,6 +797,7 @@
                         <path_regex>Path regex</path_regex>
                         <path_contains>Path contains</path_contains>
                         <url_parameter>URL parameter contains</url_parameter>
+                        <ssl_fc>SSL/TLS connection established</ssl_fc>
                         <ssl_c_verify_code>SSL Client certificate verify error result</ssl_c_verify_code>
                         <ssl_c_verify>SSL Client certificate is valid</ssl_c_verify>
                         <ssl_c_ca_commonname>SSL Client issued by CA common-name</ssl_c_ca_commonname>

--- a/net/haproxy/src/opnsense/scripts/OPNsense/HAProxy/exportCerts.php
+++ b/net/haproxy/src/opnsense/scripts/OPNsense/HAProxy/exportCerts.php
@@ -77,7 +77,7 @@ foreach ($configNodes as $key => $value) {
                                             if (!empty((string)$cert->caref)) {
                                                 $cert = (array)$cert;
                                                 $ca = ca_chain($cert);
-                                                $pem_content .= $ca;
+                                                $pem_content .= "\n" . $ca;
                                             }
                                         }
                                         // generate pem file

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -155,6 +155,8 @@
 {%                 set acl_enabled = '0' %}
     # ERROR: missing parameters
 {%               endif %}
+{%             elif acl_data.expression == 'ssl_fc' %}
+{%               do acl_options.append('ssl_fc') %}
 {%             elif acl_data.expression == 'source_ip' %}
 {%               if acl_data.value|default("") != "" %}
 {%                 do acl_options.append('src ' ~ acl_data.value) %}


### PR DESCRIPTION
## New features
- support new `ssl_fc` option in ACLs to reliably test for SSL/TLS connections

## Bugfixes
- fix missing newline in exported certificate ([via forum post](https://forum.opnsense.org/index.php?topic=4947.0))