### PR TITLE
security/acme-client: release 1.10

### DIFF
--- a/security/acme-client/Makefile
+++ b/security/acme-client/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		acme-client
-PLUGIN_VERSION=		1.9
+PLUGIN_VERSION=		1.10
 PLUGIN_COMMENT=		Let's Encrypt client
 PLUGIN_MAINTAINER=	opnsense@moov.de
 PLUGIN_DEPENDS=		acme.sh bind911

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/settings.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/settings.xml
@@ -37,4 +37,11 @@
         <help><![CDATA[The maximum time in seconds to wait for a restart action to complete. When the timeout is reached the command is forcefully aborted. Defaults to 600 seconds.]]></help>
         <advanced>true</advanced>
     </field>
+    <field>
+        <id>acmeclient.settings.logLevel</id>
+        <label>Log Level</label>
+        <type>dropdown</type>
+        <help><![CDATA[Specifies the log level for acme.sh, default is "normal". All other log levels add information for debug purposes, but be aware that this will break the log formatting in the GUI.]]></help>
+        <advanced>true</advanced>
+    </field>
 </form>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -1,7 +1,7 @@
 <model>
 
     <mount>//OPNsense/AcmeClient</mount>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <description>
         a secure Let's Encrypt plugin
     </description>
@@ -101,6 +101,15 @@
                 <multiple>N</multiple>
                 <Required>N</Required>
             </haproxyBackendRef>
+            <logLevel type="OptionField">
+                <Required>Y</Required>
+                <default>normal</default>
+                <OptionValues>
+                    <normal>normal</normal>
+                    <extended>extended</extended>
+                    <debug>debug</debug>
+                </OptionValues>
+            </logLevel>
         </settings>
         <accounts>
             <account type="ArrayField">

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -982,6 +982,7 @@ function import_certificate($certObj, $modelObj)
     // Write changes to config
     // TODO: Legacy code, should be replaced with code from OPNsense framework
     write_config("${import_log_message} Let's Encrypt SSL certificate: ${cert_cn}");
+    log_error("AcmeClient: ${import_log_message} Let's Encrypt SSL certificate: ${cert_cn}");
 
     // Update (acme) certificate object (through MVC framework)
     $uuid = $certObj->attributes()->uuid;

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -286,11 +286,17 @@ function eval_optional_acme_args()
     $configObj = Config::getInstance()->object();
 
     $acme_args = array();
+
     // Force certificate renewal?
     $acme_args[] = isset($options["F"]) ? "--force" : null;
+
     // Use LE staging environment?
     $acme_args[] = $configObj->OPNsense->AcmeClient->settings->environment == "stg" ? "--staging" : null;
     $acme_args[] = isset($options["S"]) ? "--staging" : null; // for debug purpose
+
+    // Set log level
+    $acme_args[] = $configObj->OPNsense->AcmeClient->settings->logLevel == "normal" ? "--log-level 1" : "--log-level 2";
+    $acme_args[] = $configObj->OPNsense->AcmeClient->settings->logLevel == "debug" ? "--debug" : null;
 
     // Remove empty and duplicate elements from array
     return(array_unique(array_filter($acme_args)));
@@ -390,7 +396,6 @@ function run_acme_account_registration($acctObj, $certObj, $modelObj)
         $acmecmd = "/usr/local/sbin/acme.sh "
           . implode(" ", $acme_args) . " "
           . "--registeraccount "
-          . "--log-level 2 "
           . "--home /var/etc/acme-client/home "
           . "--accountconf " . $account_conf_file;
         //echo "DEBUG: executing command: " . $acmecmd . "\n";
@@ -739,7 +744,6 @@ function run_acme_validation($certObj, $valObj, $acctObj)
       . "--domain " . (string)$certObj->name . " "
       . $altnames
       . $acme_validation . " "
-      . "--log-level 2 "
       . "--home /var/etc/acme-client/home "
       . "--keylength 4096 "
       . "--accountconf " . $account_conf_file . " "
@@ -804,7 +808,6 @@ function revoke_cert($certObj, $valObj, $acctObj)
       . implode(" ", $acme_args) . " "
       . "--revoke "
       . "--domain " . (string)$certObj->name . " "
-      . "--log-level 2 "
       . "--home /var/etc/acme-client/home "
       . "--keylength 4096 "
       . "--accountconf " . $account_conf_file;


### PR DESCRIPTION
## New features
- allow to configure acme.sh's log level (advanced option)
- write import events to the system log (#256)
- update acme.sh to version 2.7.4

## Bugfixes
- fix log file display in GUI (https://github.com/opnsense/plugins/issues/69)
- switch default log level for acme.sh from 2 to 1
