### PR TITLE
Quagga: New tab in general diagnostics 

### DIFF
--- a/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/Api/DiagnosticsController.php
+++ b/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/Api/DiagnosticsController.php
@@ -59,6 +59,12 @@ class DiagnosticsController extends ApiControllerBase
         $response = $backend->configdRun("quagga diag-bgp summary");
         return array("response" => $response);
     }
+    public function showrunningconfigAction()
+    {
+        $backend = new Backend();
+        $response = $backend->configdRun("quagga general-runningconfig");
+        return array("response" => $response);
+    }
     private function get_ospf_information($name)
     {
         $backend = new Backend();

--- a/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/Api/DiagnosticsController.php
+++ b/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/Api/DiagnosticsController.php
@@ -62,7 +62,7 @@ class DiagnosticsController extends ApiControllerBase
     public function showrunningconfigAction()
     {
         $backend = new Backend();
-        $response = json_decode(trim($backend->configdRun("quagga general-runningconfig")));
+        $response = $backend->configdRun("quagga general-runningconfig");
         return array("response" => $response);
     }
     private function get_ospf_information($name)

--- a/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/Api/DiagnosticsController.php
+++ b/net/quagga/src/opnsense/mvc/app/controllers/OPNsense/Quagga/Api/DiagnosticsController.php
@@ -62,7 +62,7 @@ class DiagnosticsController extends ApiControllerBase
     public function showrunningconfigAction()
     {
         $backend = new Backend();
-        $response = $backend->configdRun("quagga general-runningconfig");
+        $response = json_decode(trim($backend->configdRun("quagga general-runningconfig")));
         return array("response" => $response);
     }
     private function get_ospf_information($name)

--- a/net/quagga/src/opnsense/mvc/app/views/OPNsense/Quagga/diagnosticsgeneral.volt
+++ b/net/quagga/src/opnsense/mvc/app/views/OPNsense/Quagga/diagnosticsgeneral.volt
@@ -109,7 +109,9 @@ $(document).ready(function() {
     $('#routing6').html(content)
     //$('#routing6 table').bootgrid({converters: dataconverters})
   });
-
+  ajaxCall(url="/api/quagga/diagnostics/runningconfig", sendData={}, callback=function(data,status) {
+      $("#runningconfig").text(data['response']);
+  });
 
 });
 </script>
@@ -118,9 +120,13 @@ $(document).ready(function() {
 <ul class="nav nav-tabs" data-tabs="tabs" id="maintabs">
     <li class="active"><a data-toggle="tab" href="#routing">{{ lang._('IPv4 Routes') }}</a></li>
     <li><a data-toggle="tab" href="#routing6">{{ lang._('IPv6 Routes') }}</a></li>
+    <li><a data-toggle="tab" href="#showrun">{{ lang._('Running Configuration') }}</a></li>
 </ul>
 
 <div class="tab-content content-box tab-content">
     <div id="routing" class="tab-pane fade in active"></div>
     <div id="routing6" class="tab-pane fade in"></div>
+    <div id="showrun" class="tab-pane fade in">
+      <pre id="general-runningconfig"></pre>
+    </div>
 </div>

--- a/net/quagga/src/opnsense/mvc/app/views/OPNsense/Quagga/diagnosticsgeneral.volt
+++ b/net/quagga/src/opnsense/mvc/app/views/OPNsense/Quagga/diagnosticsgeneral.volt
@@ -127,6 +127,6 @@ $(document).ready(function() {
     <div id="routing" class="tab-pane fade in active"></div>
     <div id="routing6" class="tab-pane fade in"></div>
     <div id="showrun" class="tab-pane fade in">
-      <pre id="general-runningconfig"></pre>
+      <pre id="runningconfig"></pre>
     </div>
 </div>

--- a/net/quagga/src/opnsense/mvc/app/views/OPNsense/Quagga/diagnosticsgeneral.volt
+++ b/net/quagga/src/opnsense/mvc/app/views/OPNsense/Quagga/diagnosticsgeneral.volt
@@ -109,7 +109,7 @@ $(document).ready(function() {
     $('#routing6').html(content)
     //$('#routing6 table').bootgrid({converters: dataconverters})
   });
-  ajaxCall(url="/api/quagga/diagnostics/runningconfig", sendData={}, callback=function(data,status) {
+  ajaxCall(url="/api/quagga/diagnostics/showrunningconfig", sendData={}, callback=function(data,status) {
       $("#runningconfig").text(data['response']);
   });
 

--- a/net/quagga/src/opnsense/service/conf/actions.d/actions_quagga.conf
+++ b/net/quagga/src/opnsense/service/conf/actions.d/actions_quagga.conf
@@ -111,3 +111,9 @@ command:/usr/local/opnsense/scripts/quagga/quagga.rb --general-routes6
 parameters:
 type:script_output
 message: Print IPv6 Routing Table
+
+[general-runningconfig]
+command:/usr/local/bin/vtysh -c "show run"
+parameters:
+type:script_output
+message: Show running configuration


### PR DESCRIPTION
New tab in Diagnostics - General, Displaying the running configuration as plain text. 
This might be easier for CLI guys migrating to UI / OPN

E.g. me or OutBackDingo are plain CLI guys and it would be nice to see what changes in UI do to the running-config.