### PR TITLE
Postfix sender restrictions

### DIFF
--- a/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
+++ b/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
@@ -50,7 +50,7 @@
         <id>general.reject_unknown_sender_domain</id>
         <label>Reject Unknown Sender Domain</label>
         <type>checkbox</type>
-        <help>This will reject mails from domains, which do not exist.</help>
+        <help>This will reject mails from domains which do not exist.</help>
     </field>
     <field>
         <id>general.reject_unknown_recipient_domain</id>

--- a/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
+++ b/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
@@ -41,4 +41,58 @@
         <type>text</type>
         <help>The smtpd_banner parameter specifies the text that follows the 220 code in the SMTP server's greeting banner. Default is "'System Hostname' ESMTP Postfix".</help>
     </field>
+    <field>
+        <id>general.check_recipient_access</id>
+        <label>Check Recipient Access</label>
+        <type>select_multiple</type>
+        <allownew>true</allownew>
+    </field>
+    <field>
+        <id>general.reject_unauth_pipelining</id>
+        <label>Reject Unauthenticated Pipelining</label>
+        <type>checkbox</type>
+    </field>
+    <field>
+        <id>general.reject_unknown_sender_domain</id>
+        <label>Reject Unknown Sender Domain</label>
+        <type>checkbox</type>
+        <help>This will reject mails from domains, which do not exist.</help>
+    </field>
+    <field>
+        <id>general.reject_unknown_recipient_domain</id>
+        <label>Reject Unknown Recipient Domain</label>
+        <type>checkbox</type>
+    </field>
+    <field>
+        <id>general.reject_non_fqdn_sender</id>
+        <label>Reject Non FQDN Sender</label>
+        <type>checkbox</type>
+        <help>For example senders without a domain or only a hostname.</help>
+    </field>
+    <field>
+        <id>general.reject_non_fqdn_recipient</id>
+        <label>Reject Non FQDN Recipient</label>
+        <type>checkbox</type>
+        <help>For example recipients without a domain or only a hostname.</help>
+    </field>
+    <field>
+        <id>general.permit_sasl_authenticated</id>
+        <label>Permit SASL Authenticated</label>
+        <type>checkbox</type>
+    </field>
+    <field>
+        <id>general.permit_tls_clientcerts</id>
+        <label>Permit TLS Client Certificate Authenticated Users</label>
+        <type>checkbox</type>
+    </field>
+    <field>
+        <id>general.permit_mynetworks</id>
+        <label>Permit My Networks</label>
+        <type>checkbox</type>
+    </field>
+    <field>
+        <id>general.reject_unauth_destination</id>
+        <label>Reject Unauthenticated Destination</label>
+        <type>checkbox</type>
+    </field>
 </form>

--- a/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
+++ b/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
@@ -42,12 +42,6 @@
         <help>The smtpd_banner parameter specifies the text that follows the 220 code in the SMTP server's greeting banner. Default is "'System Hostname' ESMTP Postfix".</help>
     </field>
     <field>
-        <id>general.check_recipient_access</id>
-        <label>Check Recipient Access</label>
-        <type>select_multiple</type>
-        <allownew>true</allownew>
-    </field>
-    <field>
         <id>general.reject_unauth_pipelining</id>
         <label>Reject Unauthenticated Pipelining</label>
         <type>checkbox</type>

--- a/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
+++ b/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
@@ -31,5 +31,47 @@
             <default></default>
             <Required>N</Required>
         </banner>
+        <check_recipient_access type="CSVListField">
+            <Required>N</Required>
+        </check_recipient_access>
+        <reject_unauth_pipelining type="BooleanField">
+            <default>1</default>
+            <Required>Y</Required>
+        </reject_unauth_pipelining>
+        <check_sender_access type="CSVListField">
+            <Required>N</Required>
+        </check_sender_access>
+        <reject_unknown_sender_domain type="BooleanField">
+            <default>1</default>
+            <Required>Y</Required>
+        </reject_unknown_sender_domain>
+        <reject_unknown_recipient_domain type="BooleanField">
+            <default>1</default>
+            <Required>Y</Required>
+        </reject_unknown_recipient_domain>
+        <reject_non_fqdn_sender type="BooleanField">
+            <default>1</default>
+            <Required>Y</Required>
+        </reject_non_fqdn_sender>
+        <reject_non_fqdn_recipient type="BooleanField">
+            <default>1</default>
+            <Required>Y</Required>
+        </reject_non_fqdn_recipient>
+        <permit_sasl_authenticated type="BooleanField">
+            <default>1</default>
+            <Required>Y</Required>
+        </permit_sasl_authenticated>
+        <permit_tls_clientcerts type="BooleanField">
+            <default>1</default>
+            <Required>Y</Required>
+        </permit_tls_clientcerts>
+        <permit_mynetworks type="BooleanField">
+            <default>1</default>
+            <Required>Y</Required>
+        </permit_mynetworks>
+        <reject_unauth_destination type="BooleanField">
+            <default>1</default>
+            <Required>Y</Required>
+        </reject_unauth_destination>
     </items>
 </model>

--- a/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
+++ b/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
@@ -31,15 +31,13 @@
             <default></default>
             <Required>N</Required>
         </banner>
-        <check_recipient_access type="CSVListField">
-            <Required>N</Required>
+        <check_recipient_access type="ArrayField">
         </check_recipient_access>
         <reject_unauth_pipelining type="BooleanField">
             <default>1</default>
             <Required>Y</Required>
         </reject_unauth_pipelining>
-        <check_sender_access type="CSVListField">
-            <Required>N</Required>
+        <check_sender_access type="ArrayField">
         </check_sender_access>
         <reject_unknown_sender_domain type="BooleanField">
             <default>1</default>

--- a/mail/postfix/src/opnsense/scripts/OPNsense/Postfix/setup.sh
+++ b/mail/postfix/src/opnsense/scripts/OPNsense/Postfix/setup.sh
@@ -28,3 +28,5 @@ chown -R root:postfix /var/spool/postfix/pid
 
 # Create Transporttable
 postmap /usr/local/etc/postfix/transport
+postmap /usr/local/etc/postfix/recipient_access
+postmap /usr/local/etc/postfix/sender_access

--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/+TARGETS
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/+TARGETS
@@ -2,5 +2,5 @@ main.cf:/usr/local/etc/postfix/main.cf
 master.cf:/usr/local/etc/postfix/master.cf
 postfix:/etc/rc.conf.d/postfix
 transport:/usr/local/etc/postfix/transport
-recipient_access:/usr/local/etc/postfix/check_recipient_access
-sender_access:/usr/local/etc/postfix/check_sender_access
+recipient_access:/usr/local/etc/postfix/recipient_access
+sender_access:/usr/local/etc/postfix/sender_access

--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/+TARGETS
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/+TARGETS
@@ -2,3 +2,5 @@ main.cf:/usr/local/etc/postfix/main.cf
 master.cf:/usr/local/etc/postfix/master.cf
 postfix:/etc/rc.conf.d/postfix
 transport:/usr/local/etc/postfix/transport
+recipient_access:/usr/local/etc/postfix/check_recipient_access
+sender_access:/usr/local/etc/postfix/check_sender_access

--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
@@ -27,8 +27,8 @@ readme_directory = no
 inet_protocols = all
 meta_directory = /usr/local/libexec/postfix
 shlib_directory = /usr/local/lib/postfix
-relay_domains = btree:/usr/local/etc/postfix/transport
-transport_maps = btree:/usr/local/etc/postfix/transport
+relay_domains = hash:/usr/local/etc/postfix/transport
+transport_maps = hash:/usr/local/etc/postfix/transport
 ##########################
 # END SYSTEM DEFAULTS
 ##########################
@@ -75,13 +75,13 @@ milter_default_action = accept
 {# Sender Restrictions #}
 {% set smtpd_recipient_restrictions=[] %}
 {% if helpers.exists('OPNsense.postfix.general.check_recipient_access') %}
-{% do smtpd_recipient_restrictions.append('check_recipient_access btree:/usr/local/etc/postfix/recipient_access') %}
+{% do smtpd_recipient_restrictions.append('check_recipient_access hash:/usr/local/etc/postfix/recipient_access') %}
 {% endif %}
 {% if helpers.exists('OPNsense.postfix.general.reject_unauth_pipelining') and OPNsense.postfix.general.reject_unauth_pipelining == '1' %}
 {% do smtpd_recipient_restrictions.append('reject_unauth_pipelining') %}
 {% endif %}
 {% if helpers.exists('OPNsense.postfix.general.check_sender_access') %}
-{% do smtpd_recipient_restrictions.append('check_sender_access btree:/usr/local/etc/postfix/sender_access') %}
+{% do smtpd_recipient_restrictions.append('check_sender_access hash:/usr/local/etc/postfix/sender_access') %}
 {% endif %}
 {% if helpers.exists('OPNsense.postfix.general.reject_unknown_sender_domain') and OPNsense.postfix.general.reject_unknown_sender_domain == '1' %}
 {% do smtpd_recipient_restrictions.append('reject_unknown_sender_domain') %}

--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
@@ -72,4 +72,46 @@ milter_mail_macros =  i {mail_addr} {client_addr} {client_name} {auth_authen}
 milter_default_action = accept
 {% endif %}
 
+{# Sender Restrictions #}
+{% set smtpd_recipient_restrictions=[] %}
+{% if helpers.exists('OPNsense.postfix.general.check_recipient_access') and OPNsense.postfix.general.check_recipient_access != '' %}
+{% do smtpd_recipient_restrictions.append('check_recipient_access hash:/etc/postfix/check_recipient_access') %}
+{% endif %}
+{% if helpers.exists('OPNsense.postfix.general.reject_unauth_pipelining') and OPNsense.postfix.general.reject_unauth_pipelining == '1' %}
+{% do smtpd_recipient_restrictions.append('reject_unauth_pipelining') %}
+{% endif %}
+{% if helpers.exists('OPNsense.postfix.general.check_sender_access') and OPNsense.postfix.general.check_sender_access != '' %}
+{% do smtpd_recipient_restrictions.append('check_sender_access hash:/etc/postfix/check_sender_access') %}
+{% endif %}
+{% if helpers.exists('OPNsense.postfix.general.reject_unknown_sender_domain') and OPNsense.postfix.general.reject_unknown_sender_domain == '1' %}
+{% do smtpd_recipient_restrictions.append('reject_unknown_sender_domain') %}
+{% endif %}
+{% if helpers.exists('OPNsense.postfix.general.reject_unknown_recipient_domain') and OPNsense.postfix.general.reject_unknown_recipient_domain == '1' %}
+{% do smtpd_recipient_restrictions.append('reject_unknown_recipient_domain') %}
+{% endif %}
+{% if helpers.exists('OPNsense.postfix.general.reject_non_fqdn_sender') and OPNsense.postfix.general.reject_non_fqdn_sender == '1' %}
+{% do smtpd_recipient_restrictions.append('reject_non_fqdn_sender') %}
+{% endif %}
+{% if helpers.exists('OPNsense.postfix.general.reject_non_fqdn_recipient') and OPNsense.postfix.general.reject_non_fqdn_recipient == '1' %}
+{% do smtpd_recipient_restrictions.append('reject_non_fqdn_recipient') %}
+{% endif %}
+{% if helpers.exists('OPNsense.postfix.general.permit_sasl_authenticated') and OPNsense.postfix.general.permit_sasl_authenticated == '1' %}
+{% do smtpd_recipient_restrictions.append('permit_sasl_authenticated') %}
+{% endif %}
+{% if helpers.exists('OPNsense.postfix.general.permit_tls_clientcerts') and OPNsense.postfix.general.permit_tls_clientcerts == '1' %}
+{% do smtpd_recipient_restrictions.append('permit_tls_clientcerts') %}
+{% endif %}
+{% if helpers.exists('OPNsense.postfix.general.permit_mynetworks') and OPNsense.postfix.general.permit_mynetworks == '1' %}
+{% do smtpd_recipient_restrictions.append('permit_mynetworks') %}
+{% endif %}
+{% if helpers.exists('OPNsense.postfix.general.reject_unauth_destination') and OPNsense.postfix.general.reject_unauth_destination == '1' %}
+{% do smtpd_recipient_restrictions.append('reject_unauth_destination') %}
+{% endif %}
+
+{% if smtpd_recipient_restrictions|length >= 1 %}
+smtpd_recipient_restrictions = {{ smtpd_recipient_restrictions | join(', ') }}
+{% endif %}
+
+smtp_helo_required = yes
+
 {% endif %}

--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
@@ -27,8 +27,8 @@ readme_directory = no
 inet_protocols = all
 meta_directory = /usr/local/libexec/postfix
 shlib_directory = /usr/local/lib/postfix
-relay_domains = hash:/usr/local/etc/postfix/transport
-transport_maps = hash:/usr/local/etc/postfix/transport
+relay_domains = btree:/usr/local/etc/postfix/transport
+transport_maps = btree:/usr/local/etc/postfix/transport
 ##########################
 # END SYSTEM DEFAULTS
 ##########################
@@ -74,14 +74,14 @@ milter_default_action = accept
 
 {# Sender Restrictions #}
 {% set smtpd_recipient_restrictions=[] %}
-{% if helpers.exists('OPNsense.postfix.general.check_recipient_access') and OPNsense.postfix.general.check_recipient_access != '' %}
-{% do smtpd_recipient_restrictions.append('check_recipient_access hash:/etc/postfix/check_recipient_access') %}
+{% if helpers.exists('OPNsense.postfix.general.check_recipient_access') %}
+{% do smtpd_recipient_restrictions.append('check_recipient_access btree:/usr/local/etc/postfix/recipient_access') %}
 {% endif %}
 {% if helpers.exists('OPNsense.postfix.general.reject_unauth_pipelining') and OPNsense.postfix.general.reject_unauth_pipelining == '1' %}
 {% do smtpd_recipient_restrictions.append('reject_unauth_pipelining') %}
 {% endif %}
-{% if helpers.exists('OPNsense.postfix.general.check_sender_access') and OPNsense.postfix.general.check_sender_access != '' %}
-{% do smtpd_recipient_restrictions.append('check_sender_access hash:/etc/postfix/check_sender_access') %}
+{% if helpers.exists('OPNsense.postfix.general.check_sender_access') %}
+{% do smtpd_recipient_restrictions.append('check_sender_access btree:/usr/local/etc/postfix/sender_access') %}
 {% endif %}
 {% if helpers.exists('OPNsense.postfix.general.reject_unknown_sender_domain') and OPNsense.postfix.general.reject_unknown_sender_domain == '1' %}
 {% do smtpd_recipient_restrictions.append('reject_unknown_sender_domain') %}
@@ -112,6 +112,6 @@ milter_default_action = accept
 smtpd_recipient_restrictions = {{ smtpd_recipient_restrictions | join(', ') }}
 {% endif %}
 
-smtp_helo_required = yes
+smtpd_helo_required = yes
 
 {% endif %}

--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/recipient_access
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/recipient_access
@@ -1,0 +1,4 @@
+{% if helpers.exists('OPNsense.postfix.general.enabled') and OPNsense.postfix.general.enabled == '1' %}
+{%   if helpers.exists('OPNsense.postfix.general.check_recipient_access') %}
+{%   endif %}
+{% endif %}

--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/sender_access
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/sender_access
@@ -1,0 +1,4 @@
+{% if helpers.exists('OPNsense.postfix.general.enabled') and OPNsense.postfix.general.enabled == '1' %}
+{%   if helpers.exists('OPNsense.postfix.general.check_recipient_access') %}
+{%   endif %}
+{% endif %}


### PR DESCRIPTION
Just add some basic additional security before release.

sender and recipient access is only a stub and will be ignored. Can be later added for advanced filtering based on mail addresses.