### PR TITLE
sysutils/monit: set mailserver type to CSVListField, fix validation

### DIFF
--- a/sysutils/monit/Makefile
+++ b/sysutils/monit/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		monit
-PLUGIN_VERSION=		1.2
+PLUGIN_VERSION=		1.3
 PLUGIN_COMMENT=		Proactive system monitoring
 PLUGIN_MAINTAINER=	frank.brendel@eurolog.com
 PLUGIN_DEPENDS=		monit

--- a/sysutils/monit/Makefile
+++ b/sysutils/monit/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		monit
-PLUGIN_VERSION=		1.1
+PLUGIN_VERSION=		1.2
 PLUGIN_COMMENT=		Proactive system monitoring
 PLUGIN_MAINTAINER=	frank.brendel@eurolog.com
 PLUGIN_DEPENDS=		monit

--- a/sysutils/monit/src/opnsense/mvc/app/controllers/OPNsense/Monit/forms/general.xml
+++ b/sysutils/monit/src/opnsense/mvc/app/controllers/OPNsense/Monit/forms/general.xml
@@ -20,7 +20,9 @@
    <field>
       <id>monit.general.mailserver</id>
       <label>Mail Server</label>
-      <type>text</type>
+      <type>select_multiple</type>
+      <allownew>true</allownew>
+      <style>tokenize</style>
       <help><![CDATA[Comma separated list of SMTP servers for alert delivery.]]></help>
    </field>
    <field>

--- a/sysutils/monit/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.xml
+++ b/sysutils/monit/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.xml
@@ -118,7 +118,7 @@
          </enabled>
          <name type="TextField">
             <Required>Y</Required>
-            <mask>/^([0-9a-zA-Z\._\-]){1,255}$/u</mask>
+            <mask>/^([0-9a-zA-Z\._\-\$]){1,255}$/u</mask>
             <ValidationMessage>Should be a string between 1 and 255 characters. Allowed characters are letters and numbers as well as underscore, minus and dot.</ValidationMessage>
          </name>
          <type type="OptionField">

--- a/sysutils/monit/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.xml
+++ b/sysutils/monit/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.xml
@@ -22,10 +22,11 @@
             <MaximumValue>86400</MaximumValue>
             <ValidationMessage>Start Delay needs to be an integer value between 0 and 86400</ValidationMessage>
          </startdelay>
-         <mailserver type="TextField">
+         <mailserver type="CSVListField">
             <default>127.0.0.1</default>
             <Required>Y</Required>
-            <mask>/^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-4]|2[0-5][0-9]|[01]?[0-9][0-9]?)$/</mask>
+            <multiple>Y</multiple>
+            <mask>/^((?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9]),?)+$/</mask>
             <ValidationMessage>Mail Server must be a valid IPv4 address</ValidationMessage>
          </mailserver>
          <port type="IntegerField">
@@ -119,7 +120,7 @@
          <name type="TextField">
             <Required>Y</Required>
             <mask>/^([0-9a-zA-Z\._\-\$]){1,255}$/u</mask>
-            <ValidationMessage>Should be a string between 1 and 255 characters. Allowed characters are letters and numbers as well as underscore, minus and dot.</ValidationMessage>
+            <ValidationMessage>Should be a string between 1 and 255 characters. Allowed characters are letters and numbers as well as underscore, minus, dot and the dollar sign.</ValidationMessage>
          </name>
          <type type="OptionField">
             <Required>Y</Required>

--- a/sysutils/monit/src/opnsense/scripts/OPNsense/Monit/post-install.php
+++ b/sysutils/monit/src/opnsense/scripts/OPNsense/Monit/post-install.php
@@ -54,10 +54,6 @@ $LoadAvg1 = $nCPU[0] * 2;
 $LoadAvg5 = $nCPU[0] + ($nCPU[0] / 2);
 $LoadAvg15 = $nCPU[0];
 
-// get FQDN
-$hostName = $cfgObj->system->hostname;
-$domainName = $cfgObj->system->domain;
-
 // inherit SMTP settings from System->Settings->Notifications
 $generalSettings = array();
 if (!empty($cfgObj->notifications->smtp->ipaddress)) {
@@ -101,7 +97,7 @@ $defaultTests = array(
 // define system service
 $systemService = array(
     "enabled" => 1,
-    "name" => $hostName . "." . $domainName,
+    "name" => '$HOST',
     "type" => "system",
     "tests" => ""
 );


### PR DESCRIPTION
To add multiple mail server as described in [Setting-a-mail-server-for-alert-delivery](https://mmonit.com/monit/documentation/monit.html#Setting-a-mail-server-for-alert-delivery) the mailserver type was changed to CSVListField.
This pull request is a fix for #181 