### PR TITLE
C-ICAP: Allow disabling access.log

### DIFF
--- a/www/c-icap/src/opnsense/mvc/app/controllers/OPNsense/CICAP/forms/general.xml
+++ b/www/c-icap/src/opnsense/mvc/app/controllers/OPNsense/CICAP/forms/general.xml
@@ -77,4 +77,10 @@
         <type>text</type>
         <help>A name for this server. Used when displaying information about this server (logs, info service, etc).</help>
     </field>
+    <field>
+        <id>general.enable_accesslog</id>
+        <label>Enable access logging</label>
+        <type>checkbox</type>
+        <help>This will enable logging of access log.</help>
+    </field>
 </form>

--- a/www/c-icap/src/opnsense/mvc/app/models/OPNsense/CICAP/General.xml
+++ b/www/c-icap/src/opnsense/mvc/app/models/OPNsense/CICAP/General.xml
@@ -58,5 +58,9 @@
             <default></default>
             <Required>N</Required>
         </servername>
-	</items>
+        <enable_accesslog type="BooleanField">
+            <default>1</default>
+            <Required>Y</Required>
+        </enable_accesslog>	    
+    </items>
 </model>

--- a/www/c-icap/src/opnsense/service/templates/OPNsense/CICAP/c-icap.conf
+++ b/www/c-icap/src/opnsense/service/templates/OPNsense/CICAP/c-icap.conf
@@ -55,7 +55,9 @@ RemoteProxyUsers off
 RemoteProxyUserHeader X-Authenticated-User
 RemoteProxyUserHeaderEncoded on
 ServerLog /var/log/c-icap/server.log
+{% if helpers.exists('OPNsense.cicap.general.enable_accesslog') and OPNsense.cicap.general.enable_accesslog == '1' %}
 AccessLog /var/log/c-icap/access.log
+{% endif %}
 Service echo srv_echo.so
 Include virus_scan.conf
 


### PR DESCRIPTION
access.log is quite useless as it doesn't log any useful and detected viruses are sent to server.log.

Discussed in #268
