### PR TITLE
net/haproxy: server port is not required

### DIFF
--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -567,7 +567,7 @@
                     <MinimumValue>1</MinimumValue>
                     <MaximumValue>65535</MaximumValue>
                     <ValidationMessage>Please specify a value between 1 and 65535.</ValidationMessage>
-                    <Required>Y</Required>
+                    <Required>N</Required>
                 </port>
                 <checkport type="IntegerField">
                     <default></default>


### PR DESCRIPTION
According to the [haproxy documentation](http://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4.2-server):

```
<port> is an optional port specification. If set, all connections will
be sent to this port. If unset, the same port the client
connected to will be used. The port may also be prefixed by a "+"
or a "-". In this case, the server's port will be determined by
adding this value to the client's port.
```

Allowing this makes it much simpler to setup a reverse proxy when 
multiple ports need to be proxied to the same server.