### PR TITLE
Quagga: use correct interfaces

### DIFF
--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
@@ -1,6 +1,7 @@
 {% macro cline(directive, modelname) -%}{% if modelname %}
   ip ospf {{ directive }} {{ modelname }}
 {% endif %}{%- endmacro %}
+{% from 'OPNsense/Macros/interface.macro' import physical_interface %}
 {% if helpers.exists('OPNsense.quagga.ospf.enabled') and OPNsense.quagga.ospf.enabled == '1' %}
 !
 ! Zebra configuration saved from vty
@@ -12,7 +13,7 @@
 {% if helpers.exists('OPNsense.quagga.ospf.interfaces.interface') %}
 {%   for interface in helpers.toList('OPNsense.quagga.ospf.interfaces.interface') %}
 {%     if interface.enabled == '1' %}
-interface {{ interface.interfacename }}
+interface {{ physical_interface(interface.interfacename) }}
 {{       cline("authentication",interface.authtype)
 }}{{       cline("authentication-key",interface.authkey)
 }}{{       cline("cost",interface.cost)
@@ -32,7 +33,7 @@ router ospf
 {% endfor %}{% endif %}
 {% if helpers.exists('OPNsense.quagga.ospf.passiveinterfaces') and OPNsense.quagga.ospf.passiveinterfaces != '' %}
 {% for line in OPNsense.quagga.ospf.passiveinterfaces.split(',') %}
- passive-interface {{ line }}
+ passive-interface {{ physical_interface(line) }}
 {% endfor %}{% endif %}
 {% if helpers.exists('OPNsense.quagga.ospf.networks.network') %}
 {%   for network in helpers.toList('OPNsense.quagga.ospf.networks.network') %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/ripd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/ripd.conf
@@ -1,4 +1,5 @@
 {% if helpers.exists('OPNsense.quagga.rip.enabled') and OPNsense.quagga.rip.enabled == '1' %}
+{% from 'OPNsense/Macros/interface.macro' import physical_interface %}
 !
 ! Zebra configuration saved from vty
 !   2017/03/26 22:40:16
@@ -20,7 +21,7 @@ router rip
 {%  endif %}
 {% if helpers.exists('OPNsense.quagga.rip.passiveinterfaces') and OPNsense.quagga.rip.passiveinterfaces != '' %}
 {% for line in OPNsense.quagga.rip.passiveinterfaces.split(',') %}
- passive-interface {{ line }}
+ passive-interface {{ physical_interface(line) }}
 {% endfor %}{% endif %}
 !
 line vty


### PR DESCRIPTION
@fichtner this must go to the stable branch before release. It will map OPNsense names to real interface names like Quagga expects. Otherwise interfaces and passive interfaces will not work (core functionality will do).