### PR TITLE
net/freeradius: fix super stupid mistake

### DIFF
--- a/net/freeradius/Makefile
+++ b/net/freeradius/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		freeradius
-PLUGIN_VERSION=		1.2.0
+PLUGIN_VERSION=		1.2.1
 PLUGIN_COMMENT=		RADIUS Authentication, Authorization and Accounting Server
 PLUGIN_DEPENDS=		freeradius3
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Eap.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Eap.xml
@@ -4,7 +4,7 @@
     <version>1.0.0</version>
     <items>
         <default_eap_type type="OptionField">
-            <default>MD5</default>
+            <default>md5</default>
             <Required>Y</Required>
             <multiple>N</multiple>
             <OptionValues>

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Eap.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Eap.xml
@@ -4,7 +4,7 @@
     <version>1.0.0</version>
     <items>
         <default_eap_type type="OptionField">
-            <default>md5</default>
+            <default>MD5</default>
             <Required>Y</Required>
             <multiple>N</multiple>
             <OptionValues>

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-eap
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-eap
@@ -181,7 +181,8 @@ eap {
                 private_key_password =
                 private_key_file = ${certdir}/cert_opn.pem
                 certificate_file = ${certdir}/cert_opn.pem
-{%   else %}
+{%   endif %}              
+{% else %}
                 private_key_password = whatever
                 private_key_file = ${certdir}/server.pem
                 #  If Private key & Certificate are located in
@@ -195,7 +196,6 @@ eap {
                 #  of the CA certificates used to sign the
                 #  server certificate.
                 certificate_file = ${certdir}/server.pem
-{%   endif %}
 {% endif %}
                 #  Trusted Root CA list
                 #
@@ -210,9 +210,9 @@ eap {
 {% if helpers.exists('OPNsense.freeradius.eap.enable_client_cert') and OPNsense.freeradius.eap.enable_client_cert == '1' %}
 {%   if helpers.exists('OPNsense.freeradius.eap.ca') and OPNsense.freeradius.eap.ca != '' %}
                 ca_file = ${certdir}/ca_opn.pem
-{%   else %}
-                ca_file = ${cadir}/ca.pem
 {%   endif %}
+{% else %}
+                ca_file = ${cadir}/ca.pem
 {% endif %}
                 #  OpenSSL will automatically create certificate chains,
                 #  unless we tell it to not do that.  The problem is that
@@ -298,9 +298,9 @@ eap {
 {% if helpers.exists('OPNsense.freeradius.eap.enable_client_cert') and OPNsense.freeradius.eap.enable_client_cert == '1' %}
 {%   if helpers.exists('OPNsense.freeradius.eap.crl') and OPNsense.freeradius.eap.crl != '' %}
                 check_crl = yes
-{%   else %}
-        #       check_crl = yes
 {%   endif %}
+{% else %}
+        #       check_crl = yes
 {% endif %}
                 # Check if intermediate CAs have been revoked.
         #       check_all_crl = yes

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-eap
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-eap
@@ -28,6 +28,8 @@ eap {
         #
 {% if helpers.exists('OPNsense.freeradius.eap.default_eap_type') and OPNsense.freeradius.eap.default_eap_type != '' %}
         default_eap_type = {{ OPNsense.freeradius.eap.default_eap_type }}
+{% else %}
+        default_eap_type = md5
 {% endif %}
 
         #  A list is maintained to correlate EAP-Response
@@ -194,6 +196,7 @@ eap {
                 #  server certificate.
                 certificate_file = ${certdir}/server.pem
 {%   endif %}
+{% endif %}
                 #  Trusted Root CA list
                 #
                 #  ALL of the CA's in this list will be trusted
@@ -204,11 +207,13 @@ eap {
                 #  In that case, this CA file should contain
                 #  *one* CA certificate.
                 #
+{% if helpers.exists('OPNsense.freeradius.eap.enable_client_cert') and OPNsense.freeradius.eap.enable_client_cert == '1' %}
 {%   if helpers.exists('OPNsense.freeradius.eap.ca') and OPNsense.freeradius.eap.ca != '' %}
                 ca_file = ${certdir}/ca_opn.pem
 {%   else %}
                 ca_file = ${cadir}/ca.pem
 {%   endif %}
+{% endif %}
                 #  OpenSSL will automatically create certificate chains,
                 #  unless we tell it to not do that.  The problem is that
                 #  it sometimes gets the chains right from a certificate
@@ -290,11 +295,13 @@ eap {
                 #    'c_rehash' is OpenSSL's command.
                 #  3) uncomment the lines below.
                 #  5) Restart radiusd
+{% if helpers.exists('OPNsense.freeradius.eap.enable_client_cert') and OPNsense.freeradius.eap.enable_client_cert == '1' %}
 {%   if helpers.exists('OPNsense.freeradius.eap.crl') and OPNsense.freeradius.eap.crl != '' %}
                 check_crl = yes
 {%   else %}
         #       check_crl = yes
 {%   endif %}
+{% endif %}
                 # Check if intermediate CAs have been revoked.
         #       check_all_crl = yes
 
@@ -570,7 +577,7 @@ eap {
                         # softfail = no
                 }
         }
-{% endif %}
+
         ## EAP-TLS
         #
         #  As of Version 3.0, the TLS configuration for TLS-based


### PR DESCRIPTION
Reported by Dominian via IRC
Default install loads EAP but false closing bracket when client eap authentication is disabled.