### PR TITLE
net/haproxy: bugfix release 2.1

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		haproxy
-PLUGIN_VERSION=		2.0
+PLUGIN_VERSION=		2.1
 PLUGIN_COMMENT=		Reliable, high performance TCP/HTTP load balancer
 PLUGIN_DEPENDS=		haproxy
 PLUGIN_MAINTAINER=	opnsense@moov.de

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -607,7 +607,7 @@ frontend {{frontend.name}}
 {%             do ssl_options.append('ciphers ' ~ frontend.ssl_cipherList) %}
 {%           endif %}
 {#           # HSTS #}
-{%           if frontend.ssl_hstsEnabled|default("") == '1' %}
+{%           if frontend.ssl_hstsEnabled|default("") == '1' and frontend.mode == 'http' %}
     http-response set-header Strict-Transport-Security max-age={{frontend.ssl_hstsMaxAge}}
 {%           endif %}
 {%         endif %}

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -606,10 +606,10 @@ frontend {{frontend.name}}
 {%           if frontend.ssl_cipherList|default("") != "" %}
 {%             do ssl_options.append('ciphers ' ~ frontend.ssl_cipherList) %}
 {%           endif %}
-{%         endif %}
-{#         # HSTS #}
-{%         if frontend.ssl_hstsEnabled|default("") == '1' %}
+{#           # HSTS #}
+{%           if frontend.ssl_hstsEnabled|default("") == '1' %}
     http-response set-header Strict-Transport-Security max-age={{frontend.ssl_hstsMaxAge}}
+{%           endif %}
 {%         endif %}
 {%       endif %}
 {#       # bind/listen configuration #}


### PR DESCRIPTION
## New features
none

## Bugfixes
- do not enable HSTS unconditionally (now works as described in #380)
- enable HSTS only for HTTP frontends