### PR TITLE
net-mgmt/zabbix-agent: fix validation mask for listenIP (again)

### DIFF
--- a/net-mgmt/zabbix-agent/src/opnsense/mvc/app/models/OPNsense/ZabbixAgent/ZabbixAgent.xml
+++ b/net-mgmt/zabbix-agent/src/opnsense/mvc/app/models/OPNsense/ZabbixAgent/ZabbixAgent.xml
@@ -35,7 +35,6 @@
                 <listenIP type="CSVListField">
                     <Required>Y</Required>
                     <multiple>Y</multiple>
-                    <mask>/^((([0-9a-zA-Z._\-]+:[0-9a-zA-Z._\-]+)([,]){0,1}))*/u</mask>
                     <mask>/^((([0-9a-zA-Z._\-\*:]+)([,]){0,1}))*/u</mask>
                     <ChangeCase>lower</ChangeCase>
                     <ValidationMessage>Please provide valid IP addresses, i.e. 10.0.0.1.</ValidationMessage>


### PR DESCRIPTION
Fixes yet another silly copy'n'paste error on my side. (#194)
Just a cosmetic fix, no version bump required.