### PR TITLE
net/haproxy: "use_server" will only work for backends

### DIFF
--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogAction.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogAction.xml
@@ -64,8 +64,11 @@
         <id>action.use_server</id>
         <label>Use server</label>
         <type>dropdown</type>
-        <help><![CDATA[HAProxy will use this server if the condition evaluates to true.]]></help>
+        <help><![CDATA[HAProxy will use this server instead of other servers that are specified in the Backend Pool. The server must exist in the context where this rule is applied.]]></help>
     </field>
+    <field>
+        <label>NOTE: The specified server must be present in the Backend Pool where this rule is applied.</label>
+        <type>info</type>
     <field>
         <label>Parameters</label>
         <type>header</type>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -1023,8 +1023,8 @@
                     <Required>Y</Required>
                     <!-- XXX TODO: use more user-friendly names instead of HAProxys option names -->
                     <OptionValues>
-                        <use_backend>Use specified backend</use_backend>
-                        <use_server>Use specified server</use_server>
+                        <use_backend>Use specified Backend Pool</use_backend>
+                        <use_server>Override server in Backend Pool</use_server>
                         <http-request_allow>http-request allow</http-request_allow>
                         <http-request_deny>http-request deny</http-request_deny>
                         <http-request_tarpit>http-request tarpit</http-request_tarpit>


### PR DESCRIPTION
In HAProxy "use_server" will only work for backends. Besides that, the specified server **must already be defined** for the backend. Otherwise HAProxy will refuse to start with the "unable to find server" error message.

http://cbonte.github.io/haproxy-dconv/1.7/configuration.html#use-server

This patch rephrases the "use_server" option, add a note and improve the help text.
It's related to #264 and a similar report on IRC.