### PR TITLE
mail/postfix: add smtp security enforcement and certificate selection

### DIFF
--- a/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
+++ b/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
@@ -77,7 +77,7 @@
         <id>general.smtpclient_security</id>
         <label>SMTP Client Security</label>
         <type>dropdown</type>
-        <help>Choose none to disable TLS for sending mail. Set encrypt to enforce TLS security, please don't use this for Internet wide communication as no every server supports TLS yet. Default is may which will use TLS when offered.</help>
+        <help>Choose "none" to disable TLS for sending mail. Set encrypt to enforce TLS security, please do not use this for Internet wide communication as not every server supports TLS yet. Default is may which will use TLS when offered.</help>
     </field>
     <field>
         <id>general.reject_unauth_pipelining</id>

--- a/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
+++ b/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
@@ -62,6 +62,12 @@
         <help>This will disable known weak ciphers like DES, RC4 or MD5.</help>
     </field>
     <field>
+        <id>general.certificate</id>
+        <label>Server Certificate</label>
+        <type>dropdown</type>
+        <help>Choose the certificate to use when other servers want to do TLS with you.</help>
+    </field>
+    <field>
         <id>general.smtpclient_security</id>
         <label>SMTP Client Security</label>
         <type>dropdown</type>

--- a/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
+++ b/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
@@ -68,6 +68,12 @@
         <help>Choose the certificate to use when other servers want to do TLS with you.</help>
     </field>
     <field>
+        <id>general.ca</id>
+        <label>Root CA</label>
+        <type>dropdown</type>
+        <help>Choose the Certificate Authority which signed your certificate.</help>
+    </field>
+    <field>
         <id>general.smtpclient_security</id>
         <label>SMTP Client Security</label>
         <type>dropdown</type>

--- a/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
+++ b/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
@@ -62,6 +62,12 @@
         <help>This will disable known weak ciphers like DES, RC4 or MD5.</help>
     </field>
     <field>
+        <id>general.smtpclient_security</id>
+        <label>SMTP Client Security</label>
+        <type>dropdown</type>
+        <help>Choose none to disable TLS for sending mail. Set encrypt to enforce TLS security, please don't use this for Internet wide communication as no every server supports TLS yet. Default is may which will use TLS when offered.</help>
+    </field>
+    <field>
         <id>general.reject_unauth_pipelining</id>
         <label>Reject Unauthenticated Pipelining</label>
         <type>checkbox</type>

--- a/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
+++ b/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
@@ -77,7 +77,7 @@
         <id>general.smtpclient_security</id>
         <label>SMTP Client Security</label>
         <type>dropdown</type>
-        <help>Choose "none" to disable TLS for sending mail. Set encrypt to enforce TLS security, please do not use this for Internet wide communication as not every server supports TLS yet. Default is may which will use TLS when offered.</help>
+        <help>Choose "none" to disable TLS for sending mail. Set encrypt to enforce TLS security, please do not use this for Internet wide communication as not every server supports TLS yet. Default is "may" which will use TLS when offered.</help>
     </field>
     <field>
         <id>general.reject_unauth_pipelining</id>

--- a/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
+++ b/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
@@ -43,6 +43,10 @@
             <default>1</default>
             <Required>Y</Required>
         </disable_weak_ciphers>
+        <certificate type="CertificateField">
+            <Type>cert</Type>
+            <Required>N</Required>
+        </certificate>
         <smtpclient_security type="OptionField">
             <default>may</default>
             <Required>Y</Required>

--- a/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
+++ b/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
@@ -47,6 +47,10 @@
             <Type>cert</Type>
             <Required>N</Required>
         </certificate>
+        <ca type="CertificateField">
+            <Type>ca</Type>
+            <Required>N</Required>
+        </ca>
         <smtpclient_security type="OptionField">
             <default>may</default>
             <Required>Y</Required>

--- a/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
+++ b/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
@@ -43,6 +43,15 @@
             <default>1</default>
             <Required>Y</Required>
         </disable_weak_ciphers>
+        <smtpclient_security type="OptionField">
+            <default>may</default>
+            <Required>Y</Required>
+            <OptionValues>
+                <none>none</none>
+                <may>may</may>
+                <encrypt>encrypt</encrypt>
+            </OptionValues>
+        </smtpclient_security>
         <check_recipient_access type="ArrayField">
         </check_recipient_access>
         <reject_unauth_pipelining type="BooleanField">

--- a/mail/postfix/src/opnsense/scripts/OPNsense/Postfix/generate_certs.php
+++ b/mail/postfix/src/opnsense/scripts/OPNsense/Postfix/generate_certs.php
@@ -1,0 +1,85 @@
+#!/usr/local/bin/php
+<?php
+
+/*
+ *    Copyright (C) 2015 Deciso B.V.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// use legacy code to generate certs and ca's
+// eventually we need to replace this.
+require_once("config.inc");
+require_once("certs.inc");
+require_once("legacy_bindings.inc");
+
+use OPNsense\Core\Config;
+
+$cert_pem_filename = '/usr/local/etc/postfix/cert_opn.pem';
+$cert_pem_content = '';
+
+$ca_pem_filename = '/usr/local/etc/postfix/ca_opn.pem';
+$ca_pem_content = '';
+
+// traverse Postfix plugin for certficiates
+$configObj = Config::getInstance()->object();
+if (isset($configObj->OPNsense->postfix)) {
+    foreach ($configObj->OPNsense->postfix->children() as $find_cert) {
+        $cert_refid = (string)$find_cert->certificate;
+        // if eap has a certificate attached, search for its contents
+        if ($cert_refid != "") {
+            foreach ($configObj->cert as $cert) {
+                if ($cert_refid == (string)$cert->refid) {
+                    // generate cert pem file
+                    $pem_content = trim(str_replace("\n\n", "\n", str_replace(
+                        "\r",
+                        "",
+                        base64_decode((string)$cert->crt)
+                    )));
+
+                    $pem_content .= "\n";
+                    $pem_content .= trim(str_replace(
+                        "\n\n",
+                        "\n",
+                        str_replace("\r", "", base64_decode((string)$cert->prv))
+                    ));
+                    $pem_content .= "\n";
+                    $cert_pem_content .= $pem_content;
+                    // generate ca pem file
+                    if (!empty($cert->caref)) {
+                        $cert = (array)$cert;
+                        $ca_pem_content .= ca_chain($cert);
+                    }
+                }
+            }
+        }
+    }
+}
+
+file_put_contents($cert_pem_filename, $cert_pem_content);
+chmod($cert_pem_filename, 0600);
+echo "Certificates generated $cert_pem_filename\n";
+
+file_put_contents($ca_pem_filename, $ca_pem_content);
+chmod($ca_pem_filename, 0600);
+echo "Certificates generated $ca_pem_filename\n";

--- a/mail/postfix/src/opnsense/scripts/OPNsense/Postfix/setup.sh
+++ b/mail/postfix/src/opnsense/scripts/OPNsense/Postfix/setup.sh
@@ -30,3 +30,5 @@ chown -R root:postfix /var/spool/postfix/pid
 postmap /usr/local/etc/postfix/transport
 postmap /usr/local/etc/postfix/recipient_access
 postmap /usr/local/etc/postfix/sender_access
+
+/usr/local/opnsense/scripts/OPNsense/Postfix/generate_certs.php

--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
@@ -79,7 +79,7 @@ smtpd_tls_exclude_ciphers = aNULL, eNULL, EXPORT, DES, RC4, MD5, PSK, aECDH, EDH
 smtp_tls_security_level = {{ OPNsense.postfix.general.smtpclient_security }}
 {% endif %}
 {% if helpers.exists('OPNsense.postfix.general.certificate') and OPNsense.postfix.general.certificate != '' %}
-smtpd_tls_cert_file = {{ OPNsense.postfix.general.certificate }}
+smtpd_tls_cert_file = /usr/local/etc/postfix/cert_opn.pem
 {% endif %}
 
 {% if helpers.exists('OPNsense.postfix.antispam.enable_rspamd') and OPNsense.postfix.antispam.enable_rspamd == '1' %}

--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
@@ -75,6 +75,9 @@ smtp_tls_protocols=!SSLv2,!SSLv3
 {% if helpers.exists('OPNsense.postfix.general.disable_weak_ciphers') and OPNsense.postfix.general.disable_weak_ciphers == '1' %}
 smtpd_tls_exclude_ciphers = aNULL, eNULL, EXPORT, DES, RC4, MD5, PSK, aECDH, EDH-DSS-DES-CBC3-SHA, EDH-RSA-DES-CDC3-SHA, KRB5-DE5, CBC3-SHA
 {% endif %}
+{% if helpers.exists('OPNsense.postfix.general.smtpclient_security') and OPNsense.postfix.general.smtpclient_security != '' %}
+smtp_tls_security_level = {{ OPNsense.postfix.general.smtpclient_security }}
+{% endif %}
 
 {% if helpers.exists('OPNsense.postfix.antispam.enable_rspamd') and OPNsense.postfix.antispam.enable_rspamd == '1' %}
 smtpd_milters = inet:localhost:11332

--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
@@ -78,6 +78,9 @@ smtpd_tls_exclude_ciphers = aNULL, eNULL, EXPORT, DES, RC4, MD5, PSK, aECDH, EDH
 {% if helpers.exists('OPNsense.postfix.general.smtpclient_security') and OPNsense.postfix.general.smtpclient_security != '' %}
 smtp_tls_security_level = {{ OPNsense.postfix.general.smtpclient_security }}
 {% endif %}
+{% if helpers.exists('OPNsense.postfix.general.certificate') and OPNsense.postfix.general.certificate != '' %}
+smtpd_tls_cert_file = {{ OPNsense.postfix.general.certificate }}
+{% endif %}
 
 {% if helpers.exists('OPNsense.postfix.antispam.enable_rspamd') and OPNsense.postfix.antispam.enable_rspamd == '1' %}
 smtpd_milters = inet:localhost:11332

--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
@@ -79,7 +79,11 @@ smtpd_tls_exclude_ciphers = aNULL, eNULL, EXPORT, DES, RC4, MD5, PSK, aECDH, EDH
 smtp_tls_security_level = {{ OPNsense.postfix.general.smtpclient_security }}
 {% endif %}
 {% if helpers.exists('OPNsense.postfix.general.certificate') and OPNsense.postfix.general.certificate != '' %}
+smtpd_use_tls = yes
 smtpd_tls_cert_file = /usr/local/etc/postfix/cert_opn.pem
+{% endif %}
+{% if helpers.exists('OPNsense.postfix.general.ca') and OPNsense.postfix.general.ca != '' %}
+smtpd_tls_CAfile = /usr/local/etc/postfix/ca_opn.pem
 {% endif %}
 
 {% if helpers.exists('OPNsense.postfix.antispam.enable_rspamd') and OPNsense.postfix.antispam.enable_rspamd == '1' %}


### PR DESCRIPTION
- Let the user choose whether the SMTP MUST be encrypted or MAY be encrypted
- Let the user choose certficate and CA, looks good under https://de.ssl-tools.net/mailservers