### PR TITLE
C-icap: Fix defaults in the model

### DIFF
--- a/www/c-icap/src/opnsense/mvc/app/models/OPNsense/CICAP/Antivirus.xml
+++ b/www/c-icap/src/opnsense/mvc/app/models/OPNsense/CICAP/Antivirus.xml
@@ -8,7 +8,7 @@
             <Required>Y</Required>
         </enable_clamav>
         <scanfiletypes type="OptionField">
-            <default></default>
+            <default>TEXT, DATA, EXECUTABLE, ARCHIVE, GIF, JPEG, MSOFFICE</default>
 	    <multiple>Y</multiple>
             <Required>Y</Required>
 	        <OptionValues>
@@ -34,7 +34,7 @@
             <Required>Y</Required>
         </allow204responses>
         <passonerror type="BooleanField">
-            <default>N</default>
+            <default>0</default>
             <Required>Y</Required>
         </passonerror>
         <maxobjectsize type="TextField">

--- a/www/c-icap/src/opnsense/mvc/app/models/OPNsense/CICAP/Antivirus.xml
+++ b/www/c-icap/src/opnsense/mvc/app/models/OPNsense/CICAP/Antivirus.xml
@@ -8,7 +8,7 @@
             <Required>Y</Required>
         </enable_clamav>
         <scanfiletypes type="OptionField">
-            <default>TEXT, DATA, EXECUTABLE, ARCHIVE, GIF, JPEG, MSOFFICE</default>
+            <default>TEXT,DATA,EXECUTABLE,ARCHIVE,GIF,JPEG,MSOFFICE</default>
             <multiple>Y</multiple>
             <Required>Y</Required>
                 <OptionValues>

--- a/www/c-icap/src/opnsense/mvc/app/models/OPNsense/CICAP/Antivirus.xml
+++ b/www/c-icap/src/opnsense/mvc/app/models/OPNsense/CICAP/Antivirus.xml
@@ -9,17 +9,17 @@
         </enable_clamav>
         <scanfiletypes type="OptionField">
             <default>TEXT, DATA, EXECUTABLE, ARCHIVE, GIF, JPEG, MSOFFICE</default>
-	    <multiple>Y</multiple>
+            <multiple>Y</multiple>
             <Required>Y</Required>
-	        <OptionValues>
-		    <TEXT>Text files</TEXT>
-		    <DATA>Binary files</DATA>
-		    <EXECUTABLE>Executables</EXECUTABLE>
-		    <ARCHIVE>Archives</ARCHIVE>
-		    <GIF>GIF animations</GIF>
-		    <JPEG>JPEG pictures</JPEG>
-		    <MSOFFICE>Microsoft office files</MSOFFICE>
-		</OptionValues>
+                <OptionValues>
+                    <TEXT>Text files</TEXT>
+                    <DATA>Binary files</DATA>
+                    <EXECUTABLE>Executables</EXECUTABLE>
+                    <ARCHIVE>Archives</ARCHIVE>
+                    <GIF>GIF animations</GIF>
+                    <JPEG>JPEG pictures</JPEG>
+                    <MSOFFICE>Microsoft office files</MSOFFICE>
+                </OptionValues>
         </scanfiletypes>
         <sendpercentdata type="IntegerField">
             <default>5</default>


### PR DESCRIPTION
No defaults for a required field and "N" instead of "0" for a BooleanField.