### PR TITLE
sysutils/monit: set variable $HOST as system name for proper sync to cluster nodes

### DIFF
--- a/sysutils/monit/Makefile
+++ b/sysutils/monit/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		monit
-PLUGIN_VERSION=		1.1
+PLUGIN_VERSION=		1.2
 PLUGIN_COMMENT=		Proactive system monitoring
 PLUGIN_MAINTAINER=	frank.brendel@eurolog.com
 PLUGIN_DEPENDS=		monit

--- a/sysutils/monit/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.xml
+++ b/sysutils/monit/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.xml
@@ -118,7 +118,7 @@
          </enabled>
          <name type="TextField">
             <Required>Y</Required>
-            <mask>/^([0-9a-zA-Z\._\-]){1,255}$/u</mask>
+            <mask>/^([0-9a-zA-Z\._\-\$]){1,255}$/u</mask>
             <ValidationMessage>Should be a string between 1 and 255 characters. Allowed characters are letters and numbers as well as underscore, minus and dot.</ValidationMessage>
          </name>
          <type type="OptionField">

--- a/sysutils/monit/src/opnsense/scripts/OPNsense/Monit/post-install.php
+++ b/sysutils/monit/src/opnsense/scripts/OPNsense/Monit/post-install.php
@@ -54,10 +54,6 @@ $LoadAvg1 = $nCPU[0] * 2;
 $LoadAvg5 = $nCPU[0] + ($nCPU[0] / 2);
 $LoadAvg15 = $nCPU[0];
 
-// get FQDN
-$hostName = $cfgObj->system->hostname;
-$domainName = $cfgObj->system->domain;
-
 // inherit SMTP settings from System->Settings->Notifications
 $generalSettings = array();
 if (!empty($cfgObj->notifications->smtp->ipaddress)) {
@@ -101,7 +97,7 @@ $defaultTests = array(
 // define system service
 $systemService = array(
     "enabled" => 1,
-    "name" => $hostName . "." . $domainName,
+    "name" => '$HOST',
     "type" => "system",
     "tests" => ""
 );


### PR DESCRIPTION
When synchronizing the config the hostname of the MASTER is set for the System check on the BACKUP node. Using the variable $HOST will set the correct hostname on the BACKUP node.