### PR TITLE
add service reload button like in security/tor

### DIFF
--- a/net/frr/Makefile
+++ b/net/frr/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		frr
-PLUGIN_VERSION=		0.0.1
+PLUGIN_VERSION=		0.0.2
 PLUGIN_COMMENT=		FRR Routing Suite
 PLUGIN_DEPENDS=		frr ruby
 PLUGIN_MAINTAINER=	franz.fabian.94@gmail.com

--- a/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/bgp.volt
+++ b/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/bgp.volt
@@ -67,10 +67,11 @@ POSSIBILITY OF SUCH DAMAGE.
             </tbody>
             <tfoot>
                 <tr>
-                    <td colspan="5"></td>
-                <td>
-                    <button data-action="add" type="button" class="btn btn-xs btn-default"><span class="fa fa-plus"></span></button>
-                    <!-- <button data-action="deleteSelected" type="button" class="btn btn-xs btn-default"><span class="fa fa-trash-o"></span></button> -->
+                    <td colspan="10"></td>
+                    <td colspan="1">
+                        <button data-action="add" type="button" class="btn btn-xs btn-default"><span class="fa fa-plus"></span></button>
+                        <!-- <button data-action="deleteSelected" type="button" class="btn btn-xs btn-default"><span class="fa fa-trash-o"></span></button> -->
+                        <button type="button" class="btn btn-xs reload_btn btn-primary"><span class="fa fa-refresh reloadAct_progress"></span></button>
                     </td>
                 </tr>
             </tfoot>
@@ -96,6 +97,7 @@ POSSIBILITY OF SUCH DAMAGE.
                 <td>
                     <button data-action="add" type="button" class="btn btn-xs btn-default"><span class="fa fa-plus"></span></button>
                     <!-- <button data-action="deleteSelected" type="button" class="btn btn-xs btn-default"><span class="fa fa-trash-o"></span></button> -->
+                    <button type="button" class="btn btn-xs reload_btn btn-primary"><span class="fa fa-refresh reloadAct_progress"></span> {{ lang._('Reload Service') }}</button>
                     </td>
                 </tr>
             </tfoot>
@@ -122,6 +124,7 @@ POSSIBILITY OF SUCH DAMAGE.
                 <td>
                     <button data-action="add" type="button" class="btn btn-xs btn-default"><span class="fa fa-plus"></span></button>
                     <!-- <button data-action="deleteSelected" type="button" class="btn btn-xs btn-default"><span class="fa fa-trash-o"></span></button> -->
+                    <button type="button" class="btn btn-xs reload_btn btn-primary"><span class="fa fa-refresh reloadAct_progress"></span> {{ lang._('Reload Service') }}</button>
                     </td>
                 </tr>
             </tfoot>
@@ -148,6 +151,7 @@ POSSIBILITY OF SUCH DAMAGE.
                     <td colspan="5"></td>
                 <td>
                     <button data-action="add" type="button" class="btn btn-xs btn-default"><span class="fa fa-plus"></span></button>
+                    <button type="button" class="btn btn-xs reload_btn btn-primary"><span class="fa fa-refresh reloadAct_progress"></span> {{ lang._('Reload Service') }}</button>
                     </td>
                 </tr>
             </tfoot>
@@ -156,28 +160,41 @@ POSSIBILITY OF SUCH DAMAGE.
 </div>
 
 <script type="text/javascript">
+
+function quagga_update_status() {
+    ajaxCall(url="/api/quagga/service/status", sendData={}, callback=function(data,status) {
+        updateServiceStatusUI(data['status']);
+    });
+}
+
 $(document).ready(function() {
   var data_get_map = {'frm_bgp_settings':"/api/quagga/bgp/get"};
   mapDataToFormUI(data_get_map).done(function(data){
       formatTokenizersUI();
       $('.selectpicker').selectpicker('refresh');
   });
-  ajaxCall(url="/api/quagga/service/status", sendData={}, callback=function(data,status) {
-      updateServiceStatusUI(data['status']);
-  });
+  quagga_update_status();
 
   // link save button to API set action
   $("#saveAct").click(function(){
       saveFormToEndpoint(url="/api/quagga/bgp/set",formid='frm_bgp_settings',callback_ok=function(){
-        $("#saveAct_progress").addClass("fa fa-spinner fa-pulse");
-        ajaxCall(url="/api/quagga/service/reconfigure", sendData={}, callback=function(data,status) {
-          ajaxCall(url="/api/quagga/service/status", sendData={}, callback=function(data,status) {
-            updateServiceStatusUI(data['status']);
+          $("#saveAct_progress").addClass("fa fa-spinner fa-pulse");
+          ajaxCall(url="/api/quagga/service/reconfigure", sendData={}, callback=function(data,status) {
+              quagga_update_status();
+              $("#saveAct_progress").removeClass("fa fa-spinner fa-pulse");
           });
-          $("#saveAct_progress").removeClass("fa fa-spinner fa-pulse");
-        });
       });
   });
+  
+  /* allow a user to manually reload the service (for forms which do not do it automatically) */
+  $('.reload_btn').click(function reload_handler() {
+    $(".reloadAct_progress").addClass("fa-spin");
+    ajaxCall(url="/api/quagga/service/reconfigure", sendData={}, callback=function(data,status) {
+        quagga_update_status();
+        $(".reloadAct_progress").removeClass("fa-spin");
+    });
+  });
+  
   $("#grid-neighbors").UIBootgrid(
     { 'search':'/api/quagga/bgp/searchNeighbor',
       'get':'/api/quagga/bgp/getNeighbor/',

--- a/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/ospf.volt
+++ b/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/ospf.volt
@@ -66,6 +66,7 @@ POSSIBILITY OF SUCH DAMAGE.
                   <td>
                       <button data-action="add" type="button" class="btn btn-xs btn-default"><span class="fa fa-plus"></span></button>
                       <!-- <button data-action="deleteSelected" type="button" class="btn btn-xs btn-default"><span class="fa fa-trash-o"></span></button> -->
+                      <button type="button" class="btn btn-xs reload_btn btn-primary"><span class="fa fa-refresh reloadAct_progress"></span> {{ lang._('Reload Service') }}</button>
                   </td>
               </tr>
           </tfoot>
@@ -93,6 +94,7 @@ POSSIBILITY OF SUCH DAMAGE.
                     <td>
                         <button data-action="add" type="button" class="btn btn-xs btn-default"><span class="fa fa-plus"></span></button>
                         <!-- <button data-action="deleteSelected" type="button" class="btn btn-xs btn-default"><span class="fa fa-trash-o"></span></button> -->
+                        <button type="button" class="btn btn-xs reload_btn btn-primary"><span class="fa fa-refresh reloadAct_progress"></span> {{ lang._('Reload Service') }}</button>
                     </td>
                 </tr>
             </tfoot>
@@ -119,6 +121,7 @@ POSSIBILITY OF SUCH DAMAGE.
                 <td>
                     <button data-action="add" type="button" class="btn btn-xs btn-default"><span class="fa fa-plus"></span></button>
                     <!-- <button data-action="deleteSelected" type="button" class="btn btn-xs btn-default"><span class="fa fa-trash-o"></span></button> -->
+                    <button type="button" class="btn btn-xs reload_btn btn-primary"><span class="fa fa-refresh reloadAct_progress"></span> {{ lang._('Reload Service') }}</button>
                     </td>
                 </tr>
             </tfoot>
@@ -127,28 +130,43 @@ POSSIBILITY OF SUCH DAMAGE.
     </div>
 
 <script type="text/javascript">
+
+function quagga_update_status() {
+  ajaxCall(url="/api/quagga/service/status", sendData={}, callback=function(data,status) {
+    updateServiceStatusUI(data['status']);
+  });
+}
+
 $( document ).ready(function() {
   var data_get_map = {'frm_ospf_settings':"/api/quagga/ospfsettings/get"};
   mapDataToFormUI(data_get_map).done(function(data){
       formatTokenizersUI();
       $('.selectpicker').selectpicker('refresh');
   });
-  ajaxCall(url="/api/quagga/service/status", sendData={}, callback=function(data,status) {
-      updateServiceStatusUI(data['status']);
-  });
+  quagga_update_status();
 
   // link save button to API set action
   $("#saveAct").click(function(){
       saveFormToEndpoint(url="/api/quagga/ospfsettings/set",formid='frm_ospf_settings',callback_ok=function(){
         $("#saveAct_progress").addClass("fa fa-spinner fa-pulse");
         ajaxCall(url="/api/quagga/service/reconfigure", sendData={}, callback=function(data,status) {
-          ajaxCall(url="/api/quagga/service/status", sendData={}, callback=function(data,status) {
-            updateServiceStatusUI(data['status']);
-          });
+          quagga_update_status();
           $("#saveAct_progress").removeClass("fa fa-spinner fa-pulse");
         });
       });
   });
+  
+  
+  /* allow a user to manually reload the service (for forms which do not do it automatically) */
+  $('.reload_btn').click(function reload_handler() {
+    $(".reloadAct_progress").addClass("fa-spin");
+    ajaxCall(url="/api/quagga/service/reconfigure", sendData={}, callback=function(data,status) {
+      quagga_update_status();
+      $(".reloadAct_progress").removeClass("fa-spin");
+    });
+  });
+  
+  
   $("#grid-networks").UIBootgrid(
     { 'search':'/api/quagga/ospfsettings/searchNetwork',
       'get':'/api/quagga/ospfsettings/getNetwork/',

--- a/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/ospf6.volt
+++ b/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/ospf6.volt
@@ -65,6 +65,7 @@ POSSIBILITY OF SUCH DAMAGE.
                     <td>
                         <button data-action="add" type="button" class="btn btn-xs btn-default"><span class="fa fa-plus"></span></button>
                         <!-- <button data-action="deleteSelected" type="button" class="btn btn-xs btn-default"><span class="fa fa-trash-o"></span></button> -->
+                        <button type="button" class="btn btn-xs reload_btn btn-primary"><span class="fa fa-refresh reloadAct_progress"></span> {{ lang._('Reload Service') }}</button>
                     </td>
                 </tr>
             </tfoot>
@@ -74,6 +75,13 @@ POSSIBILITY OF SUCH DAMAGE.
     </div>
 
 <script type="text/javascript">
+
+function quagga_update_status() {
+  ajaxCall(url="/api/quagga/service/status", sendData={}, callback=function(data,status) {
+    updateServiceStatusUI(data['status']);
+  });
+}
+
 $( document ).ready(function() {
   var data_get_map = {'frm_ospf6_settings':"/api/quagga/ospf6settings/get"};
   mapDataToFormUI(data_get_map).done(function(data){
@@ -81,21 +89,26 @@ $( document ).ready(function() {
       $('.selectpicker').selectpicker('refresh');
   });
 
-  ajaxCall(url="/api/quagga/service/status", sendData={}, callback=function(data,status) {
-      updateServiceStatusUI(data['status']);
-  });
+  quagga_update_status();
 
   // link save button to API set action
   $("#saveAct").click(function(){
       saveFormToEndpoint(url="/api/quagga/ospf6settings/set",formid='frm_ospf6_settings',callback_ok=function(){
         $("#saveAct_progress").addClass("fa fa-spinner fa-pulse");
         ajaxCall(url="/api/quagga/service/reconfigure", sendData={}, callback=function(data,status) {
-          ajaxCall(url="/api/quagga/service/status", sendData={}, callback=function(data,status) {
-            updateServiceStatusUI(data['status']);
-          });
+          quagga_update_status();
           $("#saveAct_progress").removeClass("fa fa-spinner fa-pulse");
         });
       });
+  });
+  
+  /* allow a user to manually reload the service (for forms which do not do it automatically) */
+  $('.reload_btn').click(function reload_handler() {
+    $(".reloadAct_progress").addClass("fa-spin");
+    ajaxCall(url="/api/quagga/service/reconfigure", sendData={}, callback=function(data,status) {
+      quagga_update_status();
+      $(".reloadAct_progress").removeClass("fa-spin");
+    });
   });
 
   $("#grid-interfaces").UIBootgrid(


### PR DESCRIPTION
this will add buttons like in the tor plugin with one exception:
in the view bgp -> neighbors: the table has not enough space so it is only the icon there.

@fichtner should we bump the version?