### PR TITLE
Allow RemoteProxyUsers in c-icap

### DIFF
--- a/www/c-icap/src/opnsense/mvc/app/controllers/OPNsense/CICAP/forms/general.xml
+++ b/www/c-icap/src/opnsense/mvc/app/controllers/OPNsense/CICAP/forms/general.xml
@@ -83,4 +83,10 @@
         <type>checkbox</type>
         <help>This will enable logging of access log.</help>
     </field>
+    <field>
+        <id>general.localSquid</id>
+        <label>Use c-icap with local squid</label>
+        <type>checkbox</type>
+        <help>This will allow to take settings user name from local squid</help>
+    </field>
 </form>

--- a/www/c-icap/src/opnsense/mvc/app/models/OPNsense/CICAP/General.xml
+++ b/www/c-icap/src/opnsense/mvc/app/models/OPNsense/CICAP/General.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/cicap/general</mount>
     <description>c-icap configuration</description>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <items>
         <enabled type="BooleanField">
             <default>0</default>

--- a/www/c-icap/src/opnsense/mvc/app/models/OPNsense/CICAP/General.xml
+++ b/www/c-icap/src/opnsense/mvc/app/models/OPNsense/CICAP/General.xml
@@ -62,5 +62,9 @@
             <default>1</default>
             <Required>Y</Required>
         </enable_accesslog>
+        <localSquid type="BooleanField">
+            <default>1</default>
+            <Required>Y</Required>
+        </localSquid>
     </items>
 </model>

--- a/www/c-icap/src/opnsense/service/templates/OPNsense/CICAP/c-icap.conf
+++ b/www/c-icap/src/opnsense/service/templates/OPNsense/CICAP/c-icap.conf
@@ -41,20 +41,28 @@ ServerName {{ OPNsense.cicap.general.servername }}
 {% else %}
 ServerName {{ system.hostname }}
 {% endif %}
-{% if helpers.exists('OPNsense.proxy.forward.icap.SendUsername') and OPNsense.proxy.forward.icap.SendUsername == '1' %}
+{% if helpers.exists('OPNsense.cicap.general.localSquid') and OPNsense.cicap.general.localSquid == '1' %}
+{%      if helpers.exists('OPNsense.proxy.forward.icap.SendUsername') and OPNsense.proxy.forward.icap.SendUsername == '1' %}
 RemoteProxyUsers on
 acl AUTH auth *
 icap_access allow AUTH 127.0.0.1
-{% else %}
+{%      else %}
 RemoteProxyUsers off
-{% endif %}
-{% if helpers.exists('OPNsense.proxy.forward.icap.EncodeUsername') and OPNsense.proxy.forward.icap.EncodeUsername == '1' %}
+{%      endif %}
+{%      if helpers.exists('OPNsense.proxy.forward.icap.EncodeUsername') and OPNsense.proxy.forward.icap.EncodeUsername == '1' %}
 RemoteProxyUserHeaderEncoded on
-{% else %}
+{%      else %}
 RemoteProxyUserHeaderEncoded off
-{% endif %}
-{% if helpers.exists('OPNsense.proxy.forward.icap.UsernameHeader') and OPNsense.proxy.forward.icap.UsernameHeader != '' %}
+{%      endif %}
+{%      if helpers.exists('OPNsense.proxy.forward.icap.UsernameHeader') and OPNsense.proxy.forward.icap.UsernameHeader != '' %}
 RemoteProxyUserHeader {{OPNsense.proxy.forward.icap.UsernameHeader}}
+{%      endif %}
+{% else %}
+RemoteProxyUsers on
+acl AUTH auth *
+icap_access allow AUTH 127.0.0.1
+RemoteProxyUserHeaderEncoded on
+RemoteProxyUserHeader X-Authenticated-User
 {% endif %}
 TmpDir /var/tmp
 MaxMemObject 131072

--- a/www/c-icap/src/opnsense/service/templates/OPNsense/CICAP/c-icap.conf
+++ b/www/c-icap/src/opnsense/service/templates/OPNsense/CICAP/c-icap.conf
@@ -53,7 +53,7 @@ RemoteProxyUserHeaderEncoded on
 {% else %}
 RemoteProxyUserHeaderEncoded off
 {% endif %}
-{% if helpers.exists('OPNsense.proxy.forward.icap.UsernameHeader') %}
+{% if helpers.exists('OPNsense.proxy.forward.icap.UsernameHeader') and OPNsense.proxy.forward.icap.UsernameHeader != '' %}
 RemoteProxyUserHeader {{OPNsense.proxy.forward.icap.UsernameHeader}}
 {% endif %}
 TmpDir /var/tmp

--- a/www/c-icap/src/opnsense/service/templates/OPNsense/CICAP/c-icap.conf
+++ b/www/c-icap/src/opnsense/service/templates/OPNsense/CICAP/c-icap.conf
@@ -41,6 +41,21 @@ ServerName {{ OPNsense.cicap.general.servername }}
 {% else %}
 ServerName {{ system.hostname }}
 {% endif %}
+{% if helpers.exists('OPNsense.proxy.forward.icap.SendUsername') and OPNsense.proxy.forward.icap.SendUsername == '1' %}
+RemoteProxyUsers on
+acl AUTH auth *
+icap_access allow AUTH 127.0.0.1
+{% else %}
+RemoteProxyUsers off
+{% endif %}
+{% if helpers.exists('OPNsense.proxy.forward.icap.EncodeUsername') and OPNsense.proxy.forward.icap.EncodeUsername == '1' %}
+RemoteProxyUserHeaderEncoded on
+{% else %}
+RemoteProxyUserHeaderEncoded off
+{% endif %}
+{% if helpers.exists('OPNsense.proxy.forward.icap.UsernameHeader') %}
+RemoteProxyUserHeader {{OPNsense.proxy.forward.icap.UsernameHeader}}
+{% endif %}
 TmpDir /var/tmp
 MaxMemObject 131072
 DebugLevel 1
@@ -51,9 +66,6 @@ ServicesDir /usr/local/lib/c_icap
 TemplateDir /usr/local/share/c_icap/templates/
 TemplateDefaultLanguage en
 LoadMagicFile /usr/local/etc/c-icap/c-icap.magic
-RemoteProxyUsers off
-RemoteProxyUserHeader X-Authenticated-User
-RemoteProxyUserHeaderEncoded on
 ServerLog /var/log/c-icap/server.log
 {% if helpers.exists('OPNsense.cicap.general.enable_accesslog') and OPNsense.cicap.general.enable_accesslog == '1' %}
 AccessLog /var/log/c-icap/access.log


### PR DESCRIPTION
In /var/log/c-icap/server.log is not displayed the user name

Wed Sep 13 10:52:41 2017, 79793/3542196480, VIRUS DETECTED: Eicar-Test-Signature , http client ip: 192.168.12.101, http user: -, http url: http://www.eicar.org/download/eicar.com