### PR TITLE
[AcmeClient] Fix non-object error

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/Api/SettingsController.php
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/Api/SettingsController.php
@@ -333,7 +333,7 @@ class SettingsController extends ApiMutableModelControllerBase
                             //$this->getLogger()->error("LE HAProxy DEBUG: checking frontend: ${_frontend}");
                             $frontend = $mdlHAProxy->getByFrontendID($_frontend);
                             // Make sure the frontend was found in config.
-                            if (!empty((string)$frontend->id)) {
+                            if (!is_null($frontend) && !empty((string)$frontend->id)) {
                                 // Check if the HAProxy ACME Action is linked to this frontend.
                                 $_actions = $frontend->linkedActions;
                                 if (strpos($_actions, $action_ref) !== false) {


### PR DESCRIPTION
Fix null object when a validation method use a removed HA Proxy frontend

![image](https://cloud.githubusercontent.com/assets/1301995/25363598/faad9982-295b-11e7-93b3-d734c1285380.png)
