### PR TITLE
net/haproxy: hide statistics tabs if service is not enabled

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		haproxy
-PLUGIN_VERSION=		1.14
+PLUGIN_VERSION=		1.15
 PLUGIN_COMMENT=		Reliable, high performance TCP/HTTP load balancer
 PLUGIN_DEPENDS=		haproxy
 PLUGIN_MAINTAINER=	opnsense@moov.de

--- a/net/haproxy/src/opnsense/mvc/app/views/OPNsense/HAProxy/statistics.volt
+++ b/net/haproxy/src/opnsense/mvc/app/views/OPNsense/HAProxy/statistics.volt
@@ -64,6 +64,7 @@ POSSIBILITY OF SUCH DAMAGE.
                     callback = function (data, status) {
                         if (status == "success") {
                             // status
+                            $("#status_nav").show();
                             $("#grid-status").bootgrid('destroy');
                             var html = [];
                             $.each(data, function (key, value) {
@@ -94,6 +95,7 @@ POSSIBILITY OF SUCH DAMAGE.
                     callback = function (data, status) {
                         if (status == "success") {
                             // counters
+                            $("#counters_nav").show();
                             $("#grid-counters").bootgrid('destroy');
                             var html = [];
                             $.each(data, function (key, value) {
@@ -124,6 +126,7 @@ POSSIBILITY OF SUCH DAMAGE.
                     callback = function (data, status) {
                         if (status == "success") {
                             // tables
+                            $("#tables_nav").show();
                             $("#grid-tables").bootgrid('destroy');
                             var html = [];
                             $.each(data, function (key, value) {
@@ -157,9 +160,9 @@ POSSIBILITY OF SUCH DAMAGE.
 
 <ul class="nav nav-tabs" role="tablist"  id="maintabs">
     <li class="active"><a data-toggle="tab" href="#info"><b>{{ lang._('Overview') }}</b></a></li>
-    <li><a data-toggle="tab" href="#status"><b>{{ lang._('Status') }}</b></a></li>
-    <li><a data-toggle="tab" href="#counters"><b>{{ lang._('Counters') }}</b></a></li>
-    <li><a data-toggle="tab" href="#tables"><b>{{ lang._('Stick Tables') }}</b></a></li>
+    <li><a data-toggle="tab" href="#status" id="status_nav" style="display:none"><b>{{ lang._('Status') }}</b></a></li>
+    <li><a data-toggle="tab" href="#counters" id="counters_nav" style="display:none"><b>{{ lang._('Counters') }}</b></a></li>
+    <li><a data-toggle="tab" href="#tables" id="tables_nav" style="display:none"><b>{{ lang._('Stick Tables') }}</b></a></li>
 </ul>
 
 <div class="content-box tab-content">


### PR DESCRIPTION
The (nonfunctional) sub tabs are now hidden if the HAProxy service is not running (or to be more precise: if stats cannot be retrieved).

![hidden-tabs](https://cloud.githubusercontent.com/assets/909706/26168292/dc0dc8b8-3b39-11e7-9098-e87baa8431fd.png)

closes #154 