### PR TITLE
Quagga: Add AS-Path Lists and Route-Maps to BGP

### DIFF
--- a/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/Api/BgpController.php
+++ b/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/Api/BgpController.php
@@ -81,7 +81,7 @@ class BgpController extends ApiMutableModelControllerBase
         $grid = new UIModelGrid($mdlBGP->neighbors->neighbor);
         return $grid->fetchBindRequest(
             $this->request,
-            array("enabled", "address", "remoteas", "updatesource", "nexthopself", "defaultoriginate", "linkedRoutemap" )
+            array("enabled", "address", "remoteas", "updatesource", "nexthopself", "defaultoriginate", "linkedRoutemapIn", "linkedRoutemapOut" )
         );
     }
 

--- a/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/Api/BgpController.php
+++ b/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/Api/BgpController.php
@@ -178,7 +178,7 @@ class BgpController extends ApiMutableModelControllerBase
         $grid = new UIModelGrid($mdlBGP->aspaths->aspath);
         return $grid->fetchBindRequest(
             $this->request,
-            array("enabled", "name", "number", "action", "as" )
+            array("enabled", "number", "action", "as" )
         );
     }
 

--- a/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/bgp.xml
+++ b/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/bgp.xml
@@ -9,7 +9,7 @@
         <id>bgp.asnumber</id>
         <label>BGP AS Number</label>
         <type>text</type>
-        <hint>Your AS Number here</hint>
+        <help>Your AS Number here</help>
     </field>
     <field>
         <id>bgp.networks</id>

--- a/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPASPath.xml
+++ b/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPASPath.xml
@@ -3,20 +3,24 @@
     <id>aspath.enabled</id>
     <label>Enabled</label>
     <type>checkbox</type>
+    <help>Enable / Disable</help>
   </field>
   <field>
     <id>aspath.number</id>
     <label>Number</label>
     <type>text</type>
+    <help>The ACL rule number (1-299)</help>
   </field>
   <field>
     <id>aspath.action</id>
     <label>Action</label>
     <type>select_multiple</type>
+    <help>Action</help>
   </field>
   <field>
     <id>aspath.as</id>
     <label>AS</label>
     <type>text</type>
+    <help>The AS pattern you want to match, regexp allowed. It's not validated so please be careful!</help>
   </field>
 </form>

--- a/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPASPath.xml
+++ b/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPASPath.xml
@@ -5,11 +5,6 @@
     <type>checkbox</type>
   </field>
   <field>
-    <id>aspath.name</id>
-    <label>Name</label>
-    <type>text</type>
-  </field>  
-  <field>
     <id>aspath.number</id>
     <label>Number</label>
     <type>text</type>

--- a/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPASPath.xml
+++ b/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPASPath.xml
@@ -9,7 +9,7 @@
     <id>aspath.number</id>
     <label>Number</label>
     <type>text</type>
-    <help>The ACL rule number (1-299); keep in mind that there are no sequence numbers with AS-Path lists. When you want to add a new line between you have to completely remove the ACL!</help>
+    <help>The ACL rule number (10-99); keep in mind that there are no sequence numbers with AS-Path lists. When you want to add a new line between you have to completely remove the ACL!</help>
   </field>
   <field>
     <id>aspath.action</id>

--- a/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPASPath.xml
+++ b/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPASPath.xml
@@ -9,7 +9,7 @@
     <id>aspath.number</id>
     <label>Number</label>
     <type>text</type>
-    <help>The ACL rule number (1-299)</help>
+    <help>The ACL rule number (1-299); keep in mind that there are no sequence numbers with AS-Path lists. When you want to add a new line between you have to completely remove the ACL!</help>
   </field>
   <field>
     <id>aspath.action</id>
@@ -21,6 +21,6 @@
     <id>aspath.as</id>
     <label>AS</label>
     <type>text</type>
-    <help>The AS pattern you want to match, regexp allowed. It's not validated so please be careful!</help>
+    <help>The AS pattern you want to match, regexp allowed (e.g. *$ or _1$). It's not validated so please be careful!</help>
   </field>
 </form>

--- a/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPASPath.xml
+++ b/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPASPath.xml
@@ -15,7 +15,7 @@
     <id>aspath.action</id>
     <label>Action</label>
     <type>select_multiple</type>
-    <help>Action</help>
+    <help>Set permit for match or deny to negate the rule.</help>
   </field>
   <field>
     <id>aspath.as</id>

--- a/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPNeighbor.xml
+++ b/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPNeighbor.xml
@@ -36,12 +36,12 @@
     <id>neighbor.linkedRoutemapIn</id>
     <label>Route-Map In</label>
     <type>dropdown</type>
-    <help>Route-Map for Inbound direction</help>
+    <help>Route-Map for inbound direction</help>
   </field>
   <field>
     <id>neighbor.linkedRoutemapOut</id>
     <label>Route-Map Out</label>
     <type>dropdown</type>
-    <help>Route-Map for Outbound direction</help>
+    <help>Route-Map for outbound direction</help>
   </field>
 </form>

--- a/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPRouteMaps.xml
+++ b/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPRouteMaps.xml
@@ -3,21 +3,25 @@
     <id>routemap.enabled</id>
     <label>Enabled</label>
     <type>checkbox</type>
+    <help>Enable / Disable</help>
   </field>
   <field>
     <id>routemap.name</id>
     <label>Name</label>
     <type>text</type>
+    <help>Route-map Name</help>
   </field>
   <field>
     <id>routemap.action</id>
     <label>Action</label>
     <type>select_multiple</type>
+    <help>Action</help>
   </field>
   <field>
     <id>routemap.id</id>
     <label>ID</label>
     <type>text</type>
+    <help>Route-map ID</help>
   </field>
   <field>
     <id>routemap.match</id>
@@ -25,10 +29,12 @@
     <type>select_multiple</type>
     <style>tokenize</style>
     <allownew>true</allownew>
+    <help>Select the AS-Path list</help>
   </field>
     <field>
     <id>routemap.set</id>
     <label>Set</label>
     <type>text</type>
+    <help>Free text field for your set, please be careful! You can set e.g. "local-prefernce 300" or "community 1:1"</help>
   </field>
 </form>

--- a/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPRouteMaps.xml
+++ b/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPRouteMaps.xml
@@ -21,7 +21,7 @@
     <id>routemap.id</id>
     <label>ID</label>
     <type>text</type>
-    <help>Route-map ID</help>
+    <help>Route-map ID. Be aware that the sorting will be done under the hood, so when you add an entry between it get's to the right position</help>
   </field>
   <field>
     <id>routemap.match</id>

--- a/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPRouteMaps.xml
+++ b/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPRouteMaps.xml
@@ -35,6 +35,6 @@
     <id>routemap.set</id>
     <label>Set</label>
     <type>text</type>
-    <help>Free text field for your set, please be careful! You can set e.g. "local-prefernce 300" or "community 1:1"</help>
+    <help>Free text field for your set, please be careful! You can set e.g. "local-prefernce 300" or "community 1:1" (http://www.nongnu.org/quagga/docs/docs-multi/Route-Map-Set-Command.html#Route-Map-Set-Command)</help>
   </field>
 </form>

--- a/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPRouteMaps.xml
+++ b/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPRouteMaps.xml
@@ -9,13 +9,13 @@
     <id>routemap.name</id>
     <label>Name</label>
     <type>text</type>
-    <help>Route-map Name</help>
+    <help>Route-map name to match and set your patterns, it will be enabled via the neigbor configuration.</help>
   </field>
   <field>
     <id>routemap.action</id>
     <label>Action</label>
     <type>select_multiple</type>
-    <help>Action</help>
+    <help>Set permit for match or deny to negate the rule.</help>
   </field>
   <field>
     <id>routemap.id</id>

--- a/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPRouteMaps.xml
+++ b/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPRouteMaps.xml
@@ -21,7 +21,7 @@
     <id>routemap.id</id>
     <label>ID</label>
     <type>text</type>
-    <help>Route-map ID. Be aware that the sorting will be done under the hood, so when you add an entry between it get's to the right position</help>
+    <help>Route-map ID between 10 and 99. Be aware that the sorting will be done under the hood, so when you add an entry between it get's to the right position</help>
   </field>
   <field>
     <id>routemap.match</id>

--- a/net/quagga/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
+++ b/net/quagga/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
@@ -97,7 +97,8 @@
                                 <default>1</default>
                                 <Required>Y</Required>
                         </enabled>                         
-                        <number type="AutoNumberField">
+                        <number type="IntegerField">
+                                <default></default>
                                 <Required>Y</Required>
                                 <MinimumValue>1</MinimumValue>
                                 <MaximumValue>299</MaximumValue>
@@ -134,7 +135,7 @@
                                         <deny>Deny</deny>
                                 </OptionValues>
                         </action>
-                        <id type="AutoNumberField">
+                        <id type="IntegerField">
                                 <default></default>
                                 <Required>Y</Required>
                                 <MinimumValue>1</MinimumValue>

--- a/net/quagga/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
+++ b/net/quagga/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
@@ -149,7 +149,7 @@
                                         <template>
                                                 <source>OPNsense.quagga.bgp</source>
                                                 <items>aspaths.aspath</items>
-                                                <display>name</display>
+                                                <display>number</display>
                                         </template>
                                 </Model>
                                 <ValidationMessage>Related item not found</ValidationMessage>

--- a/net/quagga/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
+++ b/net/quagga/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
@@ -96,11 +96,7 @@
                         <enabled type="BooleanField">
                                 <default>1</default>
                                 <Required>Y</Required>
-                        </enabled>
-                        <name type="TextField">
-                                <default></default>
-                                <Required>Y</Required>
-                        </name>                           
+                        </enabled>                         
                         <number type="AutoNumberField">
                                 <Required>Y</Required>
                                 <MinimumValue>1</MinimumValue>

--- a/net/quagga/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
+++ b/net/quagga/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
@@ -100,8 +100,8 @@
                         <number type="IntegerField">
                                 <default></default>
                                 <Required>Y</Required>
-                                <MinimumValue>1</MinimumValue>
-                                <MaximumValue>299</MaximumValue>
+                                <MinimumValue>10</MinimumValue>
+                                <MaximumValue>99</MaximumValue>
                         </number>
                         <action type="OptionField">
                                 <default></default>
@@ -138,8 +138,8 @@
                         <id type="IntegerField">
                                 <default></default>
                                 <Required>Y</Required>
-                                <MinimumValue>1</MinimumValue>
-                                <MaximumValue>1000</MaximumValue>
+                                <MinimumValue>10</MinimumValue>
+                                <MaximumValue>99</MaximumValue>
                         </id>
                         <match type="ModelRelationField">
                                 <Model>

--- a/net/quagga/src/opnsense/mvc/app/views/OPNsense/Quagga/bgp.volt
+++ b/net/quagga/src/opnsense/mvc/app/views/OPNsense/Quagga/bgp.volt
@@ -81,10 +81,10 @@ POSSIBILITY OF SUCH DAMAGE.
         <table id="grid-aspaths" class="table table-responsive" data-editDialog="DialogEditBGPASPaths">
             <thead>
                 <tr>
-                    <th data-column-id="enabled" data-type="string" data-formatter="rowtoggle">{{ lang._('Enabled') }}</th>
-                    <th data-column-id="number" data-type="string" data-visible="true">{{ lang._('Number') }}</th>
-                    <th data-column-id="action" data-type="string" data-visible="true">{{ lang._('Action') }}</th>
-                    <th data-column-id="as" data-type="string" data-visible="true">{{ lang._('AS') }}</th>
+                    <th data-column-id="enabled" data-type="string" data-formatter="rowtoggle" data-sortable="false">{{ lang._('Enabled') }}</th>
+                    <th data-column-id="number" data-type="string" data-visible="true" data-sortable="true">{{ lang._('Number') }}</th>
+                    <th data-column-id="action" data-type="string" data-visible="true" data-sortable="false">{{ lang._('Action') }}</th>
+                    <th data-column-id="as" data-type="string" data-visible="true" data-sortable="false">{{ lang._('AS') }}</th>
                     <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
                     <th data-column-id="commands" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
                 </tr>

--- a/net/quagga/src/opnsense/mvc/app/views/OPNsense/Quagga/bgp.volt
+++ b/net/quagga/src/opnsense/mvc/app/views/OPNsense/Quagga/bgp.volt
@@ -111,7 +111,7 @@ POSSIBILITY OF SUCH DAMAGE.
                     <th data-column-id="name" data-type="string" data-visible="true">{{ lang._('Name') }}</th>
                     <th data-column-id="action" data-type="string" data-visible="true">{{ lang._('Action') }}</th>
                     <th data-column-id="id" data-type="string" data-visible="true">{{ lang._('ID') }}</th>
-                    <th data-column-id="match" data-type="string" data-visible="true">{{ lang._('Match') }}</th>
+                    <th data-column-id="match" data-type="string" data-visible="true">{{ lang._('AS-Path List') }}</th>
                     <th data-column-id="set" data-type="string" data-visible="true">{{ lang._('Set') }}</th>
                     <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
                     <th data-column-id="commands" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>

--- a/net/quagga/src/opnsense/mvc/app/views/OPNsense/Quagga/bgp.volt
+++ b/net/quagga/src/opnsense/mvc/app/views/OPNsense/Quagga/bgp.volt
@@ -84,7 +84,7 @@ POSSIBILITY OF SUCH DAMAGE.
                     <th data-column-id="enabled" data-type="string" data-formatter="rowtoggle" data-sortable="false">{{ lang._('Enabled') }}</th>
                     <th data-column-id="number" data-type="string" data-visible="true" data-sortable="true">{{ lang._('Number') }}</th>
                     <th data-column-id="action" data-type="string" data-visible="true" data-sortable="false">{{ lang._('Action') }}</th>
-                    <th data-column-id="as" data-type="string" data-visible="true" data-sortable="false">{{ lang._('AS') }}</th>
+                    <th data-column-id="as" data-type="string" data-visible="true" data-sortable="false">{{ lang._('AS Number') }}</th>
                     <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
                     <th data-column-id="commands" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
                 </tr>
@@ -111,7 +111,7 @@ POSSIBILITY OF SUCH DAMAGE.
                     <th data-column-id="name" data-type="string" data-visible="true">{{ lang._('Name') }}</th>
                     <th data-column-id="action" data-type="string" data-visible="true">{{ lang._('Action') }}</th>
                     <th data-column-id="id" data-type="string" data-visible="true">{{ lang._('ID') }}</th>
-                    <th data-column-id="match" data-type="string" data-visible="true">{{ lang._('AS-Path List') }}</th>
+                    <th data-column-id="match" data-type="string" data-visible="true">{{ lang._('AS Path List') }}</th>
                     <th data-column-id="set" data-type="string" data-visible="true">{{ lang._('Set') }}</th>
                     <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
                     <th data-column-id="commands" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -34,7 +34,6 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%           for aspath in neighbor.linkedRoutemapOut.split(",") %}
 {%             set routemap_data = helpers.getUUID(aspath) %}
 {%             if routemap_data != '' %}
-!
  neighbor {{ neighbor.address }} route-map {{ routemap_data.name }} out 
 {%             endif %}
 {%           endfor %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -67,7 +67,7 @@ route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
 {%           for neighbor in routemap.match.split(",") %}
 {%             set routemap_data = helpers.getUUID(neighbor.linkedRoutemapOut) %}
 {%             if routemap_data != '' %}
- neighbor {{ OPNsense.quagga.bgp.neighbors.neighbor.address }} route-map {{ routemap_data.name }} out 
+ neighbor {{ neighbor.address }} route-map {{ routemap_data.name }} out 
 {%             endif %}
 {%           endfor %}
 {%         endif %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -28,10 +28,14 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
  neighbor {{ neighbor.address }} default-originate
 {%         endif %}
 {%         if 'linkedRoutemapIn' in neighbor and neighbor.linkedRoutemapIn != '' %}
- neighbor {{ neighbor.address }} route-map {{ OPNsense.quagga.bgp.routemaps.routemap.name }}in
+ neighbor {{ neighbor.address }} route-map {{ OPNsense.quagga.bgp.routemaps.routemap.name }} in
 {%         endif %}
-{%         if 'linkedRoutemapOut' in neighbor and neighbor.linkedRoutemapOut != '' %}
- neighbor {{ neighbor.address }} route-map {{ OPNsense.quagga.bgp.routemaps.routemap.name }}out
+{%         if helpers.exists('OPNsense.quagga.bgp.neighbors.linkedRoutemapOut' %}
+{%           for linkedRoutemapOut in helpers.toList('OPNsense.quagga.bgp.neighbors.neighbor.linkedRoutemapOut') %}
+{%             if neighbor.linkedRoutemapOut == '1' %}
+ neighbor {{ neighbor.address }} route-map {{ OPNsense.quagga.bgp.routemaps.routemap.name }} out
+{%             endif %}
+{%           endfor %}
 {%         endif %}
 {%       endif %}
 {%     endfor %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -56,7 +56,7 @@ ip as-path access-list {{ aspath.number }} {{ aspath.action }} {{ aspath.as }}
 {%   endif %}
 ! 
 {%   if helpers.exists('OPNsense.quagga.bgp.routemaps.routemap') %}
-{%     for routemap in helpers.toList('OPNsense.quagga.bgp.routemaps.routemap'|sort(attribute='name'))|sort(attribute='id') %}
+{%     for routemap in helpers.toList('OPNsense.quagga.bgp.routemaps.routemap')|sort(attribute='name',attribute='id') %}
 {%       if routemap.enabled == '1' %}
 route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
 {%         if routemap.match|default("") != "" %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -57,22 +57,20 @@ ip as-path access-list {{ aspath.number }} {{ aspath.action }} {{ aspath.as }}
 ! 
 {%   if helpers.exists('OPNsense.quagga.bgp.routemaps.routemap') %}
 {%     for routemap in helpers.toList('OPNsense.quagga.bgp.routemaps.routemap')|sort(attribute='name') %}
-{%     for routemapX in routemap|sort(attribute='routemap.id') %}
-{%       if routemapX.enabled == '1' %}
-route-map {{ routemapX.name }} {{ routemapX.action }} {{ routemapX.id }}
-{%         if routemapX.match|default("") != "" %}
-{%           for aspath in routemapX.match.split(",") %}
+{%       if routemap.enabled == '1' %}
+route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
+{%         if routemap.match|default("") != "" %}
+{%           for aspath in routemap.match.split(",") %}
 {%             set aspath_data = helpers.getUUID(aspath) %}
-{%             if 'match' in routemapX and routemapX.match != '' %}
+{%             if 'match' in routemap and routemap.match != '' %}
  match as-path {{ aspath_data.number }}
 {%             endif %}
 {%           endfor %}
 {%         endif %}
-{%         if routemapX.set != '' %}
- set {{ routemapX.set }}
+{%         if routemap.set != '' %}
+ set {{ routemap.set }}
 {%         endif %}
 {%       endif %}
-{%     endfor %}
 {%     endfor %}
 {%   endif %}
 !

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -57,7 +57,7 @@ ip as-path access-list {{ aspath.number }} {{ aspath.action }} {{ aspath.as }}
 ! 
 {%   if helpers.exists('OPNsense.quagga.bgp.routemaps.routemap') %}
 {%     for routemap in helpers.toList('OPNsense.quagga.bgp.routemaps.routemap')|sort(attribute='name') %}
-{%     for routemapX in routemap|sort(attribute='id') %}
+{%     for routemapX in routemap|sort(attribute='routemap.id') %}
 {%       if routemapX.enabled == '1' %}
 route-map {{ routemapX.name }} {{ routemapX.action }} {{ routemapX.id }}
 {%         if routemap.match|default("") != "" %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -63,10 +63,10 @@ route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
 {%   if helpers.exists('OPNsense.quagga.bgp.neighbors.neighbor') %}
 {%     for neighbor in helpers.toList('OPNsense.quagga.bgp.neighbors.neighbor') %}
 {%       if neighbor.enabled == '1' %}
-{%         if linkedRoutemapOut is defined %}
+{%         if neighbor.linkedRoutemapOut is defined %}
 {%           for neighbor.linkedRoutemapOut in helpers.getUUID('OPNsense.quagga.bgp.neighbors.neighbor.linkedRoutemapOut') %}
 {%             if neighbor.linkedRoutemapOut != '' %}
- neighbor {{ OPNsense.quagga.bgp.neighbors.neighbor.address }} route-map {{ routemap.name }} out 
+ neighbor {{ OPNsense.quagga.bgp.neighbors.neighbor.address }} route-map {{ OPNsense.quagga.bgp.routemaps.routemap.name }} out 
 {%             endif %}
 {%           endfor %}
 {%         endif %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -57,19 +57,19 @@ ip as-path access-list {{ aspath.number }} {{ aspath.action }} {{ aspath.as }}
 ! 
 {%   if helpers.exists('OPNsense.quagga.bgp.routemaps.routemap') %}
 {%     for routemap in helpers.toList('OPNsense.quagga.bgp.routemaps.routemap')|sort(attribute='name') %}
-{%     for routemapX in routemaps.routemap|sort(attribute='routemap.id') %}
+{%     for routemapX in routemap|sort(attribute='id') %}
 {%       if routemapX.enabled == '1' %}
 route-map {{ routemapX.name }} {{ routemapX.action }} {{ routemapX.id }}
-{%         if routemap.match|default("") != "" %}
-{%           for aspath in routemap.match.split(",") %}
+{%         if routemapX.match|default("") != "" %}
+{%           for aspath in routemapX.match.split(",") %}
 {%             set aspath_data = helpers.getUUID(aspath) %}
-{%             if 'match' in routemap and routemap.match != '' %}
+{%             if 'match' in routemapX and routemapX.match != '' %}
  match as-path {{ aspath_data.number }}
 {%             endif %}
 {%           endfor %}
 {%         endif %}
-{%         if routemap.set != '' %}
- set {{ routemap.set }}
+{%         if routemapX.set != '' %}
+ set {{ routemapX.set }}
 {%         endif %}
 {%       endif %}
 {%     endfor %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -56,7 +56,7 @@ ip as-path access-list {{ aspath.number }} {{ aspath.action }} {{ aspath.as }}
 {%   endif %}
 ! 
 {%   if helpers.exists('OPNsense.quagga.bgp.routemaps.routemap') %}
-{%     for routemap in helpers.sortDictList('OPNsense.quagga.bgp.routemaps.routemap', 'name') %}
+{%     for routemap in helpers.sortDictList(OPNsense.quagga.bgp.routemaps.routemap, 'name') %}
 {%       if routemap.enabled == '1' %}
 route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
 {%         if routemap.match|default("") != "" %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -27,8 +27,11 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%         if 'defaultoriginate' in neighbor and neighbor.defaultoriginate == '1' %}
  neighbor {{ neighbor.address }} default-originate
 {%         endif %}
-{%         if 'linkedRoutemap' in neighbor and neighbor.linkedRoutemap != '' %}
- neighbor {{ neighbor.address }} route-map {{ OPNsense.quagga.bgp.routemaps.routemap.name }}
+{%         if 'linkedRoutemapIn' in neighbor and neighbor.linkedRoutemapIn != '' %}
+ neighbor {{ neighbor.address }} route-map {{ OPNsense.quagga.bgp.routemaps.routemap.name }} in
+{%         endif %}
+{%         if 'linkedRoutemapOut' in neighbor and neighbor.linkedRoutemapOut != '' %}
+ neighbor {{ neighbor.address }} route-map {{ OPNsense.quagga.bgp.routemaps.routemap.name }} out
 {%         endif %}
 {%       endif %}
 {%     endfor %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -65,7 +65,7 @@ route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
 {%       if neighbor.enabled == '1' %}
 {%         if neighbor.linkedRoutemapOut is defined %}
 {%           for neighbor in routemap.match.split(",") %}
-{%             set linkedRoutemapOut = helpers.getUUID(linkedRoutemapOut) %}
+{%             set linkedRoutemapOut = helpers.getUUID(neighbor.linkedRoutemapOut) %}
 {%             if linkedRoutemapOut != '' %}
  neighbor {{ OPNsense.quagga.bgp.neighbors.neighbor.address }} route-map {{ linkedRoutemapOut.name }} out 
 {%             endif %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -27,8 +27,13 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%         if 'defaultoriginate' in neighbor and neighbor.defaultoriginate == '1' %}
  neighbor {{ neighbor.address }} default-originate
 {%         endif %}
-{%         if 'linkedRoutemapIn' in neighbor and neighbor.linkedRoutemapIn != '' %}
- neighbor {{ neighbor.address }} route-map {{ OPNsense.quagga.bgp.routemaps.routemap.name }} in
+{%         if neighbor.linkedRoutemapIn|default("") != "" %}
+{%           for aspath in neighbor.linkedRoutemapIn.split(",") %}
+{%             set routemap2_data = helpers.getUUID(aspath) %}
+{%             if routemap2_data != '' %}
+ neighbor {{ neighbor.address }} route-map {{ routemap2_data.name }} in 
+{%             endif %}
+{%           endfor %}
 {%         endif %}
 {%         if neighbor.linkedRoutemapOut|default("") != "" %}
 {%           for aspath in neighbor.linkedRoutemapOut.split(",") %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -64,7 +64,8 @@ route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
 {%     for neighbor in helpers.toList('OPNsense.quagga.bgp.neighbors.neighbor') %}
 {%       if neighbor.enabled == '1' %}
 {%         if neighbor.linkedRoutemapOut is defined %}
-{%           for neighbor.linkedRoutemapOut in helpers.getUUID('OPNsense.quagga.bgp.neighbors.neighbor.linkedRoutemapOut') %}
+{%           for neighbor in routemap.match.split(",") %}
+{%             set linkedRoutemapOut = helpers.getUUID(linkedRoutemapOut) %}
 {%             if neighbor.linkedRoutemapOut != '' %}
  neighbor {{ OPNsense.quagga.bgp.neighbors.neighbor.address }} route-map {{ OPNsense.quagga.bgp.routemaps.routemap.name }} out 
 {%             endif %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -56,7 +56,7 @@ ip as-path access-list {{ aspath.number }} {{ aspath.action }} {{ aspath.as }}
 {%   endif %}
 ! 
 {%   if helpers.exists('OPNsense.quagga.bgp.routemaps.routemap') %}
-{%     for routemap in helpers.sortDictList(OPNsense.quagga.bgp.routemaps.routemap, 'name') %}
+{%     for routemap in helpers.sortDictList(OPNsense.quagga.bgp.routemaps.routemap, 'name')|sort(attribute='id') %}
 {%       if routemap.enabled == '1' %}
 route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
 {%         if routemap.match|default("") != "" %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -66,8 +66,8 @@ route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
 {%         if neighbor.linkedRoutemapOut is defined %}
 {%           for neighbor in routemap.match.split(",") %}
 {%             set linkedRoutemapOut = helpers.getUUID(linkedRoutemapOut) %}
-{%             if neighbor.linkedRoutemapOut != '' %}
- neighbor {{ OPNsense.quagga.bgp.neighbors.neighbor.address }} route-map {{ OPNsense.quagga.bgp.routemaps.routemap.name }} out 
+{%             if linkedRoutemapOut != '' %}
+ neighbor {{ OPNsense.quagga.bgp.neighbors.neighbor.address }} route-map {{ linkedRoutemapOut.name }} out 
 {%             endif %}
 {%           endfor %}
 {%         endif %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -34,6 +34,8 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%           for linkedRoutemapOut in helpers.toList('OPNsense.quagga.bgp.neighbors.neighbor.linkedRoutemapOut') %}
 {%             if neighbor.linkedRoutemapOut != '' %}
  neighbor {{ neighbor.address }} route-map {{ OPNsense.quagga.bgp.routemaps.routemap.name }} out
+ neighbor {{ neighbor.address }} route-map {{ routemap.name }} out
+ neighbor {{ neighbor.address }} route-map {{ neighbor.remotead }} out 
 {%             endif %}
 {%           endfor %}
 {%         endif %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -56,7 +56,7 @@ ip as-path access-list {{ aspath.number }} {{ aspath.action }} {{ aspath.as }}
 {%   endif %}
 ! 
 {%   if helpers.exists('OPNsense.quagga.bgp.routemaps.routemap') %}
-{%     for routemap in helpers.sortDictList(OPNsense.quagga.bgp.routemaps.routemap, 'name')|sort(attribute='id') %}
+{%     for routemap in helpers.sortDictList(OPNsense.quagga.bgp.routemaps.routemap, 'name') %}
 {%       if routemap.enabled == '1' %}
 route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
 {%         if routemap.match|default("") != "" %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -56,7 +56,7 @@ ip as-path access-list {{ aspath.number }} {{ aspath.action }} {{ aspath.as }}
 {%   endif %}
 ! 
 {%   if helpers.exists('OPNsense.quagga.bgp.routemaps.routemap') %}
-{%     for routemap in helpers.toList('OPNsense.quagga.bgp.routemaps.routemap')|sort(attribute='name') %}
+{%     for routemap in helpers.sortDictList('OPNsense.quagga.bgp.routemaps.routemap', 'name') %}
 {%       if routemap.enabled == '1' %}
 route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
 {%         if routemap.match|default("") != "" %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -65,9 +65,9 @@ route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
 {%       if neighbor.enabled == '1' %}
 {%         if neighbor.linkedRoutemapOut is defined %}
 {%           for neighbor in routemap.match.split(",") %}
-{%             set linkedRoutemapOut = helpers.getUUID(neighbor.linkedRoutemapOut) %}
-{%             if linkedRoutemapOut != '' %}
- neighbor {{ OPNsense.quagga.bgp.neighbors.neighbor.address }} route-map {{ linkedRoutemapOut.name }} out 
+{%             set routemap_data = helpers.getUUID(neighbor.linkedRoutemapOut) %}
+{%             if routemap_data != '' %}
+ neighbor {{ OPNsense.quagga.bgp.neighbors.neighbor.address }} route-map {{ routemap_data.name }} out 
 {%             endif %}
 {%           endfor %}
 {%         endif %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -30,9 +30,9 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%         if 'linkedRoutemapIn' in neighbor and neighbor.linkedRoutemapIn != '' %}
  neighbor {{ neighbor.address }} route-map {{ OPNsense.quagga.bgp.routemaps.routemap.name }} in
 {%         endif %}
-{%         if neighbor.linkedRoutemapOut is defined %}
-{%           for neighbor in routemap.match.split(",") %}
-{%             set routemap_data = helpers.getUUID(neighbor.linkedRoutemapOut) %}
+{%         if neighbor.linkedRoutemapOut|default("") != "" %}
+{%           for aspath in neighbor.linkedRoutemapOut.split(",") %}
+{%             set routemap_data = helpers.getUUID(aspath) %}
 {%             if routemap_data != '' %}
 ! Je gesetzter route-map soll hier stehen "neighbor <ip> route-map <route-map name> out
  neighbor {{ neighbor.address }} route-map {{ routemap_data.name }} out 

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -56,7 +56,7 @@ ip as-path access-list {{ aspath.number }} {{ aspath.action }} {{ aspath.as }}
 {%   endif %}
 ! 
 {%   if helpers.exists('OPNsense.quagga.bgp.routemaps.routemap') %}
-{%     for routemap in helpers.toList('OPNsense.quagga.bgp.routemaps.routemap')|sort(attribute='id') %}
+{%     for routemap in helpers.toList('OPNsense.quagga.bgp.routemaps.routemap')|sort(attribute='name')|sort(attribute='id') %}
 {%       if routemap.enabled == '1' %}
 route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
 {%         if routemap.match|default("") != "" %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -28,10 +28,10 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
  neighbor {{ neighbor.address }} default-originate
 {%         endif %}
 {%         if 'linkedRoutemapIn' in neighbor and neighbor.linkedRoutemapIn != '' %}
- neighbor {{ neighbor.address }} route-map {{ OPNsense.quagga.bgp.routemaps.routemap.name }} in
+ neighbor {{ neighbor.address }} route-map {{ OPNsense.quagga.bgp.routemaps.routemap.name }}in
 {%         endif %}
 {%         if 'linkedRoutemapOut' in neighbor and neighbor.linkedRoutemapOut != '' %}
- neighbor {{ neighbor.address }} route-map {{ OPNsense.quagga.bgp.routemaps.routemap.name }} out
+ neighbor {{ neighbor.address }} route-map {{ OPNsense.quagga.bgp.routemaps.routemap.name }}out
 {%         endif %}
 {%       endif %}
 {%     endfor %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -32,7 +32,7 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%         endif %}
 {%         if helpers.exists('OPNsense.quagga.bgp.neighbors.neighbor.linkedRoutemapOut') %}
 {%           for linkedRoutemapOut in helpers.toList('OPNsense.quagga.bgp.neighbors.neighbor.linkedRoutemapOut') %}
-{%             if neighbor.linkedRoutemapOut == '1' %}
+{%             if neighbor.linkedRoutemapOut != '' %}
  neighbor {{ neighbor.address }} route-map {{ OPNsense.quagga.bgp.routemaps.routemap.name }} out
 {%             endif %}
 {%           endfor %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -56,7 +56,7 @@ ip as-path access-list {{ aspath.number }} {{ aspath.action }} {{ aspath.as }}
 {%   endif %}
 ! 
 {%   if helpers.exists('OPNsense.quagga.bgp.routemaps.routemap') %}
-{%     for routemap in helpers.toList('OPNsense.quagga.bgp.routemaps.routemap')|sort(attribute='routemap.id') %}
+{%     for routemap in helpers.toList('OPNsense.quagga.bgp.routemaps.routemap')|sort(attribute='id') %}
 {%       if routemap.enabled == '1' %}
 route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
 {%         if routemap.match|default("") != "" %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -60,10 +60,16 @@ route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
  set {{ routemap.set }}
 {%         endif %}
 
+{%   if helpers.exists('OPNsense.quagga.bgp.neighbors.neighbor') %}
+{%     for neighbor in helpers.toList('OPNsense.quagga.bgp.neighbors.neighbor') %}
+{%       if neighbor.enabled == '1' %}
 {%         if helpers.exists('OPNsense.quagga.bgp.neighbors.neighbor.linkedRoutemapOut') %}
 {%           for linkedRoutemapOut in helpers.toList('OPNsense.quagga.bgp.neighbors.neighbor.linkedRoutemapOut') %}
 {%             if neighbor.linkedRoutemapOut != '' %}
  neighbor {{ OPNsense.quagga.bgp.neighbors.neighbor.address }} route-map {{ OPNsense.quagga.bgp.routemaps.routemap.name }} out 
+{%             endif %}
+{%           endfor %}
+{%         endif %}
 {%             endif %}
 {%           endfor %}
 {%         endif %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -56,7 +56,7 @@ ip as-path access-list {{ aspath.number }} {{ aspath.action }} {{ aspath.as }}
 {%   endif %}
 ! 
 {%   if helpers.exists('OPNsense.quagga.bgp.routemaps.routemap') %}
-{%     for routemap in helpers.toList('OPNsense.quagga.bgp.routemaps.routemap')|sort(attribute='name')|sort(attribute='id') %}
+{%     for routemap in helpers.toList('OPNsense.quagga.bgp.routemaps.routemap'|sort(attribute='name'))|sort(attribute='id') %}
 {%       if routemap.enabled == '1' %}
 route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
 {%         if routemap.match|default("") != "" %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -64,9 +64,9 @@ route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
 {%     for neighbor in helpers.toList('OPNsense.quagga.bgp.neighbors.neighbor') %}
 {%       if neighbor.enabled == '1' %}
 {%         if helpers.exists('OPNsense.quagga.bgp.neighbors.neighbor.linkedRoutemapOut') %}
-{%           for linkedRoutemapOut in helpers.toList('OPNsense.quagga.bgp.neighbors.neighbor.linkedRoutemapOut') %}
+{%           for key,item in helpers.toList('OPNsense.quagga.bgp.neighbors.neighbor.linkedRoutemapOut') %}
 {%             if neighbor.linkedRoutemapOut != '' %}
- neighbor {{ OPNsense.quagga.bgp.neighbors.neighbor.address }} route-map {{ OPNsense.quagga.bgp.routemaps.routemap.name }} out 
+ neighbor {{ OPNsense.quagga.bgp.neighbors.neighbor.address }} route-map {{ item.name }} out 
 {%             endif %}
 {%           endfor %}
 {%         endif %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -59,8 +59,13 @@ ip as-path access-list {{ aspath.number }} {{ aspath.action }} {{ aspath.as }}
 {%     for routemap in helpers.toList('OPNsense.quagga.bgp.routemaps.routemap') %}
 {%       if routemap.enabled == '1' %}
 route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
-{%         if 'match' in routemap and routemap.match != '' %}
- match as-path {{ OPNsense.quagga.bgp.aspaths.aspath.number }}
+{%         if routemap.match|default("") != "" %}
+{%           for aspath in routemap.match.split(",") %}
+{%             set aspath_data = helpers.getUUID(aspath) %}
+{%             if 'match' in routemap and routemap.match != '' %}
+ match as-path {{ aspath_data.number }}
+{%             endif %}
+{%           endfor %}
 {%         endif %}
 {%         if routemap.set != '' %}
  set {{ routemap.set }}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -33,9 +33,7 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%         if helpers.exists('OPNsense.quagga.bgp.neighbors.neighbor.linkedRoutemapOut') %}
 {%           for linkedRoutemapOut in helpers.toList('OPNsense.quagga.bgp.neighbors.neighbor.linkedRoutemapOut') %}
 {%             if neighbor.linkedRoutemapOut != '' %}
- neighbor {{ neighbor.address }} route-map {{ OPNsense.quagga.bgp.routemaps.routemap.name }} out
- neighbor {{ neighbor.address }} route-map {{ routemap.name }} out
- neighbor {{ neighbor.address }} route-map {{ neighbor.remotead }} out 
+ neighbor {{ neighbor.address }} route-map {{ OPNsense.quagga.bgp.routemaps.routemap.name }} out 
 {%             endif %}
 {%           endfor %}
 {%         endif %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -63,10 +63,10 @@ route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
 {%   if helpers.exists('OPNsense.quagga.bgp.neighbors.neighbor') %}
 {%     for neighbor in helpers.toList('OPNsense.quagga.bgp.neighbors.neighbor') %}
 {%       if neighbor.enabled == '1' %}
-{%         if helpers.exists('OPNsense.quagga.bgp.neighbors.neighbor.linkedRoutemapOut') %}
-{%           for key,item in helpers.toList('OPNsense.quagga.bgp.neighbors.neighbor.linkedRoutemapOut') %}
+{%         if linkedRoutemapOut is defined %}
+{%           for neighbor.linkedRoutemapOut in helpers.getUUID('OPNsense.quagga.bgp.neighbors.neighbor.linkedRoutemapOut') %}
 {%             if neighbor.linkedRoutemapOut != '' %}
- neighbor {{ OPNsense.quagga.bgp.neighbors.neighbor.address }} route-map {{ item.name }} out 
+ neighbor {{ OPNsense.quagga.bgp.neighbors.neighbor.address }} route-map {{ routemap.name }} out 
 {%             endif %}
 {%           endfor %}
 {%         endif %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -56,7 +56,7 @@ ip as-path access-list {{ aspath.number }} {{ aspath.action }} {{ aspath.as }}
 {%   endif %}
 ! 
 {%   if helpers.exists('OPNsense.quagga.bgp.routemaps.routemap') %}
-{%     for routemap in helpers.toList('OPNsense.quagga.bgp.routemaps.routemap') %}
+{%     for routemap in helpers.toList('OPNsense.quagga.bgp.routemaps.routemap')|sort(attribute='routemap.id') %}
 {%       if routemap.enabled == '1' %}
 route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
 {%         if routemap.match|default("") != "" %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -59,7 +59,7 @@ ip as-path access-list {{ aspath.number }} {{ aspath.action }} {{ aspath.as }}
 {%     for routemap in helpers.toList('OPNsense.quagga.bgp.routemaps.routemap') %}
 {%       if routemap.enabled == '1' %}
 route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
-{%         if routemap.match != '' %}
+{%         if 'match' in routemap and routemap.match != '' %}
  match as-path {{ OPNsense.quagga.bgp.aspaths.aspath.number }}
 {%         endif %}
 {%         if routemap.set != '' %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -57,7 +57,7 @@ ip as-path access-list {{ aspath.number }} {{ aspath.action }} {{ aspath.as }}
 ! 
 {%   if helpers.exists('OPNsense.quagga.bgp.routemaps.routemap') %}
 {%     for routemap in helpers.toList('OPNsense.quagga.bgp.routemaps.routemap')|sort(attribute='name') %}
-{%     for routemapX in routemap|sort(attribute='routemap.id') %}
+{%     for routemapX in routemaps.routemap|sort(attribute='routemap.id') %}
 {%       if routemapX.enabled == '1' %}
 route-map {{ routemapX.name }} {{ routemapX.action }} {{ routemapX.id }}
 {%         if routemap.match|default("") != "" %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -30,51 +30,41 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%         if 'linkedRoutemapIn' in neighbor and neighbor.linkedRoutemapIn != '' %}
  neighbor {{ neighbor.address }} route-map {{ OPNsense.quagga.bgp.routemaps.routemap.name }} in
 {%         endif %}
-{%         if helpers.exists('OPNsense.quagga.bgp.neighbors.neighbor.linkedRoutemapOut') %}
-{%           for linkedRoutemapOut in helpers.toList('OPNsense.quagga.bgp.neighbors.neighbor.linkedRoutemapOut') %}
-{%             if neighbor.linkedRoutemapOut != '' %}
- neighbor {{ neighbor.address }} route-map {{ OPNsense.quagga.bgp.routemaps.routemap.name }} out 
-{%             endif %}
-{%           endfor %}
-{%         endif %}
-{%       endif %}
-{%     endfor %}
-{%   endif %}
-!
-{%   if helpers.exists('OPNsense.quagga.bgp.aspaths.aspath') %}
-{%     for aspath in helpers.toList('OPNsense.quagga.bgp.aspaths.aspath') %}
-{%       if aspath.enabled == '1' %}
-ip as-path access-list {{ aspath.number }} {{ aspath.action }} {{ aspath.as }}
-{%       endif %}
-{%     endfor %}
-{%   endif %}
-!
-{%   if helpers.exists('OPNsense.quagga.bgp.routemaps.routemap') %}
-{%     for routemap in helpers.toList('OPNsense.quagga.bgp.routemaps.routemap') %}
-{%       if routemap.enabled == '1' %}
-route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
-{%         if routemap.match != '' %}
- match as-path {{ OPNsense.quagga.bgp.aspaths.aspath.number }}
-{%         endif %}
-{%         if routemap.set != '' %}
- set {{ routemap.set }}
-{%         endif %}
-
-{%   if helpers.exists('OPNsense.quagga.bgp.neighbors.neighbor') %}
-{%     for neighbor in helpers.toList('OPNsense.quagga.bgp.neighbors.neighbor') %}
-{%       if neighbor.enabled == '1' %}
 {%         if neighbor.linkedRoutemapOut is defined %}
 {%           for neighbor in routemap.match.split(",") %}
 {%             set routemap_data = helpers.getUUID(neighbor.linkedRoutemapOut) %}
 {%             if routemap_data != '' %}
+! Je gesetzter route-map soll hier stehen "neighbor <ip> route-map <route-map name> out
  neighbor {{ neighbor.address }} route-map {{ routemap_data.name }} out 
 {%             endif %}
 {%           endfor %}
 {%         endif %}
-{%             endif %}
-{%           endfor %}
+{%       endif %}
+{%     endfor %}
+{%   endif %}
+! AS Path anlegen
+{%   if helpers.exists('OPNsense.quagga.bgp.aspaths.aspath') %}
+{%     for aspath in helpers.toList('OPNsense.quagga.bgp.aspaths.aspath') %}
+{%       if aspath.enabled == '1' %}
+! AS-Path wird gesetzt wie in UI gewuenscht mit fortlaufender Nummer 
+ip as-path access-list {{ aspath.number }} {{ aspath.action }} {{ aspath.as }}
+{%       endif %}
+{%     endfor %}
+{%   endif %}
+! route-maps werden angelegt
+{%   if helpers.exists('OPNsense.quagga.bgp.routemaps.routemap') %}
+{%     for routemap in helpers.toList('OPNsense.quagga.bgp.routemaps.routemap') %}
+{%       if routemap.enabled == '1' %}
+! route-map mit name, einem permit oder deny und einer fortlaufenden ID
+route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
+{%         if routemap.match != '' %}
+! wenn eine match ueber die UI definiert ist, dann setzen und als Quelle die as-path Liste mit deren Nummer
+ match as-path {{ OPNsense.quagga.bgp.aspaths.aspath.number }}
 {%         endif %}
-
+{%         if routemap.set != '' %}
+! Wenn eine set gesetzte ist den Freitext von .set einfuegen
+ set {{ routemap.set }}
+{%         endif %}
 {%       endif %}
 {%     endfor %}
 {%   endif %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -59,6 +59,15 @@ route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
 {%         if routemap.set != '' %}
  set {{ routemap.set }}
 {%         endif %}
+
+{%         if helpers.exists('OPNsense.quagga.bgp.neighbors.neighbor.linkedRoutemapOut') %}
+{%           for linkedRoutemapOut in helpers.toList('OPNsense.quagga.bgp.neighbors.neighbor.linkedRoutemapOut') %}
+{%             if neighbor.linkedRoutemapOut != '' %}
+ neighbor {{ neighbor.address }} route-map {{ OPNsense.quagga.bgp.routemaps.routemap.name }} out 
+{%             endif %}
+{%           endfor %}
+{%         endif %}
+
 {%       endif %}
 {%     endfor %}
 {%   endif %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -34,7 +34,7 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%           for aspath in neighbor.linkedRoutemapOut.split(",") %}
 {%             set routemap_data = helpers.getUUID(aspath) %}
 {%             if routemap_data != '' %}
-! Je gesetzter route-map soll hier stehen "neighbor <ip> route-map <route-map name> out
+!
  neighbor {{ neighbor.address }} route-map {{ routemap_data.name }} out 
 {%             endif %}
 {%           endfor %}
@@ -42,27 +42,23 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%       endif %}
 {%     endfor %}
 {%   endif %}
-! AS Path anlegen
+!
 {%   if helpers.exists('OPNsense.quagga.bgp.aspaths.aspath') %}
 {%     for aspath in helpers.toList('OPNsense.quagga.bgp.aspaths.aspath') %}
 {%       if aspath.enabled == '1' %}
-! AS-Path wird gesetzt wie in UI gewuenscht mit fortlaufender Nummer 
 ip as-path access-list {{ aspath.number }} {{ aspath.action }} {{ aspath.as }}
 {%       endif %}
 {%     endfor %}
 {%   endif %}
-! route-maps werden angelegt
+! 
 {%   if helpers.exists('OPNsense.quagga.bgp.routemaps.routemap') %}
 {%     for routemap in helpers.toList('OPNsense.quagga.bgp.routemaps.routemap') %}
 {%       if routemap.enabled == '1' %}
-! route-map mit name, einem permit oder deny und einer fortlaufenden ID
 route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
 {%         if routemap.match != '' %}
-! wenn eine match ueber die UI definiert ist, dann setzen und als Quelle die as-path Liste mit deren Nummer
  match as-path {{ OPNsense.quagga.bgp.aspaths.aspath.number }}
 {%         endif %}
 {%         if routemap.set != '' %}
-! Wenn eine set gesetzte ist den Freitext von .set einfuegen
  set {{ routemap.set }}
 {%         endif %}
 {%       endif %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -30,7 +30,7 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%         if 'linkedRoutemapIn' in neighbor and neighbor.linkedRoutemapIn != '' %}
  neighbor {{ neighbor.address }} route-map {{ OPNsense.quagga.bgp.routemaps.routemap.name }} in
 {%         endif %}
-{%         if helpers.exists('OPNsense.quagga.bgp.neighbors.linkedRoutemapOut' %}
+{%         if helpers.exists('OPNsense.quagga.bgp.neighbors.linkedRoutemapOut') %}
 {%           for linkedRoutemapOut in helpers.toList('OPNsense.quagga.bgp.neighbors.neighbor.linkedRoutemapOut') %}
 {%             if neighbor.linkedRoutemapOut == '1' %}
  neighbor {{ neighbor.address }} route-map {{ OPNsense.quagga.bgp.routemaps.routemap.name }} out

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -57,9 +57,9 @@ ip as-path access-list {{ aspath.number }} {{ aspath.action }} {{ aspath.as }}
 ! 
 {%   if helpers.exists('OPNsense.quagga.bgp.routemaps.routemap') %}
 {%     for routemap in helpers.toList('OPNsense.quagga.bgp.routemaps.routemap')|sort(attribute='name') %}
-{%     for routemapX in routemap|sort(attribute='idÄ) %}
-{%       if routemap.enabled == '1' %}
-route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
+{%     for routemapX in routemap|sort(attribute='id') %}
+{%       if routemapX.enabled == '1' %}
+route-map {{ routemapX.name }} {{ routemapX.action }} {{ routemapX.id }}
 {%         if routemap.match|default("") != "" %}
 {%           for aspath in routemap.match.split(",") %}
 {%             set aspath_data = helpers.getUUID(aspath) %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -56,7 +56,8 @@ ip as-path access-list {{ aspath.number }} {{ aspath.action }} {{ aspath.as }}
 {%   endif %}
 ! 
 {%   if helpers.exists('OPNsense.quagga.bgp.routemaps.routemap') %}
-{%     for routemap in helpers.toList('OPNsense.quagga.bgp.routemaps.routemap')|sort(attribute='name',attribute='id') %}
+{%     for routemap in helpers.toList('OPNsense.quagga.bgp.routemaps.routemap')|sort(attribute='name') %}
+{%     for routemapX in routemap|sort(attribute='idÄ) %}
 {%       if routemap.enabled == '1' %}
 route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
 {%         if routemap.match|default("") != "" %}
@@ -71,6 +72,7 @@ route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
  set {{ routemap.set }}
 {%         endif %}
 {%       endif %}
+{%     endfor %}
 {%     endfor %}
 {%   endif %}
 !

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -63,7 +63,7 @@ route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
 {%         if helpers.exists('OPNsense.quagga.bgp.neighbors.neighbor.linkedRoutemapOut') %}
 {%           for linkedRoutemapOut in helpers.toList('OPNsense.quagga.bgp.neighbors.neighbor.linkedRoutemapOut') %}
 {%             if neighbor.linkedRoutemapOut != '' %}
- neighbor {{ neighbor.address }} route-map {{ OPNsense.quagga.bgp.routemaps.routemap.name }} out 
+ neighbor {{ OPNsense.quagga.bgp.neighbors.neighbor.address }} route-map {{ OPNsense.quagga.bgp.routemaps.routemap.name }} out 
 {%             endif %}
 {%           endfor %}
 {%         endif %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -57,7 +57,7 @@ ip as-path access-list {{ aspath.number }} {{ aspath.action }} {{ aspath.as }}
 ! 
 {%   if helpers.exists('OPNsense.quagga.bgp.routemaps.routemap') %}
 {%     for routemap in helpers.toList('OPNsense.quagga.bgp.routemaps.routemap')|sort(attribute='name') %}
-{%     for routemapX in routemap|sort(attribute='id') %}
+{%     for routemapX in routemap|sort(attribute='routemap.id') %}
 {%       if routemapX.enabled == '1' %}
 route-map {{ routemapX.name }} {{ routemapX.action }} {{ routemapX.id }}
 {%         if routemapX.match|default("") != "" %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -48,7 +48,7 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%   endif %}
 !
 {%   if helpers.exists('OPNsense.quagga.bgp.aspaths.aspath') %}
-{%     for aspath in helpers.toList('OPNsense.quagga.bgp.aspaths.aspath') %}
+{%     for aspath in helpers.sortDictList(OPNsense.quagga.bgp.aspaths.aspath, 'number' ) %}
 {%       if aspath.enabled == '1' %}
 ip as-path access-list {{ aspath.number }} {{ aspath.action }} {{ aspath.as }}
 {%       endif %}

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -30,7 +30,7 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%         if 'linkedRoutemapIn' in neighbor and neighbor.linkedRoutemapIn != '' %}
  neighbor {{ neighbor.address }} route-map {{ OPNsense.quagga.bgp.routemaps.routemap.name }} in
 {%         endif %}
-{%         if helpers.exists('OPNsense.quagga.bgp.neighbors.linkedRoutemapOut') %}
+{%         if helpers.exists('OPNsense.quagga.bgp.neighbors.neighbor.linkedRoutemapOut') %}
 {%           for linkedRoutemapOut in helpers.toList('OPNsense.quagga.bgp.neighbors.neighbor.linkedRoutemapOut') %}
 {%             if neighbor.linkedRoutemapOut == '1' %}
  neighbor {{ neighbor.address }} route-map {{ OPNsense.quagga.bgp.routemaps.routemap.name }} out

--- a/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/quagga/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -56,7 +56,7 @@ ip as-path access-list {{ aspath.number }} {{ aspath.action }} {{ aspath.as }}
 {%   endif %}
 ! 
 {%   if helpers.exists('OPNsense.quagga.bgp.routemaps.routemap') %}
-{%     for routemap in helpers.sortDictList(OPNsense.quagga.bgp.routemaps.routemap, 'name') %}
+{%     for routemap in helpers.sortDictList(OPNsense.quagga.bgp.routemaps.routemap, 'name', 'id' ) %}
 {%       if routemap.enabled == '1' %}
 route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
 {%         if routemap.match|default("") != "" %}


### PR DESCRIPTION
Hi,

this PR is for adding as-path ACLs via route-maps to the neighbors.
Example config after adding all:

```
router bgp 65001
 network 192.168.0.0/24
 neighbor 1.1.1.1 remote-as 65333
 neighbor 1.1.1.1 update-source em0
 neighbor 1.1.1.1 route-map TESTMAP in
 neighbor 1.1.1.1 route-map RR out
 neighbor 1.1.1.2 remote-as 65334
 neighbor 1.1.1.2 update-source em0
 neighbor 1.1.1.2 route-map TESTMAP out
!
ip as-path access-list 1 permit _4500$
ip as-path access-list 1 permit 4444
ip as-path access-list 2 permit .$
ip as-path access-list 3 deny 3456
ip as-path access-list 4 permit 23
ip as-path access-list 6 permit 444
!
route-map RR permit 10
 match as-path 1
 set local-preference 300
route-map RR permit 20
 match as-path 2
 set community 4444:33
route-map TESTMAP permit 10
 set local-preference 320

```

I added large helps to mitigate confusion, hope this is ok.
I think it's quite stable but should stay in devel for some time, so please don't make this a stopper for #155 and #156 


And again my thanks to @fabianfrz @fichtner @fraenki and @AdSchellevis for your help and patience 👍 