### PR TITLE
net-mgmt/telegraf: fix helptext, ready for stable

### DIFF
--- a/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/output.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/output.xml
@@ -3,7 +3,7 @@
         <id>output.influx_enable</id>
         <label>Enable Influx</label>
         <type>checkbox</type>
-        <help>This will enable InfluxDB as output.</help>
+        <help>This will enable InfluxDB as output. Format is without square brackets, just like http://192.168.0.1:8086.</help>
     </field>
     <field>
         <id>output.influx_url</id>


### PR DESCRIPTION
I only found this missing help text to make some confusions, with this it's ready for production.
The last dot is debateable, it's a sentence but doesn't belong to the link. 
You decide @fichtner 