### PR TITLE
Suppress output when no SMART devices available

### DIFF
--- a/sysutils/smart/src/www/diag_smart.php
+++ b/sysutils/smart/src/www/diag_smart.php
@@ -138,7 +138,7 @@ switch($action) {
     // Get all AD* and DA* (IDE and SCSI) devices currently installed and stores them in the $devs array
     exec("ls /dev | grep '^\(ad\|da\|ada\)[0-9]\{1,2\}$'", $devs);
     
-    if ($devs) {
+    if (count($devs) > 0) {
     ?>
 
             <div class="content-box tab-content table-responsive">

--- a/sysutils/smart/src/www/diag_smart.php
+++ b/sysutils/smart/src/www/diag_smart.php
@@ -305,7 +305,7 @@ switch($action) {
 
     <?php
     } else {
-        echo "No SMART devices.";
+        echo gettext("No SMART devices.");
     }
     break;
   }

--- a/sysutils/smart/src/www/diag_smart.php
+++ b/sysutils/smart/src/www/diag_smart.php
@@ -137,6 +137,8 @@ switch($action) {
 
     // Get all AD* and DA* (IDE and SCSI) devices currently installed and stores them in the $devs array
     exec("ls /dev | grep '^\(ad\|da\|ada\)[0-9]\{1,2\}$'", $devs);
+    
+    if ($devs) {
     ?>
 
             <div class="content-box tab-content table-responsive">
@@ -302,6 +304,9 @@ switch($action) {
       </section>
 
     <?php
+    } else {
+        echo "No SMART devices.";
+    }
     break;
   }
 }


### PR DESCRIPTION
Small fix. Prevents empty form dropdowns when no SMART devices are available (i.e. running in a VM with a vdisk)