### PR TITLE
Fix label.

### DIFF
--- a/databases/redis/src/opnsense/mvc/app/controllers/OPNsense/Redis/forms/settings.xml
+++ b/databases/redis/src/opnsense/mvc/app/controllers/OPNsense/Redis/forms/settings.xml
@@ -95,7 +95,7 @@
     <subtab id="redis-performance-slow-transactions" description="Slow Transactions">
       <field>
         <id>redis.slowlog.slower_than</id>
-        <label>Log Transactions Slower Than (µS)</label>
+        <label>Log Transactions Slower Than (microsecond)</label>
         <type>text</type>
         <help>0: Log everything, Positive Value: Log events that take longer than specified, Negative Value: Log nothing.</help>
       </field>


### PR DESCRIPTION
Does not start the translation
Traceback (most recent call last):
  File "./scripts/collect.py", line 70, in <module>
    fOut.write(line)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xb5' in position 44: ordinal not in range(128)
