### PR TITLE
A new plugin to allow SCP config backups to a remote host.

### DIFF
--- a/sysutils/scp-backup/Makefile
+++ b/sysutils/scp-backup/Makefile
@@ -1,0 +1,7 @@
+PLUGIN_NAME=		scp-backup
+PLUGIN_VERSION=		0.1.0
+PLUGIN_COMMENT=		Perform config backups using SCP.
+PLUGIN_MAINTAINER=	dharrigan@gmail.com
+PLUGIN_DEVEL=		yes
+
+.include "../../Mk/plugins.mk"

--- a/sysutils/scp-backup/pkg-descr
+++ b/sysutils/scp-backup/pkg-descr
@@ -1,0 +1,1 @@
+A simple plugin to perform config backups using SCP. 

--- a/sysutils/scp-backup/src/opnsense/mvc/app/controllers/OPNsense/ScpBackup/Api/GeneralController.php
+++ b/sysutils/scp-backup/src/opnsense/mvc/app/controllers/OPNsense/ScpBackup/Api/GeneralController.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ *    Copyright (C) 2018 David Harrigan
+ *    Copyright (C) 2015 - 2017 Deciso B.V.
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+namespace OPNsense\ScpBackup\Api;
+
+use \OPNsense\Base\ApiMutableModelControllerBase;
+use \OPNsense\Core\Backend;
+use \OPNsense\Core\Config;
+use \OPNsense\Cron\Cron;
+use \OPNsense\ScpBackup\General;
+
+class GeneralController extends ApiMutableModelControllerBase
+{
+    static protected $internalModelName = 'general';
+    static protected $internalModelClass = 'OPNsense\ScpBackup\General';
+
+    public function getAction()
+    {
+        $result = array();
+        if ($this->request->isGet()) {
+            $mdlGeneral = $this->getModel();
+            $publicKey = fopen("/conf/sshd/ssh_host_rsa_key.pub", "r");
+            if($publicKey) {
+                $mdlGeneral->publickey = fread($publicKey, filesize("/conf/sshd/ssh_host_rsa_key.pub"));
+                fclose($publicKey);
+            }
+            $result['general'] = $mdlGeneral->getNodes();
+        }
+        return $result;
+    }
+
+    public function setAction()
+    {
+        $result = array("result"=>"failed");
+        if ($this->request->isPost()) {
+            $mdlGeneral = $this->getModel();
+            $backend = new Backend();
+            $mdlCron = new Cron();
+            $mdlGeneral->setNodes($this->request->getPost("general"));
+            $mdlGeneral->publickey = null;
+            $valMsgs = $mdlGeneral->performValidation();
+            foreach ($valMsgs as $field => $msg) {
+                if (!array_key_exists("validation", $result)) {
+                    $result["validations"] = array();
+                } 
+                $result["validations"][$msg->getField()] = $msg->getMessage();
+            }
+            if($valMsgs->count() == 0) {
+                if($mdlGeneral->cronuuid->__toString() == "" and $mdlGeneral->enabled->__toString() == "1") {
+                    // First Time Save
+                    $cronUuid = $mdlCron->newDailyJob("ScpBackup", "scpbackup perform", "Backup config using SCP", "*", "1");
+                    if ($mdlCron->performValidation()->count() == 0) {
+                        $mdlCron->serializeToConfig();
+                        // save data to config, do not validate because the current in memory model doesn't know about the cron item just created.
+                        $mdlGeneral->cronuuid = $cronUuid;
+                        $mdlGeneral->serializeToConfig($validateFullModel = false, $disable_validation = true);
+                        Config::getInstance()->save();
+                        $backend->configdRun('template reload OPNsense/Cron');
+                        $result["result"] = "cron job [" . $cronUuid . "] created to backup config file daily using SCP.";
+                    }
+                } elseif ($mdlGeneral->cronuuid->__toString() != "" and $mdlGeneral->enabled->__toString() == "0") {
+                    // Removal of Cron Job and deactivation of the backup
+                    $cronUuid = $mdlGeneral->cronuuid->__toString();
+                    if($mdlCron->jobs->job->del($cronUuid)) {
+                        $mdlCron->serializeToConfig();
+                        $mdlGeneral->cronuuid = null;
+                        $mdlGeneral->serializeToConfig($validateFullModel = false, $disable_validation = true);
+                        Config::getInstance()->save();
+                        $backend->configdRun('template reload OPNsense/Cron');
+                        $result["result"] = "cron job [" . $cronUuid . "] to backup config file deleted.";
+                    } else {
+                        $result["result"] = "unable to delete cron job [". $cronUuid . "]";
+                    }
+                } else {
+                    // Update the backup configuration
+                    $mdlGeneral->serializeToConfig();
+                    Config::getInstance()->save();
+                    $result["result"] = "SCP backup configuration updated.";
+                }
+            }
+        }
+        return $result;
+    }
+
+}

--- a/sysutils/scp-backup/src/opnsense/mvc/app/controllers/OPNsense/ScpBackup/GeneralController.php
+++ b/sysutils/scp-backup/src/opnsense/mvc/app/controllers/OPNsense/ScpBackup/GeneralController.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ *    Copyright (C) 2018 David Harrigan
+ *    Copyright (C) 2015 - 2017 Deciso B.V.
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+namespace OPNsense\ScpBackup;
+
+class GeneralController extends \OPNsense\Base\IndexController
+{
+    public function indexAction()
+    {
+        $this->view->pick('OPNsense/ScpBackup/general');
+        $this->view->generalForm = $this->getForm("general");
+    }
+}
+

--- a/sysutils/scp-backup/src/opnsense/mvc/app/controllers/OPNsense/ScpBackup/forms/general.xml
+++ b/sysutils/scp-backup/src/opnsense/mvc/app/controllers/OPNsense/ScpBackup/forms/general.xml
@@ -1,0 +1,39 @@
+<form>
+  <field>
+    <id>general.enabled</id>
+    <label>Enabled</label>
+    <type>checkbox</type>
+    <help>This will activate the SCP backup plugin.</help>
+  </field>
+  <field>
+    <id>general.hostname</id>
+    <label>Hostname</label>
+    <type>text</type>
+    <help>Set the remote hostname.</help>
+  </field>
+  <field>
+    <id>general.port</id>
+    <label>Port</label>
+    <type>text</type>
+    <help>Set the remote port.</help>
+  </field>
+  <field>
+    <id>general.username</id>
+    <label>Remote Username</label>
+    <type>text</type>
+    <help>Set the remote username.</help>
+  </field>
+  <field>
+    <id>general.remotedirectory</id>
+    <label>Remote Directory</label>
+    <type>text</type>
+    <help>Set the remote directory to backup the config file to.</help>
+  </field>
+  <field>
+    <id>general.publickey</id>
+    <label>Local Root's Public Key</label>
+    <type>textbox</type>
+    <help>The public key of the local root user. This public key must be added to the remote user's authorized_keys - otherwise backups will fail.</help>
+    <readonly>true</readonly>
+  </field>
+</form>

--- a/sysutils/scp-backup/src/opnsense/mvc/app/models/OPNsense/ScpBackup/ACL/ACL.xml
+++ b/sysutils/scp-backup/src/opnsense/mvc/app/models/OPNsense/ScpBackup/ACL/ACL.xml
@@ -1,0 +1,9 @@
+<acl>
+    <page-system-configuration-ScpBackup>
+        <name>System: Configuration: SCP Backup</name>
+        <patterns>
+            <pattern>ui/ScpBackup/*</pattern>
+            <pattern>api/ScpBackup/*</pattern>
+        </patterns>
+    </page-system-configuration-ScpBackup>
+</acl>

--- a/sysutils/scp-backup/src/opnsense/mvc/app/models/OPNsense/ScpBackup/General.php
+++ b/sysutils/scp-backup/src/opnsense/mvc/app/models/OPNsense/ScpBackup/General.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ *    Copyright (C) 2018 David Harrigan
+ *    Copyright (C) 2015 - 2017 Deciso B.V.
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+namespace OPNsense\ScpBackup;
+
+use OPNsense\Base\BaseModel;
+
+class General extends BaseModel
+{
+
+}
+

--- a/sysutils/scp-backup/src/opnsense/mvc/app/models/OPNsense/ScpBackup/General.xml
+++ b/sysutils/scp-backup/src/opnsense/mvc/app/models/OPNsense/ScpBackup/General.xml
@@ -1,0 +1,44 @@
+<model>
+    <mount>//OPNsense/ScpBackup</mount>
+    <description>
+        scp-backup - a simple plugin to backup the config using SCP.
+    </description>
+    <version>0.1.0</version>
+    <items>
+        <enabled type="BooleanField">
+          <default>0</default>
+          <Required>Y</Required>
+        </enabled>
+        <hostname type="TextField">
+          <default></default>
+          <Required>Y</Required>
+          <mask>/\S*/</mask>
+          <ValidationMessage>Please provide a hostname (no spaces allowed)</ValidationMessage>
+        </hostname>
+        <port type="IntegerField">
+          <default>22</default>
+          <Required>Y</Required>
+          <MinimumValue>1</MinimumValue>
+          <MaximumValue>65535</MaximumValue>
+          <ValidationMessage>Please provide a valid port number between 1 and 65535. Port 22 is the default.</ValidationMessage>
+        </port>
+        <username type="TextField">
+          <default>root</default>
+          <Required>Y</Required>
+          <mask>/^[a-z0-9_-]{3,32}$/</mask>
+          <ValidationMessage>Please provide a valid username ([a-z0-9_-]{3,32}).</ValidationMessage>
+        </username>
+        <remotedirectory type="TextField">
+          <default>./</default>
+          <Required>Y</Required>
+          <ValidationMessage>Please provide a remote directory.</ValidationMessage>
+        </remotedirectory>
+        <publickey type="TextField">
+          <Required>N</Required>
+        </publickey>
+        <cronuuid type="TextField">
+          <Required>N</Required>
+        </cronuuid>
+    </items>
+</model>
+

--- a/sysutils/scp-backup/src/opnsense/mvc/app/models/OPNsense/ScpBackup/Menu/Menu.xml
+++ b/sysutils/scp-backup/src/opnsense/mvc/app/models/OPNsense/ScpBackup/Menu/Menu.xml
@@ -1,0 +1,8 @@
+<menu>
+    <System>
+      <Configuration>
+        <ScpBackup VisibleName="SCP Backup" url="/ui/scpbackup/general/index"/>
+      </Configuration>
+    </System>
+</menu>
+

--- a/sysutils/scp-backup/src/opnsense/mvc/app/views/OPNsense/ScpBackup/general.volt
+++ b/sysutils/scp-backup/src/opnsense/mvc/app/views/OPNsense/ScpBackup/general.volt
@@ -1,0 +1,55 @@
+{#
+
+Copyright (C) 2018 David Harrigan
+OPNsense® is Copyright © 2015 – 2017 by Deciso B.V.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1.  Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+2.  Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+#}
+<script type="text/javascript">
+    $(document).ready(function() {
+        var data_get_map = {'frm_general_settings':"/api/scpbackup/general/get"};
+
+        mapDataToFormUI(data_get_map).done(function(data) {
+            formatTokenizersUI();
+            $('.selectpicker').selectpicker('refresh');
+        });
+
+        $("#saveAct").click(function() {
+            $("#saveAct_progress").addClass("fa fa-spinner fa-pulse");
+            saveFormToEndpoint(url="/api/scpbackup/general/set", formid='frm_general_settings', callback_ok=function(data, status) {
+                $("#saveAct_progress").removeClass("fa fa-spinner fa-pulse");
+            });
+        });
+
+    });
+</script>
+
+<div class="content-box" style="padding-bottom: 1.5em;">
+    {{ partial("layout_partials/base_form", ['fields':generalForm,'id':'frm_general_settings']) }}
+    <div class="col-md-12">
+        <hr />
+        <button class="btn btn-primary" id="saveAct" type="button"><b>{{ lang._('Save') }}</b> <i id="saveAct_progress"></i></button>
+    </div>
+</div>

--- a/sysutils/scp-backup/src/opnsense/scripts/OPNsense/ScpBackup/ScpBackup.php
+++ b/sysutils/scp-backup/src/opnsense/scripts/OPNsense/ScpBackup/ScpBackup.php
@@ -1,0 +1,65 @@
+#!/usr/local/bin/php
+<?php
+
+/**
+ *    Copyright (C) 2018 David Harrigan
+ *    Copyright (C) 2015 - 2017 Deciso B.V.
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+require_once("util.inc");
+require_once("config.inc");
+
+use OPNsense\Base;
+use OPNsense\Core\Config;
+
+$config = Config::getInstance()->object(); 
+$scpBackup = $config->OPNsense->ScpBackup;
+
+if(isset($scpBackup) && isset($scpBackup->enabled) && $scpBackup->enabled == 1) {
+    $hostname = escapeshellarg($scpBackup->hostname);
+    $username = escapeshellarg($scpBackup->username);
+    $port = $scpBackup->port;
+    $remoteDirectory = empty(trim($scpBackup->remotedirectory)) ? "./" : $scpBackup->remotedirectory;
+    $identifyFile = "/conf/sshd/ssh_host_rsa_key";
+    $configFile = "/conf/config.xml";
+
+    if(!substr($remoteDirectory, -1) == "/") {
+        $remoteDirectory = $remoteDirectory . "/";
+    }
+
+    $remoteDirectoryFullPath = escapeshellarg($remoteDirectory . "config-" . date('Y-m-d-H-i') . ".xml");
+
+    $command = "scp -P $port -i $identifyFile $configFile $username@$hostname:$remoteDirectoryFullPath";
+
+    syslog(LOG_WARNING, "scp_backup command: $command");
+
+    exec(escapeshellcmd($command), $output, $returnCode);
+
+    if($returnCode != 0) {
+        syslog(LOG_ERR, "scp_backup command: return code [$returnCode]");
+    }
+}

--- a/sysutils/scp-backup/src/opnsense/service/conf/actions.d/actions_scpbackup.conf
+++ b/sysutils/scp-backup/src/opnsense/service/conf/actions.d/actions_scpbackup.conf
@@ -1,0 +1,6 @@
+[perform]
+command: /usr/local/opnsense/scripts/OPNsense/ScpBackup/ScpBackup.php;exit 0
+parameters:
+type: script_output
+message: cronjob running to backup config to remote location
+description: Backup config using SCP


### PR DESCRIPTION
This simple plugin takes a few parameters, such as hostname and username and
schedules a cron job to remotely scp the config.xml file at regular intervals.
It uses the public/private keypair of the built-in root user as the source of
the key exchange. This means that the public key must be copied to the remote
host and added to the authorized_keys file (for the defined user).

The remote file is backed up as `config-YYYY-DD-MM-HH-MM.xml`, for example:
`config-2018-01-02-15-40.xml`. It's possible to change the remote location of
where the config file is backed up to.

The cron job can be modified under System/Settings/Cron and the schedule
adjusted to suit the backup frequency requirements.

-=david=-

closes #457