### PR TITLE
Update collectd.conf

### DIFF
--- a/net-mgmt/collectd/src/opnsense/service/templates/OPNsense/Collectd/collectd.conf
+++ b/net-mgmt/collectd/src/opnsense/service/templates/OPNsense/Collectd/collectd.conf
@@ -94,7 +94,7 @@ LoadPlugin write_graphite
     Protocol "tcp"
     ReconnectInterval 0
     LogSendErrors true
-    Prefix "collectd"
+    Prefix "collectd."
     Postfix "collectd"
     StoreRates true
     AlwaysAppendDS false


### PR DESCRIPTION
added '.' for the prefix section to proper populate graphite
as in https://www.digitalocean.com/community/tutorials/how-to-configure-collectd-to-gather-system-metrics-for-graphite-on-ubuntu-14-04