### PR TITLE
security/acme-client: tighten validation masks, "Name" -> "Common Name"

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogCertificate.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogCertificate.xml
@@ -7,9 +7,9 @@
     </field>
     <field>
         <id>certificate.name</id>
-        <label>Name</label>
+        <label>Common Name</label>
         <type>text</type>
-        <help>Name to identify this certificate.</help>
+        <help>Common Name (CN) for this certificate.</help>
     </field>
     <field>
         <id>certificate.description</id>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -152,8 +152,8 @@
                 </enabled>
                 <name type="TextField">
                     <Required>Y</Required>
-                    <mask>/^.{1,255}$/u</mask>
-                    <ValidationMessage>Should be a string between 1 and 255 characters.</ValidationMessage>
+                    <mask>/^[^\s^\t^,^;^\\^\/^(^)^\[^\]]{1,255}$/u</mask>
+                    <ValidationMessage>Please provide a valid FQDN, i.e. www.example.com or mail.example.com (max 255 characters).</ValidationMessage>
                 </name>
                 <description type="TextField">
                     <Required>N</Required>
@@ -163,9 +163,9 @@
                 <altNames type="CSVListField">
                     <Required>N</Required>
                     <multiple>Y</multiple>
-                    <mask>/^.{1,16384}$/u</mask>
+                    <mask>/^[^\s^\t^;^\\^\/^(^)^\[^\]]{1,65536}$/u</mask>
                     <ChangeCase>lower</ChangeCase>
-                    <ValidationMessage>Please provide a valid FQDN, i.e. www.example.com or mail.example.com. Field length is limited to 16384 characters.</ValidationMessage>
+                    <ValidationMessage>Please provide one or more valid FQDNs, i.e. www.example.com or mail.example.com. Field length is limited to 65536 characters.</ValidationMessage>
                 </altNames>
                 <account type="ModelRelationField">
                     <Model>

--- a/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/certificates.volt
+++ b/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/certificates.volt
@@ -382,7 +382,7 @@ POSSIBILITY OF SUCH DAMAGE.
             <thead>
             <tr>
                 <th data-column-id="enabled" data-width="6em" data-type="string" data-formatter="rowtoggle">{{ lang._('Enabled') }}</th>
-                <th data-column-id="name" data-type="string">{{ lang._('Certificate Name') }}</th>
+                <th data-column-id="name" data-type="string">{{ lang._('Common Name') }}</th>
                 <th data-column-id="altNames" data-type="string">{{ lang._('Multi-Domain (SAN)') }}</th>
                 <th data-column-id="description" data-type="string">{{ lang._('Description') }}</th>
                 <th data-column-id="lastUpdate" data-type="string" data-formatter="certdate">{{ lang._('Issue/Renewal Date') }}</th>


### PR DESCRIPTION
A user reported an issue with acme on IRC. After some debugging it turned out that a whitespace in the certificate name was causing this issue. This PR extends the validation mask to disallow several characters that are not valid in this context. We're not using an advanced regex here to make sure all IDN domains are still supported.

Besides that, the "Certificate Name" was changed to "Common Name" to improve clarity. It was misinterpreted as an arbitrary identifier by some users, but now it's clear that this name is part of the certificate.

Furthermore the altNames field size was increased from 16384 to 65536.