### PR TITLE
Remove curl option "anyauth" for "custom" and "customv6" DynDNS updates...

### DIFF
--- a/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
+++ b/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
@@ -608,7 +608,6 @@ class updatedns {
                         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, TRUE);
                     else
                         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE);
-                    curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
                     curl_setopt($ch, CURLOPT_USERPWD, "{$this->_dnsUser}:{$this->_dnsPass}");
                 }
                 $server = str_replace("%IP%", $this->_dnsIP, $this->_dnsUpdateURL);


### PR DESCRIPTION
...as discussed in #188