### PR TITLE
C-ICAP: fix typo for maxsize value

### DIFF
--- a/www/c-icap/src/opnsense/service/templates/OPNsense/CICAP/virus_scan.conf
+++ b/www/c-icap/src/opnsense/service/templates/OPNsense/CICAP/virus_scan.conf
@@ -19,7 +19,7 @@ virus_scan.Allow204Responces on
 {% if helpers.exists('OPNsense.cicap.antivirus.passonerror') and OPNsense.cicap.antivirus.passonerror != '' %}
 virus_scan.PassOnError off
 {% endif %}
-{% if helpers.exists('OPNsense.cicap.antivirus.cmaxobjectsize') and OPNsense.cicap.antivirus.maxobjectsize != '' %}
+{% if helpers.exists('OPNsense.cicap.antivirus.maxobjectsize') and OPNsense.cicap.antivirus.maxobjectsize != '' %}
 virus_scan.MaxObjectSize  5M
 {% endif %}
 Module common clamd_mod.so


### PR DESCRIPTION
Entry will not be set.