### PR TITLE
bugfix/247 Improve Zerotier Start/Stop Behaviour

### DIFF
--- a/net/zerotier/Makefile
+++ b/net/zerotier/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		zerotier
-PLUGIN_VERSION=		1.0
+PLUGIN_VERSION=		1.1.0
 PLUGIN_COMMENT=		Virtual Networks That Just Work
 PLUGIN_DEPENDS=		zerotier
 PLUGIN_MAINTAINER=	dharrigan@gmail.com

--- a/net/zerotier/src/etc/inc/plugins.inc.d/zerotier.inc
+++ b/net/zerotier/src/etc/inc/plugins.inc.d/zerotier.inc
@@ -29,15 +29,8 @@
 
 function zerotier_enabled()
 {
-    $mdl = new \OPNsense\Zerotier\Zerotier();
-
-    foreach ($mdl->networks->network->__items as $network) {
-        if ($network->enabled == '1') {
-            return true;
-        }
-    }
-
-    return false;
+    $zerotier = new \OPNsense\Zerotier\Zerotier();
+    return (string)$zerotier->enabled == '1';
 }
 
 function zerotier_services()

--- a/net/zerotier/src/opnsense/mvc/app/controllers/OPNsense/Zerotier/IndexController.php
+++ b/net/zerotier/src/opnsense/mvc/app/controllers/OPNsense/Zerotier/IndexController.php
@@ -35,6 +35,7 @@ class IndexController extends \OPNsense\Base\IndexController
     {
         $this->view->title = "VPN: Zerotier";
         $this->view->pick('OPNsense/Zerotier/index');
-        $this->view->formDialogNetwork = $this->getForm("dialogNetwork");
+        $this->view->globalForm = $this->getForm("global");
+        $this->view->dialogNetworkForm = $this->getForm("dialogNetwork");
     }
 }

--- a/net/zerotier/src/opnsense/mvc/app/controllers/OPNsense/Zerotier/forms/global.xml
+++ b/net/zerotier/src/opnsense/mvc/app/controllers/OPNsense/Zerotier/forms/global.xml
@@ -1,0 +1,8 @@
+<form>
+    <field>
+        <id>zerotier.enabled</id>
+        <label>Enable the Zerotier Service</label>
+        <type>checkbox</type>
+        <help>This will activate the Zerotier service</help>
+    </field>
+</form>

--- a/net/zerotier/src/opnsense/mvc/app/models/OPNsense/Zerotier/Zerotier.xml
+++ b/net/zerotier/src/opnsense/mvc/app/models/OPNsense/Zerotier/Zerotier.xml
@@ -3,7 +3,12 @@
     <description>
         Zerotier - Virtual Networks That Just Work.
     </description>
+    <version>1.1.0</version>
     <items>
+        <enabled type="BooleanField">
+            <default>0</default>
+            <Required>Y</Required>
+        </enabled>
         <networks>
             <network type="ArrayField">
                 <enabled type="BooleanField">

--- a/net/zerotier/src/opnsense/service/templates/OPNsense/zerotier/zerotier
+++ b/net/zerotier/src/opnsense/service/templates/OPNsense/zerotier/zerotier
@@ -1,10 +1,4 @@
-{% set networks = [] %}
-{% for network in helpers.toList('OPNsense.zerotier.networks.network') %}
-{%   if network.enabled == '1' %}
-{%     do networks.append(network) %}
-{%   endif %}
-{% endfor %}
-{% if networks|length > 0 %}
+{% if helpers.exists('OPNsense.zerotier.enabled') and OPNsense.zerotier.enabled == '1' %}
 zerotier_enable="YES"
 {% else %}
 zerotier_enable="NO"


### PR DESCRIPTION
https://github.com/opnsense/plugins/issues/247

This commit improves upon the way that Zerotier starts and stops and how
networks are added/removed and activated/deactivated. There is now a "Global"
tab on the Zerotier page that enables or disables the service which is
honoured between reboots. Additionally, the service needs to be active in
order for networks to be added and removed. If the service is not active, then
the tab "Networks" will be disabled and the user will not be able to
add/remove or activate/deactivate Zerotier networks.

This should fix the observed problems raised in the issue.

The "Global" tab will be extended later to include further information and
actions, especially when Zerotier API usage is developed.

-=david=-