### PR TITLE
net/siproxd: fixed rtp_port_high in template

### DIFF
--- a/net/siproxd/Makefile
+++ b/net/siproxd/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		siproxd
-PLUGIN_VERSION=		1.0
+PLUGIN_VERSION=		1.1
 PLUGIN_COMMENT=		Siproxd is a proxy daemon for the SIP protocol
 PLUGIN_DEPENDS=		siproxd
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net/siproxd/src/opnsense/service/templates/OPNsense/Siproxd/siproxd.conf
+++ b/net/siproxd/src/opnsense/service/templates/OPNsense/Siproxd/siproxd.conf
@@ -41,7 +41,7 @@ rtp_proxy_enable = 1
 rtp_port_low  = {{ OPNsense.siproxd.general.rtp_port_low }}
 {% endif %}
 {% if helpers.exists('OPNsense.siproxd.general.rtp_port_high') and OPNsense.siproxd.general.rtp_port_high != '' %}
-rtp_port_low  = {{ OPNsense.siproxd.general.rtp_port_high }}
+rtp_port_high = {{ OPNsense.siproxd.general.rtp_port_high }}
 {% endif %}
 {% if helpers.exists('OPNsense.siproxd.general.rtp_timeout') and OPNsense.siproxd.general.rtp_timeout != '' %}
 rtp_timeout = {{ OPNsense.siproxd.general.rtp_timeout }}


### PR DESCRIPTION
Fixed a copy and paste issue in net/siproxd/src/opnsense/service/templates/OPNsense/Siproxd/siproxd.conf: `rtp_port_high` was not set from the UI.

On my setup, RTP relaying failed because of this issue. SIP calls were established but audio didn't work. Error messages:

    ERROR: rtp_relay_start_fwd: no RTP port available or bind() failed

were logged.

The fix was tested under 17.7 latest as of today.