### PR TITLE
security/acme-client: configure DNS API hook location for acme.sh

### DIFF
--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -689,6 +689,9 @@ function run_acme_validation($certObj, $valObj, $acctObj)
         }
     }
 
+    // Teach acme.sh about DNS API hook location
+    $proc_env['_SCRIPT_HOME'] = '/usr/local/share/examples/acme.sh';
+
     // Run acme client
     // NOTE: We "export" certificates to our own directory, so we don't have to deal
     // with domain names in filesystem, but instead can use the ID of our certObj.


### PR DESCRIPTION
The FreeBSD port `security/acme.sh` installs DNS API hook scripts in `/usr/local/share/examples/acme.sh`. This is a non-default location for acme.sh, thus we need to tell acme.sh where to find these scripts.