### PR TITLE
net/freeradius: add extended logging and daily session limit

### DIFF
--- a/net/freeradius/Makefile
+++ b/net/freeradius/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		freeradius
-PLUGIN_VERSION=		1.2.1
+PLUGIN_VERSION=		1.3.0
 PLUGIN_COMMENT=		RADIUS Authentication, Authorization and Accounting Server
 PLUGIN_DEPENDS=		freeradius3
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/dialogEditFreeRADIUSUser.xml
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/dialogEditFreeRADIUSUser.xml
@@ -78,7 +78,7 @@
         <help>Set the maximum download bandwith for ChilliSpot attribute. The value is treated as kbits/s.</help>
     </field>
     <field>
-        <id>user.max_session_limit</id>
+        <id>user.sessionlimit_max_session_limit</id>
         <label>Max Daily Session</label>
         <type>text</type>
         <help>Set the maximum session limit in seconds. This can be used by the Captive Portal.</help>

--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/dialogEditFreeRADIUSUser.xml
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/dialogEditFreeRADIUSUser.xml
@@ -77,4 +77,10 @@
         <type>text</type>
         <help>Set the maximum download bandwith for ChilliSpot attribute. The value is treated as kbits/s.</help>
     </field>
+    <field>
+        <id>user.max_session_limit</id>
+        <label>Max Session Limit</label>
+        <type>text</type>
+        <help>Set the maximum session limit in seconds. This can be used by the Captive Portal.</help>
+    </field>
 </form>

--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/dialogEditFreeRADIUSUser.xml
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/dialogEditFreeRADIUSUser.xml
@@ -79,7 +79,7 @@
     </field>
     <field>
         <id>user.max_session_limit</id>
-        <label>Max Session Limit</label>
+        <label>Max Daily Session</label>
         <type>text</type>
         <help>Set the maximum session limit in seconds. This can be used by the Captive Portal.</help>
     </field>

--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/general.xml
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/general.xml
@@ -24,7 +24,7 @@
         <help>This enables the ChilliSpot attributes assignment via users tab.</help>
     </field>
      <field>
-        <id>general.log_destinaion</id>
+        <id>general.log_destination</id>
         <label>Log to File or Syslog</label>
         <type>dropdown</type>
         <help>Set where to log radius requests, defaults to file.</help>

--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/general.xml
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/general.xml
@@ -24,7 +24,7 @@
         <help>This enables the ChilliSpot attributes assignment via users tab.</help>
     </field>
     <field>
-        <id>general.enable_daily_sessionlimit</id>
+        <id>general.sessionlimit</id>
         <label>Enable Daily Session Limit</label>
         <type>checkbox</type>
         <help>This enables the Max-Daily-Session attribute assignment via users tab.</help>

--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/general.xml
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/general.xml
@@ -23,6 +23,12 @@
         <type>checkbox</type>
         <help>This enables the ChilliSpot attributes assignment via users tab.</help>
     </field>
+    <field>
+        <id>general.enable_daily_sessionlimit</id>
+        <label>Enable Daily Session Limit</label>
+        <type>checkbox</type>
+        <help>This enables the Max-Daily-Session attribute assignment via users tab.</help>
+    </field>
      <field>
         <id>general.log_destination</id>
         <label>Log to File or Syslog</label>

--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/general.xml
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/general.xml
@@ -23,4 +23,28 @@
         <type>checkbox</type>
         <help>This enables the ChilliSpot attributes assignment via users tab.</help>
     </field>
+     <field>
+        <id>general.log_destinaion</id>
+        <label>Log to File or Syslog</label>
+        <type>dropdown</type>
+        <help>Set where to log radius requests, defaults to file.</help>
+    </field>
+     <field>
+        <id>general.log_authentication_request</id>
+        <label>Log Authentication Request</label>
+        <type>checkbox</type>
+        <help>Enable the logging of authentication requests, including MAC addresses.</help>
+    </field>
+     <field>
+        <id>general.log_authbadpass</id>
+        <label>Log Authentication Bad Password</label>
+        <type>checkbox</type>
+        <help>Logs password if it is rejected.</help>
+    </field>
+     <field>
+        <id>general.log_authgoodpass</id>
+        <label>Log Authentication Good Password</label>
+        <type>checkbox</type>
+        <help>Logs password if it is correct.</help>
+    </field>
 </form>

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/General.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/General.xml
@@ -19,6 +19,10 @@
             <default>0</default>
             <Required>N</Required>
         </chillispot>
+        <enable_daily_sessionlimit type="BooleanField">
+            <default>0</default>
+            <Required>N</Required>
+        </enable_daily_sessionlimit>
         <log_destination type="OptionField">
             <default>files</default>
             <Required>Y</Required>

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/General.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/General.xml
@@ -20,11 +20,11 @@
             <Required>N</Required>
         </chillispot>
         <log_destinaion type="OptionField">
-            <default>File</default>
+            <default>files</default>
             <Required>Y</Required>
             <OptionValues>
-                <File>File</File>
-                <Syslog>Syslog</Syslog>
+                <files>files</files>
+                <syslog>syslog</syslog>
             </OptionValues>    
         </log_destinaion>
         <log_authentication_request type="BooleanField">

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/General.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/General.xml
@@ -19,5 +19,25 @@
             <default>0</default>
             <Required>N</Required>
         </chillispot>
+        <log_destinaion type="OptionField">
+            <default>File</default>
+            <Required>Y</Required>
+            <OptionValues>
+                <File>File</File>
+                <Syslog>Syslog</Syslog>
+            </OptionValues>    
+        </log_destinaion>
+        <log_authentication_request type="BooleanField">
+            <default>0</default>
+            <Required>N</Required>
+        </log_authentication_request>
+        <log_authbadpass type="BooleanField">
+            <default>0</default>
+            <Required>N</Required>
+        </log_authbadpass>
+        <log_authgoodpass type="BooleanField">
+            <default>0</default>
+            <Required>N</Required>
+        </log_authgoodpass>
     </items>
 </model>

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/General.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/General.xml
@@ -19,14 +19,14 @@
             <default>0</default>
             <Required>N</Required>
         </chillispot>
-        <log_destinaion type="OptionField">
+        <log_destination type="OptionField">
             <default>files</default>
             <Required>Y</Required>
             <OptionValues>
                 <files>files</files>
                 <syslog>syslog</syslog>
             </OptionValues>    
-        </log_destinaion>
+        </log_destination>
         <log_authentication_request type="BooleanField">
             <default>0</default>
             <Required>N</Required>

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/General.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/General.xml
@@ -19,10 +19,10 @@
             <default>0</default>
             <Required>N</Required>
         </chillispot>
-        <enable_daily_sessionlimit type="BooleanField">
+        <sessionlimit type="BooleanField">
             <default>0</default>
             <Required>N</Required>
-        </enable_daily_sessionlimit>
+        </sessionlimit>
         <log_destination type="OptionField">
             <default>files</default>
             <Required>Y</Required>

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/User.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/User.xml
@@ -63,6 +63,10 @@
                                 <default></default>
                                 <Required>N</Required>
                         </chillispot_bw_max_down>
+                        <max_session_limit type="IntegerField">
+                                <default></default>
+                                <Required>N</Required>
+                        </max_session_limit>
             </user>
         </users>
     </items>

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/User.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/User.xml
@@ -63,10 +63,10 @@
                                 <default></default>
                                 <Required>N</Required>
                         </chillispot_bw_max_down>
-                        <max_session_limit type="IntegerField">
+                        <sessionlimit_max_session_limit type="IntegerField">
                                 <default></default>
                                 <Required>N</Required>
-                        </max_session_limit>
+                        </sessionlimit_max_session_limit>
             </user>
         </users>
     </items>

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/+TARGETS
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/+TARGETS
@@ -1,4 +1,5 @@
 clients.conf:/usr/local/etc/raddb/clients.conf
+dictionary:/usr/local/etc/raddb/dictionary
 mods-enabled-eap:/usr/local/etc/raddb/mods-enabled/eap
 radiusd:/etc/rc.conf.d/radiusd
 radiusd.conf:/usr/local/etc/raddb/radiusd.conf

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/+TARGETS
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/+TARGETS
@@ -1,6 +1,7 @@
 clients.conf:/usr/local/etc/raddb/clients.conf
 mods-enabled-eap:/usr/local/etc/raddb/mods-enabled/eap
 radiusd:/etc/rc.conf.d/radiusd
+radiusd.conf:/usr/local/etc/raddb/radiusd.conf
 sites-enabled-default:/usr/local/etc/raddb/sites-enabled/default
 sites-enabled-inner-tunnel:/usr/local/etc/raddb/sites-enabled/inner-tunnel
 users:/usr/local/etc/raddb/mods-config/files/authorize

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/dictionary
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/dictionary
@@ -1,0 +1,2 @@
+ATTRIBUTE       Daily-Session-Time      3000    integer
+ATTRIBUTE       Max-Daily-Session       3001    integer

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/dictionary
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/dictionary
@@ -1,2 +1,2 @@
-ATTRIBUTE       Daily-Session-Time      3000    integer
+#ATTRIBUTE       Daily-Session-Time      3000    integer
 ATTRIBUTE       Max-Daily-Session       3001    integer

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-counter
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-counter
@@ -1,0 +1,81 @@
+# -*- text -*-
+#
+#  $Id: a5ac1e60ef117a2c59ace1a9d061d8f70d1da538 $
+
+#  counter module:
+#  This module takes an attribute (count-attribute).
+#  It also takes a key, and creates a counter for each unique
+#  key.  The count is incremented when accounting packets are
+#  received by the server.  The value of the increment depends
+#  on the attribute type.
+#  If the attribute is Acct-Session-Time or of an integer type we add
+#  the value of the attribute. If it is anything else we increase the
+#  counter by one.
+#
+#  The 'reset' parameter defines when the counters are all reset to
+#  zero.  It can be hourly, daily, weekly, monthly or never.
+#
+#  hourly: Reset on 00:00 of every hour
+#  daily: Reset on 00:00:00 every day
+#  weekly: Reset on 00:00:00 on sunday
+#  monthly: Reset on 00:00:00 of the first day of each month
+#
+#  It can also be user defined. It should be of the form:
+#  num[hdwm] where:
+#  h: hours, d: days, w: weeks, m: months
+#  If the letter is omitted days will be assumed. In example:
+#  reset = 10h (reset every 10 hours)
+#  reset = 12  (reset every 12 days)
+#
+#
+#  The check_name attribute defines an attribute which will be
+#  registered by the counter module and can be used to set the
+#  maximum allowed value for the counter after which the user
+#  is rejected.
+#  Something like:
+#
+#  DEFAULT Max-Daily-Session := 36000
+#          Fall-Through = 1
+#
+#  You should add the counter module in the instantiate
+#  section so that it registers check_name before the files
+#  module reads the users file.
+#
+#  If check_name is set and the user is to be rejected then we
+#  send back a Reply-Message and we log a Failure-Message in
+#  the radius.log
+#
+#  If the count attribute is Acct-Session-Time then on each
+#  login we send back the remaining online time as a
+#  Session-Timeout attribute ELSE and if the reply_name is
+#  set, we send back that attribute.  The reply_name attribute
+#  MUST be of an integer type.
+#
+#  The counter-name can also be used instead of using the check_name
+#  like below:
+#
+#  DEFAULT  Daily-Session-Time > 3600, Auth-Type = Reject
+#      Reply-Message = "You've used up more than one hour today"
+#
+#  The allowed_service_type attribute can be used to only take
+#  into account specific sessions. For example if a user first
+#  logs in through a login menu and then selects ppp there will
+#  be two sessions. One for Login-User and one for Framed-User
+#  service type. We only need to take into account the second one.
+#
+#  The module should be added in the instantiate, authorize and
+#  accounting sections.  Make sure that in the authorize
+#  section it comes after any module which sets the
+#  'check_name' attribute.
+#
+counter daily {
+        filename = ${db_dir}/db.daily
+        key = User-Name
+        count_attribute = Acct-Session-Time
+        reset = daily
+        counter_name = Daily-Session-Time
+        check_name = Max-Daily-Session
+        reply_name = Session-Timeout
+        allowed_service_type = Framed-User
+        cache_size = 5000
+}

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-counter
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-counter
@@ -1,3 +1,6 @@
+
+{% if helpers.exists('OPNsense.freeradius.general.enabled') and OPNsense.freeradius.general.enabled == '1' %}
+
 # -*- text -*-
 #
 #  $Id: a5ac1e60ef117a2c59ace1a9d061d8f70d1da538 $
@@ -79,3 +82,5 @@ counter daily {
         allowed_service_type = Framed-User
         cache_size = 5000
 }
+
+{% endif %}

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-counter
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-counter
@@ -1,4 +1,3 @@
-
 {% if helpers.exists('OPNsense.freeradius.general.enabled') and OPNsense.freeradius.general.enabled == '1' %}
 
 # -*- text -*-

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/radiusd.conf
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/radiusd.conf
@@ -78,7 +78,7 @@ modules {
 }
 
 instantiate {
-{% if helpers.exists('OPNsense.freeradius.general.enable_daily_sessionlimit') and OPNsense.freeradius.general.enable_daily_sessionlimit == '1' %}        
+{% if helpers.exists('OPNsense.freeradius.general.sessionlimit') and OPNsense.freeradius.general.sessionlimit == '1' %}        
         daily
 {% endif %}
 }

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/radiusd.conf
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/radiusd.conf
@@ -1,0 +1,782 @@
+# -*- text -*-
+##
+## radiusd.conf -- FreeRADIUS server configuration file - 3.0.15
+##
+##      http://www.freeradius.org/
+##      $Id: a83c1f6874e69df8692ebce57174bf0dd52fd502 $
+##
+
+######################################################################
+#
+#       Read "man radiusd" before editing this file.  See the section
+#       titled DEBUGGING.  It outlines a method where you can quickly
+#       obtain the configuration you want, without running into
+#       trouble.
+#
+#       Run the server in debugging mode, and READ the output.
+#
+#               $ radiusd -X
+#
+#       We cannot emphasize this point strongly enough.  The vast
+#       majority of problems can be solved by carefully reading the
+#       debugging output, which includes warnings about common issues,
+#       and suggestions for how they may be fixed.
+#
+#       There may be a lot of output, but look carefully for words like:
+#       "warning", "error", "reject", or "failure".  The messages there
+#       will usually be enough to guide you to a solution.
+#
+#       If you are going to ask a question on the mailing list, then
+#       explain what you are trying to do, and include the output from
+#       debugging mode (radiusd -X).  Failure to do so means that all
+#       of the responses to your question will be people telling you
+#       to "post the output of radiusd -X".
+
+######################################################################
+#
+#       The location of other config files and logfiles are declared
+#       in this file.
+#
+#       Also general configuration for modules can be done in this
+#       file, it is exported through the API to modules that ask for
+#       it.
+#
+#       See "man radiusd.conf" for documentation on the format of this
+#       file.  Note that the individual configuration items are NOT
+#       documented in that "man" page.  They are only documented here,
+#       in the comments.
+#
+#       The "unlang" policy language can be used to create complex
+#       if / else policies.  See "man unlang" for details.
+#
+
+prefix = /usr/local
+exec_prefix = ${prefix}
+sysconfdir = ${prefix}/etc
+localstatedir = /var
+sbindir = ${exec_prefix}/sbin
+logdir = /var/log
+raddbdir = ${sysconfdir}/raddb
+radacctdir = ${logdir}/radacct
+
+#
+#  name of the running server.  See also the "-n" command-line option.
+name = radiusd
+
+#  Location of config and logfiles.
+confdir = ${raddbdir}
+modconfdir = ${confdir}/mods-config
+certdir = ${confdir}/certs
+cadir   = ${confdir}/certs
+run_dir = ${localstatedir}/run/${name}
+
+# Should likely be ${localstatedir}/lib/radiusd
+db_dir = ${raddbdir}
+
+#
+# libdir: Where to find the rlm_* modules.
+#
+#   This should be automatically set at configuration time.
+#
+#   If the server builds and installs, but fails at execution time
+#   with an 'undefined symbol' error, then you can use the libdir
+#   directive to work around the problem.
+#
+#   The cause is usually that a library has been installed on your
+#   system in a place where the dynamic linker CANNOT find it.  When
+#   executing as root (or another user), your personal environment MAY
+#   be set up to allow the dynamic linker to find the library.  When
+#   executing as a daemon, FreeRADIUS MAY NOT have the same
+#   personalized configuration.
+#
+#   To work around the problem, find out which library contains that symbol,
+#   and add the directory containing that library to the end of 'libdir',
+#   with a colon separating the directory names.  NO spaces are allowed.
+#
+#   e.g. libdir = /usr/local/lib:/opt/package/lib
+#
+#   You can also try setting the LD_LIBRARY_PATH environment variable
+#   in a script which starts the server.
+#
+#   If that does not work, then you can re-configure and re-build the
+#   server to NOT use shared libraries, via:
+#
+#       ./configure --disable-shared
+#       make
+#       make install
+#
+libdir = /usr/local/lib/freeradius-3*
+
+#  pidfile: Where to place the PID of the RADIUS server.
+#
+#  The server may be signalled while it's running by using this
+#  file.
+#
+#  This file is written when ONLY running in daemon mode.
+#
+#  e.g.:  kill -HUP `cat /var/run/radiusd/radiusd.pid`
+#
+pidfile = ${run_dir}/${name}.pid
+
+#
+#  correct_escapes: use correct backslash escaping
+#
+#  Prior to version 3.0.5, the handling of backslashes was a little
+#  awkward, i.e. "wrong".  In some cases, to get one backslash into
+#  a regex, you had to put 4 in the config files.
+#
+#  Version 3.0.5 fixes that.  However, for backwards compatibility,
+#  the new method of escaping is DISABLED BY DEFAULT.  This means
+#  that upgrading to 3.0.5 won't break your configuration.
+#
+#  If you don't have double backslashes (i.e. \\) in your configuration,
+#  this won't matter to you.  If you do have them, fix that to use only
+#  one backslash, and then set "correct_escapes = true".
+#
+#  You can check for this by doing:
+#
+#       $ grep '\\\\' $(find raddb -type f -print)
+#
+correct_escapes = true
+
+#  panic_action: Command to execute if the server dies unexpectedly.
+#
+#  FOR PRODUCTION SYSTEMS, ACTIONS SHOULD ALWAYS EXIT.
+#  AN INTERACTIVE ACTION MEANS THE SERVER IS NOT RESPONDING TO REQUESTS.
+#  AN INTERACTICE ACTION MEANS THE SERVER WILL NOT RESTART.
+#
+#  THE SERVER MUST NOT BE ALLOWED EXECUTE UNTRUSTED PANIC ACTION CODE
+#  PATTACH CAN BE USED AS AN ATTACK VECTOR.
+#
+#  The panic action is a command which will be executed if the server
+#  receives a fatal, non user generated signal, i.e. SIGSEGV, SIGBUS,
+#  SIGABRT or SIGFPE.
+#
+#  This can be used to start an interactive debugging session so
+#  that information regarding the current state of the server can
+#  be acquired.
+#
+#  The following string substitutions are available:
+#  - %e   The currently executing program e.g. /sbin/radiusd
+#  - %p   The PID of the currently executing program e.g. 12345
+#
+#  Standard ${} substitutions are also allowed.
+#
+#  An example panic action for opening an interactive session in GDB would be:
+#
+#panic_action = "gdb %e %p"
+#
+#  Again, don't use that on a production system.
+#
+#  An example panic action for opening an automated session in GDB would be:
+#
+#panic_action = "gdb -silent -x ${raddbdir}/panic.gdb %e %p 2>&1 | tee ${logdir}/gdb-${name}-%p.log"
+#
+#  That command can be used on a production system.
+#
+
+#  max_request_time: The maximum time (in seconds) to handle a request.
+#
+#  Requests which take more time than this to process may be killed, and
+#  a REJECT message is returned.
+#
+#  WARNING: If you notice that requests take a long time to be handled,
+#  then this MAY INDICATE a bug in the server, in one of the modules
+#  used to handle a request, OR in your local configuration.
+#
+#  This problem is most often seen when using an SQL database.  If it takes
+#  more than a second or two to receive an answer from the SQL database,
+#  then it probably means that you haven't indexed the database.  See your
+#  SQL server documentation for more information.
+#
+#  Useful range of values: 5 to 120
+#
+max_request_time = 30
+
+#  cleanup_delay: The time to wait (in seconds) before cleaning up
+#  a reply which was sent to the NAS.
+#
+#  The RADIUS request is normally cached internally for a short period
+#  of time, after the reply is sent to the NAS.  The reply packet may be
+#  lost in the network, and the NAS will not see it.  The NAS will then
+#  re-send the request, and the server will respond quickly with the
+#  cached reply.
+#
+#  If this value is set too low, then duplicate requests from the NAS
+#  MAY NOT be detected, and will instead be handled as separate requests.
+#
+#  If this value is set too high, then the server will cache too many
+#  requests, and some new requests may get blocked.  (See 'max_requests'.)
+#
+#  Useful range of values: 2 to 10
+#
+cleanup_delay = 5
+
+#  max_requests: The maximum number of requests which the server keeps
+#  track of.  This should be 256 multiplied by the number of clients.
+#  e.g. With 4 clients, this number should be 1024.
+#
+#  If this number is too low, then when the server becomes busy,
+#  it will not respond to any new requests, until the 'cleanup_delay'
+#  time has passed, and it has removed the old requests.
+#
+#  If this number is set too high, then the server will use a bit more
+#  memory for no real benefit.
+#
+#  If you aren't sure what it should be set to, it's better to set it
+#  too high than too low.  Setting it to 1000 per client is probably
+#  the highest it should be.
+#
+#  Useful range of values: 256 to infinity
+#
+max_requests = 16384
+
+#  hostname_lookups: Log the names of clients or just their IP addresses
+#  e.g., www.freeradius.org (on) or 206.47.27.232 (off).
+#
+#  The default is 'off' because it would be overall better for the net
+#  if people had to knowingly turn this feature on, since enabling it
+#  means that each client request will result in AT LEAST one lookup
+#  request to the nameserver.   Enabling hostname_lookups will also
+#  mean that your server may stop randomly for 30 seconds from time
+#  to time, if the DNS requests take too long.
+#
+#  Turning hostname lookups off also means that the server won't block
+#  for 30 seconds, if it sees an IP address which has no name associated
+#  with it.
+#
+#  allowed values: {no, yes}
+#
+hostname_lookups = no
+
+#
+#  Logging section.  The various "log_*" configuration items
+#  will eventually be moved here.
+#
+log {
+        #
+        #  Destination for log messages.  This can be one of:
+        #
+        #       files - log to "file", as defined below.
+        #       syslog - to syslog (see also the "syslog_facility", below.
+        #       stdout - standard output
+        #       stderr - standard error.
+        #
+        #  The command-line option "-X" over-rides this option, and forces
+        #  logging to go to stdout.
+        #
+        destination = files
+
+        #
+        #  Highlight important messages sent to stderr and stdout.
+        #
+        #  Option will be ignored (disabled) if output if TERM is not
+        #  an xterm or output is not to a TTY.
+        #
+        colourise = yes
+
+        #
+        #  The logging messages for the server are appended to the
+        #  tail of this file if destination == "files"
+        #
+        #  If the server is running in debugging mode, this file is
+        #  NOT used.
+        #
+        file = ${logdir}/radius.log
+
+        #
+        #  Which syslog facility to use, if ${destination} == "syslog"
+        #
+        #  The exact values permitted here are OS-dependent.  You probably
+        #  don't want to change this.
+        #
+        syslog_facility = daemon
+
+        #  Log the full User-Name attribute, as it was found in the request.
+        #
+        # allowed values: {no, yes}
+        #
+        stripped_names = no
+
+        #  Log authentication requests to the log file.
+        #
+        #  allowed values: {no, yes}
+        #
+        auth = no
+
+        #  Log passwords with the authentication requests.
+        #  auth_badpass  - logs password if it's rejected
+        #  auth_goodpass - logs password if it's correct
+        #
+        #  allowed values: {no, yes}
+        #
+        auth_badpass = no
+        auth_goodpass = no
+
+        #  Log additional text at the end of the "Login OK" messages.
+        #  for these to work, the "auth" and "auth_goodpass" or "auth_badpass"
+        #  configurations above have to be set to "yes".
+        #
+        #  The strings below are dynamically expanded, which means that
+        #  you can put anything you want in them.  However, note that
+        #  this expansion can be slow, and can negatively impact server
+        #  performance.
+        #
+#       msg_goodpass = ""
+#       msg_badpass = ""
+
+        #  The message when the user exceeds the Simultaneous-Use limit.
+        #
+        msg_denied = "You are already logged in - access denied"
+}
+
+#  The program to execute to do concurrency checks.
+checkrad = ${sbindir}/checkrad
+
+# SECURITY CONFIGURATION
+#
+#  There may be multiple methods of attacking on the server.  This
+#  section holds the configuration items which minimize the impact
+#  of those attacks
+#
+security {
+        #  chroot: directory where the server does "chroot".
+        #
+        #  The chroot is done very early in the process of starting
+        #  the server.  After the chroot has been performed it
+        #  switches to the "user" listed below (which MUST be
+        #  specified).  If "group" is specified, it switches to that
+        #  group, too.  Any other groups listed for the specified
+        #  "user" in "/etc/group" are also added as part of this
+        #  process.
+        #
+        #  The current working directory (chdir / cd) is left
+        #  *outside* of the chroot until all of the modules have been
+        #  initialized.  This allows the "raddb" directory to be left
+        #  outside of the chroot.  Once the modules have been
+        #  initialized, it does a "chdir" to ${logdir}.  This means
+        #  that it should be impossible to break out of the chroot.
+        #
+        #  If you are worried about security issues related to this
+        #  use of chdir, then simply ensure that the "raddb" directory
+        #  is inside of the chroot, end be sure to do "cd raddb"
+        #  BEFORE starting the server.
+        #
+        #  If the server is statically linked, then the only files
+        #  that have to exist in the chroot are ${run_dir} and
+        #  ${logdir}.  If you do the "cd raddb" as discussed above,
+        #  then the "raddb" directory has to be inside of the chroot
+        #  directory, too.
+        #
+#       chroot = /path/to/chroot/directory
+
+        # user/group: The name (or #number) of the user/group to run radiusd as.
+        #
+        #   If these are commented out, the server will run as the
+        #   user/group that started it.  In order to change to a
+        #   different user/group, you MUST be root ( or have root
+        #   privileges ) to start the server.
+        #
+        #   We STRONGLY recommend that you run the server with as few
+        #   permissions as possible.  That is, if you're not using
+        #   shadow passwords, the user and group items below should be
+        #   set to radius'.
+        #
+        #  NOTE that some kernels refuse to setgid(group) when the
+        #  value of (unsigned)group is above 60000; don't use group
+        #  "nobody" on these systems!
+        #
+        #  On systems with shadow passwords, you might have to set
+        #  'group = shadow' for the server to be able to read the
+        #  shadow password file.  If you can authenticate users while
+        #  in debug mode, but not in daemon mode, it may be that the
+        #  debugging mode server is running as a user that can read
+        #  the shadow info, and the user listed below can not.
+        #
+        #  The server will also try to use "initgroups" to read
+        #  /etc/groups.  It will join all groups where "user" is a
+        #  member.  This can allow for some finer-grained access
+        #  controls.
+        #
+#       user = radius
+#       group = radius
+
+        #  Core dumps are a bad thing.  This should only be set to
+        #  'yes' if you're debugging a problem with the server.
+        #
+        #  allowed values: {no, yes}
+        #
+        allow_core_dumps = no
+
+        #
+        #  max_attributes: The maximum number of attributes
+        #  permitted in a RADIUS packet.  Packets which have MORE
+        #  than this number of attributes in them will be dropped.
+        #
+        #  If this number is set too low, then no RADIUS packets
+        #  will be accepted.
+        #
+        #  If this number is set too high, then an attacker may be
+        #  able to send a small number of packets which will cause
+        #  the server to use all available memory on the machine.
+        #
+        #  Setting this number to 0 means "allow any number of attributes"
+        max_attributes = 200
+
+        #
+        #  reject_delay: When sending an Access-Reject, it can be
+        #  delayed for a few seconds.  This may help slow down a DoS
+        #  attack.  It also helps to slow down people trying to brute-force
+        #  crack a users password.
+        #
+        #  Setting this number to 0 means "send rejects immediately"
+        #
+        #  If this number is set higher than 'cleanup_delay', then the
+        #  rejects will be sent at 'cleanup_delay' time, when the request
+        #  is deleted from the internal cache of requests.
+        #
+        #  As of Version 3.0.5, "reject_delay" has sub-second resolution.
+        #  e.g. "reject_delay =  1.4" seconds is possible.
+        #
+        #  Useful ranges: 1 to 5
+        reject_delay = 1
+
+        #
+        #  status_server: Whether or not the server will respond
+        #  to Status-Server requests.
+        #
+        #  When sent a Status-Server message, the server responds with
+        #  an Access-Accept or Accounting-Response packet.
+        #
+        #  This is mainly useful for administrators who want to "ping"
+        #  the server, without adding test users, or creating fake
+        #  accounting packets.
+        #
+        #  It's also useful when a NAS marks a RADIUS server "dead".
+        #  The NAS can periodically "ping" the server with a Status-Server
+        #  packet.  If the server responds, it must be alive, and the
+        #  NAS can start using it for real requests.
+        #
+        #  See also raddb/sites-available/status
+        #
+        status_server = yes
+
+
+}
+
+# PROXY CONFIGURATION
+#
+#  proxy_requests: Turns proxying of RADIUS requests on or off.
+#
+#  The server has proxying turned on by default.  If your system is NOT
+#  set up to proxy requests to another server, then you can turn proxying
+#  off here.  This will save a small amount of resources on the server.
+#
+#  If you have proxying turned off, and your configuration files say
+#  to proxy a request, then an error message will be logged.
+#
+#  To disable proxying, change the "yes" to "no", and comment the
+#  $INCLUDE line.
+#
+#  allowed values: {no, yes}
+#
+proxy_requests  = yes
+$INCLUDE proxy.conf
+
+
+# CLIENTS CONFIGURATION
+#
+#  Client configuration is defined in "clients.conf".
+#
+
+#  The 'clients.conf' file contains all of the information from the old
+#  'clients' and 'naslist' configuration files.  We recommend that you
+#  do NOT use 'client's or 'naslist', although they are still
+#  supported.
+#
+#  Anything listed in 'clients.conf' will take precedence over the
+#  information from the old-style configuration files.
+#
+$INCLUDE clients.conf
+
+
+# THREAD POOL CONFIGURATION
+#
+#  The thread pool is a long-lived group of threads which
+#  take turns (round-robin) handling any incoming requests.
+#
+#  You probably want to have a few spare threads around,
+#  so that high-load situations can be handled immediately.  If you
+#  don't have any spare threads, then the request handling will
+#  be delayed while a new thread is created, and added to the pool.
+#
+#  You probably don't want too many spare threads around,
+#  otherwise they'll be sitting there taking up resources, and
+#  not doing anything productive.
+#
+#  The numbers given below should be adequate for most situations.
+#
+thread pool {
+        #  Number of servers to start initially --- should be a reasonable
+        #  ballpark figure.
+        start_servers = 5
+
+        #  Limit on the total number of servers running.
+        #
+        #  If this limit is ever reached, clients will be LOCKED OUT, so it
+        #  should NOT BE SET TOO LOW.  It is intended mainly as a brake to
+        #  keep a runaway server from taking the system with it as it spirals
+        #  down...
+        #
+        #  You may find that the server is regularly reaching the
+        #  'max_servers' number of threads, and that increasing
+        #  'max_servers' doesn't seem to make much difference.
+        #
+        #  If this is the case, then the problem is MOST LIKELY that
+        #  your back-end databases are taking too long to respond, and
+        #  are preventing the server from responding in a timely manner.
+        #
+        #  The solution is NOT do keep increasing the 'max_servers'
+        #  value, but instead to fix the underlying cause of the
+        #  problem: slow database, or 'hostname_lookups=yes'.
+        #
+        #  For more information, see 'max_request_time', above.
+        #
+        max_servers = 32
+
+        #  Server-pool size regulation.  Rather than making you guess
+        #  how many servers you need, FreeRADIUS dynamically adapts to
+        #  the load it sees, that is, it tries to maintain enough
+        #  servers to handle the current load, plus a few spare
+        #  servers to handle transient load spikes.
+        #
+        #  It does this by periodically checking how many servers are
+        #  waiting for a request.  If there are fewer than
+        #  min_spare_servers, it creates a new spare.  If there are
+        #  more than max_spare_servers, some of the spares die off.
+        #  The default values are probably OK for most sites.
+        #
+        min_spare_servers = 3
+        max_spare_servers = 10
+
+        #  When the server receives a packet, it places it onto an
+        #  internal queue, where the worker threads (configured above)
+        #  pick it up for processing.  The maximum size of that queue
+        #  is given here.
+        #
+        #  When the queue is full, any new packets will be silently
+        #  discarded.
+        #
+        #  The most common cause of the queue being full is that the
+        #  server is dependent on a slow database, and it has received
+        #  a large "spike" of traffic.  When that happens, there is
+        #  very little you can do other than make sure the server
+        #  receives less traffic, or make sure that the database can
+        #  handle the load.
+        #
+#       max_queue_size = 65536
+
+        #  There may be memory leaks or resource allocation problems with
+        #  the server.  If so, set this value to 300 or so, so that the
+        #  resources will be cleaned up periodically.
+        #
+        #  This should only be necessary if there are serious bugs in the
+        #  server which have not yet been fixed.
+        #
+        #  '0' is a special value meaning 'infinity', or 'the servers never
+        #  exit'
+        max_requests_per_server = 0
+
+        #  Automatically limit the number of accounting requests.
+        #  This configuration item tracks how many requests per second
+        #  the server can handle.  It does this by tracking the
+        #  packets/s received by the server for processing, and
+        #  comparing that to the packets/s handled by the child
+        #  threads.
+        #
+
+        #  If the received PPS is larger than the processed PPS, *and*
+        #  the queue is more than half full, then new accounting
+        #  requests are probabilistically discarded.  This lowers the
+        #  number of packets that the server needs to process.  Over
+        #  time, the server will "catch up" with the traffic.
+        #
+        #  Throwing away accounting packets is usually safe and low
+        #  impact.  The NAS will retransmit them in a few seconds, or
+        #  even a few minutes.  Vendors should read RFC 5080 Section 2.2.1
+        #  to see how accounting packets should be retransmitted.  Using
+        #  any other method is likely to cause network meltdowns.
+        #
+        auto_limit_acct = no
+}
+
+######################################################################
+#
+#  SNMP notifications.  Uncomment the following line to enable
+#  snmptraps.  Note that you MUST also configure the full path
+#  to the "snmptrap" command in the "trigger.conf" file.
+#
+#$INCLUDE trigger.conf
+
+# MODULE CONFIGURATION
+#
+#  The names and configuration of each module is located in this section.
+#
+#  After the modules are defined here, they may be referred to by name,
+#  in other sections of this configuration file.
+#
+modules {
+        #
+        #  Each module has a configuration as follows:
+        #
+        #       name [ instance ] {
+        #               config_item = value
+        #               ...
+        #       }
+        #
+        #  The 'name' is used to load the 'rlm_name' library
+        #  which implements the functionality of the module.
+        #
+        #  The 'instance' is optional.  To have two different instances
+        #  of a module, it first must be referred to by 'name'.
+        #  The different copies of the module are then created by
+        #  inventing two 'instance' names, e.g. 'instance1' and 'instance2'
+        #
+        #  The instance names can then be used in later configuration
+        #  INSTEAD of the original 'name'.  See the 'radutmp' configuration
+        #  for an example.
+        #
+
+        #
+        #  As of 3.0, modules are in mods-enabled/.  Files matching
+        #  the regex /[a-zA-Z0-9_.]+/ are loaded.  The modules are
+        #  initialized ONLY if they are referenced in a processing
+        #  section, such as authorize, authenticate, accounting,
+        #  pre/post-proxy, etc.
+        #
+        $INCLUDE mods-enabled/
+}
+
+# Instantiation
+#
+#  This section orders the loading of the modules.  Modules
+#  listed here will get loaded BEFORE the later sections like
+#  authorize, authenticate, etc. get examined.
+#
+#  This section is not strictly needed.  When a section like
+#  authorize refers to a module, it's automatically loaded and
+#  initialized.  However, some modules may not be listed in any
+#  of the following sections, so they can be listed here.
+#
+#  Also, listing modules here ensures that you have control over
+#  the order in which they are initialized.  If one module needs
+#  something defined by another module, you can list them in order
+#  here, and ensure that the configuration will be OK.
+#
+#  After the modules listed here have been loaded, all of the modules
+#  in the "mods-enabled" directory will be loaded.  Loading the
+#  "mods-enabled" directory means that unlike Version 2, you usually
+#  don't need to list modules here.
+#
+instantiate {
+        #
+        # We list the counter module here so that it registers
+        # the check_name attribute before any module which sets
+        # it
+#       daily
+
+        # subsections here can be thought of as "virtual" modules.
+        #
+        # e.g. If you have two redundant SQL servers, and you want to
+        # use them in the authorize and accounting sections, you could
+        # place a "redundant" block in each section, containing the
+        # exact same text.  Or, you could uncomment the following
+        # lines, and list "redundant_sql" in the authorize and
+        # accounting sections.
+        #
+        #  The "virtual" module defined here can also be used with
+        #  dynamic expansions, under a few conditions:
+        #
+        #  * The section is "redundant", or "load-balance", or
+        #    "redundant-load-balance"
+        #  * The section contains modules ONLY, and no sub-sections
+        #  * all modules in the section are using the same rlm_
+        #    driver, e.g. They are all sql, or all ldap, etc.
+        #
+        #  When those conditions are satisfied, the server will
+        #  automatically register a dynamic expansion, using the
+        #  name of the "virtual" module.  In the example below,
+        #  it will be "redundant_sql".  You can then use this expansion
+        #  just like any other:
+        #
+        #       update reply {
+        #               Filter-Id := "%{redundant_sql: ... }"
+        #       }
+        #
+        #  In this example, the expansion is done via module "sql1",
+        #  and if that expansion fails, using module "sql2".
+        #
+        #  For best results, configure the "pool" subsection of the
+        #  module so that "retry_delay" is non-zero.  That will allow
+        #  the redundant block to quickly ignore all "down" SQL
+        #  databases.  If instead we have "retry_delay = 0", then
+        #  every time the redundant block is used, the server will try
+        #  to open a connection to every "down" database, causing
+        #  problems.
+        #
+        #redundant redundant_sql {
+        #       sql1
+        #       sql2
+        #}
+}
+
+######################################################################
+#
+#  Policies are virtual modules, similar to those defined in the
+#  "instantiate" section above.
+#
+#  Defining a policy in one of the policy.d files means that it can be
+#  referenced in multiple places as a *name*, rather than as a series of
+#  conditions to match, and actions to take.
+#
+#  Policies are something like subroutines in a normal language, but
+#  they cannot be called recursively. They MUST be defined in order.
+#  If policy A calls policy B, then B MUST be defined before A.
+#
+######################################################################
+policy {
+        $INCLUDE policy.d/
+}
+
+######################################################################
+#
+#       Load virtual servers.
+#
+#       This next $INCLUDE line loads files in the directory that
+#       match the regular expression: /[a-zA-Z0-9_.]+/
+#
+#       It allows you to define new virtual servers simply by placing
+#       a file into the raddb/sites-enabled/ directory.
+#
+$INCLUDE sites-enabled/
+
+######################################################################
+#
+#       All of the other configuration sections like "authorize {}",
+#       "authenticate {}", "accounting {}", have been moved to the
+#       the file:
+#
+#               raddb/sites-available/default
+#
+#       This is the "default" virtual server that has the same
+#       configuration as in version 1.0.x and 1.1.x.  The default
+#       installation enables this virtual server.  You should
+#       edit it to create policies for your local site.
+#
+#       For more documentation on virtual servers, see:
+#
+#               raddb/sites-available/README
+#
+######################################################################
+
+{% endif %}

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/radiusd.conf
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/radiusd.conf
@@ -98,7 +98,7 @@ hostname_lookups = no
 #  will eventually be moved here.
 #
 log {
-{% if helpers.exists('OPNsense.freeradius.general.log_authentication_request') and OPNsense.freeradius.general.log_authentication_request == '' %}
+{% if helpers.exists('OPNsense.freeradius.general.log_authentication_request') and OPNsense.freeradius.general.log_authentication_request != '' %}
         destination = {{ OPNsense.freeradius.general.log_authentication_request }}
 {% endif %}
         colourise = yes

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/radiusd.conf
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/radiusd.conf
@@ -18,85 +18,11 @@ db_dir = ${raddbdir}
 libdir = /usr/local/lib/freeradius-3*
 pidfile = ${run_dir}/${name}.pid
 correct_escapes = true
-
-#  max_request_time: The maximum time (in seconds) to handle a request.
-#
-#  Requests which take more time than this to process may be killed, and
-#  a REJECT message is returned.
-#
-#  WARNING: If you notice that requests take a long time to be handled,
-#  then this MAY INDICATE a bug in the server, in one of the modules
-#  used to handle a request, OR in your local configuration.
-#
-#  This problem is most often seen when using an SQL database.  If it takes
-#  more than a second or two to receive an answer from the SQL database,
-#  then it probably means that you haven't indexed the database.  See your
-#  SQL server documentation for more information.
-#
-#  Useful range of values: 5 to 120
-#
 max_request_time = 30
-
-#  cleanup_delay: The time to wait (in seconds) before cleaning up
-#  a reply which was sent to the NAS.
-#
-#  The RADIUS request is normally cached internally for a short period
-#  of time, after the reply is sent to the NAS.  The reply packet may be
-#  lost in the network, and the NAS will not see it.  The NAS will then
-#  re-send the request, and the server will respond quickly with the
-#  cached reply.
-#
-#  If this value is set too low, then duplicate requests from the NAS
-#  MAY NOT be detected, and will instead be handled as separate requests.
-#
-#  If this value is set too high, then the server will cache too many
-#  requests, and some new requests may get blocked.  (See 'max_requests'.)
-#
-#  Useful range of values: 2 to 10
-#
 cleanup_delay = 5
-
-#  max_requests: The maximum number of requests which the server keeps
-#  track of.  This should be 256 multiplied by the number of clients.
-#  e.g. With 4 clients, this number should be 1024.
-#
-#  If this number is too low, then when the server becomes busy,
-#  it will not respond to any new requests, until the 'cleanup_delay'
-#  time has passed, and it has removed the old requests.
-#
-#  If this number is set too high, then the server will use a bit more
-#  memory for no real benefit.
-#
-#  If you aren't sure what it should be set to, it's better to set it
-#  too high than too low.  Setting it to 1000 per client is probably
-#  the highest it should be.
-#
-#  Useful range of values: 256 to infinity
-#
 max_requests = 16384
-
-#  hostname_lookups: Log the names of clients or just their IP addresses
-#  e.g., www.freeradius.org (on) or 206.47.27.232 (off).
-#
-#  The default is 'off' because it would be overall better for the net
-#  if people had to knowingly turn this feature on, since enabling it
-#  means that each client request will result in AT LEAST one lookup
-#  request to the nameserver.   Enabling hostname_lookups will also
-#  mean that your server may stop randomly for 30 seconds from time
-#  to time, if the DNS requests take too long.
-#
-#  Turning hostname lookups off also means that the server won't block
-#  for 30 seconds, if it sees an IP address which has no name associated
-#  with it.
-#
-#  allowed values: {no, yes}
-#
 hostname_lookups = no
 
-#
-#  Logging section.  The various "log_*" configuration items
-#  will eventually be moved here.
-#
 log {
 {% if helpers.exists('OPNsense.freeradius.general.log_destination') and OPNsense.freeradius.general.log_destination != '' %}
         destination = {{ OPNsense.freeradius.general.log_destination }}
@@ -123,63 +49,12 @@ log {
         msg_denied = "You are already logged in - access denied"
 }
 
-#  The program to execute to do concurrency checks.
 checkrad = ${sbindir}/checkrad
 
 security {
         allow_core_dumps = no
-
-        #
-        #  max_attributes: The maximum number of attributes
-        #  permitted in a RADIUS packet.  Packets which have MORE
-        #  than this number of attributes in them will be dropped.
-        #
-        #  If this number is set too low, then no RADIUS packets
-        #  will be accepted.
-        #
-        #  If this number is set too high, then an attacker may be
-        #  able to send a small number of packets which will cause
-        #  the server to use all available memory on the machine.
-        #
-        #  Setting this number to 0 means "allow any number of attributes"
         max_attributes = 200
-
-        #
-        #  reject_delay: When sending an Access-Reject, it can be
-        #  delayed for a few seconds.  This may help slow down a DoS
-        #  attack.  It also helps to slow down people trying to brute-force
-        #  crack a users password.
-        #
-        #  Setting this number to 0 means "send rejects immediately"
-        #
-        #  If this number is set higher than 'cleanup_delay', then the
-        #  rejects will be sent at 'cleanup_delay' time, when the request
-        #  is deleted from the internal cache of requests.
-        #
-        #  As of Version 3.0.5, "reject_delay" has sub-second resolution.
-        #  e.g. "reject_delay =  1.4" seconds is possible.
-        #
-        #  Useful ranges: 1 to 5
         reject_delay = 1
-
-        #
-        #  status_server: Whether or not the server will respond
-        #  to Status-Server requests.
-        #
-        #  When sent a Status-Server message, the server responds with
-        #  an Access-Accept or Accounting-Response packet.
-        #
-        #  This is mainly useful for administrators who want to "ping"
-        #  the server, without adding test users, or creating fake
-        #  accounting packets.
-        #
-        #  It's also useful when a NAS marks a RADIUS server "dead".
-        #  The NAS can periodically "ping" the server with a Status-Server
-        #  packet.  If the server responds, it must be alive, and the
-        #  NAS can start using it for real requests.
-        #
-        #  See also raddb/sites-available/status
-        #
         status_server = yes
 
 
@@ -190,96 +65,11 @@ $INCLUDE proxy.conf
 $INCLUDE clients.conf
 
 thread pool {
-        #  Number of servers to start initially --- should be a reasonable
-        #  ballpark figure.
         start_servers = 5
-
-        #  Limit on the total number of servers running.
-        #
-        #  If this limit is ever reached, clients will be LOCKED OUT, so it
-        #  should NOT BE SET TOO LOW.  It is intended mainly as a brake to
-        #  keep a runaway server from taking the system with it as it spirals
-        #  down...
-        #
-        #  You may find that the server is regularly reaching the
-        #  'max_servers' number of threads, and that increasing
-        #  'max_servers' doesn't seem to make much difference.
-        #
-        #  If this is the case, then the problem is MOST LIKELY that
-        #  your back-end databases are taking too long to respond, and
-        #  are preventing the server from responding in a timely manner.
-        #
-        #  The solution is NOT do keep increasing the 'max_servers'
-        #  value, but instead to fix the underlying cause of the
-        #  problem: slow database, or 'hostname_lookups=yes'.
-        #
-        #  For more information, see 'max_request_time', above.
-        #
         max_servers = 32
-
-        #  Server-pool size regulation.  Rather than making you guess
-        #  how many servers you need, FreeRADIUS dynamically adapts to
-        #  the load it sees, that is, it tries to maintain enough
-        #  servers to handle the current load, plus a few spare
-        #  servers to handle transient load spikes.
-        #
-        #  It does this by periodically checking how many servers are
-        #  waiting for a request.  If there are fewer than
-        #  min_spare_servers, it creates a new spare.  If there are
-        #  more than max_spare_servers, some of the spares die off.
-        #  The default values are probably OK for most sites.
-        #
         min_spare_servers = 3
         max_spare_servers = 10
-
-        #  When the server receives a packet, it places it onto an
-        #  internal queue, where the worker threads (configured above)
-        #  pick it up for processing.  The maximum size of that queue
-        #  is given here.
-        #
-        #  When the queue is full, any new packets will be silently
-        #  discarded.
-        #
-        #  The most common cause of the queue being full is that the
-        #  server is dependent on a slow database, and it has received
-        #  a large "spike" of traffic.  When that happens, there is
-        #  very little you can do other than make sure the server
-        #  receives less traffic, or make sure that the database can
-        #  handle the load.
-        #
-#       max_queue_size = 65536
-
-        #  There may be memory leaks or resource allocation problems with
-        #  the server.  If so, set this value to 300 or so, so that the
-        #  resources will be cleaned up periodically.
-        #
-        #  This should only be necessary if there are serious bugs in the
-        #  server which have not yet been fixed.
-        #
-        #  '0' is a special value meaning 'infinity', or 'the servers never
-        #  exit'
         max_requests_per_server = 0
-
-        #  Automatically limit the number of accounting requests.
-        #  This configuration item tracks how many requests per second
-        #  the server can handle.  It does this by tracking the
-        #  packets/s received by the server for processing, and
-        #  comparing that to the packets/s handled by the child
-        #  threads.
-        #
-
-        #  If the received PPS is larger than the processed PPS, *and*
-        #  the queue is more than half full, then new accounting
-        #  requests are probabilistically discarded.  This lowers the
-        #  number of packets that the server needs to process.  Over
-        #  time, the server will "catch up" with the traffic.
-        #
-        #  Throwing away accounting packets is usually safe and low
-        #  impact.  The NAS will retransmit them in a few seconds, or
-        #  even a few minutes.  Vendors should read RFC 5080 Section 2.2.1
-        #  to see how accounting packets should be retransmitted.  Using
-        #  any other method is likely to cause network meltdowns.
-        #
         auto_limit_acct = no
 }
 

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/radiusd.conf
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/radiusd.conf
@@ -1,54 +1,4 @@
-# -*- text -*-
-##
-## radiusd.conf -- FreeRADIUS server configuration file - 3.0.15
-##
-##      http://www.freeradius.org/
-##      $Id: a83c1f6874e69df8692ebce57174bf0dd52fd502 $
-##
-
-######################################################################
-#
-#       Read "man radiusd" before editing this file.  See the section
-#       titled DEBUGGING.  It outlines a method where you can quickly
-#       obtain the configuration you want, without running into
-#       trouble.
-#
-#       Run the server in debugging mode, and READ the output.
-#
-#               $ radiusd -X
-#
-#       We cannot emphasize this point strongly enough.  The vast
-#       majority of problems can be solved by carefully reading the
-#       debugging output, which includes warnings about common issues,
-#       and suggestions for how they may be fixed.
-#
-#       There may be a lot of output, but look carefully for words like:
-#       "warning", "error", "reject", or "failure".  The messages there
-#       will usually be enough to guide you to a solution.
-#
-#       If you are going to ask a question on the mailing list, then
-#       explain what you are trying to do, and include the output from
-#       debugging mode (radiusd -X).  Failure to do so means that all
-#       of the responses to your question will be people telling you
-#       to "post the output of radiusd -X".
-
-######################################################################
-#
-#       The location of other config files and logfiles are declared
-#       in this file.
-#
-#       Also general configuration for modules can be done in this
-#       file, it is exported through the API to modules that ask for
-#       it.
-#
-#       See "man radiusd.conf" for documentation on the format of this
-#       file.  Note that the individual configuration items are NOT
-#       documented in that "man" page.  They are only documented here,
-#       in the comments.
-#
-#       The "unlang" policy language can be used to create complex
-#       if / else policies.  See "man unlang" for details.
-#
+{% if helpers.exists('OPNsense.freeradius.general.enabled') and OPNsense.freeradius.general.enabled == '1' %}
 
 prefix = /usr/local
 exec_prefix = ${prefix}
@@ -58,122 +8,16 @@ sbindir = ${exec_prefix}/sbin
 logdir = /var/log
 raddbdir = ${sysconfdir}/raddb
 radacctdir = ${logdir}/radacct
-
-#
-#  name of the running server.  See also the "-n" command-line option.
 name = radiusd
-
-#  Location of config and logfiles.
 confdir = ${raddbdir}
 modconfdir = ${confdir}/mods-config
 certdir = ${confdir}/certs
 cadir   = ${confdir}/certs
 run_dir = ${localstatedir}/run/${name}
-
-# Should likely be ${localstatedir}/lib/radiusd
 db_dir = ${raddbdir}
-
-#
-# libdir: Where to find the rlm_* modules.
-#
-#   This should be automatically set at configuration time.
-#
-#   If the server builds and installs, but fails at execution time
-#   with an 'undefined symbol' error, then you can use the libdir
-#   directive to work around the problem.
-#
-#   The cause is usually that a library has been installed on your
-#   system in a place where the dynamic linker CANNOT find it.  When
-#   executing as root (or another user), your personal environment MAY
-#   be set up to allow the dynamic linker to find the library.  When
-#   executing as a daemon, FreeRADIUS MAY NOT have the same
-#   personalized configuration.
-#
-#   To work around the problem, find out which library contains that symbol,
-#   and add the directory containing that library to the end of 'libdir',
-#   with a colon separating the directory names.  NO spaces are allowed.
-#
-#   e.g. libdir = /usr/local/lib:/opt/package/lib
-#
-#   You can also try setting the LD_LIBRARY_PATH environment variable
-#   in a script which starts the server.
-#
-#   If that does not work, then you can re-configure and re-build the
-#   server to NOT use shared libraries, via:
-#
-#       ./configure --disable-shared
-#       make
-#       make install
-#
 libdir = /usr/local/lib/freeradius-3*
-
-#  pidfile: Where to place the PID of the RADIUS server.
-#
-#  The server may be signalled while it's running by using this
-#  file.
-#
-#  This file is written when ONLY running in daemon mode.
-#
-#  e.g.:  kill -HUP `cat /var/run/radiusd/radiusd.pid`
-#
 pidfile = ${run_dir}/${name}.pid
-
-#
-#  correct_escapes: use correct backslash escaping
-#
-#  Prior to version 3.0.5, the handling of backslashes was a little
-#  awkward, i.e. "wrong".  In some cases, to get one backslash into
-#  a regex, you had to put 4 in the config files.
-#
-#  Version 3.0.5 fixes that.  However, for backwards compatibility,
-#  the new method of escaping is DISABLED BY DEFAULT.  This means
-#  that upgrading to 3.0.5 won't break your configuration.
-#
-#  If you don't have double backslashes (i.e. \\) in your configuration,
-#  this won't matter to you.  If you do have them, fix that to use only
-#  one backslash, and then set "correct_escapes = true".
-#
-#  You can check for this by doing:
-#
-#       $ grep '\\\\' $(find raddb -type f -print)
-#
 correct_escapes = true
-
-#  panic_action: Command to execute if the server dies unexpectedly.
-#
-#  FOR PRODUCTION SYSTEMS, ACTIONS SHOULD ALWAYS EXIT.
-#  AN INTERACTIVE ACTION MEANS THE SERVER IS NOT RESPONDING TO REQUESTS.
-#  AN INTERACTICE ACTION MEANS THE SERVER WILL NOT RESTART.
-#
-#  THE SERVER MUST NOT BE ALLOWED EXECUTE UNTRUSTED PANIC ACTION CODE
-#  PATTACH CAN BE USED AS AN ATTACK VECTOR.
-#
-#  The panic action is a command which will be executed if the server
-#  receives a fatal, non user generated signal, i.e. SIGSEGV, SIGBUS,
-#  SIGABRT or SIGFPE.
-#
-#  This can be used to start an interactive debugging session so
-#  that information regarding the current state of the server can
-#  be acquired.
-#
-#  The following string substitutions are available:
-#  - %e   The currently executing program e.g. /sbin/radiusd
-#  - %p   The PID of the currently executing program e.g. 12345
-#
-#  Standard ${} substitutions are also allowed.
-#
-#  An example panic action for opening an interactive session in GDB would be:
-#
-#panic_action = "gdb %e %p"
-#
-#  Again, don't use that on a production system.
-#
-#  An example panic action for opening an automated session in GDB would be:
-#
-#panic_action = "gdb -silent -x ${raddbdir}/panic.gdb %e %p 2>&1 | tee ${logdir}/gdb-${name}-%p.log"
-#
-#  That command can be used on a production system.
-#
 
 #  max_request_time: The maximum time (in seconds) to handle a request.
 #
@@ -254,42 +98,9 @@ hostname_lookups = no
 #  will eventually be moved here.
 #
 log {
-        #
-        #  Destination for log messages.  This can be one of:
-        #
-        #       files - log to "file", as defined below.
-        #       syslog - to syslog (see also the "syslog_facility", below.
-        #       stdout - standard output
-        #       stderr - standard error.
-        #
-        #  The command-line option "-X" over-rides this option, and forces
-        #  logging to go to stdout.
-        #
         destination = files
-
-        #
-        #  Highlight important messages sent to stderr and stdout.
-        #
-        #  Option will be ignored (disabled) if output if TERM is not
-        #  an xterm or output is not to a TTY.
-        #
         colourise = yes
-
-        #
-        #  The logging messages for the server are appended to the
-        #  tail of this file if destination == "files"
-        #
-        #  If the server is running in debugging mode, this file is
-        #  NOT used.
-        #
         file = ${logdir}/radius.log
-
-        #
-        #  Which syslog facility to use, if ${destination} == "syslog"
-        #
-        #  The exact values permitted here are OS-dependent.  You probably
-        #  don't want to change this.
-        #
         syslog_facility = daemon
 
         #  Log the full User-Name attribute, as it was found in the request.
@@ -333,79 +144,7 @@ log {
 #  The program to execute to do concurrency checks.
 checkrad = ${sbindir}/checkrad
 
-# SECURITY CONFIGURATION
-#
-#  There may be multiple methods of attacking on the server.  This
-#  section holds the configuration items which minimize the impact
-#  of those attacks
-#
 security {
-        #  chroot: directory where the server does "chroot".
-        #
-        #  The chroot is done very early in the process of starting
-        #  the server.  After the chroot has been performed it
-        #  switches to the "user" listed below (which MUST be
-        #  specified).  If "group" is specified, it switches to that
-        #  group, too.  Any other groups listed for the specified
-        #  "user" in "/etc/group" are also added as part of this
-        #  process.
-        #
-        #  The current working directory (chdir / cd) is left
-        #  *outside* of the chroot until all of the modules have been
-        #  initialized.  This allows the "raddb" directory to be left
-        #  outside of the chroot.  Once the modules have been
-        #  initialized, it does a "chdir" to ${logdir}.  This means
-        #  that it should be impossible to break out of the chroot.
-        #
-        #  If you are worried about security issues related to this
-        #  use of chdir, then simply ensure that the "raddb" directory
-        #  is inside of the chroot, end be sure to do "cd raddb"
-        #  BEFORE starting the server.
-        #
-        #  If the server is statically linked, then the only files
-        #  that have to exist in the chroot are ${run_dir} and
-        #  ${logdir}.  If you do the "cd raddb" as discussed above,
-        #  then the "raddb" directory has to be inside of the chroot
-        #  directory, too.
-        #
-#       chroot = /path/to/chroot/directory
-
-        # user/group: The name (or #number) of the user/group to run radiusd as.
-        #
-        #   If these are commented out, the server will run as the
-        #   user/group that started it.  In order to change to a
-        #   different user/group, you MUST be root ( or have root
-        #   privileges ) to start the server.
-        #
-        #   We STRONGLY recommend that you run the server with as few
-        #   permissions as possible.  That is, if you're not using
-        #   shadow passwords, the user and group items below should be
-        #   set to radius'.
-        #
-        #  NOTE that some kernels refuse to setgid(group) when the
-        #  value of (unsigned)group is above 60000; don't use group
-        #  "nobody" on these systems!
-        #
-        #  On systems with shadow passwords, you might have to set
-        #  'group = shadow' for the server to be able to read the
-        #  shadow password file.  If you can authenticate users while
-        #  in debug mode, but not in daemon mode, it may be that the
-        #  debugging mode server is running as a user that can read
-        #  the shadow info, and the user listed below can not.
-        #
-        #  The server will also try to use "initgroups" to read
-        #  /etc/groups.  It will join all groups where "user" is a
-        #  member.  This can allow for some finer-grained access
-        #  controls.
-        #
-#       user = radius
-#       group = radius
-
-        #  Core dumps are a bad thing.  This should only be set to
-        #  'yes' if you're debugging a problem with the server.
-        #
-        #  allowed values: {no, yes}
-        #
         allow_core_dumps = no
 
         #
@@ -464,58 +203,10 @@ security {
 
 }
 
-# PROXY CONFIGURATION
-#
-#  proxy_requests: Turns proxying of RADIUS requests on or off.
-#
-#  The server has proxying turned on by default.  If your system is NOT
-#  set up to proxy requests to another server, then you can turn proxying
-#  off here.  This will save a small amount of resources on the server.
-#
-#  If you have proxying turned off, and your configuration files say
-#  to proxy a request, then an error message will be logged.
-#
-#  To disable proxying, change the "yes" to "no", and comment the
-#  $INCLUDE line.
-#
-#  allowed values: {no, yes}
-#
 proxy_requests  = yes
 $INCLUDE proxy.conf
-
-
-# CLIENTS CONFIGURATION
-#
-#  Client configuration is defined in "clients.conf".
-#
-
-#  The 'clients.conf' file contains all of the information from the old
-#  'clients' and 'naslist' configuration files.  We recommend that you
-#  do NOT use 'client's or 'naslist', although they are still
-#  supported.
-#
-#  Anything listed in 'clients.conf' will take precedence over the
-#  information from the old-style configuration files.
-#
 $INCLUDE clients.conf
 
-
-# THREAD POOL CONFIGURATION
-#
-#  The thread pool is a long-lived group of threads which
-#  take turns (round-robin) handling any incoming requests.
-#
-#  You probably want to have a few spare threads around,
-#  so that high-load situations can be handled immediately.  If you
-#  don't have any spare threads, then the request handling will
-#  be delayed while a new thread is created, and added to the pool.
-#
-#  You probably don't want too many spare threads around,
-#  otherwise they'll be sitting there taking up resources, and
-#  not doing anything productive.
-#
-#  The numbers given below should be adequate for most situations.
-#
 thread pool {
         #  Number of servers to start initially --- should be a reasonable
         #  ballpark figure.
@@ -610,173 +301,17 @@ thread pool {
         auto_limit_acct = no
 }
 
-######################################################################
-#
-#  SNMP notifications.  Uncomment the following line to enable
-#  snmptraps.  Note that you MUST also configure the full path
-#  to the "snmptrap" command in the "trigger.conf" file.
-#
-#$INCLUDE trigger.conf
-
-# MODULE CONFIGURATION
-#
-#  The names and configuration of each module is located in this section.
-#
-#  After the modules are defined here, they may be referred to by name,
-#  in other sections of this configuration file.
-#
 modules {
-        #
-        #  Each module has a configuration as follows:
-        #
-        #       name [ instance ] {
-        #               config_item = value
-        #               ...
-        #       }
-        #
-        #  The 'name' is used to load the 'rlm_name' library
-        #  which implements the functionality of the module.
-        #
-        #  The 'instance' is optional.  To have two different instances
-        #  of a module, it first must be referred to by 'name'.
-        #  The different copies of the module are then created by
-        #  inventing two 'instance' names, e.g. 'instance1' and 'instance2'
-        #
-        #  The instance names can then be used in later configuration
-        #  INSTEAD of the original 'name'.  See the 'radutmp' configuration
-        #  for an example.
-        #
-
-        #
-        #  As of 3.0, modules are in mods-enabled/.  Files matching
-        #  the regex /[a-zA-Z0-9_.]+/ are loaded.  The modules are
-        #  initialized ONLY if they are referenced in a processing
-        #  section, such as authorize, authenticate, accounting,
-        #  pre/post-proxy, etc.
-        #
         $INCLUDE mods-enabled/
 }
 
-# Instantiation
-#
-#  This section orders the loading of the modules.  Modules
-#  listed here will get loaded BEFORE the later sections like
-#  authorize, authenticate, etc. get examined.
-#
-#  This section is not strictly needed.  When a section like
-#  authorize refers to a module, it's automatically loaded and
-#  initialized.  However, some modules may not be listed in any
-#  of the following sections, so they can be listed here.
-#
-#  Also, listing modules here ensures that you have control over
-#  the order in which they are initialized.  If one module needs
-#  something defined by another module, you can list them in order
-#  here, and ensure that the configuration will be OK.
-#
-#  After the modules listed here have been loaded, all of the modules
-#  in the "mods-enabled" directory will be loaded.  Loading the
-#  "mods-enabled" directory means that unlike Version 2, you usually
-#  don't need to list modules here.
-#
 instantiate {
-        #
-        # We list the counter module here so that it registers
-        # the check_name attribute before any module which sets
-        # it
-#       daily
-
-        # subsections here can be thought of as "virtual" modules.
-        #
-        # e.g. If you have two redundant SQL servers, and you want to
-        # use them in the authorize and accounting sections, you could
-        # place a "redundant" block in each section, containing the
-        # exact same text.  Or, you could uncomment the following
-        # lines, and list "redundant_sql" in the authorize and
-        # accounting sections.
-        #
-        #  The "virtual" module defined here can also be used with
-        #  dynamic expansions, under a few conditions:
-        #
-        #  * The section is "redundant", or "load-balance", or
-        #    "redundant-load-balance"
-        #  * The section contains modules ONLY, and no sub-sections
-        #  * all modules in the section are using the same rlm_
-        #    driver, e.g. They are all sql, or all ldap, etc.
-        #
-        #  When those conditions are satisfied, the server will
-        #  automatically register a dynamic expansion, using the
-        #  name of the "virtual" module.  In the example below,
-        #  it will be "redundant_sql".  You can then use this expansion
-        #  just like any other:
-        #
-        #       update reply {
-        #               Filter-Id := "%{redundant_sql: ... }"
-        #       }
-        #
-        #  In this example, the expansion is done via module "sql1",
-        #  and if that expansion fails, using module "sql2".
-        #
-        #  For best results, configure the "pool" subsection of the
-        #  module so that "retry_delay" is non-zero.  That will allow
-        #  the redundant block to quickly ignore all "down" SQL
-        #  databases.  If instead we have "retry_delay = 0", then
-        #  every time the redundant block is used, the server will try
-        #  to open a connection to every "down" database, causing
-        #  problems.
-        #
-        #redundant redundant_sql {
-        #       sql1
-        #       sql2
-        #}
 }
 
-######################################################################
-#
-#  Policies are virtual modules, similar to those defined in the
-#  "instantiate" section above.
-#
-#  Defining a policy in one of the policy.d files means that it can be
-#  referenced in multiple places as a *name*, rather than as a series of
-#  conditions to match, and actions to take.
-#
-#  Policies are something like subroutines in a normal language, but
-#  they cannot be called recursively. They MUST be defined in order.
-#  If policy A calls policy B, then B MUST be defined before A.
-#
-######################################################################
 policy {
         $INCLUDE policy.d/
 }
 
-######################################################################
-#
-#       Load virtual servers.
-#
-#       This next $INCLUDE line loads files in the directory that
-#       match the regular expression: /[a-zA-Z0-9_.]+/
-#
-#       It allows you to define new virtual servers simply by placing
-#       a file into the raddb/sites-enabled/ directory.
-#
 $INCLUDE sites-enabled/
-
-######################################################################
-#
-#       All of the other configuration sections like "authorize {}",
-#       "authenticate {}", "accounting {}", have been moved to the
-#       the file:
-#
-#               raddb/sites-available/default
-#
-#       This is the "default" virtual server that has the same
-#       configuration as in version 1.0.x and 1.1.x.  The default
-#       installation enables this virtual server.  You should
-#       edit it to create policies for your local site.
-#
-#       For more documentation on virtual servers, see:
-#
-#               raddb/sites-available/README
-#
-######################################################################
 
 {% endif %}

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/radiusd.conf
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/radiusd.conf
@@ -98,20 +98,13 @@ hostname_lookups = no
 #  will eventually be moved here.
 #
 log {
-{% if helpers.exists('OPNsense.freeradius.general.log_authentication_request') and OPNsense.freeradius.general.log_authentication_request == 'File' %}
-        destination = files
-{% else %}
-        destination = syslog
+{% if helpers.exists('OPNsense.freeradius.general.log_authentication_request') and OPNsense.freeradius.general.log_authentication_request == '' %}
+        destination = {{ OPNsense.freeradius.general.log_authentication_request }}
 {% endif %}
         colourise = yes
         file = ${logdir}/radius.log
         syslog_facility = daemon
         stripped_names = no
-
-        #  Log authentication requests to the log file.
-        #
-        #  allowed values: {no, yes}
-        #
 {% if helpers.exists('OPNsense.freeradius.general.log_authentication_request') and OPNsense.freeradius.general.log_authentication_request == '1' %}
         auth = yes
 {% else %}

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/radiusd.conf
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/radiusd.conf
@@ -98,8 +98,8 @@ hostname_lookups = no
 #  will eventually be moved here.
 #
 log {
-{% if helpers.exists('OPNsense.freeradius.general.log_authentication_request') and OPNsense.freeradius.general.log_authentication_request != '' %}
-        destination = {{ OPNsense.freeradius.general.log_authentication_request }}
+{% if helpers.exists('OPNsense.freeradius.general.log_destination') and OPNsense.freeradius.general.log_destination != '' %}
+        destination = {{ OPNsense.freeradius.general.log_destination }}
 {% endif %}
         colourise = yes
         file = ${logdir}/radius.log

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/radiusd.conf
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/radiusd.conf
@@ -98,46 +98,35 @@ hostname_lookups = no
 #  will eventually be moved here.
 #
 log {
+{% if helpers.exists('OPNsense.freeradius.general.log_authentication_request') and OPNsense.freeradius.general.log_authentication_request == 'File' %}
         destination = files
+{% else %}
+        destination = syslog
+{% endif %}
         colourise = yes
         file = ${logdir}/radius.log
         syslog_facility = daemon
-
-        #  Log the full User-Name attribute, as it was found in the request.
-        #
-        # allowed values: {no, yes}
-        #
         stripped_names = no
 
         #  Log authentication requests to the log file.
         #
         #  allowed values: {no, yes}
         #
+{% if helpers.exists('OPNsense.freeradius.general.log_authentication_request') and OPNsense.freeradius.general.log_authentication_request == '1' %}
+        auth = yes
+{% else %}
         auth = no
-
-        #  Log passwords with the authentication requests.
-        #  auth_badpass  - logs password if it's rejected
-        #  auth_goodpass - logs password if it's correct
-        #
-        #  allowed values: {no, yes}
-        #
+{% endif %}
+{% if helpers.exists('OPNsense.freeradius.general.log_authbadpass') and OPNsense.freeradius.general.log_authbadpass == '1' %}
+        auth_badpass = yes
+{% else %}
         auth_badpass = no
+{% endif %}
+{% if helpers.exists('OPNsense.freeradius.general.log_authgoodpass') and OPNsense.freeradius.general.log_authgoodpass == '1' %}        
+        auth_goodpass = yes
+{% else %}
         auth_goodpass = no
-
-        #  Log additional text at the end of the "Login OK" messages.
-        #  for these to work, the "auth" and "auth_goodpass" or "auth_badpass"
-        #  configurations above have to be set to "yes".
-        #
-        #  The strings below are dynamically expanded, which means that
-        #  you can put anything you want in them.  However, note that
-        #  this expansion can be slow, and can negatively impact server
-        #  performance.
-        #
-#       msg_goodpass = ""
-#       msg_badpass = ""
-
-        #  The message when the user exceeds the Simultaneous-Use limit.
-        #
+{% endif %}
         msg_denied = "You are already logged in - access denied"
 }
 

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/radiusd.conf
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/radiusd.conf
@@ -78,6 +78,9 @@ modules {
 }
 
 instantiate {
+{% if helpers.exists('OPNsense.freeradius.general.enable_daily_sessionlimit') and OPNsense.freeradius.general.enable_daily_sessionlimit == '1' %}        
+        daily
+{% endif %}
 }
 
 policy {

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/radiusd.conf
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/radiusd.conf
@@ -15,6 +15,7 @@ certdir = ${confdir}/certs
 cadir   = ${confdir}/certs
 run_dir = ${localstatedir}/run/${name}
 db_dir = ${raddbdir}
+# libdir ends with an asterisk since package maintainer always appends the current version number to the directory name.
 libdir = /usr/local/lib/freeradius-3*
 pidfile = ${run_dir}/${name}.pid
 correct_escapes = true

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/sites-enabled-default
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/sites-enabled-default
@@ -1,243 +1,33 @@
 {% if helpers.exists('OPNsense.freeradius.general.enabled') and OPNsense.freeradius.general.enabled == '1' %}
-######################################################################
-#
-#       As of 2.0.0, FreeRADIUS supports virtual hosts using the
-#       "server" section, and configuration directives.
-#
-#       Virtual hosts should be put into the "sites-available"
-#       directory.  Soft links should be created in the "sites-enabled"
-#       directory to these files.  This is done in a normal installation.
-#
-#       If you are using 802.1X (EAP) authentication, please see also
-#       the "inner-tunnel" virtual server.  You will likely have to edit
-#       that, too, for authentication to work.
-#
-#       $Id: 292abcc492c6e21594ed93b2fbbd9ab226e4440d $
-#
-######################################################################
-#
-#       Read "man radiusd" before editing this file.  See the section
-#       titled DEBUGGING.  It outlines a method where you can quickly
-#       obtain the configuration you want, without running into
-#       trouble.  See also "man unlang", which documents the format
-#       of this file.
-#
-#       This configuration is designed to work in the widest possible
-#       set of circumstances, with the widest possible number of
-#       authentication methods.  This means that in general, you should
-#       need to make very few changes to this file.
-#
-#       The best way to configure the server for your local system
-#       is to CAREFULLY edit this file.  Most attempts to make large
-#       edits to this file will BREAK THE SERVER.  Any edits should
-#       be small, and tested by running the server with "radiusd -X".
-#       Once the edits have been verified to work, save a copy of these
-#       configuration files somewhere.  (e.g. as a "tar" file).  Then,
-#       make more edits, and test, as above.
-#
-#       There are many "commented out" references to modules such
-#       as ldap, sql, etc.  These references serve as place-holders.
-#       If you need the functionality of that module, then configure
-#       it in radiusd.conf, and un-comment the references to it in
-#       this file.  In most cases, those small changes will result
-#       in the server being able to connect to the DB, and to
-#       authenticate users.
-#
-######################################################################
 
 server default {
-#
-#  If you want the server to listen on additional addresses, or on
-#  additional ports, you can use multiple "listen" sections.
-#
-#  Each section make the server listen for only one type of packet,
-#  therefore authentication and accounting have to be configured in
-#  different sections.
-#
-#  The server ignore all "listen" section if you are using '-i' and '-p'
-#  on the command line.
-#
+
 listen {
-        #  Type of packets to listen for.
-        #  Allowed values are:
-        #       auth    listen for authentication packets
-        #       acct    listen for accounting packets
-        #       proxy   IP to use for sending proxied packets
-        #       detail  Read from the detail file.  For examples, see
-        #               raddb/sites-available/copy-acct-to-home-server
-        #       status  listen for Status-Server packets.  For examples,
-        #               see raddb/sites-available/status
-        #       coa     listen for CoA-Request and Disconnect-Request
-        #               packets.  For examples, see the file
-        #               raddb/sites-available/coa
-        #
         type = auth
-
-        #  Note: "type = proxy" lets you control the source IP used for
-        #        proxying packets, with some limitations:
-        #
-        #    * A proxy listener CANNOT be used in a virtual server section.
-        #    * You should probably set "port = 0".
-        #    * Any "clients" configuration will be ignored.
-        #
-        #  See also proxy.conf, and the "src_ipaddr" configuration entry
-        #  in the sample "home_server" section.  When you specify the
-        #  source IP address for packets sent to a home server, the
-        #  proxy listeners are automatically created.
-
-        #  ipaddr/ipv4addr/ipv6addr - IP address on which to listen.
-        #  If multiple ones are listed, only the first one will
-        #  be used, and the others will be ignored.
-        #
-        #  The configuration options accept the following syntax:
-        #
-        #  ipv4addr - IPv4 address (e.g.192.0.2.3)
-        #           - wildcard (i.e. *)
-        #           - hostname (radius.example.com)
-        #             Only the A record for the host name is used.
-        #             If there is no A record, an error is returned,
-        #             and the server fails to start.
-        #
-        #  ipv6addr - IPv6 address (e.g. 2001:db8::1)
-        #           - wildcard (i.e. *)
-        #           - hostname (radius.example.com)
-        #             Only the AAAA record for the host name is used.
-        #             If there is no AAAA record, an error is returned,
-        #             and the server fails to start.
-        #
-        #  ipaddr   - IPv4 address as above
-        #           - IPv6 address as above
-        #           - wildcard (i.e. *), which means IPv4 wildcard.
-        #           - hostname
-        #             If there is only one A or AAAA record returned
-        #             for the host name, it is used.
-        #             If multiple A or AAAA records are returned
-        #             for the host name, only the first one is used.
-        #             If both A and AAAA records are returned
-        #             for the host name, only the A record is used.
-        #
-        # ipv4addr = *
-        # ipv6addr = *
         ipaddr = *
-
-        #  Port on which to listen.
-        #  Allowed values are:
-        #       integer port number (1812)
-        #       0 means "use /etc/services for the proper port"
         port = 0
 
-        #  Some systems support binding to an interface, in addition
-        #  to the IP address.  This feature isn't strictly necessary,
-        #  but for sites with many IP addresses on one interface,
-        #  it's useful to say "listen on all addresses for eth0".
-        #
-        #  If your system does not support this feature, you will
-        #  get an error if you try to use it.
-        #
-#       interface = eth0
-
-        #  Per-socket lists of clients.  This is a very useful feature.
-        #
-        #  The name here is a reference to a section elsewhere in
-        #  radiusd.conf, or clients.conf.  Having the name as
-        #  a reference allows multiple sockets to use the same
-        #  set of clients.
-        #
-        #  If this configuration is used, then the global list of clients
-        #  is IGNORED for this "listen" section.  Take care configuring
-        #  this feature, to ensure you don't accidentally disable a
-        #  client you need.
-        #
-        #  See clients.conf for the configuration of "per_socket_clients".
-        #
-#       clients = per_socket_clients
-
-        #
-        #  Connection limiting for sockets with "proto = tcp".
-        #
-        #  This section is ignored for other kinds of sockets.
-        #
         limit {
-              #
-              #  Limit the number of simultaneous TCP connections to the socket
-              #
-              #  The default is 16.
-              #  Setting this to 0 means "no limit"
               max_connections = 16
-
-              #  The per-socket "max_requests" option does not exist.
-
-              #
-              #  The lifetime, in seconds, of a TCP connection.  After
-              #  this lifetime, the connection will be closed.
-              #
-              #  Setting this to 0 means "forever".
               lifetime = 0
-
-              #
-              #  The idle timeout, in seconds, of a TCP connection.
-              #  If no packets have been received over the connection for
-              #  this time, the connection will be closed.
-              #
-              #  Setting this to 0 means "no timeout".
-              #
-              #  We STRONGLY RECOMMEND that you set an idle timeout.
-              #
               idle_timeout = 30
         }
 }
 
-#
-#  This second "listen" section is for listening on the accounting
-#  port, too.
-#
 listen {
         ipaddr = *
-#       ipv6addr = ::
         port = 0
         type = acct
-#       interface = eth0
-#       clients = per_socket_clients
 
         limit {
-                #  The number of packets received can be rate limited via the
-                #  "max_pps" configuration item.  When it is set, the server
-                #  tracks the total number of packets received in the previous
-                #  second.  If the count is greater than "max_pps", then the
-                #  new packet is silently discarded.  This helps the server
-                #  deal with overload situations.
-                #
-                #  The packets/s counter is tracked in a sliding window.  This
-                #  means that the pps calculation is done for the second
-                #  before the current packet was received.  NOT for the current
-                #  wall-clock second, and NOT for the previous wall-clock second.
-                #
-                #  Useful values are 0 (no limit), or 100 to 10000.
-                #  Values lower than 100 will likely cause the server to ignore
-                #  normal traffic.  Few systems are capable of handling more than
-                #  10K packets/s.
-                #
-                #  It is most useful for accounting systems.  Set it to 50%
-                #  more than the normal accounting load, and you can be sure that
-                #  the server will never get overloaded
-                #
-#               max_pps = 0
-
-                # Only for "proto = tcp". These are ignored for "udp" sockets.
-                #
-#               idle_timeout = 0
-#               lifetime = 0
-#               max_connections = 0
         }
 }
 
-# IPv6 versions of the above - read their full config to understand options
 listen {
         type = auth
-        ipv6addr = ::   # any.  ::1 == localhost
+        ipv6addr = ::
         port = 0
-#       interface = eth0
-#       clients = per_socket_clients
+        
         limit {
               max_connections = 16
               lifetime = 0
@@ -249,709 +39,96 @@ listen {
         ipv6addr = ::
         port = 0
         type = acct
-#       interface = eth0
-#       clients = per_socket_clients
 
         limit {
-#               max_pps = 0
-#               idle_timeout = 0
-#               lifetime = 0
-#               max_connections = 0
         }
 }
 
-#  Authorization. First preprocess (hints and huntgroups files),
-#  then realms, and finally look in the "users" file.
-#
-#  Any changes made here should also be made to the "inner-tunnel"
-#  virtual server.
-#
-#  The order of the realm modules will determine the order that
-#  we try to find a matching realm.
-#
-#  Make *sure* that 'preprocess' comes before any realm if you
-#  need to setup hints for the remote radius server
 authorize {
-        #
-        #  Take a User-Name, and perform some checks on it, for spaces and other
-        #  invalid characters.  If the User-Name appears invalid, reject the
-        #  request.
-        #
-        #  See policy.d/filter for the definition of the filter_username policy.
-        #
         filter_username
-
-        #
-        #  Some broken equipment sends passwords with embedded zeros.
-        #  i.e. the debug output will show
-        #
-        #       User-Password = "password\000\000"
-        #
-        #  This policy will fix it to just be "password".
-        #
-#       filter_password
-
-        #
-        #  The preprocess module takes care of sanitizing some bizarre
-        #  attributes in the request, and turning them into attributes
-        #  which are more standard.
-        #
-        #  It takes care of processing the 'raddb/mods-config/preprocess/hints'
-        #  and the 'raddb/mods-config/preprocess/huntgroups' files.
         preprocess
-
-        #  If you intend to use CUI and you require that the Operator-Name
-        #  be set for CUI generation and you want to generate CUI also
-        #  for your local clients then uncomment the operator-name
-        #  below and set the operator-name for your clients in clients.conf
-#       operator-name
-
-        #
-        #  If you want to generate CUI for some clients that do not
-        #  send proper CUI requests, then uncomment the
-        #  cui below and set "add_cui = yes" for these clients in clients.conf
-#       cui
-
-        #
-        #  If you want to have a log of authentication requests,
-        #  un-comment the following line.
-#       auth_log
-
-        #
-        #  The chap module will set 'Auth-Type := CHAP' if we are
-        #  handling a CHAP request and Auth-Type has not already been set
         chap
-
-        #
-        #  If the users are logging in with an MS-CHAP-Challenge
-        #  attribute for authentication, the mschap module will find
-        #  the MS-CHAP-Challenge attribute, and add 'Auth-Type := MS-CHAP'
-        #  to the request, which will cause the server to then use
-        #  the mschap module for authentication.
         mschap
-
-        #
-        #  If you have a Cisco SIP server authenticating against
-        #  FreeRADIUS, uncomment the following line, and the 'digest'
-        #  line in the 'authenticate' section.
         digest
-
-        #
-        #  The WiMAX specification says that the Calling-Station-Id
-        #  is 6 octets of the MAC.  This definition conflicts with
-        #  RFC 3580, and all common RADIUS practices.  Un-commenting
-        #  the "wimax" module here means that it will fix the
-        #  Calling-Station-Id attribute to the normal format as
-        #  specified in RFC 3580 Section 3.21
-#       wimax
-
-        #
-        #  Look for IPASS style 'realm/', and if not found, look for
-        #  '@realm', and decide whether or not to proxy, based on
-        #  that.
-#       IPASS
-
-        #
-        #  If you are using multiple kinds of realms, you probably
-        #  want to set "ignore_null = yes" for all of them.
-        #  Otherwise, when the first style of realm doesn't match,
-        #  the other styles won't be checked.
-        #
         suffix
-#       ntdomain
-
-        #
-        #  This module takes care of EAP-MD5, EAP-TLS, and EAP-LEAP
-        #  authentication.
-        #
-        #  It also sets the EAP-Type attribute in the request
-        #  attribute list to the EAP type from the packet.
-        #
-        #  The EAP module returns "ok" or "updated" if it is not yet ready
-        #  to authenticate the user.  The configuration below checks for
-        #  "ok", and stops processing the "authorize" section if so.
-        #
-        #  Any LDAP and/or SQL servers will not be queried for the
-        #  initial set of packets that go back and forth to set up
-        #  TTLS or PEAP.
-        #
-        #  The "updated" check is commented out for compatibility with
-        #  previous versions of this configuration, but you may wish to
-        #  uncomment it as well; this will further reduce the number of
-        #  LDAP and/or SQL queries for TTLS or PEAP.
-        #
         eap {
                 ok = return
-#               updated = return
         }
-
-        #
-        #  Pull crypt'd passwords from /etc/passwd or /etc/shadow,
-        #  using the system API's to get the password.  If you want
-        #  to read /etc/passwd or /etc/shadow directly, see the
-        #  mods-available/passwd module.
-        #
-#       unix
-
-        #
-        #  Read the 'users' file.  In v3, this is located in
-        #  raddb/mods-config/files/authorize
         files
-
-        #
-        #  Look in an SQL database.  The schema of the database
-        #  is meant to mirror the "users" file.
-        #
-        #  See "Authorization Queries" in mods-available/sql
         -sql
-
-        #
-        #  If you are using /etc/smbpasswd, and are also doing
-        #  mschap authentication, the un-comment this line, and
-        #  configure the 'smbpasswd' module.
-#       smbpasswd
-
-        #
-        #  The ldap module reads passwords from the LDAP database.
         -ldap
 
-        #
-        #  Enforce daily limits on time spent logged in.
 {% if helpers.exists('OPNsense.freeradius.general.sessionlimit') and OPNsense.freeradius.general.sessionlimit == '1' %}        
         daily
 {% endif %}
 
-        #
         expiration
         logintime
-
-        #
-        #  If no other module has claimed responsibility for
-        #  authentication, then try to use PAP.  This allows the
-        #  other modules listed above to add a "known good" password
-        #  to the request, and to do nothing else.  The PAP module
-        #  will then see that password, and use it to do PAP
-        #  authentication.
-        #
-        #  This module should be listed last, so that the other modules
-        #  get a chance to set Auth-Type for themselves.
-        #
         pap
-
-        #
-        #  If "status_server = yes", then Status-Server messages are passed
-        #  through the following section, and ONLY the following section.
-        #  This permits you to do DB queries, for example.  If the modules
-        #  listed here return "fail", then NO response is sent.
-        #
-#       Autz-Type Status-Server {
-#
-#       }
 }
 
-
-#  Authentication.
-#
-#
-#  This section lists which modules are available for authentication.
-#  Note that it does NOT mean 'try each module in order'.  It means
-#  that a module from the 'authorize' section adds a configuration
-#  attribute 'Auth-Type := FOO'.  That authentication type is then
-#  used to pick the appropriate module from the list below.
-#
-
-#  In general, you SHOULD NOT set the Auth-Type attribute.  The server
-#  will figure it out on its own, and will do the right thing.  The
-#  most common side effect of erroneously setting the Auth-Type
-#  attribute is that one authentication method will work, but the
-#  others will not.
-#
-#  The common reasons to set the Auth-Type attribute by hand
-#  is to either forcibly reject the user (Auth-Type := Reject),
-#  or to or forcibly accept the user (Auth-Type := Accept).
-#
-#  Note that Auth-Type := Accept will NOT work with EAP.
-#
-#  Please do not put "unlang" configurations into the "authenticate"
-#  section.  Put them in the "post-auth" section instead.  That's what
-#  the post-auth section is for.
-#
 authenticate {
-        #
-        #  PAP authentication, when a back-end database listed
-        #  in the 'authorize' section supplies a password.  The
-        #  password can be clear-text, or encrypted.
         Auth-Type PAP {
                 pap
         }
-
-        #
-        #  Most people want CHAP authentication
-        #  A back-end database listed in the 'authorize' section
-        #  MUST supply a CLEAR TEXT password.  Encrypted passwords
-        #  won't work.
         Auth-Type CHAP {
                 chap
         }
-
-        #
-        #  MSCHAP authentication.
         Auth-Type MS-CHAP {
                 mschap
         }
-
-        #
-        #  For old names, too.
-        #
         mschap
-
-        #
-        #  If you have a Cisco SIP server authenticating against
-        #  FreeRADIUS, uncomment the following line, and the 'digest'
-        #  line in the 'authorize' section.
         digest
-
-        #
-        #  Pluggable Authentication Modules.
-#       pam
-
-        #  Uncomment it if you want to use ldap for authentication
-        #
-        #  Note that this means "check plain-text password against
-        #  the ldap database", which means that EAP won't work,
-        #  as it does not supply a plain-text password.
-        #
-        #  We do NOT recommend using this.  LDAP servers are databases.
-        #  They are NOT authentication servers.  FreeRADIUS is an
-        #  authentication server, and knows what to do with authentication.
-        #  LDAP servers do not.
-        #
-#       Auth-Type LDAP {
-#               ldap
-#       }
-
-        #
-        #  Allow EAP authentication.
         eap
-
-        #
-        #  The older configurations sent a number of attributes in
-        #  Access-Challenge packets, which wasn't strictly correct.
-        #  If you want to filter out these attributes, uncomment
-        #  the following lines.
-        #
-#       Auth-Type eap {
-#               eap {
-#                       handled = 1
-#               }
-#               if (handled && (Response-Packet-Type == Access-Challenge)) {
-#                       attr_filter.access_challenge.post-auth
-#                       handled  # override the "updated" code from attr_filter
-#               }
-#       }
 }
 
-
-#
-#  Pre-accounting.  Decide which accounting type to use.
-#
 preacct {
         preprocess
-
-        #
-        #  Merge Acct-[Input|Output]-Gigawords and Acct-[Input-Output]-Octets
-        #  into a single 64bit counter Acct-[Input|Output]-Octets64.
-        #
-#       acct_counters64
-
-        #
-        #  Session start times are *implied* in RADIUS.
-        #  The NAS never sends a "start time".  Instead, it sends
-        #  a start packet, *possibly* with an Acct-Delay-Time.
-        #  The server is supposed to conclude that the start time
-        #  was "Acct-Delay-Time" seconds in the past.
-        #
-        #  The code below creates an explicit start time, which can
-        #  then be used in other modules.  It will be *mostly* correct.
-        #  Any errors are due to the 1-second resolution of RADIUS,
-        #  and the possibility that the time on the NAS may be off.
-        #
-        #  The start time is: NOW - delay - session_length
-        #
-
-#       update request {
-#               FreeRADIUS-Acct-Session-Start-Time = "%{expr: %l - %{%{Acct-Session-Time}:-0} - %{%{Acct-Delay-Time}:-0}}"
-#       }
-
-
-        #
-        #  Ensure that we have a semi-unique identifier for every
-        #  request, and many NAS boxes are broken.
         acct_unique
-
-        #
-        #  Look for IPASS-style 'realm/', and if not found, look for
-        #  '@realm', and decide whether or not to proxy, based on
-        #  that.
-        #
-        #  Accounting requests are generally proxied to the same
-        #  home server as authentication requests.
-#       IPASS
         suffix
-#       ntdomain
-
-        #
-        #  Read the 'acct_users' file
         files
 }
 
-#
-#  Accounting.  Log the accounting data.
-#
+
 accounting {
-        #  Update accounting packet by adding the CUI attribute
-        #  recorded from the corresponding Access-Accept
-        #  use it only if your NAS boxes do not support CUI themselves
-#       cui
-        #
-        #  Create a 'detail'ed log of the packets.
-        #  Note that accounting requests which are proxied
-        #  are also logged in the detail file.
         detail
 {% if helpers.exists('OPNsense.freeradius.general.sessionlimit') and OPNsense.freeradius.general.sessionlimit == '1' %}        
         daily
         sradutmp
 {% endif %}
-
-        #  Update the wtmp file
-        #
-        #  If you don't use "radlast", you can delete this line.
         unix
-
-        #
-        #  For Simultaneous-Use tracking.
-        #
-        #  Due to packet losses in the network, the data here
-        #  may be incorrect.  There is little we can do about it.
-#       radutmp
-#       sradutmp
-
-        #  Return an address to the IP Pool when we see a stop record.
-#       main_pool
-
-        #
-        #  Log traffic to an SQL database.
-        #
-        #  See "Accounting queries" in mods-available/sql
         -sql
-
-        #
-        #  If you receive stop packets with zero session length,
-        #  they will NOT be logged in the database.  The SQL module
-        #  will print a message (only in debugging mode), and will
-        #  return "noop".
-        #
-        #  You can ignore these packets by uncommenting the following
-        #  three lines.  Otherwise, the server will not respond to the
-        #  accounting request, and the NAS will retransmit.
-        #
-#       if (noop) {
-#               ok
-#       }
-
-        #
-        #  Instead of sending the query to the SQL server,
-        #  write it into a log file.
-        #
-#       sql_log
-
-        #  Cisco VoIP specific bulk accounting
-#       pgsql-voip
-
-        # For Exec-Program and Exec-Program-Wait
         exec
-
-        #  Filter attributes from the accounting response.
         attr_filter.accounting_response
-
-        #
-        #  See "Autz-Type Status-Server" for how this works.
-        #
-#       Acct-Type Status-Server {
-#
-#       }
 }
 
-
-#  Session database, used for checking Simultaneous-Use. Either the radutmp
-#  or rlm_sql module can handle this.
-#  The rlm_sql module is *much* faster
 session {
-#       radutmp
-
-        #
-        #  See "Simultaneous Use Checking Queries" in mods-available/sql
-#       sql
 }
 
-
-#  Post-Authentication
-#  Once we KNOW that the user has been authenticated, there are
-#  additional steps we can take.
 post-auth {
-        #
-        #  If you need to have a State attribute, you can
-        #  add it here.  e.g. for later CoA-Request with
-        #  State, and Service-Type = Authorize-Only.
-        #
-#       if (!&reply:State) {
-#               update reply {
-#                       State := "0x%{randstr:16h}"
-#               }
-#       }
-
-        #
-        #  For EAP-TTLS and PEAP, add the cached attributes to the reply.
-        #  The "session-state" attributes are automatically cached when
-        #  an Access-Challenge is sent, and automatically retrieved
-        #  when an Access-Request is received.
-        #
-        #  The session-state attributes are automatically deleted after
-        #  an Access-Reject or Access-Accept is sent.
-        #
         update {
                 &reply: += &session-state:
         }
-
-        #  Get an address from the IP Pool.
-#       main_pool
-
-
-        #  Create the CUI value and add the attribute to Access-Accept.
-        #  Uncomment the line below if *returning* the CUI.
-#       cui
-
-        #
-        #  If you want to have a log of authentication replies,
-        #  un-comment the following line, and enable the
-        #  'detail reply_log' module.
-#       reply_log
-
-        #
-        #  After authenticating the user, do another SQL query.
-        #
-        #  See "Authentication Logging Queries" in mods-available/sql
         -sql
-
-        #
-        #  Instead of sending the query to the SQL server,
-        #  write it into a log file.
-        #
-#       sql_log
-
-        #
-        #  Un-comment the following if you want to modify the user's object
-        #  in LDAP after a successful login.
-        #
-#       ldap
-
-        # For Exec-Program and Exec-Program-Wait
         exec
-
-        #
-        #  Calculate the various WiMAX keys.  In order for this to work,
-        #  you will need to define the WiMAX NAI, usually via
-        #
-        #       update request {
-        #              WiMAX-MN-NAI = "%{User-Name}"
-        #       }
-        #
-        #  If you want various keys to be calculated, you will need to
-        #  update the reply with "template" values.  The module will see
-        #  this, and replace the template values with the correct ones
-        #  taken from the cryptographic calculations.  e.g.
-        #
-        #       update reply {
-        #               WiMAX-FA-RK-Key = 0x00
-        #               WiMAX-MSK = "%{EAP-MSK}"
-        #       }
-        #
-        #  You may want to delete the MS-MPPE-*-Keys from the reply,
-        #  as some WiMAX clients behave badly when those attributes
-        #  are included.  See "raddb/modules/wimax", configuration
-        #  entry "delete_mppe_keys" for more information.
-        #
-#       wimax
-
-
-        #  If there is a client certificate (EAP-TLS, sometimes PEAP
-        #  and TTLS), then some attributes are filled out after the
-        #  certificate verification has been performed.  These fields
-        #  MAY be available during the authentication, or they may be
-        #  available only in the "post-auth" section.
-        #
-        #  The first set of attributes contains information about the
-        #  issuing certificate which is being used.  The second
-        #  contains information about the client certificate (if
-        #  available).
-#
-#       update reply {
-#              Reply-Message += "%{TLS-Cert-Serial}"
-#              Reply-Message += "%{TLS-Cert-Expiration}"
-#              Reply-Message += "%{TLS-Cert-Subject}"
-#              Reply-Message += "%{TLS-Cert-Issuer}"
-#              Reply-Message += "%{TLS-Cert-Common-Name}"
-#              Reply-Message += "%{TLS-Cert-Subject-Alt-Name-Email}"
-#
-#              Reply-Message += "%{TLS-Client-Cert-Serial}"
-#              Reply-Message += "%{TLS-Client-Cert-Expiration}"
-#              Reply-Message += "%{TLS-Client-Cert-Subject}"
-#              Reply-Message += "%{TLS-Client-Cert-Issuer}"
-#              Reply-Message += "%{TLS-Client-Cert-Common-Name}"
-#              Reply-Message += "%{TLS-Client-Cert-Subject-Alt-Name-Email}"
-#       }
-
-        #  Insert class attribute (with unique value) into response,
-        #  aids matching auth and acct records, and protects against duplicate
-        #  Acct-Session-Id. Note: Only works if the NAS has implemented
-        #  RFC 2865 behaviour for the class attribute, AND if the NAS
-        #  supports long Class attributes.  Many older or cheap NASes
-        #  only support 16-octet Class attributes.
-#       insert_acct_class
-
-        #  MacSEC requires the use of EAP-Key-Name.  However, we don't
-        #  want to send it for all EAP sessions.  Therefore, the EAP
-        #  modules put required data into the EAP-Session-Id attribute.
-        #  This attribute is never put into a request or reply packet.
-        #
-        #  Uncomment the next few lines to copy the required data into
-        #  the EAP-Key-Name attribute
-#       if (&reply:EAP-Session-Id) {
-#               update reply {
-#                       EAP-Key-Name := &reply:EAP-Session-Id
-#               }
-#       }
-
-        #  Remove reply message if the response contains an EAP-Message
         remove_reply_message_if_eap
-
-        #
-        #  Access-Reject packets are sent through the REJECT sub-section of the
-        #  post-auth section.
-        #
-        #  Add the ldap module name (or instance) if you have set
-        #  'edir_account_policy_check = yes' in the ldap module configuration
-        #
-        #  The "session-state" attributes are not available here.
-        #
         Post-Auth-Type REJECT {
-                # log failed authentications in SQL, too.
                 -sql
                 attr_filter.access_reject
-
-                # Insert EAP-Failure message if the request was
-                # rejected by policy instead of because of an
-                # authentication failure
                 eap
-
-                #  Remove reply message if the response contains an EAP-Message
                 remove_reply_message_if_eap
         }
 
-        #
-        #  Filter access challenges.
-        #
         Post-Auth-Type Challenge {
-#               remove_reply_message_if_eap
-#               attr_filter.access_challenge.post-auth
         }
 
 }
 
-#
-#  When the server decides to proxy a request to a home server,
-#  the proxied request is first passed through the pre-proxy
-#  stage.  This stage can re-write the request, or decide to
-#  cancel the proxy.
-#
-#  Only a few modules currently have this method.
-#
 pre-proxy {
-        # Before proxing the request add an Operator-Name attribute identifying
-        # if the operator-name is found for this client.
-        # No need to uncomment this if you have already enabled this in
-        # the authorize section.
-#       operator-name
-
-        #  The client requests the CUI by sending a CUI attribute
-        #  containing one zero byte.
-        #  Uncomment the line below if *requesting* the CUI.
-#       cui
-
-        #  Uncomment the following line if you want to change attributes
-        #  as defined in the preproxy_users file.
-#       files
-
-        #  Uncomment the following line if you want to filter requests
-        #  sent to remote servers based on the rules defined in the
-        #  'attrs.pre-proxy' file.
-#       attr_filter.pre-proxy
-
-        #  If you want to have a log of packets proxied to a home
-        #  server, un-comment the following line, and the
-        #  'detail pre_proxy_log' section, above.
-#       pre_proxy_log
 }
 
-#
-#  When the server receives a reply to a request it proxied
-#  to a home server, the request may be massaged here, in the
-#  post-proxy stage.
-#
 post-proxy {
-
-        #  If you want to have a log of replies from a home server,
-        #  un-comment the following line, and the 'detail post_proxy_log'
-        #  section, above.
-#       post_proxy_log
-
-        #  Uncomment the following line if you want to filter replies from
-        #  remote proxies based on the rules defined in the 'attrs' file.
-#       attr_filter.post-proxy
-
-        #
-        #  If you are proxying LEAP, you MUST configure the EAP
-        #  module, and you MUST list it here, in the post-proxy
-        #  stage.
-        #
-        #  You MUST also use the 'nostrip' option in the 'realm'
-        #  configuration.  Otherwise, the User-Name attribute
-        #  in the proxied request will not match the user name
-        #  hidden inside of the EAP packet, and the end server will
-        #  reject the EAP request.
-        #
         eap
-
-        #
-        #  If the server tries to proxy a request and fails, then the
-        #  request is processed through the modules in this section.
-        #
-        #  The main use of this section is to permit robust proxying
-        #  of accounting packets.  The server can be configured to
-        #  proxy accounting packets as part of normal processing.
-        #  Then, if the home server goes down, accounting packets can
-        #  be logged to a local "detail" file, for processing with
-        #  radrelay.  When the home server comes back up, radrelay
-        #  will read the detail file, and send the packets to the
-        #  home server.
-        #
-        #  With this configuration, the server always responds to
-        #  Accounting-Requests from the NAS, but only writes
-        #  accounting packets to disk if the home server is down.
-        #
-#       Post-Proxy-Type Fail-Accounting {
-#                       detail
-#       }
 }
 }
 {% endif %}

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/sites-enabled-default
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/sites-enabled-default
@@ -621,6 +621,7 @@ accounting {
         detail
 {% if helpers.exists('OPNsense.freeradius.general.enable_daily_sessionlimit') and OPNsense.freeradius.general.enable_daily_sessionlimit == '1' %}        
         daily
+        sradutmp
 {% endif %}
 
         #  Update the wtmp file

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/sites-enabled-default
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/sites-enabled-default
@@ -418,7 +418,9 @@ authorize {
 
         #
         #  Enforce daily limits on time spent logged in.
-#       daily
+{% if helpers.exists('OPNsense.freeradius.general.enable_daily_sessionlimit') and OPNsense.freeradius.general.enable_daily_sessionlimit == '1' %}        
+        daily
+{% endif %}
 
         #
         expiration
@@ -617,7 +619,9 @@ accounting {
         #  Note that accounting requests which are proxied
         #  are also logged in the detail file.
         detail
-#       daily
+{% if helpers.exists('OPNsense.freeradius.general.enable_daily_sessionlimit') and OPNsense.freeradius.general.enable_daily_sessionlimit == '1' %}        
+        daily
+{% endif %}
 
         #  Update the wtmp file
         #

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/sites-enabled-default
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/sites-enabled-default
@@ -1,5 +1,4 @@
 {% if helpers.exists('OPNsense.freeradius.general.enabled') and OPNsense.freeradius.general.enabled == '1' %}
-{% raw %}
 ######################################################################
 #
 #       As of 2.0.0, FreeRADIUS supports virtual hosts using the
@@ -418,7 +417,7 @@ authorize {
 
         #
         #  Enforce daily limits on time spent logged in.
-{% if helpers.exists('OPNsense.freeradius.general.enable_daily_sessionlimit') and OPNsense.freeradius.general.enable_daily_sessionlimit == '1' %}        
+{% if helpers.exists('OPNsense.freeradius.general.sessionlimit') and OPNsense.freeradius.general.sessionlimit == '1' %}        
         daily
 {% endif %}
 
@@ -619,7 +618,7 @@ accounting {
         #  Note that accounting requests which are proxied
         #  are also logged in the detail file.
         detail
-{% if helpers.exists('OPNsense.freeradius.general.enable_daily_sessionlimit') and OPNsense.freeradius.general.enable_daily_sessionlimit == '1' %}        
+{% if helpers.exists('OPNsense.freeradius.general.sessionlimit') and OPNsense.freeradius.general.sessionlimit == '1' %}        
         daily
         sradutmp
 {% endif %}
@@ -955,5 +954,4 @@ post-proxy {
 #       }
 }
 }
-{% endraw %}
 {% endif %}

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/users
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/users
@@ -15,7 +15,7 @@
        WISPr-Bandwidth-Min-Down = {{ user_list.wispr_bw_min_down }}{% endif %}{% if user_list.wispr_bw_max_down is defined %},
        WISPr-Bandwidth-Max-Down = {{ user_list.wispr_bw_max_down }}{% endif %}{% if user_list.chillispot_bw_max_up is defined %},
        ChilliSpot-Bandwidth-Max-Up = {{ user_list.chillispot_bw_max_up }}{% endif %}{% if user_list.chillispot_bw_max_down is defined %},
-       ChilliSpot-Bandwidth-Max-Down = {{ user_list.chillispot_bw_max_down }}{% if user_list.max_session_limit is defined %},
+       ChilliSpot-Bandwidth-Max-Down = {{ user_list.chillispot_bw_max_down }}{% endif %}{% if user_list.max_session_limit is defined %},
        Max-Daily-Session = {{ user_list.max_session_limit }}
 {%       endif %}
 

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/users
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/users
@@ -15,8 +15,8 @@
        WISPr-Bandwidth-Min-Down = {{ user_list.wispr_bw_min_down }}{% endif %}{% if user_list.wispr_bw_max_down is defined %},
        WISPr-Bandwidth-Max-Down = {{ user_list.wispr_bw_max_down }}{% endif %}{% if user_list.chillispot_bw_max_up is defined %},
        ChilliSpot-Bandwidth-Max-Up = {{ user_list.chillispot_bw_max_up }}{% endif %}{% if user_list.chillispot_bw_max_down is defined %},
-       ChilliSpot-Bandwidth-Max-Down = {{ user_list.chillispot_bw_max_down }}{% endif %}{% if user_list.max_session_limit is defined %},
-       Max-Daily-Session = {{ user_list.max_session_limit }}
+       ChilliSpot-Bandwidth-Max-Down = {{ user_list.chillispot_bw_max_down }}{% endif %}{% if user_list.sessionlimit_max_session_limit is defined %},
+       Max-Daily-Session = {{ user_list.sessionlimit_max_session_limit }}
 {%       endif %}
 
 {%     endif %}

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/users
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/users
@@ -15,7 +15,8 @@
        WISPr-Bandwidth-Min-Down = {{ user_list.wispr_bw_min_down }}{% endif %}{% if user_list.wispr_bw_max_down is defined %},
        WISPr-Bandwidth-Max-Down = {{ user_list.wispr_bw_max_down }}{% endif %}{% if user_list.chillispot_bw_max_up is defined %},
        ChilliSpot-Bandwidth-Max-Up = {{ user_list.chillispot_bw_max_up }}{% endif %}{% if user_list.chillispot_bw_max_down is defined %},
-       ChilliSpot-Bandwidth-Max-Down = {{ user_list.chillispot_bw_max_down }}
+       ChilliSpot-Bandwidth-Max-Down = {{ user_list.chillispot_bw_max_down }}{% if user_list.max_session_limit is defined %},
+       Max-Daily-Session = {{ user_list.max_session_limit }}
 {%       endif %}
 
 {%     endif %}

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/users
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/users
@@ -16,7 +16,7 @@
        WISPr-Bandwidth-Max-Down = {{ user_list.wispr_bw_max_down }}{% endif %}{% if user_list.chillispot_bw_max_up is defined %},
        ChilliSpot-Bandwidth-Max-Up = {{ user_list.chillispot_bw_max_up }}{% endif %}{% if user_list.chillispot_bw_max_down is defined %},
        ChilliSpot-Bandwidth-Max-Down = {{ user_list.chillispot_bw_max_down }}{% endif %}{% if user_list.sessionlimit_max_session_limit is defined %},
-       Max-Daily-Session = {{ user_list.sessionlimit_max_session_limit }}
+       Max-Daily-Session := {{ user_list.sessionlimit_max_session_limit }}
 {%       endif %}
 
 {%     endif %}


### PR DESCRIPTION
- Reintroduce radiusd.conf with dynamic lib dir
- Let the user choose to log to file or via syslog
- Add dictionary file
- Let the user enable logging of good/bad pass 
- Let the user enable daily session limit for captive portal

I need this in master for a devel pkg but needs some more testing by community, so stable better for 17.7.9 or 18.1 with some more additions. :)