### PR TITLE
security/acme-client: fix 'Compilation failed: number too big'

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -163,9 +163,9 @@
                 <altNames type="CSVListField">
                     <Required>N</Required>
                     <multiple>Y</multiple>
-                    <mask>/^[^\s^\t^;^\\^\/^(^)^\[^\]]{1,65536}$/u</mask>
+                    <mask>/^[^\s^\t^;^\\^\/^(^)^\[^\]]{1,65535}$/u</mask>
                     <ChangeCase>lower</ChangeCase>
-                    <ValidationMessage>Please provide one or more valid FQDNs, i.e. www.example.com or mail.example.com. Field length is limited to 65536 characters.</ValidationMessage>
+                    <ValidationMessage>Please provide one or more valid FQDNs, i.e. www.example.com or mail.example.com. Field length is limited to 65535 characters.</ValidationMessage>
                 </altNames>
                 <account type="ModelRelationField">
                     <Model>


### PR DESCRIPTION
Trying to add a altName after https://github.com/opnsense/plugins/pull/214/commits/ad715d00edffab5e0fdb8fece7003d6eb5ff7713 results in the following error:

`Error at /usr/local/opnsense/mvc/app/models/OPNsense/Base/BaseModel.php:370 - preg_match(): Compilation failed: number too big in {} quantifier at offset 35 (errno=2)`

Looks like we've hit a [limit in pcre](http://pcre.sourceforge.net/pcre.txt). I've lowered the maximum size to 65535.