### PR TITLE
net/zerotier: Prevent invalid 'local.conf' on initial save.

### DIFF
--- a/net/zerotier/src/opnsense/mvc/app/controllers/OPNsense/Zerotier/Api/SettingsController.php
+++ b/net/zerotier/src/opnsense/mvc/app/controllers/OPNsense/Zerotier/Api/SettingsController.php
@@ -48,6 +48,9 @@ class SettingsController extends ApiMutableModelControllerBase
         $result = array();
         if ($this->request->isGet()) {
             $mdlZerotier = $this->getModel();
+            if(empty($mdlZerotier->localconf->__toString())) {
+                $mdlZerotier->localconf = '{}';
+            }
             $result = array("zerotier" => $mdlZerotier->getNodes());
         }
         return $result;

--- a/net/zerotier/src/opnsense/service/templates/OPNsense/zerotier/local.conf
+++ b/net/zerotier/src/opnsense/service/templates/OPNsense/zerotier/local.conf
@@ -1,3 +1,5 @@
 {% if helpers.exists('OPNsense.zerotier.localconf') and OPNsense.zerotier.localconf|default("") != "" %}
 {{ OPNsense.zerotier.localconf }}
+{% else %}
+{}
 {% endif %}


### PR DESCRIPTION
There is potential for an invalid local.conf to be written out during first
save. Whilst it doesn't stop Zerotier from starting, it does cause it to
return a 1 as an error code, thus fooling configd that the service has failed
to start. Adding in a default '{}' resolves this issue.

-=david=-