### PR TITLE
net/haproxy: switch to using HAProxy's hard stop mode by default

### DIFF
--- a/net/haproxy/src/etc/rc.syshook.d/50-haproxy.restart
+++ b/net/haproxy/src/etc/rc.syshook.d/50-haproxy.restart
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-. /etc/rc.conf.d/haproxy
-
-if [ "x${haproxy_hardstop}" == "xYES" ]; then
-    /usr/local/etc/rc.d/haproxy configtest && /usr/local/etc/rc.d/haproxy hardstop
-fi

--- a/net/haproxy/src/etc/rc.syshook.d/50-haproxy.restart
+++ b/net/haproxy/src/etc/rc.syshook.d/50-haproxy.restart
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+. /etc/rc.conf.d/haproxy
+
+if [ "x${haproxy_hardstop}" == "xYES" ]; then
+    /usr/local/etc/rc.d/haproxy configtest && /usr/local/etc/rc.d/haproxy hardstop
+fi

--- a/net/haproxy/src/etc/rc.syshook.d/50-haproxy.stop
+++ b/net/haproxy/src/etc/rc.syshook.d/50-haproxy.stop
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+. /etc/rc.conf.d/haproxy
+
+if [ "x${haproxy_hardstop}" == "xYES" ]; then
+    /usr/local/etc/rc.d/haproxy hardstop
+fi

--- a/net/haproxy/src/etc/rc.syshook.d/50-haproxy.stop
+++ b/net/haproxy/src/etc/rc.syshook.d/50-haproxy.stop
@@ -1,7 +1,3 @@
 #!/bin/sh
 
-. /etc/rc.conf.d/haproxy
-
-if [ "x${haproxy_hardstop}" == "xYES" ]; then
-    /usr/local/etc/rc.d/haproxy hardstop
-fi
+/usr/local/opnsense/scripts/OPNsense/HAProxy/rc-wrapper.sh stop

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/main.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/main.xml
@@ -11,6 +11,12 @@
                 <type>checkbox</type>
                 <help>Enable or disable the HAProxy service.</help>
             </field>
+            <field>
+                <id>haproxy.general.gracefulStop</id>
+                <label>Graceful Stop</label>
+                <type>checkbox</type>
+                <help><![CDATA[Enable HAProxy's graceful stop mode. In this mode HAProxy will continue to process existing connections until they close. Note that this may severely slow down HAProxy's shutdown, depending on the configured timeout values. If graceful stop mode is not enabled, HAProxy will use the hard stop mode where it immediately quits and all established connections are closed. Hard stop mode is recommended.]]></help>
+            </field>
         </subtab>
         <subtab id="haproxy-general-global" description="Global Parameters">
             <field>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -9,6 +9,10 @@
                 <default>0</default>
                 <Required>Y</Required>
             </enabled>
+            <gracefulStop type="BooleanField">
+                <default>0</default>
+                <Required>Y</Required>
+            </gracefulStop>
             <tuning>
                 <root type="BooleanField">
                     <default>0</default>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -1,5 +1,6 @@
 <model>
     <mount>//OPNsense/HAProxy</mount>
+    <version>1.0.0</version>
     <description>
         the HAProxy load balancer
     </description>

--- a/net/haproxy/src/opnsense/scripts/OPNsense/HAProxy/rc-wrapper.sh
+++ b/net/haproxy/src/opnsense/scripts/OPNsense/HAProxy/rc-wrapper.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+if [ -f /etc/rc.conf.d/haproxy ]; then
+. /etc/rc.conf.d/haproxy
+fi
+
+case "$1" in
+stop|restart)
+    if [ "${haproxy_hardstop}" == "YES" ]; then
+        rcprefix="hard"
+    fi
+    ;;
+esac
+
+/usr/local/etc/rc.d/haproxy ${rcprefix}${1}

--- a/net/haproxy/src/opnsense/service/conf/actions.d/actions_haproxy.conf
+++ b/net/haproxy/src/opnsense/service/conf/actions.d/actions_haproxy.conf
@@ -5,25 +5,25 @@ type:script_output
 message:setup haproxy service requirements
 
 [start]
-command:/usr/local/opnsense/scripts/OPNsense/HAProxy/setup.sh; /usr/local/etc/rc.d/haproxy start
+command:/usr/local/opnsense/scripts/OPNsense/HAProxy/setup.sh; /usr/local/opnsense/scripts/OPNsense/HAProxy/rc-wrapper.sh start
 parameters:
 type:script
 message:starting haproxy
 
 [stop]
-command:/usr/local/etc/rc.syshook.d/50-haproxy.stop; /usr/local/etc/rc.d/haproxy stop; /usr/bin/killall haproxy; exit 0
+command:/usr/local/opnsense/scripts/OPNsense/HAProxy/rc-wrapper.sh stop; /usr/bin/killall haproxy; exit 0
 parameters:
 type:script
 message:stopping haproxy
 
 [restart]
-command:/usr/local/opnsense/scripts/OPNsense/HAProxy/setup.sh; /usr/local/etc/rc.syshook.d/50-haproxy.restart; /usr/local/etc/rc.d/haproxy restart
+command:/usr/local/opnsense/scripts/OPNsense/HAProxy/setup.sh; /usr/local/opnsense/scripts/OPNsense/HAProxy/rc-wrapper.sh restart
 parameters:
 type:script
 message:restarting haproxy
 
 [reconfigure]
-command:/usr/local/opnsense/scripts/OPNsense/HAProxy/setup.sh; /usr/local/etc/rc.d/haproxy reload
+command:/usr/local/opnsense/scripts/OPNsense/HAProxy/setup.sh; /usr/local/opnsense/scripts/OPNsense/HAProxy/rc-wrapper.sh reload
 parameters:
 type:script
 message:reconfiguring haproxy

--- a/net/haproxy/src/opnsense/service/conf/actions.d/actions_haproxy.conf
+++ b/net/haproxy/src/opnsense/service/conf/actions.d/actions_haproxy.conf
@@ -11,13 +11,13 @@ type:script
 message:starting haproxy
 
 [stop]
-command:/usr/local/etc/rc.d/haproxy stop; /usr/bin/killall haproxy; exit 0
+command:/usr/local/etc/rc.syshook.d/50-haproxy.stop; /usr/local/etc/rc.d/haproxy stop; /usr/bin/killall haproxy; exit 0
 parameters:
 type:script
 message:stopping haproxy
 
 [restart]
-command:/usr/local/opnsense/scripts/OPNsense/HAProxy/setup.sh; /usr/local/etc/rc.d/haproxy restart
+command:/usr/local/opnsense/scripts/OPNsense/HAProxy/setup.sh; /usr/local/etc/rc.syshook.d/50-haproxy.restart; /usr/local/etc/rc.d/haproxy restart
 parameters:
 type:script
 message:restarting haproxy

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/rc.conf.d
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/rc.conf.d
@@ -3,7 +3,11 @@ haproxy_enable=YES
 haproxy_opnsense_bootup_run="/usr/local/opnsense/scripts/OPNsense/HAProxy/setup.sh"
 haproxy_pidfile="/var/run/haproxy.pid"
 haproxy_config="/usr/local/etc/haproxy.conf"
-# haproxy_flags=""
+{% if helpers.exists('OPNsense.HAProxy.general.gracefulStop') and OPNsense.HAProxy.general.gracefulStop|default("0") == "1" %}
+haproxy_hardstop=NO
+{% else %}
+haproxy_hardstop=YES
+{% endif %}
 {% else %}
 haproxy_enable=NO
 {% endif %}


### PR DESCRIPTION
fixes #195

From the [official HAProxy documentation](https://www.haproxy.org/download/1.7/doc/management.txt):

> HAProxy supports a graceful and a hard stop. The hard stop is simple, when the
> SIGTERM signal is sent to the haproxy process, it immediately quits and all
> established connections are closed. The graceful stop is triggered when the
> SIGUSR1 signal is sent to the haproxy process. It consists in only unbinding
> from listening ports, but continue to process existing connections until they
> close. Once the last connection is closed, the process leaves.
> 
> The hard stop method is used for the "stop" or "restart" actions of the service
> management script. The graceful stop is used for the "reload" action which
> tries to seamlessly reload a new configuration in a new process.


The rc.script in the FreeBSD port seems to always use the graceful stop. By introducing the hard stop for stop/restart actions we're actually following the official recommendations. :)