### PR TITLE
HTML Compliance - Element <button> Descendant of <a> Element

### DIFF
--- a/dns/dyndns/src/www/services_dyndns.php
+++ b/dns/dyndns/src/www/services_dyndns.php
@@ -181,7 +181,7 @@ $main_buttons = array(
                       <td><?=$dyndns['descr'];?></td>
                       <td>
                         <a href="services_dyndns_edit.php?id=<?=$i;?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
-                        <a href="#" data-id="<?=$i;?>" class="act_delete_service"><button type="button" class="btn btn-xs btn-default"><span class="fa fa-trash text-muted"></span></button></a>
+                        <a href="#" data-id="<?=$i;?>" class="act_delete_service btn btn-xs btn-default"><i class="fa fa-trash text-muted"></i></a>
                       </td>
                     </tr>
 <?php

--- a/net/igmp-proxy/src/www/services_igmpproxy.php
+++ b/net/igmp-proxy/src/www/services_igmpproxy.php
@@ -123,7 +123,7 @@ $main_buttons = array(
                       <td><?=$igmpentry['descr'];?></td>
                       <td>
                          <a href="services_igmpproxy_edit.php?id=<?=$i;?>" title="<?=gettext("Edit this IGMP entry"); ?>" class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>
-                         <a href="#" data-id="<?=$i;?>" class="act_delete_entry"><button type="button" class="btn btn-xs btn-default"><span class="fa fa-trash text-muted"></span></button></a>
+                         <a href="#" data-id="<?=$i;?>" class="act_delete_entry btn btn-xs btn-default"><i class="fa fa-trash text-muted"></i></a>
                       </td>
                     </tr>
 <?php


### PR DESCRIPTION
Error: The element button must not appear as a descendant of the a element.

Specification:
http://w3c.github.io/html/textlevel-semantics.html#the-a-element
"Allowed ARIA role attribute values: link (default - do not set), button, checkbox, radio, switch, tab or treeitem"
"The <a> element may be wrapped around entire paragraphs, lists, tables, and so forth, even entire sections, so long as there is no interactive content within (e.g., buttons or other links)."