### PR TITLE
Fix cloudflare proxy status reset on dyndns update

### DIFF
--- a/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
+++ b/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
@@ -637,8 +637,8 @@ class updatedns {
                             "content" => "{$this->_dnsIP}",
                             "type" => "A",
                             "name" => "{$this->_dnsHost}",
-                            "proxiable" => false,
-                            "proxied" => false
+                            "proxiable" => $output->result[0]->proxiable,
+                            "proxied" => $output->result[0]->proxied
                         );
                         $data_json = json_encode($hostData);
                         $updateHostId = "https://{$dnsServer}/client/v4/zones/{$zone}/dns_records/{$host}";


### PR DESCRIPTION
This prevents resetting of the cloudflare "proxy" status (if this host is proxied/protected by cloudflare) of the updated DNS record.