### PR TITLE
net/freeradius: Add basic LDAP support to FreeRADIUS

### DIFF
--- a/net/freeradius/Makefile
+++ b/net/freeradius/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		freeradius
-PLUGIN_VERSION=		1.4.1
+PLUGIN_VERSION=		1.5.0
 PLUGIN_COMMENT=		RADIUS Authentication, Authorization and Accounting Server
 PLUGIN_DEPENDS=		freeradius3
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/Api/LdapController.php
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/Api/LdapController.php
@@ -30,47 +30,10 @@
 
 namespace OPNsense\Freeradius\Api;
 
-use \OPNsense\Base\ApiControllerBase;
-use \OPNsense\Freeradius\Ldap;
-use \OPNsense\Core\Config;
+use \OPNsense\Base\ApiMutableModelControllerBase;
 
-class LdapController extends ApiControllerBase
+class LdapController extends ApiMutableModelControllerBase
 {
-    public function getAction()
-    {
-        // define list of configurable settings
-        $result = array();
-        if ($this->request->isGet()) {
-            $mdlLDAP = new LDAP();
-            $result['ldap'] = $mdlLDAP->getNodes();
-        }
-        return $result;
-    }
-
-    public function setAction()
-    {
-        $result = array("result"=>"failed");
-        if ($this->request->isPost()) {
-            // load model and update with provided data
-            $mdlLDAP = new LDAP();
-            $mdlLDAP->setNodes($this->request->getPost("ldap"));
-
-            // perform validation
-            $valMsgs = $mdlLDAP->performValidation();
-            foreach ($valMsgs as $field => $msg) {
-                if (!array_key_exists("validations", $result)) {
-                    $result["validations"] = array();
-                }
-                $result["validations"]["ldap.".$msg->getField()] = $msg->getMessage();
-            }
-
-            // serialize model to config and save
-            if ($valMsgs->count() == 0) {
-                $mdlLDAP->serializeToConfig();
-                Config::getInstance()->save();
-                $result["result"] = "saved";
-            }
-        }
-        return $result;
-    }
+    static protected $internalModelName = 'ldap';
+    static protected $internalModelClass = '\OPNsense\Freeradius\Ldap';
 }

--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/Api/LdapController.php
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/Api/LdapController.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ *    Copyright (C) 2015 - 2017 Deciso B.V.
+ *    Copyright (C) 2017 Michael Muenz
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+namespace OPNsense\Freeradius\Api;
+
+use \OPNsense\Base\ApiControllerBase;
+use \OPNsense\Freeradius\Ldap;
+use \OPNsense\Core\Config;
+
+class LdapController extends ApiControllerBase
+{
+    public function getAction()
+    {
+        // define list of configurable settings
+        $result = array();
+        if ($this->request->isGet()) {
+            $mdlLDAP = new LDAP();
+            $result['ldap'] = $mdlLDAP->getNodes();
+        }
+        return $result;
+    }
+
+    public function setAction()
+    {
+        $result = array("result"=>"failed");
+        if ($this->request->isPost()) {
+            // load model and update with provided data
+            $mdlLDAP = new LDAP();
+            $mdlLDAP->setNodes($this->request->getPost("ldap"));
+
+            // perform validation
+            $valMsgs = $mdlLDAP->performValidation();
+            foreach ($valMsgs as $field => $msg) {
+                if (!array_key_exists("validations", $result)) {
+                    $result["validations"] = array();
+                }
+                $result["validations"]["ldap.".$msg->getField()] = $msg->getMessage();
+            }
+
+            // serialize model to config and save
+            if ($valMsgs->count() == 0) {
+                $mdlLDAP->serializeToConfig();
+                Config::getInstance()->save();
+                $result["result"] = "saved";
+            }
+        }
+        return $result;
+    }
+}

--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/LdapController.php
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/LdapController.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * Copyright (C) 2017 Michael Muenz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Freeradius;
+
+class LdapController extends \OPNsense\Base\IndexController
+{
+    public function indexAction()
+    {
+        $this->view->ldapForm = $this->getForm("ldap");
+        $this->view->pick('OPNsense/Freeradius/ldap');
+    }
+}

--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/general.xml
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/general.xml
@@ -15,7 +15,7 @@
         <id>general.ldap_enabled</id>
         <label>Enable LDAP</label>
         <type>checkbox</type>
-        <help>This allows you to bind to an external LDAP server, use configuration in submenu LDAP.</help>
+        <help>This allows you to bind to an external LDAP server. Be aware that FreeRADIUS wont start if there's no further configuration.</help>
     </field>
     <field>
         <id>general.wispr</id>

--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/general.xml
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/general.xml
@@ -15,7 +15,7 @@
         <id>general.ldap_enabled</id>
         <label>Enable LDAP</label>
         <type>checkbox</type>
-        <help>This allows you to bind to an external LDAP server. Be aware that FreeRADIUS wont start if there's no further configuration.</help>
+        <help>This allows you to bind to an external LDAP server. Be aware that FreeRADIUS will not start if there is no further configuration.</help>
     </field>
     <field>
         <id>general.wispr</id>

--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/general.xml
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/general.xml
@@ -12,6 +12,12 @@
         <help>This allows you to dynamically assign VLANs on your physical switch ports.</help>
     </field>
     <field>
+        <id>general.ldap_enabled</id>
+        <label>Enable LDAP</label>
+        <type>checkbox</type>
+        <help>This allows you to bind to an external LDAP server, use configuration in submenu LDAP.</help>
+    </field>
+    <field>
         <id>general.wispr</id>
         <label>Enable WISPr attributes</label>
         <type>checkbox</type>

--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/ldap.xml
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/ldap.xml
@@ -15,7 +15,7 @@
         <id>ldap.identity</id>
         <label>Bind User</label>
         <type>text</type>
-        <help>Username to bind to LDAP.</help>
+        <help>Username to bind to LDAP, same format as in Base DN.</help>
     </field>
     <field>
         <id>ldap.password</id>

--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/ldap.xml
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/ldap.xml
@@ -1,0 +1,32 @@
+<form>
+    <field>
+        <id>ldap.protocol</id>
+        <label>Protocol Type</label>
+        <type>dropdown</type>
+        <help>Set the protocol to use.</help>
+    </field>
+    <field>
+        <id>ldap.server</id>
+        <label>Server</label>
+        <type>text</type>
+        <help>Set the hostname or IP address to connect to.</help>
+    </field>
+    <field>
+        <id>ldap.identity</id>
+        <label>Bind User</label>
+        <type>text</type>
+        <help>Username to bind to LDAP.</help>
+    </field>
+    <field>
+        <id>ldap.password</id>
+        <label>Bind Password</label>
+        <type>password</type>
+        <help>Password for the bind user.</help>
+    </field>
+    <field>
+        <id>ldap.base_dn</id>
+        <label>Base DN</label>
+        <type>text</type>
+        <help>Set the Base DN in format dc=example,dc=domain,dc=com</help>
+    </field>
+</form>

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/General.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/General.xml
@@ -11,6 +11,10 @@
             <default>0</default>
             <Required>N</Required>
         </vlanassign>
+        <ldap_enabled type="BooleanField">
+            <default>0</default>
+            <Required>N</Required>
+        </ldap_enabled>
         <wispr type="BooleanField">
             <default>0</default>
             <Required>N</Required>

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Ldap.php
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Ldap.php
@@ -1,0 +1,34 @@
+<?php
+namespace OPNsense\Freeradius;
+
+use OPNsense\Base\BaseModel;
+
+/*
+    Copyright (C) 2017 Michael Muenz
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+
+class Ldap extends BaseModel
+{
+}

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Ldap.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Ldap.xml
@@ -1,0 +1,29 @@
+<model>
+    <mount>//OPNsense/freeradius/ldap</mount>
+    <description>LDAP configuration</description>
+    <version>1.0.0</version>
+    <items>
+        <protocol type="OptionField">
+            <default>LDAPS</default>
+            <Required>Y</Required>
+            <OptionValues>
+                <LDAP>LDAP</LDAP>
+                <LDAPS>LDAPS</LDAPS>
+            </OptionValues>
+        </protocol>
+        <server type="TextField">
+            <Required>N</Required>
+        </server>
+        <identity type="TextField">
+            <Required>N</Required>
+        </identity>
+        <password type="TextField">
+            <Required>N</Required>
+        </password>
+        <base_dn type="TextField">
+            <default>dc=example,dc=domain,dc=com</default>
+            <Required>N</Required>
+        </base_dn>
+    </items>
+</model>
+

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Menu/Menu.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Menu/Menu.xml
@@ -5,6 +5,7 @@
       <Users url="/ui/freeradius/user/index" order="20"/>
       <Clients url="/ui/freeradius/client/index" order="30"/>
       <EAP url="/ui/freeradius/eap/index" order="40"/>
+      <LDAP url="/ui/freeradius/ldap/index" order="50"/>
       <LogFile VisibleName="Log File" order="80" url="/diag_logs_freeradius.php"/>
     </FreeRADIUS>
   </Services>

--- a/net/freeradius/src/opnsense/mvc/app/views/OPNsense/Freeradius/ldap.volt
+++ b/net/freeradius/src/opnsense/mvc/app/views/OPNsense/Freeradius/ldap.volt
@@ -1,0 +1,62 @@
+{#
+
+OPNsense® is Copyright © 2014 – 2017 by Deciso B.V.
+This file is Copyright © 2017 by Michael Muenz
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1.  Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+2.  Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+#}
+
+<div class="content-box" style="padding-bottom: 1.5em;">
+    {{ partial("layout_partials/base_form",['fields':ldapForm,'id':'frm_ldap_settings'])}}
+    <div class="col-md-12">
+        <hr />
+        <button class="btn btn-primary" id="saveAct" type="button"><b>{{ lang._('Save') }}</b> <i id="saveAct_progress" class=""></i></button>
+    </div>
+</div>
+
+<script type="text/javascript">
+    $( document ).ready(function () {
+        var data_get_map = {'frm_ldap_settings':"/api/freeradius/ldap/get"};
+        mapDataToFormUI(data_get_map).done(function (data) {
+            formatTokenizersUI();
+            $('.selectpicker').selectpicker('refresh');
+        });
+        ajaxCall(url="/api/freeradius/service/status", sendData={}, callback=function (data, status) {
+            updateServiceStatusUI(data['status']);
+        });
+
+        // link save button to API set action
+        $("#saveAct").click(function () {
+            saveFormToEndpoint(url="/api/freeradius/ldap/set", formid='frm_ldap_settings',callback_ok=function () {
+            $("#saveAct_progress").addClass("fa fa-spinner fa-pulse");
+                ajaxCall(url="/api/freeradius/service/reconfigure", sendData={}, callback=function (data,status) {
+                    ajaxCall(url="/api/freeradius/service/status", sendData={}, callback=function (data,status) {
+                        updateServiceStatusUI(data['status']);
+                    });
+                    $("#saveAct_progress").removeClass("fa fa-spinner fa-pulse");
+                });
+            });
+        });
+    });
+</script>

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/+TARGETS
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/+TARGETS
@@ -2,6 +2,7 @@ clients.conf:/usr/local/etc/raddb/clients.conf
 dictionary:/usr/local/etc/raddb/dictionary
 mods-enabled-counter:/usr/local/etc/raddb/mods-enabled/counter
 mods-enabled-eap:/usr/local/etc/raddb/mods-enabled/eap
+mods-enabled-ldap:/usr/local/etc/raddb/mods-enabled/ldap
 radiusd:/etc/rc.conf.d/radiusd
 radiusd.conf:/usr/local/etc/raddb/radiusd.conf
 sites-enabled-default:/usr/local/etc/raddb/sites-enabled/default

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-ldap
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-ldap
@@ -1,19 +1,6 @@
 {% if helpers.exists('OPNsense.freeradius.general.enabled') and OPNsense.freeradius.general.enabled == '1' %}
 {%   if helpers.exists('OPNsense.freeradius.general.ldap_enabled') and OPNsense.freeradius.general.ldap_enabled == '1' %}
-#
-#  Lightweight Directory Access Protocol (LDAP)
-#
 ldap {
-        #  Note that this needs to match the name(s) in the LDAP server
-        #  certificate, if you're using ldaps.  See OpenLDAP documentation
-        #  for the behavioral semantics of specifying more than one host.
-        #
-        #  Depending on the libldap in use, server may be an LDAP URI.
-        #  In the case of OpenLDAP this allows additional the following
-        #  additional schemes:
-        #  - ldaps:// (LDAP over SSL)
-        #  - ldapi:// (LDAP over Unix socket)
-        #  - ldapc:// (Connectionless LDAP)
 {%     if helpers.exists('OPNsense.freeradius.ldap.server') and OPNsense.freeradius.ldap.server != '' %}
         server = '{{ OPNsense.freeradius.ldap.protocol }}://{{ OPNsense.freeradius.ldap.server }}'
 {%     endif %}
@@ -25,365 +12,42 @@ ldap {
 {%     if helpers.exists('OPNsense.freeradius.ldap.password') and OPNsense.freeradius.ldap.password != '' %}
         password = {{ OPNsense.freeradius.ldap.password }}
 {%     endif %}        
-        #       identity = 'cn=admin,dc=example,dc=org'
-#       password = mypass
 
-        #  Unless overridden in another section, the dn from which all
-        #  searches will start from.
-        # base_dn = 'dc=example,dc=org'
 {%     if helpers.exists('OPNsense.freeradius.ldap.base_dn') and OPNsense.freeradius.ldap.base_dn != '' %}
         base_dn = '{{ OPNsense.freeradius.ldap.base_dn }}'
 {%     endif %}
-        #
-        #  SASL parameters to use for admin binds
-        #
-        #  When we're prompted by the SASL library, these control
-        #  the responses given, as well as the identity and password
-        #  directives above.
-        #
-        #  If any directive is commented out, a NULL response will be
-        #  provided to cyrus-sasl.
-        #
-        #  Unfortunately the only way to control Keberos here is through
-        #  environmental variables, as cyrus-sasl provides no API to
-        #  set the krb5 config directly.
-        #
-        #  Full documentation for MIT krb5 can be found here:
-        #
-        #       http://web.mit.edu/kerberos/krb5-devel/doc/admin/env_variables.html
-        #
-        #  At a minimum you probably want to set KRB5_CLIENT_KTNAME.
-        #
-        sasl {
-                # SASL mechanism
-#               mech = 'PLAIN'
 
-                # SASL authorisation identity to proxy.
-#               proxy = 'autz_id'
-
-                # SASL realm. Used for kerberos.
-#               realm = 'example.org'
+sasl {
         }
-
-        #
-        #  Generic valuepair attribute
-        #
-
-        #  If set, this will attribute will be retrieved in addition to any
-        #  mapped attributes.
-        #
-        #  Values should be in the format:
-        #       <radius attr> <op> <value>
-        #
-        #  Where:
-        #       <radius attr>:  Is the attribute you wish to create
-        #                       with any valid list and request qualifiers.
-        #       <op>:           Is any assignment operator (=, :=, +=, -=).
-        #       <value>:        Is the value to parse into the new valuepair.
-        #                       If the value is wrapped in double quotes it
-        #                       will be xlat expanded.
-#       valuepair_attribute = 'radiusAttribute'
-
-        #
-        #  Mapping of LDAP directory attributes to RADIUS dictionary attributes.
-        #
-
-        #  WARNING: Although this format is almost identical to the unlang
-        #  update section format, it does *NOT* mean that you can use other
-        #  unlang constructs in module configuration files.
-        #
-        #  Configuration items are in the format:
-        #       <radius attr> <op> <ldap attr>
-        #
-        #  Where:
-        #       <radius attr>:  Is the destination RADIUS attribute
-        #                       with any valid list and request qualifiers.
-        #       <op>:           Is any assignment attribute (=, :=, +=, -=).
-        #       <ldap attr>:    Is the attribute associated with user or
-        #                       profile objects in the LDAP directory.
-        #                       If the attribute name is wrapped in double
-        #                       quotes it will be xlat expanded.
-        #
-        #  Request and list qualifiers may also be placed after the 'update'
-        #  section name to set defaults destination requests/lists
-        #  for unqualified RADIUS attributes.
-        #
-        #  Note: LDAP attribute names should be single quoted unless you want
-        #  the name value to be derived from an xlat expansion, or an
-        #  attribute ref.
         update {
                 control:Password-With-Header    += 'userPassword'
-#               control:NT-Password             := 'ntPassword'
-#               reply:Reply-Message             := 'radiusReplyMessage'
-#               reply:Tunnel-Type               := 'radiusTunnelType'
-#               reply:Tunnel-Medium-Type        := 'radiusTunnelMediumType'
-#               reply:Tunnel-Private-Group-ID   := 'radiusTunnelPrivategroupId'
-
-                #  Where only a list is specified as the RADIUS attribute,
-                #  the value of the LDAP attribute is parsed as a valuepair
-                #  in the same format as the 'valuepair_attribute' (above).
                 control:                        += 'radiusControlAttribute'
                 request:                        += 'radiusRequestAttribute'
                 reply:                          += 'radiusReplyAttribute'
         }
-
-        #  Set to yes if you have eDirectory and want to use the universal
-        #  password mechanism.
-#       edir = no
-
-        #  Set to yes if you want to bind as the user after retrieving the
-        #  Cleartext-Password. This will consume the login grace, and
-        #  verify user authorization.
-#       edir_autz = no
-
-        #  Note: set_auth_type was removed in v3.x.x
-        #  Equivalent functionality can be achieved by adding the following
-        #  stanza to the authorize {} section of your virtual server.
-        #
-        #    ldap
-        #    if ((ok || updated) && User-Password) {
-        #        update {
-        #            control:Auth-Type := ldap
-        #        }
-        #    }
-
-        #
-        #  User object identification.
-        #
         user {
-                #  Where to start searching in the tree for users
                 base_dn = "${..base_dn}"
-
-                #  Filter for user objects, should be specific enough
-                #  to identify a single user object.
-                #
-                #  For Active Directory, you should use
-                #  "samaccountname=" instead of "uid="
-                #
                 filter = "(uid=%{%{Stripped-User-Name}:-%{User-Name}})"
-
-                #  SASL parameters to use for user binds
-                #
-                #  When we're prompted by the SASL library, these control
-                #  the responses given.
-                #
-                #  Any of the config items below may be an attribute ref
-                #  or and expansion, so different SASL mechs, proxy IDs
-                #  and realms may be used for different users.
                 sasl {
-                        # SASL mechanism
-#                       mech = 'PLAIN'
-
-                        # SASL authorisation identity to proxy.
-#                       proxy = &User-Name
-
-                        # SASL realm. Used for kerberos.
-#                       realm = 'example.org'
                 }
-
-                #  Search scope, may be 'base', 'one', sub' or 'children'
-#               scope = 'sub'
-
-                #  Server side result sorting
-                #
-                #  A list of space delimited attributes to order the result
-                #  set by, if the filter matches multiple objects.
-                #  Only the first result in the set will be processed.
-                #
-                #  If the attribute name is prefixed with a hyphen '-' the
-                #  sorting order will be reversed for that attribute.
-                #
-                #  If sort_by is set, and the server does not support sorting
-                #  the search will fail.
-#               sort_by = '-uid'
-
-                #  If this is undefined, anyone is authorised.
-                #  If it is defined, the contents of this attribute
-                #  determine whether or not the user is authorised
-#               access_attribute = 'dialupAccess'
-
-                #  Control whether the presence of 'access_attribute'
-                #  allows access, or denys access.
-                #
-                #  If 'yes', and the access_attribute is present, or
-                #  'no' and the access_attribute is absent then access
-                #  will be allowed.
-                #
-                #  If 'yes', and the access_attribute is absent, or
-                #  'no' and the access_attribute is present, then
-                #  access will not be allowed.
-                #
-                #  If the value of the access_attribute is 'false', it
-                #  will negate the result.
-                #
-                #  e.g.
-                #    access_positive = yes
-                #    access_attribute = userAccessAllowed
-                #
-                #  With an LDAP object containing:
-                #    userAccessAllowed: false
-                #
-                #  Will result in the user being locked out.
-#               access_positive = yes
         }
-
-        #
-        #  User membership checking.
-        #
         group {
-                #  Where to start searching in the tree for groups
                 base_dn = "${..base_dn}"
-
-                #  Filter for group objects, should match all available
-                #  group objects a user might be a member of.
                 filter = '(objectClass=posixGroup)'
-
-                # Search scope, may be 'base', 'one', sub' or 'children'
-#               scope = 'sub'
-
-                #  Attribute that uniquely identifies a group.
-                #  Is used when converting group DNs to group
-                #  names.
-#               name_attribute = cn
-
-                #  Filter to find group objects a user is a member of.
-                #  That is, group objects with attributes that
-                #  identify members (the inverse of membership_attribute).
-#               membership_filter = "(|(member=%{control:Ldap-UserDn})(memberUid=%{%{Stripped-User-Name}:-%{User-Name}}))"
-
-                #  The attribute in user objects which contain the names
-                #  or DNs of groups a user is a member of.
-                #
-                #  Unless a conversion between group name and group DN is
-                #  needed, there's no requirement for the group objects
-                #  referenced to actually exist.
                 membership_attribute = 'memberOf'
-
-                #  If cacheable_name or cacheable_dn are enabled,
-                #  all group information for the user will be
-                #  retrieved from the directory and written to LDAP-Group
-                #  attributes appropriate for the instance of rlm_ldap.
-                #
-                #  For group comparisons these attributes will be checked
-                #  instead of querying the LDAP directory directly.
-                #
-                #  This feature is intended to be used with rlm_cache.
-                #
-                #  If you wish to use this feature, you should enable
-                #  the type that matches the format of your check items
-                #  i.e. if your groups are specified as DNs then enable
-                #  cacheable_dn else enable cacheable_name.
-#               cacheable_name = 'no'
-#               cacheable_dn = 'no'
-
-                #  Override the normal cache attribute (<inst>-LDAP-Group or
-                #  LDAP-Group if using the default instance) and create a
-                #  custom attribute.  This can help if multiple module instances
-                #  are used in fail-over.
-#               cache_attribute = 'LDAP-Cached-Membership'
         }
-
-        #
-        #  User profiles. RADIUS profile objects contain sets of attributes
-        #  to insert into the request. These attributes are mapped using
-        #  the same mapping scheme applied to user objects (the update section above).
-        #
         profile {
-                #  Filter for RADIUS profile objects
-#               filter = '(objectclass=radiusprofile)'
-
-                #  The default profile.  This may be a DN or an attribute
-                #  reference.
-                #  To get old v2.2.x style behaviour, or to use the
-                #  &User-Profile attribute to specify the default profile,
-                #  set this to &control:User-Profile.
-#               default = 'cn=radprofile,dc=example,dc=org'
-
-                #  The LDAP attribute containing profile DNs to apply
-                #  in addition to the default profile above.  These are
-                #  retrieved from the user object, at the same time as the
-                #  attributes from the update section, are are applied
-                #  if authorization is successful.
-#               attribute = 'radiusProfileDn'
         }
-
-        #
-        #  Bulk load clients from the directory
-        #
         client {
-                #   Where to start searching in the tree for clients
                 base_dn = "${..base_dn}"
-
-                #
-                #  Filter to match client objects
-                #
                 filter = '(objectClass=radiusClient)'
-
-                # Search scope, may be 'base', 'one', 'sub' or 'children'
-#               scope = 'sub'
-
-                #
-                #  Sets default values (not obtained from LDAP) for new client entries
-                #
                 template {
-#                       login                           = 'test'
-#                       password                        = 'test'
-#                       proto                           = tcp
-#                       require_message_authenticator   = yes
-
-                        # Uncomment to add a home_server with the same
-                        # attributes as the client.
-#                       coa_server {
-#                               response_window = 2.0
-#                       }
                 }
-
-                #
-                #  Client attribute mappings are in the format:
-                #      <client attribute> = <ldap attribute>
-                #
-                #  The following attributes are required:
-                #    * ipaddr | ipv4addr | ipv6addr - Client IP Address.
-                #    * secret - RADIUS shared secret.
-                #
-                #  All other attributes usually supported in a client
-                #  definition are also supported here.
-                #
-                #  Schemas are available in doc/schemas/ldap for openldap and eDirectory
-                #
                 attribute {
                         ipaddr                          = 'radiusClientIdentifier'
                         secret                          = 'radiusClientSecret'
-#                       shortname                       = 'radiusClientShortname'
-#                       nas_type                        = 'radiusClientType'
-#                       virtual_server                  = 'radiusClientVirtualServer'
-#                       require_message_authenticator   = 'radiusClientRequireMa'
                 }
         }
-
-        #  Load clients on startup
-#       read_clients = no
-
-        #
-        #  Modify user object on receiving Accounting-Request
-        #
-
-        #  Useful for recording things like the last time the user logged
-        #  in, or the Acct-Session-ID for CoA/DM.
-        #
-        #  LDAP modification items are in the format:
-        #       <ldap attr> <op> <value>
-        #
-        #  Where:
-        #       <ldap attr>:    The LDAP attribute to add modify or delete.
-        #       <op>:           One of the assignment operators:
-        #                       (:=, +=, -=, ++).
-        #                       Note: '=' is *not* supported.
-        #       <value>:        The value to add modify or delete.
-        #
-        #  WARNING: If using the ':=' operator with a multi-valued LDAP
-        #  attribute, all instances of the attribute will be removed and
-        #  replaced with a single attribute.
         accounting {
                 reference = "%{tolower:type.%{Acct-Status-Type}}"
 
@@ -408,69 +72,21 @@ ldap {
                 }
         }
 
-        #
-        #  Post-Auth can modify LDAP objects too
-        #
         post-auth {
                 update {
                         description := "Authenticated at %S"
                 }
         }
 
-        #
-        #  LDAP connection-specific options.
-        #
-        #  These options set timeouts, keep-alives, etc. for the connections.
-        #
         options {
-                #  Control under which situations aliases are followed.
-                #  May be one of 'never', 'searching', 'finding' or 'always'
-                #  default: libldap's default which is usually 'never'.
-                #
-                #  LDAP_OPT_DEREF is set to this value.
-#               dereference = 'always'
-
-                #
-                #  The following two configuration items control whether the
-                #  server follows references returned by LDAP directory.
-                #  They are  mostly for Active Directory compatibility.
-                #  If you set these to 'no', then searches will likely return
-                #  'operations error', instead of a useful result.
-                #
                 chase_referrals = yes
                 rebind = yes
-
-                #  Seconds to wait for LDAP query to finish. default: 20
                 res_timeout = 10
-
-                #  Seconds LDAP server has to process the query (server-side
-                #  time limit). default: 20
-                #
-                #  LDAP_OPT_TIMELIMIT is set to this value.
                 srv_timelimit = 3
-
-                #  Seconds to wait for response of the server. (network
-                #  failures) default: 10
-                #
-                #  LDAP_OPT_NETWORK_TIMEOUT is set to this value.
                 net_timeout = 1
-
-                #  LDAP_OPT_X_KEEPALIVE_IDLE
                 idle = 60
-
-                #  LDAP_OPT_X_KEEPALIVE_PROBES
                 probes = 3
-
-                #  LDAP_OPT_X_KEEPALIVE_INTERVAL
                 interval = 3
-
-                #  ldap_debug: debug flag for LDAP SDK
-                #  (see OpenLDAP documentation).  Set this to enable
-                #  huge amounts of LDAP debugging on the screen.
-                #  You should only use this if you are an LDAP expert.
-                #
-                #       default: 0x0000 (no debugging messages)
-                #       Example:(LDAP_DEBUG_FILTER+LDAP_DEBUG_CONNS)
                 ldap_debug = 0x0028
         }
                 max = ${thread[pool].max_servers}

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-ldap
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-ldap
@@ -88,7 +88,6 @@ sasl {
                 probes = 3
                 interval = 3
                 ldap_debug = 0x0028
-        }
                 max = ${thread[pool].max_servers}
                 spare = ${thread[pool].max_spare_servers}
                 uses = 0

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-ldap
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-ldap
@@ -1,0 +1,520 @@
+{% if helpers.exists('OPNsense.freeradius.general.enabled') and OPNsense.freeradius.general.enabled == '1' %}
+{%   if helpers.exists('OPNsense.freeradius.general.ldap_enabled') and OPNsense.freeradius.general.ldap_enabled == '1' %}
+#
+#  Lightweight Directory Access Protocol (LDAP)
+#
+ldap {
+        #  Note that this needs to match the name(s) in the LDAP server
+        #  certificate, if you're using ldaps.  See OpenLDAP documentation
+        #  for the behavioral semantics of specifying more than one host.
+        #
+        #  Depending on the libldap in use, server may be an LDAP URI.
+        #  In the case of OpenLDAP this allows additional the following
+        #  additional schemes:
+        #  - ldaps:// (LDAP over SSL)
+        #  - ldapi:// (LDAP over Unix socket)
+        #  - ldapc:// (Connectionless LDAP)
+{%     if helpers.exists('OPNsense.freeradius.ldap.server') and OPNsense.freeradius.ldap.server != '' %}
+        server = '{{ OPNsense.freeradius.ldap.protocol }}://{{ OPNsense.freeradius.ldap.server }}'
+{%     endif %}
+
+{%     if helpers.exists('OPNsense.freeradius.ldap.identity') and OPNsense.freeradius.ldap.identity != '' %}
+        identity = '{{ OPNsense.freeradius.ldap.identity }}'
+{%     endif %}
+
+{%     if helpers.exists('OPNsense.freeradius.ldap.password') and OPNsense.freeradius.ldap.password != '' %}
+        identity = {{ OPNsense.freeradius.ldap.password }}
+{%     endif %}        
+        #       identity = 'cn=admin,dc=example,dc=org'
+#       password = mypass
+
+        #  Unless overridden in another section, the dn from which all
+        #  searches will start from.
+        # base_dn = 'dc=example,dc=org'
+{%     if helpers.exists('OPNsense.freeradius.ldap.base_dn') and OPNsense.freeradius.ldap.base_dn != '' %}
+        identity = '{{ OPNsense.freeradius.ldap.base_dn }}'
+{%     endif %}
+        #
+        #  SASL parameters to use for admin binds
+        #
+        #  When we're prompted by the SASL library, these control
+        #  the responses given, as well as the identity and password
+        #  directives above.
+        #
+        #  If any directive is commented out, a NULL response will be
+        #  provided to cyrus-sasl.
+        #
+        #  Unfortunately the only way to control Keberos here is through
+        #  environmental variables, as cyrus-sasl provides no API to
+        #  set the krb5 config directly.
+        #
+        #  Full documentation for MIT krb5 can be found here:
+        #
+        #       http://web.mit.edu/kerberos/krb5-devel/doc/admin/env_variables.html
+        #
+        #  At a minimum you probably want to set KRB5_CLIENT_KTNAME.
+        #
+        sasl {
+                # SASL mechanism
+#               mech = 'PLAIN'
+
+                # SASL authorisation identity to proxy.
+#               proxy = 'autz_id'
+
+                # SASL realm. Used for kerberos.
+#               realm = 'example.org'
+        }
+
+        #
+        #  Generic valuepair attribute
+        #
+
+        #  If set, this will attribute will be retrieved in addition to any
+        #  mapped attributes.
+        #
+        #  Values should be in the format:
+        #       <radius attr> <op> <value>
+        #
+        #  Where:
+        #       <radius attr>:  Is the attribute you wish to create
+        #                       with any valid list and request qualifiers.
+        #       <op>:           Is any assignment operator (=, :=, +=, -=).
+        #       <value>:        Is the value to parse into the new valuepair.
+        #                       If the value is wrapped in double quotes it
+        #                       will be xlat expanded.
+#       valuepair_attribute = 'radiusAttribute'
+
+        #
+        #  Mapping of LDAP directory attributes to RADIUS dictionary attributes.
+        #
+
+        #  WARNING: Although this format is almost identical to the unlang
+        #  update section format, it does *NOT* mean that you can use other
+        #  unlang constructs in module configuration files.
+        #
+        #  Configuration items are in the format:
+        #       <radius attr> <op> <ldap attr>
+        #
+        #  Where:
+        #       <radius attr>:  Is the destination RADIUS attribute
+        #                       with any valid list and request qualifiers.
+        #       <op>:           Is any assignment attribute (=, :=, +=, -=).
+        #       <ldap attr>:    Is the attribute associated with user or
+        #                       profile objects in the LDAP directory.
+        #                       If the attribute name is wrapped in double
+        #                       quotes it will be xlat expanded.
+        #
+        #  Request and list qualifiers may also be placed after the 'update'
+        #  section name to set defaults destination requests/lists
+        #  for unqualified RADIUS attributes.
+        #
+        #  Note: LDAP attribute names should be single quoted unless you want
+        #  the name value to be derived from an xlat expansion, or an
+        #  attribute ref.
+        update {
+                control:Password-With-Header    += 'userPassword'
+#               control:NT-Password             := 'ntPassword'
+#               reply:Reply-Message             := 'radiusReplyMessage'
+#               reply:Tunnel-Type               := 'radiusTunnelType'
+#               reply:Tunnel-Medium-Type        := 'radiusTunnelMediumType'
+#               reply:Tunnel-Private-Group-ID   := 'radiusTunnelPrivategroupId'
+
+                #  Where only a list is specified as the RADIUS attribute,
+                #  the value of the LDAP attribute is parsed as a valuepair
+                #  in the same format as the 'valuepair_attribute' (above).
+                control:                        += 'radiusControlAttribute'
+                request:                        += 'radiusRequestAttribute'
+                reply:                          += 'radiusReplyAttribute'
+        }
+
+        #  Set to yes if you have eDirectory and want to use the universal
+        #  password mechanism.
+#       edir = no
+
+        #  Set to yes if you want to bind as the user after retrieving the
+        #  Cleartext-Password. This will consume the login grace, and
+        #  verify user authorization.
+#       edir_autz = no
+
+        #  Note: set_auth_type was removed in v3.x.x
+        #  Equivalent functionality can be achieved by adding the following
+        #  stanza to the authorize {} section of your virtual server.
+        #
+        #    ldap
+        #    if ((ok || updated) && User-Password) {
+        #        update {
+        #            control:Auth-Type := ldap
+        #        }
+        #    }
+
+        #
+        #  User object identification.
+        #
+        user {
+                #  Where to start searching in the tree for users
+                base_dn = "${..base_dn}"
+
+                #  Filter for user objects, should be specific enough
+                #  to identify a single user object.
+                #
+                #  For Active Directory, you should use
+                #  "samaccountname=" instead of "uid="
+                #
+                filter = "(uid=%{%{Stripped-User-Name}:-%{User-Name}})"
+
+                #  SASL parameters to use for user binds
+                #
+                #  When we're prompted by the SASL library, these control
+                #  the responses given.
+                #
+                #  Any of the config items below may be an attribute ref
+                #  or and expansion, so different SASL mechs, proxy IDs
+                #  and realms may be used for different users.
+                sasl {
+                        # SASL mechanism
+#                       mech = 'PLAIN'
+
+                        # SASL authorisation identity to proxy.
+#                       proxy = &User-Name
+
+                        # SASL realm. Used for kerberos.
+#                       realm = 'example.org'
+                }
+
+                #  Search scope, may be 'base', 'one', sub' or 'children'
+#               scope = 'sub'
+
+                #  Server side result sorting
+                #
+                #  A list of space delimited attributes to order the result
+                #  set by, if the filter matches multiple objects.
+                #  Only the first result in the set will be processed.
+                #
+                #  If the attribute name is prefixed with a hyphen '-' the
+                #  sorting order will be reversed for that attribute.
+                #
+                #  If sort_by is set, and the server does not support sorting
+                #  the search will fail.
+#               sort_by = '-uid'
+
+                #  If this is undefined, anyone is authorised.
+                #  If it is defined, the contents of this attribute
+                #  determine whether or not the user is authorised
+#               access_attribute = 'dialupAccess'
+
+                #  Control whether the presence of 'access_attribute'
+                #  allows access, or denys access.
+                #
+                #  If 'yes', and the access_attribute is present, or
+                #  'no' and the access_attribute is absent then access
+                #  will be allowed.
+                #
+                #  If 'yes', and the access_attribute is absent, or
+                #  'no' and the access_attribute is present, then
+                #  access will not be allowed.
+                #
+                #  If the value of the access_attribute is 'false', it
+                #  will negate the result.
+                #
+                #  e.g.
+                #    access_positive = yes
+                #    access_attribute = userAccessAllowed
+                #
+                #  With an LDAP object containing:
+                #    userAccessAllowed: false
+                #
+                #  Will result in the user being locked out.
+#               access_positive = yes
+        }
+
+        #
+        #  User membership checking.
+        #
+        group {
+                #  Where to start searching in the tree for groups
+                base_dn = "${..base_dn}"
+
+                #  Filter for group objects, should match all available
+                #  group objects a user might be a member of.
+                filter = '(objectClass=posixGroup)'
+
+                # Search scope, may be 'base', 'one', sub' or 'children'
+#               scope = 'sub'
+
+                #  Attribute that uniquely identifies a group.
+                #  Is used when converting group DNs to group
+                #  names.
+#               name_attribute = cn
+
+                #  Filter to find group objects a user is a member of.
+                #  That is, group objects with attributes that
+                #  identify members (the inverse of membership_attribute).
+#               membership_filter = "(|(member=%{control:Ldap-UserDn})(memberUid=%{%{Stripped-User-Name}:-%{User-Name}}))"
+
+                #  The attribute in user objects which contain the names
+                #  or DNs of groups a user is a member of.
+                #
+                #  Unless a conversion between group name and group DN is
+                #  needed, there's no requirement for the group objects
+                #  referenced to actually exist.
+                membership_attribute = 'memberOf'
+
+                #  If cacheable_name or cacheable_dn are enabled,
+                #  all group information for the user will be
+                #  retrieved from the directory and written to LDAP-Group
+                #  attributes appropriate for the instance of rlm_ldap.
+                #
+                #  For group comparisons these attributes will be checked
+                #  instead of querying the LDAP directory directly.
+                #
+                #  This feature is intended to be used with rlm_cache.
+                #
+                #  If you wish to use this feature, you should enable
+                #  the type that matches the format of your check items
+                #  i.e. if your groups are specified as DNs then enable
+                #  cacheable_dn else enable cacheable_name.
+#               cacheable_name = 'no'
+#               cacheable_dn = 'no'
+
+                #  Override the normal cache attribute (<inst>-LDAP-Group or
+                #  LDAP-Group if using the default instance) and create a
+                #  custom attribute.  This can help if multiple module instances
+                #  are used in fail-over.
+#               cache_attribute = 'LDAP-Cached-Membership'
+        }
+
+        #
+        #  User profiles. RADIUS profile objects contain sets of attributes
+        #  to insert into the request. These attributes are mapped using
+        #  the same mapping scheme applied to user objects (the update section above).
+        #
+        profile {
+                #  Filter for RADIUS profile objects
+#               filter = '(objectclass=radiusprofile)'
+
+                #  The default profile.  This may be a DN or an attribute
+                #  reference.
+                #  To get old v2.2.x style behaviour, or to use the
+                #  &User-Profile attribute to specify the default profile,
+                #  set this to &control:User-Profile.
+#               default = 'cn=radprofile,dc=example,dc=org'
+
+                #  The LDAP attribute containing profile DNs to apply
+                #  in addition to the default profile above.  These are
+                #  retrieved from the user object, at the same time as the
+                #  attributes from the update section, are are applied
+                #  if authorization is successful.
+#               attribute = 'radiusProfileDn'
+        }
+
+        #
+        #  Bulk load clients from the directory
+        #
+        client {
+                #   Where to start searching in the tree for clients
+                base_dn = "${..base_dn}"
+
+                #
+                #  Filter to match client objects
+                #
+                filter = '(objectClass=radiusClient)'
+
+                # Search scope, may be 'base', 'one', 'sub' or 'children'
+#               scope = 'sub'
+
+                #
+                #  Sets default values (not obtained from LDAP) for new client entries
+                #
+                template {
+#                       login                           = 'test'
+#                       password                        = 'test'
+#                       proto                           = tcp
+#                       require_message_authenticator   = yes
+
+                        # Uncomment to add a home_server with the same
+                        # attributes as the client.
+#                       coa_server {
+#                               response_window = 2.0
+#                       }
+                }
+
+                #
+                #  Client attribute mappings are in the format:
+                #      <client attribute> = <ldap attribute>
+                #
+                #  The following attributes are required:
+                #    * ipaddr | ipv4addr | ipv6addr - Client IP Address.
+                #    * secret - RADIUS shared secret.
+                #
+                #  All other attributes usually supported in a client
+                #  definition are also supported here.
+                #
+                #  Schemas are available in doc/schemas/ldap for openldap and eDirectory
+                #
+                attribute {
+                        ipaddr                          = 'radiusClientIdentifier'
+                        secret                          = 'radiusClientSecret'
+#                       shortname                       = 'radiusClientShortname'
+#                       nas_type                        = 'radiusClientType'
+#                       virtual_server                  = 'radiusClientVirtualServer'
+#                       require_message_authenticator   = 'radiusClientRequireMa'
+                }
+        }
+
+        #  Load clients on startup
+#       read_clients = no
+
+        #
+        #  Modify user object on receiving Accounting-Request
+        #
+
+        #  Useful for recording things like the last time the user logged
+        #  in, or the Acct-Session-ID for CoA/DM.
+        #
+        #  LDAP modification items are in the format:
+        #       <ldap attr> <op> <value>
+        #
+        #  Where:
+        #       <ldap attr>:    The LDAP attribute to add modify or delete.
+        #       <op>:           One of the assignment operators:
+        #                       (:=, +=, -=, ++).
+        #                       Note: '=' is *not* supported.
+        #       <value>:        The value to add modify or delete.
+        #
+        #  WARNING: If using the ':=' operator with a multi-valued LDAP
+        #  attribute, all instances of the attribute will be removed and
+        #  replaced with a single attribute.
+        accounting {
+                reference = "%{tolower:type.%{Acct-Status-Type}}"
+
+                type {
+                        start {
+                                update {
+                                        description := "Online at %S"
+                                }
+                        }
+
+                        interim-update {
+                                update {
+                                        description := "Last seen at %S"
+                                }
+                        }
+
+                        stop {
+                                update {
+                                        description := "Offline at %S"
+                                }
+                        }
+                }
+        }
+
+        #
+        #  Post-Auth can modify LDAP objects too
+        #
+        post-auth {
+                update {
+                        description := "Authenticated at %S"
+                }
+        }
+
+        #
+        #  LDAP connection-specific options.
+        #
+        #  These options set timeouts, keep-alives, etc. for the connections.
+        #
+        options {
+                #  Control under which situations aliases are followed.
+                #  May be one of 'never', 'searching', 'finding' or 'always'
+                #  default: libldap's default which is usually 'never'.
+                #
+                #  LDAP_OPT_DEREF is set to this value.
+#               dereference = 'always'
+
+                #
+                #  The following two configuration items control whether the
+                #  server follows references returned by LDAP directory.
+                #  They are  mostly for Active Directory compatibility.
+                #  If you set these to 'no', then searches will likely return
+                #  'operations error', instead of a useful result.
+                #
+                chase_referrals = yes
+                rebind = yes
+
+                #  Seconds to wait for LDAP query to finish. default: 20
+                res_timeout = 10
+
+                #  Seconds LDAP server has to process the query (server-side
+                #  time limit). default: 20
+                #
+                #  LDAP_OPT_TIMELIMIT is set to this value.
+                srv_timelimit = 3
+
+                #  Seconds to wait for response of the server. (network
+                #  failures) default: 10
+                #
+                #  LDAP_OPT_NETWORK_TIMEOUT is set to this value.
+                net_timeout = 1
+
+                #  LDAP_OPT_X_KEEPALIVE_IDLE
+                idle = 60
+
+                #  LDAP_OPT_X_KEEPALIVE_PROBES
+                probes = 3
+
+                #  LDAP_OPT_X_KEEPALIVE_INTERVAL
+                interval = 3
+
+                #  ldap_debug: debug flag for LDAP SDK
+                #  (see OpenLDAP documentation).  Set this to enable
+                #  huge amounts of LDAP debugging on the screen.
+                #  You should only use this if you are an LDAP expert.
+                #
+                #       default: 0x0000 (no debugging messages)
+                #       Example:(LDAP_DEBUG_FILTER+LDAP_DEBUG_CONNS)
+                ldap_debug = 0x0028
+        }
+
+        #
+        #  This subsection configures the tls related items
+                #
+                #  Setting 'max' to MORE than the number of threads means
+                #  that there are more connections than necessary.
+                max = ${thread[pool].max_servers}
+
+                #  Spare connections to be left idle
+                #
+                #  NOTE: Idle connections WILL be closed if "idle_timeout"
+                #  is set.  This should be less than or equal to "max" above.
+                spare = ${thread[pool].max_spare_servers}
+
+                #  Number of uses before the connection is closed
+                #
+                #  0 means "infinite"
+                uses = 0
+
+                #  The number of seconds to wait after the server tries
+                #  to open a connection, and fails.  During this time,
+                #  no new connections will be opened.
+                retry_delay = 30
+
+                #  The lifetime (in seconds) of the connection
+                lifetime = 0
+
+                #  Idle timeout (in seconds).  A connection which is
+                #  unused for this length of time will be closed.
+                idle_timeout = 60
+
+                #  NOTE: All configuration settings are enforced.  If a
+                #  connection is closed because of 'idle_timeout',
+                #  'uses', or 'lifetime', then the total number of
+                #  connections MAY fall below 'min'.  When that
+                #  happens, it will open a new connection.  It will
+                #  also log a WARNING message.
+                #
+                #  The solution is to either lower the 'min' connections,
+                #  or increase lifetime/idle_timeout.
+        }
+}
+
+{%   endif %}
+{% endif %}

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-ldap
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-ldap
@@ -23,7 +23,7 @@ ldap {
 {%     endif %}
 
 {%     if helpers.exists('OPNsense.freeradius.ldap.password') and OPNsense.freeradius.ldap.password != '' %}
-        identity = {{ OPNsense.freeradius.ldap.password }}
+        password = {{ OPNsense.freeradius.ldap.password }}
 {%     endif %}        
         #       identity = 'cn=admin,dc=example,dc=org'
 #       password = mypass
@@ -32,7 +32,7 @@ ldap {
         #  searches will start from.
         # base_dn = 'dc=example,dc=org'
 {%     if helpers.exists('OPNsense.freeradius.ldap.base_dn') and OPNsense.freeradius.ldap.base_dn != '' %}
-        identity = '{{ OPNsense.freeradius.ldap.base_dn }}'
+        base_dn = '{{ OPNsense.freeradius.ldap.base_dn }}'
 {%     endif %}
         #
         #  SASL parameters to use for admin binds

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-ldap
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-ldap
@@ -17,7 +17,7 @@ ldap {
         base_dn = '{{ OPNsense.freeradius.ldap.base_dn }}'
 {%     endif %}
 {%     raw %}
-sasl {
+        sasl {
         }
         update {
                 control:Password-With-Header    += 'userPassword'
@@ -96,6 +96,20 @@ sasl {
                 idle_timeout = 60
 
         }
+        tls {
+                require_cert    = 'allow'
+        }
+        pool {
+                start = ${thread[pool].start_servers}
+                min = ${thread[pool].min_spare_servers}
+                max = ${thread[pool].max_servers}
+                spare = ${thread[pool].max_spare_servers}
+                uses = 0
+                retry_delay = 30
+                lifetime = 0
+                idle_timeout = 60
+        }
+
 }
 {%   endraw %}
 {%   endif %}

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-ldap
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-ldap
@@ -473,46 +473,13 @@ ldap {
                 #       Example:(LDAP_DEBUG_FILTER+LDAP_DEBUG_CONNS)
                 ldap_debug = 0x0028
         }
-
-        #
-        #  This subsection configures the tls related items
-                #
-                #  Setting 'max' to MORE than the number of threads means
-                #  that there are more connections than necessary.
                 max = ${thread[pool].max_servers}
-
-                #  Spare connections to be left idle
-                #
-                #  NOTE: Idle connections WILL be closed if "idle_timeout"
-                #  is set.  This should be less than or equal to "max" above.
                 spare = ${thread[pool].max_spare_servers}
-
-                #  Number of uses before the connection is closed
-                #
-                #  0 means "infinite"
                 uses = 0
-
-                #  The number of seconds to wait after the server tries
-                #  to open a connection, and fails.  During this time,
-                #  no new connections will be opened.
                 retry_delay = 30
-
-                #  The lifetime (in seconds) of the connection
                 lifetime = 0
-
-                #  Idle timeout (in seconds).  A connection which is
-                #  unused for this length of time will be closed.
                 idle_timeout = 60
 
-                #  NOTE: All configuration settings are enforced.  If a
-                #  connection is closed because of 'idle_timeout',
-                #  'uses', or 'lifetime', then the total number of
-                #  connections MAY fall below 'min'.  When that
-                #  happens, it will open a new connection.  It will
-                #  also log a WARNING message.
-                #
-                #  The solution is to either lower the 'min' connections,
-                #  or increase lifetime/idle_timeout.
         }
 }
 

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-ldap
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-ldap
@@ -16,7 +16,7 @@ ldap {
 {%     if helpers.exists('OPNsense.freeradius.ldap.base_dn') and OPNsense.freeradius.ldap.base_dn != '' %}
         base_dn = '{{ OPNsense.freeradius.ldap.base_dn }}'
 {%     endif %}
-
+{%     raw %}
 sasl {
         }
         update {
@@ -98,6 +98,6 @@ sasl {
 
         }
 }
-
+{%   endraw %}
 {%   endif %}
 {% endif %}

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/sites-enabled-default
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/sites-enabled-default
@@ -56,8 +56,11 @@ authorize {
         }
         files
         -sql
+{% if helpers.exists('OPNsense.freeradius.general.ldap_enabled') and OPNsense.freeradius.general.ldap_enabled == '1' %}
+        ldap
+{% else %}
         -ldap
-
+{% endif %}
 {% if helpers.exists('OPNsense.freeradius.general.sessionlimit') and OPNsense.freeradius.general.sessionlimit == '1' %}
         daily
 {% endif %}
@@ -77,6 +80,11 @@ authenticate {
         Auth-Type MS-CHAP {
                 mschap
         }
+{% if helpers.exists('OPNsense.freeradius.general.ldap_enabled') and OPNsense.freeradius.general.ldap_enabled == '1' %}
+        Auth-Type LDAP {
+                ldap
+        }
+{% endif %}
         mschap
         digest
         eap


### PR DESCRIPTION
This update adds basic LDAP support. It allows to bind via LDAP and LDAPS, certification validation is disabled ATM, will follow after 18.1 or so. Also there's no search filter option available yet, but I need a devel pkg for the community to test. Perhaps this can go stable with 18.1, depends on the guys in the forums :)