### PR TITLE
net/postfix: New plugin

### DIFF
--- a/net/postfix/Makefile
+++ b/net/postfix/Makefile
@@ -1,0 +1,8 @@
+PLUGIN_NAME=		postfix
+PLUGIN_VERSION=		0.1
+PLUGIN_COMMENT=		SMTP mail relay
+PLUGIN_DEPENDS=		postfix-sasl
+PLUGIN_MAINTAINER=	m.muenz@gmail.com
+PLUGIN_DEVEL=       YES
+
+.include "../../Mk/plugins.mk"

--- a/net/postfix/pkg-descr
+++ b/net/postfix/pkg-descr
@@ -1,0 +1,5 @@
+Postfix attempts to be fast, easy to administer, and secure.
+The outside has a definite Sendmail-ish flavor, but the inside
+is completely different.
+
+WWW: http://www.postfix.org/

--- a/net/postfix/src/etc/inc/plugins.inc.d/postfix.inc
+++ b/net/postfix/src/etc/inc/plugins.inc.d/postfix.inc
@@ -1,0 +1,49 @@
+<?php
+
+/*
+    Copyright (C) 2017 Michael Muenz
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+
+function postfix_services()
+{
+    global $config;
+
+    $services = array();
+
+    if (isset($config['OPNsense']['postfix']['general']['enabled']) && $config['OPNsense']['postfix']['general']['enabled'] == 1) {
+        $services[] = array(
+            'description' => gettext('Postfix'),
+            'configd' => array(
+                'restart' => array('postfix restart'),
+                'start' => array('postfix start'),
+                'stop' => array('postfix stop'),
+            ),
+            'name' => 'postfix',
+            'pidfile' => '/var/spool/postfix/pid/master.pid'
+        );
+    }
+
+    return $services;
+}

--- a/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/Api/AntispamController.php
+++ b/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/Api/AntispamController.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ *    Copyright (C) 2015 - 2017 Deciso B.V.
+ *    Copyright (C) 2017 Michael Muenz
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+namespace OPNsense\Postfix\Api;
+
+use \OPNsense\Base\ApiControllerBase;
+use \OPNsense\Postfix\Antispam;
+use \OPNsense\Core\Config;
+
+class AntispamController extends ApiControllerBase
+{
+    public function getAction()
+    {
+        // define list of configurable settings
+        $result = array();
+        if ($this->request->isGet()) {
+            $mdlAntispam = new Antispam();
+            $result['antispam'] = $mdlAntispam->getNodes();
+        }
+        return $result;
+    }
+
+    public function setAction()
+    {
+        $result = array("result"=>"failed");
+        if ($this->request->isPost()) {
+            // load model and update with provided data
+            $mdlAntispam = new Antispam();
+            $mdlAntispam->setNodes($this->request->getPost("antispam"));
+
+            // perform validation
+            $valMsgs = $mdlAntispam->performValidation();
+            foreach ($valMsgs as $field => $msg) {
+                if (!array_key_exists("validations", $result)) {
+                    $result["validations"] = array();
+                }
+                $result["validations"]["antispam.".$msg->getField()] = $msg->getMessage();
+            }
+
+            // serialize model to config and save
+            if ($valMsgs->count() == 0) {
+                $mdlAntispam->serializeToConfig();
+                Config::getInstance()->save();
+                $result["result"] = "saved";
+            }
+        }
+        return $result;
+    }
+}

--- a/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/Api/DomainController.php
+++ b/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/Api/DomainController.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ *    Copyright (C) 2015 - 2017 Deciso B.V.
+ *    Copyright (C) 2017 Michael Muenz
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+namespace OPNsense\Postfix\Api;
+
+use \OPNsense\Postfix\Domain;
+use \OPNsense\Core\Config;
+use \OPNsense\Base\ApiMutableModelControllerBase;
+use \OPNsense\Base\UIModelGrid;
+
+class DomainController extends ApiMutableModelControllerBase
+{
+    static protected $internalModelName = 'Domain';
+    static protected $internalModelClass = '\OPNsense\Postfix\Domain';
+
+    public function getAction()
+    {
+        // define list of configurable settings
+        $result = array();
+        if ($this->request->isGet()) {
+            $mdlDomain = new Domain();
+            $result['domain'] = $mdlDomain->getNodes();
+        }
+        return $result;
+    }
+
+    public function setAction()
+    {
+        $result = array("result"=>"failed");
+        if ($this->request->isPost()) {
+            // load model and update with provided data
+            $mdlDomain = new Domain();
+            $mdlDomain->setNodes($this->request->getPost("domain"));
+            // perform validation
+            $valMsgs = $mdlDomain->performValidation();
+            foreach ($valMsgs as $field => $msg) {
+                if (!array_key_exists("validations", $result)) {
+                    $result["validations"] = array();
+                }
+                $result["validations"]["domain.".$msg->getField()] = $msg->getMessage();
+            }
+            // serialize model to config and save
+            if ($valMsgs->count() == 0) {
+                $mdlDomain->serializeToConfig();
+                Config::getInstance()->save();
+                $result["result"] = "saved";
+            }
+        }
+        return $result;
+    }
+
+    public function searchDomainAction()
+    {
+        $this->sessionClose();
+        $mdlDomain = $this->getModel();
+        $grid = new UIModelGrid($mdlDomain->domains->domain);
+        return $grid->fetchBindRequest(
+            $this->request,
+            array("enabled", "domainname", "destination" )
+        );
+    }
+
+    public function getDomainAction($uuid = null)
+    {
+        $mdlDomain = $this->getModel();
+        if ($uuid != null) {
+            $node = $mdlDomain->getNodeByReference('domains.domain.' . $uuid);
+            if ($node != null) {
+                // return node
+                return array("domain" => $node->getNodes());
+            }
+        } else {
+            $node = $mdlDomain->domains->domain->add();
+            return array("domain" => $node->getNodes());
+        }
+        return array();
+    }
+
+    public function addDomainAction()
+    {
+        $result = array("result" => "failed");
+        if ($this->request->isPost() && $this->request->hasPost("domain")) {
+            $result = array("result" => "failed", "validations" => array());
+            $mdlDomain = $this->getModel();
+            $node = $mdlDomain->domains->domain->Add();
+            $node->setNodes($this->request->getPost("domain"));
+            $valMsgs = $mdlDomain->performValidation();
+            foreach ($valMsgs as $field => $msg) {
+                $fieldnm = str_replace($node->__reference, "domain", $msg->getField());
+                $result["validations"][$fieldnm] = $msg->getMessage();
+            }
+            if (count($result['validations']) == 0) {
+                unset($result['validations']);
+                // save config if validated correctly
+                $mdlDomain->serializeToConfig();
+                Config::getInstance()->save();
+                unset($result['validations']);
+                $result["result"] = "saved";
+            }
+        }
+        return $result;
+    }
+
+    public function delDomainAction($uuid)
+    {
+        $result = array("result" => "failed");
+        if ($this->request->isPost()) {
+            $mdlDomain = $this->getModel();
+            if ($uuid != null) {
+                if ($mdlDomain->domains->domain->del($uuid)) {
+                    $mdlDomain->serializeToConfig();
+                    Config::getInstance()->save();
+                    $result['result'] = 'deleted';
+                } else {
+                    $result['result'] = 'not found';
+                }
+            }
+        }
+        return $result;
+    }
+
+    public function setDomainAction($uuid)
+    {
+        if ($this->request->isPost() && $this->request->hasPost("domain")) {
+            $mdlSetting = $this->getModel();
+            if ($uuid != null) {
+                $node = $mdlSetting->getNodeByReference('domains.domain.' . $uuid);
+                if ($node != null) {
+                    $result = array("result" => "failed", "validations" => array());
+                    $domainInfo = $this->request->getPost("domain");
+                    $node->setNodes($domainInfo);
+                    $valMsgs = $mdlSetting->performValidation();
+                    foreach ($valMsgs as $field => $msg) {
+                        $fieldnm = str_replace($node->__reference, "domain", $msg->getField());
+                        $result["validations"][$fieldnm] = $msg->getMessage();
+                    }
+                    if (count($result['validations']) == 0) {
+                        // save config if validated correctly
+                        $mdlSetting->serializeToConfig();
+                        Config::getInstance()->save();
+                        $result = array("result" => "saved");
+                    }
+                    return $result;
+                }
+            }
+        }
+        return array("result" => "failed");
+    }
+
+    public function toggle_handler($uuid, $elements, $element)
+    {
+        $result = array("result" => "failed");
+        if ($this->request->isPost()) {
+            $mdlSetting = $this->getModel();
+            if ($uuid != null) {
+                $node = $mdlSetting->getNodeByReference($elements . '.'. $element .'.' . $uuid);
+                if ($node != null) {
+                    if ($node->enabled->__toString() == "1") {
+                        $result['result'] = "Disabled";
+                        $node->enabled = "0";
+                    } else {
+                        $result['result'] = "Enabled";
+                        $node->enabled = "1";
+                    }
+                    // if item has toggled, serialize to config and save
+                    $mdlSetting->serializeToConfig();
+                    Config::getInstance()->save();
+                }
+            }
+        }
+        return $result;
+    }
+
+    public function toggleDomainAction($uuid)
+    {
+        return $this->toggle_handler($uuid, 'domains', 'domain');
+    }
+}

--- a/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/Api/GeneralController.php
+++ b/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/Api/GeneralController.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ *    Copyright (C) 2015 - 2017 Deciso B.V.
+ *    Copyright (C) 2017 Michael Muenz
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+namespace OPNsense\Postfix\Api;
+
+use \OPNsense\Base\ApiControllerBase;
+use \OPNsense\Postfix\General;
+use \OPNsense\Core\Config;
+
+class GeneralController extends ApiControllerBase
+{
+    public function getAction()
+    {
+        // define list of configurable settings
+        $result = array();
+        if ($this->request->isGet()) {
+            $mdlGeneral = new General();
+            $result['general'] = $mdlGeneral->getNodes();
+        }
+        return $result;
+    }
+
+    public function setAction()
+    {
+        $result = array("result"=>"failed");
+        if ($this->request->isPost()) {
+            // load model and update with provided data
+            $mdlGeneral = new General();
+            $mdlGeneral->setNodes($this->request->getPost("general"));
+
+            // perform validation
+            $valMsgs = $mdlGeneral->performValidation();
+            foreach ($valMsgs as $field => $msg) {
+                if (!array_key_exists("validations", $result)) {
+                    $result["validations"] = array();
+                }
+                $result["validations"]["general.".$msg->getField()] = $msg->getMessage();
+            }
+
+            // serialize model to config and save
+            if ($valMsgs->count() == 0) {
+                $mdlGeneral->serializeToConfig();
+                Config::getInstance()->save();
+                $result["result"] = "saved";
+            }
+        }
+        return $result;
+    }
+}

--- a/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/Api/ServiceController.php
+++ b/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/Api/ServiceController.php
@@ -1,0 +1,146 @@
+<?php
+
+/*
+ * Copyright (C) 2015 - 2017 Deciso B.V.
+ * Copyright (C) 2017 Michael Muenz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Postfix\Api;
+
+use \OPNsense\Base\ApiControllerBase;
+use \OPNsense\Core\Backend;
+use \OPNsense\Postfix\General;
+
+/**
+ * Class ServiceController
+ * @package OPNsense\Postfix
+ */
+class ServiceController extends ApiControllerBase
+{
+    /**
+     * start postfix service (in background)
+     * @return array
+     */
+    public function startAction()
+    {
+        if ($this->request->isPost()) {
+            $backend = new Backend();
+            $response = $backend->configdRun('postfix start');
+            return array("response" => $response);
+        } else {
+            return array("response" => array());
+        }
+    }
+
+    /**
+     * stop postfix service
+     * @return array
+     */
+    public function stopAction()
+    {
+        if ($this->request->isPost()) {
+            $backend = new Backend();
+            $response = $backend->configdRun("postfix stop");
+            return array("response" => $response);
+        } else {
+            return array("response" => array());
+        }
+    }
+
+    /**
+     * restart postfix service
+     * @return array
+     */
+    public function restartAction()
+    {
+        if ($this->request->isPost()) {
+            $backend = new Backend();
+            $response = $backend->configdRun("postfix restart");
+            return array("response" => $response);
+        } else {
+            return array("response" => array());
+        }
+    }
+
+    /**
+     * retrieve status of postfix
+     * @return array
+     * @throws \Exception
+     */
+    public function statusAction()
+    {
+        $backend = new Backend();
+        $mdlGeneral = new General();
+        $response = $backend->configdRun("postfix status");
+
+        if (strpos($response, "not running") > 0) {
+            if ($mdlGeneral->enabled->__toString() == 1) {
+                $status = "stopped";
+            } else {
+                $status = "disabled";
+            }
+        } elseif (strpos($response, "is running") > 0) {
+            $status = "running";
+        } elseif ($mdlGeneral->enabled->__toString() == 0) {
+            $status = "disabled";
+        } else {
+            $status = "unkown";
+        }
+
+
+        return array("status" => $status);
+    }
+
+    /**
+     * reconfigure postfix, generate config and reload
+     */
+    public function reconfigureAction()
+    {
+        if ($this->request->isPost()) {
+            // close session for long running action
+            $this->sessionClose();
+
+            $mdlGeneral = new General();
+            $backend = new Backend();
+
+            $runStatus = $this->statusAction();
+
+            // stop postfix if it is running or not
+            $this->stopAction();
+
+            // generate template
+            $backend->configdRun('template reload OPNsense/Postfix');
+
+            // (res)start daemon
+            if ($mdlGeneral->enabled->__toString() == 1) {
+                $this->startAction();
+            }
+
+            return array("status" => "ok");
+        } else {
+            return array("status" => "failed");
+        }
+    }
+}

--- a/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/Api/ServiceController.php
+++ b/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/Api/ServiceController.php
@@ -53,7 +53,22 @@ class ServiceController extends ApiControllerBase
             return array("response" => array());
         }
     }
-    
+
+    /**
+     * check rspamd
+     * @return array
+     */
+    public function checkrspamdAction()
+    {
+        if ($this->request->isPost()) {
+            $backend = new Backend();
+            $response = $backend->configdRun('postfix checkrspamd');
+            return array("response" => $response);
+        } else {
+            return array("response" => array());
+        }
+    }
+
     /**
      * start postfix service (in background)
      * @return array

--- a/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/Api/ServiceController.php
+++ b/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/Api/ServiceController.php
@@ -40,6 +40,21 @@ use \OPNsense\Postfix\General;
 class ServiceController extends ApiControllerBase
 {
     /**
+     * make transporttable
+     * @return array
+     */
+    public function maketransportAction()
+    {
+        if ($this->request->isPost()) {
+            $backend = new Backend();
+            $response = $backend->configdRun('postfix make-transport');
+            return array("response" => $response);
+        } else {
+            return array("response" => array());
+        }
+    }
+    
+    /**
      * start postfix service (in background)
      * @return array
      */

--- a/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/Api/ServiceController.php
+++ b/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/Api/ServiceController.php
@@ -62,7 +62,7 @@ class ServiceController extends ApiControllerBase
     {
         if ($this->request->isPost()) {
             $backend = new Backend();
-            $response = $backend->configdRun('postfix checkrspamd');
+            $response = $backend->configdRun("firmware plugin rspamd");
             return array("response" => $response);
         } else {
             return array("response" => array());

--- a/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/Api/ServiceController.php
+++ b/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/Api/ServiceController.php
@@ -60,13 +60,10 @@ class ServiceController extends ApiControllerBase
      */
     public function checkrspamdAction()
     {
-        if ($this->request->isPost()) {
-            $backend = new Backend();
-            $response = $backend->configdRun("firmware plugin rspamd");
-            return array("response" => $response);
-        } else {
-            return array("response" => array());
-        }
+        $backend = new Backend();
+        $mdlGeneral = new General();
+        $response = $backend->configdRun("firmware plugin rspamd");
+        return $response;
     }
 
     /**

--- a/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/Api/ServiceController.php
+++ b/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/Api/ServiceController.php
@@ -40,21 +40,6 @@ use \OPNsense\Postfix\General;
 class ServiceController extends ApiControllerBase
 {
     /**
-     * make transporttable
-     * @return array
-     */
-    public function maketransportAction()
-    {
-        if ($this->request->isPost()) {
-            $backend = new Backend();
-            $response = $backend->configdRun('postfix make-transport');
-            return array("response" => $response);
-        } else {
-            return array("response" => array());
-        }
-    }
-
-    /**
      * check rspamd
      * @return array
      */
@@ -159,6 +144,7 @@ class ServiceController extends ApiControllerBase
 
             // generate template
             $backend->configdRun('template reload OPNsense/Postfix');
+            $backend->configdRun('postfix make-transport');
 
             // (res)start daemon
             if ($mdlGeneral->enabled->__toString() == 1) {

--- a/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/DomainController.php
+++ b/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/DomainController.php
@@ -1,0 +1,34 @@
+<?php
+/*
+    Copyright (C) 2017 Michael Muenz
+    All rights reserved.
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+
+namespace OPNsense\Postfix;
+
+class DomainController extends \OPNsense\Base\IndexController
+{
+    public function indexAction()
+    {
+        $this->view->title = gettext("Postfix Domains");
+        $this->view->formDialogEditPostfixDomain = $this->getForm("dialogEditPostfixDomain");
+        $this->view->pick('OPNsense/Postfix/domain');
+    }
+}

--- a/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/GeneralController.php
+++ b/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/GeneralController.php
@@ -1,0 +1,38 @@
+<?php
+/*
+    Copyright (C) 2017 Michael Muenz
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+
+namespace OPNsense\Postfix;
+
+class GeneralController extends \OPNsense\Base\IndexController
+{
+    public function indexAction()
+    {
+        $this->view->title = gettext("Postfix Settings");
+        $this->view->generalForm = $this->getForm("general");
+        $this->view->pick('OPNsense/Postfix/general');
+    }
+}

--- a/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/antispam.xml
+++ b/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/antispam.xml
@@ -1,0 +1,8 @@
+<form>
+    <field>
+        <id>antispam.enable_rspamd</id>
+        <label>Enable Rspamd Integration</label>
+        <type>checkbox</type>
+        <help>This will allow Postfix to connect to rspamd via milter protocol.</help>
+    </field>
+</form>

--- a/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/dialogEditPostfixDomain.xml
+++ b/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/dialogEditPostfixDomain.xml
@@ -1,0 +1,20 @@
+<form>
+    <field>
+        <id>domain.enabled</id>
+        <label>Enabled</label>
+        <type>checkbox</type>
+        <help>This will enable or disable domain routing for this entry.</help>
+    </field>
+    <field>
+        <id>domain.domainname</id>
+        <label>Domainname</label>
+        <type>text</type>
+        <help>Set the unique domainname to relay for.</help>
+    </field>
+    <field>
+        <id>domain.destination</id>
+        <label>Destination</label>
+        <type>text</type>
+        <help>Set the IP or FQDN to where to send the mails to. Empty means MX will be used.</help>
+    </field>
+</form>

--- a/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/dialogEditPostfixDomain.xml
+++ b/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/dialogEditPostfixDomain.xml
@@ -9,7 +9,7 @@
         <id>domain.domainname</id>
         <label>Domainname</label>
         <type>text</type>
-        <help>Set the unique domainname to relay for.</help>
+        <help>Set the unique domain name to relay for.</help>
     </field>
     <field>
         <id>domain.destination</id>

--- a/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
+++ b/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
@@ -14,7 +14,7 @@
     <field>
         <id>general.mydomain</id>
         <label>System Domain</label>
-        <type>test</type>
+        <type>text</type>
         <help>The 'System Domain' parameter specifies the local internet domain name. The default is to use 'System Hostname' minus the first component. It is used as a default value for many other configuration parameters.</help>
     </field>
     <field>

--- a/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
+++ b/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
@@ -39,6 +39,6 @@
         <id>general.banner</id>
         <label>SMTP Banner</label>
         <type>text</type>
-        <help>The smtpd_banner parameter specifies the text that follows the 220 code in the SMTP server's greeting banner. Default is <'System Hostname' ESMTP Postfix>.</help>
+        <help>The smtpd_banner parameter specifies the text that follows the 220 code in the SMTP server's greeting banner. Default is "'System Hostname' ESMTP Postfix".</help>
     </field>
 </form>

--- a/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
+++ b/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
@@ -1,0 +1,44 @@
+<form>
+    <field>
+        <id>general.enabled</id>
+        <label>Enable</label>
+        <type>checkbox</type>
+        <help>This will activate the Postfix daemon.</help>
+    </field>
+    <field>
+        <id>general.myhostname</id>
+        <label>System Hostname</label>
+        <type>text</type>
+        <help>The 'System Hostname' parameter specifies the internet hostname of this mail system. The default is to use the fully-qualified domain name from gethostname(). It is used as a default value for many other configuration parameters.</help>
+    </field>
+    <field>
+        <id>general.mydomain</id>
+        <label>System Domain</label>
+        <type>test</type>
+        <help>The 'System Domain' parameter specifies the local internet domain name. The default is to use 'System Hostname' minus the first component. It is used as a default value for many other configuration parameters.</help>
+    </field>
+    <field>
+        <id>general.myorigin</id>
+        <label>System Origin</label>
+        <type>text</type>
+        <help>The 'System Origin' parameter specifies the domain that locally-posted mail appears to come from. The default is to append 'System Hostname', which is fine for small sites.</help>
+    </field>
+    <field>
+        <id>general.inet_interfaces</id>
+        <label>Listen IPs</label>
+        <type>text</type>
+        <help>The 'Listen IPs' parameter specifies the IP address to listen to. Default is to listen on all interfaces.</help>
+    </field>
+    <field>
+        <id>general.mynetworks</id>
+        <label>Trusted Networks</label>
+        <type>text</type>
+        <help>The 'Trusted Networks' parameter specifies the list of trusted SMTP clients. In particular, trusted SMTP clients are allowed to relay mail through Postfix. Please use CIDR notation like 192.168.0.0/24.</help>
+    </field>
+    <field>
+        <id>general.banner</id>
+        <label>SMTP Banner</label>
+        <type>text</type>
+        <help>The smtpd_banner parameter specifies the text that follows the 220 code in the SMTP server's greeting banner. Default is <'System Hostname' ESMTP Postfix>.</help>
+    </field>
+</form>

--- a/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
+++ b/net/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
@@ -33,7 +33,7 @@
         <id>general.mynetworks</id>
         <label>Trusted Networks</label>
         <type>text</type>
-        <help>The 'Trusted Networks' parameter specifies the list of trusted SMTP clients. In particular, trusted SMTP clients are allowed to relay mail through Postfix. Please use CIDR notation like 192.168.0.0/24.</help>
+        <help>The 'Trusted Networks' parameter specifies the list of trusted SMTP clients. In particular, trusted SMTP clients are allowed to relay mail through Postfix. Please use CIDR notation like 192.168.0.0/24 separated by spaces. IPv6 addresses have to be in square brackets like [::1]/128.</help>
     </field>
     <field>
         <id>general.banner</id>

--- a/net/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/ACL/ACL.xml
+++ b/net/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/ACL/ACL.xml
@@ -1,0 +1,9 @@
+<acl>
+   <page-services-postfix>
+      <name>Services: Postfix</name>
+      <patterns>
+         <pattern>ui/postfix/*</pattern>
+         <pattern>api/postfix/*</pattern>
+      </patterns>
+   </page-services-postfix>
+</acl>

--- a/net/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Antispam.php
+++ b/net/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Antispam.php
@@ -29,6 +29,6 @@ use OPNsense\Base\BaseModel;
     POSSIBILITY OF SUCH DAMAGE.
 */
 
-class General extends BaseModel
+class Antispam extends BaseModel
 {
 }

--- a/net/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Antispam.php
+++ b/net/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Antispam.php
@@ -1,4 +1,8 @@
 <?php
+namespace OPNsense\Postfix;
+
+use OPNsense\Base\BaseModel;
+
 /*
     Copyright (C) 2017 Michael Muenz
     All rights reserved.
@@ -25,15 +29,6 @@
     POSSIBILITY OF SUCH DAMAGE.
 */
 
-namespace OPNsense\Postfix;
-
-class GeneralController extends \OPNsense\Base\IndexController
+class General extends BaseModel
 {
-    public function indexAction()
-    {
-        $this->view->title = gettext("Postfix Settings");
-        $this->view->generalForm = $this->getForm("general");
-        $this->view->antispamForm = $this->getForm("antispam");
-        $this->view->pick('OPNsense/Postfix/general');
-    }
 }

--- a/net/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Antispam.xml
+++ b/net/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Antispam.xml
@@ -1,0 +1,11 @@
+<model>
+    <mount>//OPNsense/postfix/antispam</mount>
+    <description>Postfix Antispam configuration</description>
+    <version>1.0.0</version>
+    <items>
+        <enable_rspamd type="BooleanField">
+            <default>0</default>
+            <Required>Y</Required>
+        </enable_rspamd>
+    </items>
+</model>

--- a/net/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Domain.php
+++ b/net/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Domain.php
@@ -1,0 +1,30 @@
+<?php
+namespace OPNsense\Postfix;
+
+use OPNsense\Base\BaseModel;
+
+/*
+    Copyright (C) 2017 Michael Muenz
+    All rights reserved.
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+
+class Domain extends BaseModel
+{
+}

--- a/net/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Domain.xml
+++ b/net/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Domain.xml
@@ -1,0 +1,23 @@
+<model>
+    <mount>//OPNsense/postfix/domain</mount>
+    <description>Postfix domain configuration</description>
+    <version>1.0.0</version>
+    <items>
+        <domains>
+                <domain type="ArrayField">
+                        <enabled type="BooleanField">
+                                <default>1</default>
+                                <Required>Y</Required>
+                        </enabled>
+                        <domainname type="TextField">
+                                <default></default>
+                                <Required>Y</Required>
+                        </domainname>
+                        <destination type="NetworkField">
+                                <default></default>
+                                <Required>Y</Required>
+                        </destination>
+            </domain>
+        </domains>
+    </items>
+</model>

--- a/net/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.php
+++ b/net/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.php
@@ -1,0 +1,34 @@
+<?php
+namespace OPNsense\Postfix;
+
+use OPNsense\Base\BaseModel;
+
+/*
+    Copyright (C) 2017 Michael Muenz
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+
+class General extends BaseModel
+{
+}

--- a/net/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
+++ b/net/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
@@ -23,8 +23,8 @@
             <default>all</default>
             <Required>Y</Required>
         </inet_interfaces>
-        <mynetworks type="NetworkField">
-            <default>127.0.0.0/8,[::ffff:127.0.0.0]/104,[::1]/128</default>
+        <mynetworks type="TextField">
+            <default>127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128</default>
             <Required>Y</Required>
         </mynetworks>
         <banner type="TextField">

--- a/net/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
+++ b/net/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
@@ -1,0 +1,35 @@
+<model>
+    <mount>//OPNsense/postfix/general</mount>
+    <description>Postfix configuration</description>
+    <version>1.0.0</version>
+    <items>
+        <enabled type="BooleanField">
+            <default>0</default>
+            <Required>Y</Required>
+        </enabled>
+        <myhostname type="TextField">
+            <default></default>
+            <Required>N</Required>
+        </myhostname>
+        <mydomain type="TextField">
+            <default></default>
+            <Required>N</Required>
+        </mydomain>
+        <myorigin type="TextField">
+            <default></default>
+            <Required>N</Required>
+        </myorigin>
+        <inet_interfaces type="TextField">
+            <default>ALL</default>
+            <Required>Y</Required>
+        </inet_interfaces>
+        <mynetworks type="NetworkField">
+            <default>127.0.0.0/8,[::ffff:127.0.0.0]/104,[::1]/128</default>
+            <Required>Y</Required>
+        </mynetworks>
+        <banner type="TextField">
+            <default></default>
+            <Required>N</Required>
+        </banner>
+    </items>
+</model>

--- a/net/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
+++ b/net/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
@@ -20,7 +20,7 @@
             <Required>N</Required>
         </myorigin>
         <inet_interfaces type="TextField">
-            <default>ALL</default>
+            <default>all</default>
             <Required>Y</Required>
         </inet_interfaces>
         <mynetworks type="NetworkField">

--- a/net/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Menu/Menu.xml
+++ b/net/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Menu/Menu.xml
@@ -2,7 +2,7 @@
   <Services>
     <Postfix cssClass="fa fa-envelope fa-fw">
       <General url="/ui/postfix/general/index" order="10"/>
-      <User url="/ui/postfix/domain/index" order="20"/>
+      <Domains url="/ui/postfix/domain/index" order="20"/>
     </Postfix>
   </Services>
 </menu>

--- a/net/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Menu/Menu.xml
+++ b/net/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Menu/Menu.xml
@@ -1,0 +1,8 @@
+<menu>
+  <Services>
+    <Postfix cssClass="fa fa-envelope fa-fw">
+      <General url="/ui/postfix/general/index" order="10"/>
+      <User url="/ui/postfix/domain/index" order="20"/>
+    </Postfix>
+  </Services>
+</menu>

--- a/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/domain.volt
+++ b/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/domain.volt
@@ -1,0 +1,113 @@
+{#
+
+OPNsense® is Copyright © 2014 – 2017 by Deciso B.V.
+Copyright (C) 2017 Michael Muenz
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1.  Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2.  Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+#}
+
+<script type="text/javascript">
+
+    $( document ).ready(function() {
+        /*************************************************************************************************************
+         * link grid actions
+         *************************************************************************************************************/
+
+        $("#grid-domains").UIBootgrid(
+            {   'search':'/api/postfix/user/searchDomain',
+                'get':'/api/postfix/user/getDomain/',
+                'set':'/api/postfix/user/setDomain/',
+                'add':'/api/postfix/user/addDomain/',
+                'del':'/api/postfix/user/delDomain/',
+                'toggle':'/api/postfix/user/toggleDomain/'
+            }
+        );
+
+        /*************************************************************************************************************
+         * Commands
+         *************************************************************************************************************/
+
+        /**
+         * Reconfigure
+         */
+        $("#reconfigureAct").click(function(){
+            $("#reconfigureAct_progress").addClass("fa fa-spinner fa-pulse");
+            ajaxCall(url="/api/postfix/service/reconfigure", sendData={}, callback=function(data,status) {
+                // when done, disable progress animation.
+                $("#reconfigureAct_progress").removeClass("fa fa-spinner fa-pulse");
+
+                if (status != "success" || data['status'] != 'ok') {
+                    BootstrapDialog.show({
+                        type: BootstrapDialog.TYPE_WARNING,
+                        title: "{{ lang._('Error reconfiguring Postfix') }}",
+                        message: data['status'],
+                        draggable: true
+                    });
+                } else {
+                    ajaxCall(url="/api/postfix/service/reconfigure", sendData={});
+                }
+            });
+        });
+
+    });
+
+
+</script>
+
+<ul class="nav nav-tabs" data-tabs="tabs" id="maintabs">
+    <li class="active"><a data-toggle="tab" href="#domains">{{ lang._('Domains') }}</a></li>
+</ul>
+<div class="tab-content content-box tab-content">
+    <div id="domains" class="tab-pane fade in active">
+        <!-- tab page "domains" -->
+        <table id="grid-domains" class="table table-condensed table-hover table-striped table-responsive" data-editDialog="dialogEditPostfixDomain">
+            <thead>
+            <tr>
+                <th data-column-id="enabled" data-type="string" data-formatter="rowtoggle">{{ lang._('Enabled') }}</th>
+                <th data-column-id="domainname" data-type="string" data-visible="true">{{ lang._('Domain') }}</th>
+                <th data-column-id="destination" data-type="string" data-visible="false">{{ lang._('Destination') }}</th>
+                <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
+                <th data-column-id="commands" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>            </tr>
+            </thead>
+            <tbody>
+            </tbody>
+            <tfoot>
+            <tr>
+                <td></td>
+                <td>
+                    <button data-action="add" type="button" class="btn btn-xs btn-default"><span class="fa fa-plus"></span></button>
+                    <button data-action="deleteSelected" type="button" class="btn btn-xs btn-default"><span class="fa fa-trash-o"></span></button>
+                </td>
+            </tr>
+            </tfoot>
+        </table>
+    </div>
+    <div class="col-md-12">
+        <hr/>
+        <button class="btn btn-primary" id="reconfigureAct" type="button"><b>{{ lang._('Apply') }}</b> <i id="reconfigureAct_progress" class=""></i></button>
+        <br/><br/>
+    </div>
+</div>
+
+{{ partial("layout_partials/base_dialog",['fields':formDialogEditPostfixDomain,'id':'dialogEditPostfixDomain','label':lang._('Edit Domain')])}}

--- a/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/domain.volt
+++ b/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/domain.volt
@@ -75,9 +75,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 </script>
 
-<ul class="nav nav-tabs" data-tabs="tabs" id="maintabs">
-    <li class="active"><a data-toggle="tab" href="#domains">{{ lang._('Domains') }}</a></li>
-</ul>
 <div class="tab-content content-box tab-content">
     <div id="domains" class="tab-pane fade in active">
         <!-- tab page "domains" -->

--- a/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/domain.volt
+++ b/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/domain.volt
@@ -83,7 +83,7 @@ POSSIBILITY OF SUCH DAMAGE.
             <tr>
                 <th data-column-id="enabled" data-type="string" data-formatter="rowtoggle">{{ lang._('Enabled') }}</th>
                 <th data-column-id="domainname" data-type="string" data-visible="true">{{ lang._('Domain') }}</th>
-                <th data-column-id="destination" data-type="string" data-visible="false">{{ lang._('Destination') }}</th>
+                <th data-column-id="destination" data-type="string" data-visible="true">{{ lang._('Destination') }}</th>
                 <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
                 <th data-column-id="commands" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>            </tr>
             </thead>

--- a/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/domain.volt
+++ b/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/domain.volt
@@ -53,6 +53,7 @@ POSSIBILITY OF SUCH DAMAGE.
          */
         $("#reconfigureAct").click(function(){
             $("#reconfigureAct_progress").addClass("fa fa-spinner fa-pulse");
+            ajaxCall(url="/api/postfix/service/make-transport", sendData={});
             ajaxCall(url="/api/postfix/service/reconfigure", sendData={}, callback=function(data,status) {
                 // when done, disable progress animation.
                 $("#reconfigureAct_progress").removeClass("fa fa-spinner fa-pulse");

--- a/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/domain.volt
+++ b/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/domain.volt
@@ -35,12 +35,12 @@ POSSIBILITY OF SUCH DAMAGE.
          *************************************************************************************************************/
 
         $("#grid-domains").UIBootgrid(
-            {   'search':'/api/postfix/user/searchDomain',
-                'get':'/api/postfix/user/getDomain/',
-                'set':'/api/postfix/user/setDomain/',
-                'add':'/api/postfix/user/addDomain/',
-                'del':'/api/postfix/user/delDomain/',
-                'toggle':'/api/postfix/user/toggleDomain/'
+            {   'search':'/api/postfix/domain/searchDomain',
+                'get':'/api/postfix/domain/getDomain/',
+                'set':'/api/postfix/domain/setDomain/',
+                'add':'/api/postfix/domain/addDomain/',
+                'del':'/api/postfix/domain/delDomain/',
+                'toggle':'/api/postfix/domain/toggleDomain/'
             }
         );
 

--- a/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/domain.volt
+++ b/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/domain.volt
@@ -53,7 +53,7 @@ POSSIBILITY OF SUCH DAMAGE.
          */
         $("#reconfigureAct").click(function(){
             $("#reconfigureAct_progress").addClass("fa fa-spinner fa-pulse");
-            ajaxCall(url="/api/postfix/service/make-transport", sendData={});
+            ajaxCall(url="/api/postfix/service/maketransport", sendData={});
             ajaxCall(url="/api/postfix/service/reconfigure", sendData={}, callback=function(data,status) {
                 // when done, disable progress animation.
                 $("#reconfigureAct_progress").removeClass("fa fa-spinner fa-pulse");
@@ -66,6 +66,7 @@ POSSIBILITY OF SUCH DAMAGE.
                         draggable: true
                     });
                 } else {
+                    ajaxCall(url="/api/postfix/service/maketransport", sendData={});
                     ajaxCall(url="/api/postfix/service/reconfigure", sendData={});
                 }
             });

--- a/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/domain.volt
+++ b/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/domain.volt
@@ -53,7 +53,6 @@ POSSIBILITY OF SUCH DAMAGE.
          */
         $("#reconfigureAct").click(function(){
             $("#reconfigureAct_progress").addClass("fa fa-spinner fa-pulse");
-            ajaxCall(url="/api/postfix/service/maketransport", sendData={});
             ajaxCall(url="/api/postfix/service/reconfigure", sendData={}, callback=function(data,status) {
                 // when done, disable progress animation.
                 $("#reconfigureAct_progress").removeClass("fa fa-spinner fa-pulse");
@@ -66,7 +65,6 @@ POSSIBILITY OF SUCH DAMAGE.
                         draggable: true
                     });
                 } else {
-                    ajaxCall(url="/api/postfix/service/maketransport", sendData={});
                     ajaxCall(url="/api/postfix/service/reconfigure", sendData={});
                 }
             });

--- a/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/general.volt
+++ b/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/general.volt
@@ -1,0 +1,62 @@
+{#
+
+OPNsense® is Copyright © 2014 – 2017 by Deciso B.V.
+This file is Copyright © 2017 by Michael Muenz
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1.  Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+2.  Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+#}
+
+<div class="content-box" style="padding-bottom: 1.5em;">
+    {{ partial("layout_partials/base_form",['fields':generalForm,'id':'frm_general_settings'])}}
+    <hr />
+    <div class="col-md-12">
+        <button class="btn btn-primary" id="saveAct" type="button"><b>{{ lang._('Save') }}</b> <i id="saveAct_progress" class=""></i></button>
+    </div>
+</div>
+
+<script type="text/javascript">
+    $( document ).ready(function () {
+        var data_get_map = {'frm_general_settings':"/api/freeradius/general/get"};
+        mapDataToFormUI(data_get_map).done(function (data) {
+            formatTokenizersUI();
+            $('.selectpicker').selectpicker('refresh');
+        });
+        ajaxCall(url="/api/freeradius/service/status", sendData={}, callback=function (data, status) {
+            updateServiceStatusUI(data['status']);
+        });
+
+        // link save button to API set action
+        $("#saveAct").click(function () {
+            saveFormToEndpoint(url="/api/freeradius/general/set", formid='frm_general_settings',callback_ok=function () {
+            $("#saveAct_progress").addClass("fa fa-spinner fa-pulse");
+                ajaxCall(url="/api/freeradius/service/reconfigure", sendData={}, callback=function (data,status) {
+                    ajaxCall(url="/api/freeradius/service/status", sendData={}, callback=function (data,status) {
+                        updateServiceStatusUI(data['status']);
+                    });
+                    $("#saveAct_progress").removeClass("fa fa-spinner fa-pulse");
+                });
+            });
+        });
+    });
+</script>

--- a/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/general.volt
+++ b/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/general.volt
@@ -85,11 +85,11 @@ POSSIBILITY OF SUCH DAMAGE.
             saveFormToEndpoint(url="/api/postfix/antispam/set", formid='frm_antispam_settings',callback_ok=function(){
 		    $("#saveAct2_progress").addClass("fa fa-spinner fa-pulse");
                 ajaxCall(url="/api/postfix/service/maketransport", sendData={});
-                ajaxCall(url="/api/postfix/antispam/reconfigure", sendData={}, callback=function(data,status) {
-                    ajaxCall(url="/api/postfix/antispam/status", sendData={}, callback=function(data,status) {
+                ajaxCall(url="/api/postfix/service/reconfigure", sendData={}, callback=function(data,status) {
+                    ajaxCall(url="/api/postfix/service/status", sendData={}, callback=function(data,status) {
                         updateServiceStatusUI(data['status']);
                     });
-			        $("#saveAct2_progress").removeClass("fa fa-spinner fa-pulse");
+	            $("#saveAct2_progress").removeClass("fa fa-spinner fa-pulse");
                 });
             });
         });

--- a/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/general.volt
+++ b/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/general.volt
@@ -26,7 +26,9 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
 #}
-
+<div class="alert alert-warning" role="alert" id="missing_rspamd" style="display:none;min-height:65px;">
+    <div style="margin-top: 8px;">{{ lang._('No Rspamd plugin found, please install via System > Firmware > Plugins.')}}</div>
+</div>
 <ul class="nav nav-tabs" data-tabs="tabs" id="maintabs">
     <li class="active"><a data-toggle="tab" href="#general">{{ lang._('General') }}</a></li>
     <li><a data-toggle="tab" href="#antispam">{{ lang._('Antispam') }}</a></li>
@@ -66,6 +68,13 @@ POSSIBILITY OF SUCH DAMAGE.
         });
         ajaxCall(url="/api/postfix/service/status", sendData={}, callback=function (data, status) {
             updateServiceStatusUI(data['status']);
+        });
+
+	// check if Rspamd plugin is installed
+        ajaxCall(url="/api/postfix/service/checkrspmad", sendData={}, callback=function(data,status) {
+	    if (data == "0") {
+                $('#missing_rspamd').show();
+            }
         });
 
         // link save button to API set action

--- a/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/general.volt
+++ b/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/general.volt
@@ -71,7 +71,7 @@ POSSIBILITY OF SUCH DAMAGE.
         });
 
 	// check if Rspamd plugin is installed
-        ajaxCall(url="/api/postfix/service/checkrspmad", sendData={}, callback=function(data,status) {
+        ajaxCall(url="/api/postfix/service/checkrspamd", sendData={}, callback=function(data,status) {
 	    if (data == "0") {
                 $('#missing_rspamd').show();
             }

--- a/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/general.volt
+++ b/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/general.volt
@@ -56,16 +56,12 @@ POSSIBILITY OF SUCH DAMAGE.
 
 <script type="text/javascript">
     $( document ).ready(function () {
-        var data_get_map = {'frm_general_settings':"/api/postfix/general/get"};
+        var data_get_map = {'frm_general_settings':"/api/postfix/general/get", 'frm_antivirus_settings':"/api/postfix/antispam/get"};
         mapDataToFormUI(data_get_map).done(function (data) {
             formatTokenizersUI();
             $('.selectpicker').selectpicker('refresh');
         });
-        var data_get_map2 = {'frm_antivirus_settings':"/api/postfix/antispam/get"};
-        mapDataToFormUI(data_get_map2).done(function(data){
-            formatTokenizersUI();
-            $('.selectpicker').selectpicker('refresh');
-        });
+
         ajaxCall(url="/api/postfix/service/status", sendData={}, callback=function (data, status) {
             updateServiceStatusUI(data['status']);
         });

--- a/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/general.volt
+++ b/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/general.volt
@@ -50,6 +50,7 @@ POSSIBILITY OF SUCH DAMAGE.
         $("#saveAct").click(function () {
             saveFormToEndpoint(url="/api/postfix/general/set", formid='frm_general_settings',callback_ok=function () {
             $("#saveAct_progress").addClass("fa fa-spinner fa-pulse");
+                ajaxCall(url="/api/postfix/service/maketransport", sendData={});
                 ajaxCall(url="/api/postfix/service/reconfigure", sendData={}, callback=function (data,status) {
                     ajaxCall(url="/api/postfix/service/status", sendData={}, callback=function (data,status) {
                         updateServiceStatusUI(data['status']);

--- a/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/general.volt
+++ b/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/general.volt
@@ -43,7 +43,7 @@ POSSIBILITY OF SUCH DAMAGE.
     <div id="antispam" class="tab-pane fade in">
         <div class="content-box" style="padding-bottom: 1.5em;">
 	    <div class="alert alert-warning" role="alert" id="missing_rspamd" style="display:none;min-height:65px;">
-                <div style="margin-top: 8px;">{{ lang._('No Rspamd plugin found, please install via System > Firmware > Plugins.')}}</div>
+                <div style="margin-top: 8px;">{{ lang._('No Rspamd plugin found, please install and come back.')}}</div>
             </div>
             {{ partial("layout_partials/base_form",['fields':antispamForm,'id':'frm_antispam_settings'])}}
             <hr />

--- a/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/general.volt
+++ b/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/general.volt
@@ -26,9 +26,6 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
 #}
-<div class="alert alert-warning" role="alert" id="missing_rspamd" style="display:none;min-height:65px;">
-    <div style="margin-top: 8px;">{{ lang._('No Rspamd plugin found, please install via System > Firmware > Plugins.')}}</div>
-</div>
 <ul class="nav nav-tabs" data-tabs="tabs" id="maintabs">
     <li class="active"><a data-toggle="tab" href="#general">{{ lang._('General') }}</a></li>
     <li><a data-toggle="tab" href="#antispam">{{ lang._('Antispam') }}</a></li>
@@ -45,6 +42,9 @@ POSSIBILITY OF SUCH DAMAGE.
     </div>
     <div id="antispam" class="tab-pane fade in">
         <div class="content-box" style="padding-bottom: 1.5em;">
+	    <div class="alert alert-warning" role="alert" id="missing_rspamd" style="display:none;min-height:65px;">
+                <div style="margin-top: 8px;">{{ lang._('No Rspamd plugin found, please install via System > Firmware > Plugins.')}}</div>
+            </div>
             {{ partial("layout_partials/base_form",['fields':antispamForm,'id':'frm_antispam_settings'])}}
             <hr />
             <div class="col-md-12">

--- a/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/general.volt
+++ b/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/general.volt
@@ -27,11 +27,28 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #}
 
-<div class="content-box" style="padding-bottom: 1.5em;">
-    {{ partial("layout_partials/base_form",['fields':generalForm,'id':'frm_general_settings'])}}
-    <hr />
-    <div class="col-md-12">
-        <button class="btn btn-primary" id="saveAct" type="button"><b>{{ lang._('Save') }}</b> <i id="saveAct_progress" class=""></i></button>
+<ul class="nav nav-tabs" data-tabs="tabs" id="maintabs">
+    <li class="active"><a data-toggle="tab" href="#general">{{ lang._('General') }}</a></li>
+    <li><a data-toggle="tab" href="#antispam">{{ lang._('Antispam') }}</a></li>
+</ul>
+<div class="tab-content content-box tab-content">
+    <div id="general" class="tab-pane fade in active">
+        <div class="content-box" style="padding-bottom: 1.5em;">
+            {{ partial("layout_partials/base_form",['fields':generalForm,'id':'frm_general_settings'])}}
+            <hr />
+            <div class="col-md-12">
+                <button class="btn btn-primary"  id="saveAct" type="button"><b>{{ lang._('Save') }}</b><i id="saveAct_progress" class=""></i></button>
+            </div>
+        </div>
+    </div>
+    <div id="antispam" class="tab-pane fade in">
+        <div class="content-box" style="padding-bottom: 1.5em;">
+            {{ partial("layout_partials/base_form",['fields':antispamForm,'id':'frm_antispam_settings'])}}
+            <hr />
+            <div class="col-md-12">
+                <button class="btn btn-primary"  id="saveAct2" type="button"><b>{{ lang._('Save') }}</b><i id="saveAct2_progress" class=""></i></button>
+            </div>
+        </div>
     </div>
 </div>
 
@@ -39,6 +56,11 @@ POSSIBILITY OF SUCH DAMAGE.
     $( document ).ready(function () {
         var data_get_map = {'frm_general_settings':"/api/postfix/general/get"};
         mapDataToFormUI(data_get_map).done(function (data) {
+            formatTokenizersUI();
+            $('.selectpicker').selectpicker('refresh');
+        });
+        var data_get_map2 = {'frm_antivirus_settings':"/api/postfix/antispam/get"};
+        mapDataToFormUI(data_get_map2).done(function(data){
             formatTokenizersUI();
             $('.selectpicker').selectpicker('refresh');
         });
@@ -56,6 +78,18 @@ POSSIBILITY OF SUCH DAMAGE.
                         updateServiceStatusUI(data['status']);
                     });
                     $("#saveAct_progress").removeClass("fa fa-spinner fa-pulse");
+                });
+            });
+        });
+        $("#saveAct2").click(function(){
+            saveFormToEndpoint(url="/api/postfix/antispam/set", formid='frm_antispam_settings',callback_ok=function(){
+		    $("#saveAct2_progress").addClass("fa fa-spinner fa-pulse");
+                ajaxCall(url="/api/postfix/service/maketransport", sendData={});
+                ajaxCall(url="/api/postfix/antispam/reconfigure", sendData={}, callback=function(data,status) {
+                    ajaxCall(url="/api/postfix/antispam/status", sendData={}, callback=function(data,status) {
+                        updateServiceStatusUI(data['status']);
+                    });
+			        $("#saveAct2_progress").removeClass("fa fa-spinner fa-pulse");
                 });
             });
         });

--- a/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/general.volt
+++ b/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/general.volt
@@ -37,21 +37,21 @@ POSSIBILITY OF SUCH DAMAGE.
 
 <script type="text/javascript">
     $( document ).ready(function () {
-        var data_get_map = {'frm_general_settings':"/api/freeradius/general/get"};
+        var data_get_map = {'frm_general_settings':"/api/postfix/general/get"};
         mapDataToFormUI(data_get_map).done(function (data) {
             formatTokenizersUI();
             $('.selectpicker').selectpicker('refresh');
         });
-        ajaxCall(url="/api/freeradius/service/status", sendData={}, callback=function (data, status) {
+        ajaxCall(url="/api/postfix/service/status", sendData={}, callback=function (data, status) {
             updateServiceStatusUI(data['status']);
         });
 
         // link save button to API set action
         $("#saveAct").click(function () {
-            saveFormToEndpoint(url="/api/freeradius/general/set", formid='frm_general_settings',callback_ok=function () {
+            saveFormToEndpoint(url="/api/postfix/general/set", formid='frm_general_settings',callback_ok=function () {
             $("#saveAct_progress").addClass("fa fa-spinner fa-pulse");
-                ajaxCall(url="/api/freeradius/service/reconfigure", sendData={}, callback=function (data,status) {
-                    ajaxCall(url="/api/freeradius/service/status", sendData={}, callback=function (data,status) {
+                ajaxCall(url="/api/postfix/service/reconfigure", sendData={}, callback=function (data,status) {
+                    ajaxCall(url="/api/postfix/service/status", sendData={}, callback=function (data,status) {
                         updateServiceStatusUI(data['status']);
                     });
                     $("#saveAct_progress").removeClass("fa fa-spinner fa-pulse");

--- a/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/general.volt
+++ b/net/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/general.volt
@@ -81,7 +81,6 @@ POSSIBILITY OF SUCH DAMAGE.
         $("#saveAct").click(function () {
             saveFormToEndpoint(url="/api/postfix/general/set", formid='frm_general_settings',callback_ok=function () {
             $("#saveAct_progress").addClass("fa fa-spinner fa-pulse");
-                ajaxCall(url="/api/postfix/service/maketransport", sendData={});
                 ajaxCall(url="/api/postfix/service/reconfigure", sendData={}, callback=function (data,status) {
                     ajaxCall(url="/api/postfix/service/status", sendData={}, callback=function (data,status) {
                         updateServiceStatusUI(data['status']);
@@ -93,7 +92,6 @@ POSSIBILITY OF SUCH DAMAGE.
         $("#saveAct2").click(function(){
             saveFormToEndpoint(url="/api/postfix/antispam/set", formid='frm_antispam_settings',callback_ok=function(){
 		    $("#saveAct2_progress").addClass("fa fa-spinner fa-pulse");
-                ajaxCall(url="/api/postfix/service/maketransport", sendData={});
                 ajaxCall(url="/api/postfix/service/reconfigure", sendData={}, callback=function(data,status) {
                     ajaxCall(url="/api/postfix/service/status", sendData={}, callback=function(data,status) {
                         updateServiceStatusUI(data['status']);

--- a/net/postfix/src/opnsense/scripts/OPNsense/Postfix/setup.sh
+++ b/net/postfix/src/opnsense/scripts/OPNsense/Postfix/setup.sh
@@ -5,7 +5,7 @@ chown root:wheel /var/spool/postfix
 chmod 755 /var/spool/postfix 
 
 # Set defaults
-POSTFIX_DIRS="/var/spool/postfix/active /var/spool/postfix/bounce /var/spool/postfix/corrup /var/spool/postfix/defer /var/spool/postfix/deferred /var/spool/postfix/flush /var/spool/postfix/hold /var/spool/postfix/incoming /var/spool/postfix/private /var/spool/postfix/saved /var/spool/postfix/trace /var/db/postfix"
+POSTFIX_DIRS="/var/spool/postfix/active /var/spool/postfix/bounce /var/spool/postfix/corrupt /var/spool/postfix/defer /var/spool/postfix/deferred /var/spool/postfix/flush /var/spool/postfix/hold /var/spool/postfix/incoming /var/spool/postfix/private /var/spool/postfix/saved /var/spool/postfix/trace /var/db/postfix"
 POSTFIX_USER=postfix
 POSTFIX_GROUP=wheel
 

--- a/net/postfix/src/opnsense/scripts/OPNsense/Postfix/setup.sh
+++ b/net/postfix/src/opnsense/scripts/OPNsense/Postfix/setup.sh
@@ -10,4 +10,4 @@ for DIR in ${POSTFIX_DIRS}; do
 	chown -R ${POSTFIX_USER}:${POSTFIX_GROUP} ${DIR}
 done
 
-
+postmap /usr/local/etc/postfix/transport

--- a/net/postfix/src/opnsense/scripts/OPNsense/Postfix/setup.sh
+++ b/net/postfix/src/opnsense/scripts/OPNsense/Postfix/setup.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 
+mkdir /var/spool/postfix/
+chown root:wheel /var/spool/postfix 
+chmod 755 /var/spool/postfix 
+
 # Set defaults
-POSTFIX_DIRS="/var/spool/postfix /var/db/postfix"
+POSTFIX_DIRS="/var/spool/postfix/active /var/spool/postfix/bounce /var/spool/postfix/corrup /var/spool/postfix/defer /var/spool/postfix/deferred /var/spool/postfix/flush /var/spool/postfix/hold /var/spool/postfix/incoming /var/spool/postfix/private /var/spool/postfix/saved /var/spool/postfix/trace /var/db/postfix"
 POSTFIX_USER=postfix
 POSTFIX_GROUP=wheel
 

--- a/net/postfix/src/opnsense/scripts/OPNsense/Postfix/setup.sh
+++ b/net/postfix/src/opnsense/scripts/OPNsense/Postfix/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-mkdir /var/spool/postfix/
+mkdir -p /var/spool/postfix/
 chown root:wheel /var/spool/postfix 
 chmod 755 /var/spool/postfix 
 

--- a/net/postfix/src/opnsense/scripts/OPNsense/Postfix/setup.sh
+++ b/net/postfix/src/opnsense/scripts/OPNsense/Postfix/setup.sh
@@ -1,3 +1,26 @@
 #!/bin/sh
 
+# Set defaults
+POSTFIX_DIRS="/var/spool/postfix /var/db/postfix"
+POSTFIX_USER=postfix
+POSTFIX_GROUP=wheel
+
+for DIR in ${POSTFIX_DIRS}; do
+	mkdir -p ${DIR}
+	chmod -R 700 ${DIR}
+	chown -R ${POSTFIX_USER}:${POSTFIX_GROUP} ${DIR}
+done
+
+# Some folders need special attention
+mkdir -p /var/spool/postfix/maildrop
+mkdir -p /var/spool/postfix/public
+mkdir -p /var/spool/postfix/pid
+chmod -R 730 /var/spool/postfix/maildrop
+chmod -R 710 /var/spool/postfix/public
+chmod -R 755 /var/spool/postfix/pid
+chown -R postfix:maildrop /var/spool/postfix/maildrop
+chown -R postfix:maildrop /var/spool/postfix/public
+chown -R root:postfix /var/spool/postfix/pid
+
+# Create Transporttable
 postmap /usr/local/etc/postfix/transport

--- a/net/postfix/src/opnsense/scripts/OPNsense/Postfix/setup.sh
+++ b/net/postfix/src/opnsense/scripts/OPNsense/Postfix/setup.sh
@@ -1,13 +1,3 @@
 #!/bin/sh
 
-POSTFIX_DIRS="/var/spool/postfix /var/db/postfix"
-POSTFIX_USER=postfix
-POSTFIX_GROUP=postfix
-
-for DIR in ${POSTFIX_DIRS}; do
-	mkdir -p ${DIR}
-	chmod -R 750 ${DIR}
-	chown -R ${POSTFIX_USER}:${POSTFIX_GROUP} ${DIR}
-done
-
 postmap /usr/local/etc/postfix/transport

--- a/net/postfix/src/opnsense/scripts/OPNsense/Postfix/setup.sh
+++ b/net/postfix/src/opnsense/scripts/OPNsense/Postfix/setup.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+POSTFIX_DIRS="/var/spool/postfix /var/db/postfix"
+POSTFIX_USER=postfix
+POSTFIX_GROUP=postfix
+
+for DIR in ${POSTFIX_DIRS}; do
+	mkdir -p ${DIR}
+	chmod -R 750 ${DIR}
+	chown -R ${POSTFIX_USER}:${POSTFIX_GROUP} ${DIR}
+done
+
+

--- a/net/postfix/src/opnsense/service/conf/actions.d/actions_postfix.conf
+++ b/net/postfix/src/opnsense/service/conf/actions.d/actions_postfix.conf
@@ -1,0 +1,35 @@
+[start]
+command:/usr/local/opnsense/scripts/OPNsense/Postfix/setup.sh;/usr/local/etc/rc.d/postfix start
+parameters:
+type:script
+message:starting Postfix
+
+[stop]
+command:/usr/local/etc/rc.d/postfix stop; exit 0
+parameters:
+type:script
+message:stopping Postfix
+
+[restart]
+command:/usr/local/opnsense/scripts/OPNsense/Postfix/setup.sh;/usr/local/etc/rc.d/postfix restart
+parameters:
+type:script
+message:restarting Postfix
+
+[reconfigure]
+command:/usr/local/opnsense/scripts/OPNsense/Postfix/setup.sh;/usr/local/etc/rc.d/postfix reload
+parameters:
+type:script
+message:reconfigure Postfix
+
+[status]
+command:/usr/local/etc/rc.d/postfix status;exit 0
+parameters:
+type:script_output
+message:request Postfix status
+
+[make-transport]
+command:postmap /usr/local/etc/postfix/transport
+parameters:
+type:script_output
+message:rebuilding Transporttable

--- a/net/postfix/src/opnsense/service/templates/OPNsense/Postfix/+TARGETS
+++ b/net/postfix/src/opnsense/service/templates/OPNsense/Postfix/+TARGETS
@@ -1,0 +1,4 @@
+main.cf:/usr/local/etc/postfix/main.cf
+master.cf:/usr/local/etc/postfix/master.cf
+postfix:/etc/rc.conf.d/postfix
+transport:/usr/local/etc/postfix/transport

--- a/net/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
+++ b/net/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
@@ -70,6 +70,6 @@ non_smtpd_milters = inet:localhost:11332
 milter_protocol = 6
 milter_mail_macros =  i {mail_addr} {client_addr} {client_name} {auth_authen}
 milter_default_action = accept
-{% else %}
+{% endif %}
 
 {% endif %}

--- a/net/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
+++ b/net/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
@@ -39,7 +39,7 @@ myhostname = {{ system.hostname }}
 {% if helpers.exists('OPNsense.postfix.general.mydomain') and OPNsense.postfix.general.mydomain != '' %}
 mydomain = {{ OPNsense.postfix.general.mydomain }}
 {% else %}
-mydomain = {{ system.domainname }}
+mydomain = {{ system.domain }}
 {% endif %}
 {% if helpers.exists('OPNsense.postfix.general.myorigin') and OPNsense.postfix.general.myorigin != '' %}
 myorigin = {{ OPNsense.postfix.general.myorigin }}

--- a/net/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
+++ b/net/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
@@ -27,6 +27,8 @@ readme_directory = no
 inet_protocols = all
 meta_directory = /usr/local/libexec/postfix
 shlib_directory = /usr/local/lib/postfix
+relay_domains = hash:/usr/local/etc/postfix/transport
+transport_maps = hash:/usr/local/etc/postfix/transport
 ##########################
 # END SYSTEM DEFAULTS
 ##########################

--- a/net/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
+++ b/net/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
@@ -64,4 +64,12 @@ smtpd_banner = {{ OPNsense.postfix.general.banner }}
 smtpd_banner = $myhostname ESMTP Postfix
 {% endif %}
 
+{% if helpers.exists('OPNsense.postfix.antispam.enable_rspamd') and OPNsense.postfix.antispam.enable_rspamd == '1' %}
+smtpd_milters = inet:localhost:11332
+non_smtpd_milters = inet:localhost:11332
+milter_protocol = 6
+milter_mail_macros =  i {mail_addr} {client_addr} {client_name} {auth_authen}
+milter_default_action = accept
+{% else %}
+
 {% endif %}

--- a/net/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
+++ b/net/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
@@ -1,0 +1,65 @@
+{% if helpers.exists('OPNsense.postfix.general.enabled') and OPNsense.postfix.general.enabled == '1' %}
+
+##########################
+# START SYSTEM DEFAULTS
+##########################
+compatibility_level = 2
+queue_directory = /var/spool/postfix
+command_directory = /usr/local/sbin
+daemon_directory = /usr/local/libexec/postfix
+data_directory = /var/db/postfix
+mail_owner = postfix
+unknown_local_recipient_reject_code = 550
+mynetworks_style = host
+debug_peer_level = 2
+debugger_command =
+         PATH=/bin:/usr/bin:/usr/local/bin:/usr/X11R6/bin
+         ddd $daemon_directory/$process_name $process_id & sleep 5
+
+sendmail_path = /usr/local/sbin/sendmail
+newaliases_path = /usr/local/bin/newaliases
+mailq_path = /usr/local/bin/mailq
+setgid_group = maildrop
+html_directory = no
+manpage_directory = /usr/local/man
+sample_directory = /usr/local/etc/postfix
+readme_directory = no
+inet_protocols = all
+meta_directory = /usr/local/libexec/postfix
+shlib_directory = /usr/local/lib/postfix
+##########################
+# END SYSTEM DEFAULTS
+##########################
+
+{% if helpers.exists('OPNsense.postfix.general.myhostname') and OPNsense.postfix.general.myhostname != '' %}
+myhostname = {{ OPNsense.postfix.general.myhostname }}
+{% else %}
+myhostname = {{ system.hostname }}
+{% endif %}
+{% if helpers.exists('OPNsense.postfix.general.mydomain') and OPNsense.postfix.general.mydomain != '' %}
+mydomain = {{ OPNsense.postfix.general.mydomain }}
+{% else %}
+mydomain = {{ system.domainname }}
+{% endif %}
+{% if helpers.exists('OPNsense.postfix.general.myorigin') and OPNsense.postfix.general.myorigin != '' %}
+myorigin = {{ OPNsense.postfix.general.myorigin }}
+{% else %}
+myorigin = $myhostname
+{% endif %}
+{% if helpers.exists('OPNsense.postfix.general.inet_interfaces') and OPNsense.postfix.general.inet_interfaces != '' %}
+inet_interfaces = {{ OPNsense.postfix.general.inet_interfaces }}
+{% else %}
+inet_interfaces = ALL
+{% endif %}
+{% if helpers.exists('OPNsense.postfix.general.mynetworks') and OPNsense.postfix.general.mynetworks != '' %}
+mynetworks = {{ OPNsense.postfix.general.mynetworks }}
+{% else %}
+mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
+{% endif %}
+{% if helpers.exists('OPNsense.postfix.general.banner') and OPNsense.postfix.general.banner != '' %}
+smtpd_banner = {{ OPNsense.postfix.general.banner }}
+{% else %}
+smtpd_banner = $myhostname ESMTP Postfix
+{% endif %}
+
+{% endif %}

--- a/net/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
+++ b/net/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
@@ -49,7 +49,7 @@ myorigin = $myhostname
 {% if helpers.exists('OPNsense.postfix.general.inet_interfaces') and OPNsense.postfix.general.inet_interfaces != '' %}
 inet_interfaces = {{ OPNsense.postfix.general.inet_interfaces }}
 {% else %}
-inet_interfaces = ALL
+inet_interfaces = all
 {% endif %}
 {% if helpers.exists('OPNsense.postfix.general.mynetworks') and OPNsense.postfix.general.mynetworks != '' %}
 mynetworks = {{ OPNsense.postfix.general.mynetworks }}

--- a/net/postfix/src/opnsense/service/templates/OPNsense/Postfix/master.cf
+++ b/net/postfix/src/opnsense/service/templates/OPNsense/Postfix/master.cf
@@ -1,0 +1,135 @@
+{% if helpers.exists('OPNsense.postfix.general.enabled') and OPNsense.postfix.general.enabled == '1' %}
+#
+# Postfix master process configuration file.  For details on the format
+# of the file, see the master(5) manual page (command: "man 5 master" or
+# on-line: http://www.postfix.org/master.5.html).
+#
+# Do not forget to execute "postfix reload" after editing this file.
+#
+# ==========================================================================
+# service type  private unpriv  chroot  wakeup  maxproc command + args
+#               (yes)   (yes)   (no)    (never) (100)
+# ==========================================================================
+smtp      inet  n       -       n       -       -       smtpd
+#smtp      inet  n       -       n       -       1       postscreen
+#smtpd     pass  -       -       n       -       -       smtpd
+#dnsblog   unix  -       -       n       -       0       dnsblog
+#tlsproxy  unix  -       -       n       -       0       tlsproxy
+#submission inet n       -       n       -       -       smtpd
+#  -o syslog_name=postfix/submission
+#  -o smtpd_tls_security_level=encrypt
+#  -o smtpd_sasl_auth_enable=yes
+#  -o smtpd_tls_auth_only=yes
+#  -o smtpd_reject_unlisted_recipient=no
+#  -o smtpd_client_restrictions=$mua_client_restrictions
+#  -o smtpd_helo_restrictions=$mua_helo_restrictions
+#  -o smtpd_sender_restrictions=$mua_sender_restrictions
+#  -o smtpd_recipient_restrictions=
+#  -o smtpd_relay_restrictions=permit_sasl_authenticated,reject
+#  -o milter_macro_daemon_name=ORIGINATING
+#smtps     inet  n       -       n       -       -       smtpd
+#  -o syslog_name=postfix/smtps
+#  -o smtpd_tls_wrappermode=yes
+#  -o smtpd_sasl_auth_enable=yes
+#  -o smtpd_reject_unlisted_recipient=no
+#  -o smtpd_client_restrictions=$mua_client_restrictions
+#  -o smtpd_helo_restrictions=$mua_helo_restrictions
+#  -o smtpd_sender_restrictions=$mua_sender_restrictions
+#  -o smtpd_recipient_restrictions=
+#  -o smtpd_relay_restrictions=permit_sasl_authenticated,reject
+#  -o milter_macro_daemon_name=ORIGINATING
+#628       inet  n       -       n       -       -       qmqpd
+pickup    unix  n       -       n       60      1       pickup
+cleanup   unix  n       -       n       -       0       cleanup
+qmgr      unix  n       -       n       300     1       qmgr
+#qmgr     unix  n       -       n       300     1       oqmgr
+tlsmgr    unix  -       -       n       1000?   1       tlsmgr
+rewrite   unix  -       -       n       -       -       trivial-rewrite
+bounce    unix  -       -       n       -       0       bounce
+defer     unix  -       -       n       -       0       bounce
+trace     unix  -       -       n       -       0       bounce
+verify    unix  -       -       n       -       1       verify
+flush     unix  n       -       n       1000?   0       flush
+proxymap  unix  -       -       n       -       -       proxymap
+proxywrite unix -       -       n       -       1       proxymap
+smtp      unix  -       -       n       -       -       smtp
+relay     unix  -       -       n       -       -       smtp
+#       -o smtp_helo_timeout=5 -o smtp_connect_timeout=5
+showq     unix  n       -       n       -       -       showq
+error     unix  -       -       n       -       -       error
+retry     unix  -       -       n       -       -       error
+discard   unix  -       -       n       -       -       discard
+local     unix  -       n       n       -       -       local
+virtual   unix  -       n       n       -       -       virtual
+lmtp      unix  -       -       n       -       -       lmtp
+anvil     unix  -       -       n       -       1       anvil
+scache    unix  -       -       n       -       1       scache
+#
+# ====================================================================
+# Interfaces to non-Postfix software. Be sure to examine the manual
+# pages of the non-Postfix software to find out what options it wants.
+#
+# Many of the following services use the Postfix pipe(8) delivery
+# agent.  See the pipe(8) man page for information about ${recipient}
+# and other message envelope options.
+# ====================================================================
+#
+# maildrop. See the Postfix MAILDROP_README file for details.
+# Also specify in main.cf: maildrop_destination_recipient_limit=1
+#
+#maildrop  unix  -       n       n       -       -       pipe
+#  flags=DRhu user=vmail argv=/usr/local/bin/maildrop -d ${recipient}
+#
+# ====================================================================
+#
+# Recent Cyrus versions can use the existing "lmtp" master.cf entry.
+#
+# Specify in cyrus.conf:
+#   lmtp    cmd="lmtpd -a" listen="localhost:lmtp" proto=tcp4
+#
+# Specify in main.cf one or more of the following:
+#  mailbox_transport = lmtp:inet:localhost
+#  virtual_transport = lmtp:inet:localhost
+#
+# ====================================================================
+#
+# Cyrus 2.1.5 (Amos Gouaux)
+# Also specify in main.cf: cyrus_destination_recipient_limit=1
+#
+#cyrus     unix  -       n       n       -       -       pipe
+#  user=cyrus argv=/cyrus/bin/deliver -e -r ${sender} -m ${extension} ${user}
+#
+# ====================================================================
+#
+# Old example of delivery via Cyrus.
+#
+#old-cyrus unix  -       n       n       -       -       pipe
+#  flags=R user=cyrus argv=/cyrus/bin/deliver -e -m ${extension} ${user}
+#
+# ====================================================================
+#
+# See the Postfix UUCP_README file for configuration details.
+#
+#uucp      unix  -       n       n       -       -       pipe
+#  flags=Fqhu user=uucp argv=uux -r -n -z -a$sender - $nexthop!rmail ($recipient)
+#
+# ====================================================================
+#
+# Other external delivery methods.
+#
+#ifmail    unix  -       n       n       -       -       pipe
+#  flags=F user=ftn argv=/usr/lib/ifmail/ifmail -r $nexthop ($recipient)
+#
+#bsmtp     unix  -       n       n       -       -       pipe
+#  flags=Fq. user=bsmtp argv=/usr/local/sbin/bsmtp -f $sender $nexthop $recipient
+#
+#scalemail-backend unix -       n       n       -       2       pipe
+#  flags=R user=scalemail argv=/usr/lib/scalemail/bin/scalemail-store
+#  ${nexthop} ${user} ${extension}
+#
+#mailman   unix  -       n       n       -       -       pipe
+#  flags=FR user=list argv=/usr/lib/mailman/bin/postfix-to-mailman.py
+#  ${nexthop} ${user}
+
+
+{% endif %}

--- a/net/postfix/src/opnsense/service/templates/OPNsense/Postfix/postfix
+++ b/net/postfix/src/opnsense/service/templates/OPNsense/Postfix/postfix
@@ -1,0 +1,6 @@
+{% if helpers.exists('OPNsense.postfix.general.enabled') and OPNsense.postfix.general.enabled == '1' %}
+postfix_opnsense_bootup_run="/usr/local/opnsense/scripts/OPNsense/Postfix/setup.sh"
+postfix_enable="YES"
+{% else %}
+postfix_enable="NO"
+{% endif %}

--- a/net/postfix/src/opnsense/service/templates/OPNsense/Postfix/transport
+++ b/net/postfix/src/opnsense/service/templates/OPNsense/Postfix/transport
@@ -1,6 +1,6 @@
 {% if helpers.exists('OPNsense.postfix.general.enabled') and OPNsense.postfix.general.enabled == '1' %}
-{%   if helpers.exists('OPNsense.postfix.general.domains.domain') %}
-{%     for domain in helpers.toList('OPNsense.postfix.general.domains.domain') %}
+{%   if helpers.exists('OPNsense.postfix.domain.domains.domain') %}
+{%     for domain in helpers.toList('OPNsense.postfix.domain.domains.domain') %}
 {%       if domain.enabled == '1' %}
 {{ domain.domainname }} smtp:{{ domain.destination }}
 {%       endif %}

--- a/net/postfix/src/opnsense/service/templates/OPNsense/Postfix/transport
+++ b/net/postfix/src/opnsense/service/templates/OPNsense/Postfix/transport
@@ -1,0 +1,9 @@
+{% if helpers.exists('OPNsense.postfix.general.enabled') and OPNsense.postfix.general.enabled == '1' %}
+{%   if helpers.exists('OPNsense.postfix.general.domains.domain') %}
+{%     for domain in helpers.toList('OPNsense.postfix.general.domains.domain') %}
+{%       if domain.enabled == '1' %}
+{{ domain.domainname }} smtp:{{ domain.destination }}
+{%       endif %}
+{%     endfor %}
+{%   endif %}
+{% endif %}


### PR DESCRIPTION
This has to stay in master for a while, perhaps a release with 18.1 would be nice. 

ATM it supports:

Postfix general features like mydomain etc.:

![image](https://user-images.githubusercontent.com/20438689/32105262-272e3850-bb28-11e7-95e9-c92f8c5b00b9.png)

An rspamd integration with plugin warning:

![image](https://user-images.githubusercontent.com/20438689/32105286-396e81fa-bb28-11e7-85d6-b9d70d740d27.png)

- Domainrouting 

![image](https://user-images.githubusercontent.com/20438689/32105324-5d80f546-bb28-11e7-93a2-ed4d39eba745.png)


What you can expect within the next dev releases is full certificate und cipher management.
I want to push it now to master to better test the integration with rspamd plugin.

Please review! :)