### PR TITLE
HTML Compliance - Obsolete table attributes

### DIFF
--- a/dns/dyndns/src/www/services_dyndns_edit.php
+++ b/dns/dyndns/src/www/services_dyndns_edit.php
@@ -210,8 +210,8 @@ include("head.inc");
               <div class="table-responsive">
                 <table class="table table-striped opnsense_standard_table_form">
                   <tr>
-                    <td width="22%"><strong><?= gettext("Dynamic DNS client") ?></strong></td>
-                    <td width="78%" align="right">
+                    <td style="width:22%"><strong><?= gettext("Dynamic DNS client") ?></strong></td>
+                    <td style="width:78%; text-align:right">
                       <small><?= gettext("full help") ?> </small>
                       <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                     </td>

--- a/dns/rfc2136/src/www/services_rfc2136_edit.php
+++ b/dns/rfc2136/src/www/services_rfc2136_edit.php
@@ -136,8 +136,8 @@ include("head.inc");
               <div class="table-responsive">
                 <table class="table table-striped opnsense_standard_table_form">
                   <tr>
-                    <td width="22%"><strong><?=gettext("RFC 2136 client");?></strong></td>
-                    <td width="78%" align="right">
+                    <td style="width:22%"><strong><?=gettext("RFC 2136 client");?></strong></td>
+                    <td style="width:78%; text-align:right">
                       <small><?=gettext("full help"); ?> </small>
                       <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                     </td>

--- a/net-mgmt/snmp/src/www/services_snmp.php
+++ b/net-mgmt/snmp/src/www/services_snmp.php
@@ -154,10 +154,10 @@ include("head.inc");
                 <table class="table table-striped opnsense_standard_table_form">
                   <thead>
                     <tr>
-                      <td width="22%">
+                      <td style="width:22%">
                         <strong><?=gettext("SNMP Daemon");?></strong>
                       </td>
-                      <td width="78%" align="right">
+                      <td style="width:78%; text-align:right">
                         <small><?=gettext("full help"); ?> </small>
                         <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                         &nbsp;&nbsp;
@@ -217,8 +217,8 @@ include("head.inc");
                   </thead>
                   <tbody>
                     <tr>
-                      <td width="22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Enable");?></td>
-                      <td width="78%">
+                      <td style="width:22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext("Enable");?></td>
+                      <td style="width:78%">
                         <input name="trapenable" type="checkbox" value="yes" <?=!empty($pconfig['trapenable']) ? "checked=\"checked\"" : ""; ?> />
                       </td>
                     </tr>
@@ -265,8 +265,8 @@ include("head.inc");
                   </thead>
                   <tbody>
                     <tr>
-                      <td width="22%"><?=gettext("SNMP Modules");?></td>
-                      <td width="78%">
+                      <td style="width:22%"><?=gettext("SNMP Modules");?></td>
+                      <td style="width:78%">
                         <table class="table table-condensed">
                           <tr>
                             <td>
@@ -339,8 +339,8 @@ include("head.inc");
                       </td>
                     </tr>
                     <tr>
-                     <td width="22%" valign="top">&nbsp;</td>
-                     <td width="78%">
+                     <td style="width:22%; vertical-align:top">&nbsp;</td>
+                     <td style="width:78%">
                        <input name="Submit" type="submit" class="btn btn-primary" value="<?=gettext("Save");?>" />
                      </td>
                     </tr>

--- a/net/igmp-proxy/src/www/services_igmpproxy_edit.php
+++ b/net/igmp-proxy/src/www/services_igmpproxy_edit.php
@@ -149,8 +149,8 @@ include("head.inc");
                 <div class="table-responsive">
                   <table class="table table-striped opnsense_standard_table_form">
                     <tr>
-                      <td width="22%"><strong><?=gettext("IGMP Proxy Edit");?></strong></td>
-                      <td width="78%" align="right">
+                      <td style="width:22%"><strong><?=gettext("IGMP Proxy Edit");?></strong></td>
+                      <td style="width:78%; text-align:right">
                         <small><?=gettext("full help"); ?> </small>
                         <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                       </td>

--- a/net/l2tp/src/www/vpn_l2tp.php
+++ b/net/l2tp/src/www/vpn_l2tp.php
@@ -176,8 +176,8 @@ include("head.inc");
               <div class="table-responsive">
                 <table class="table table-striped opnsense_standard_table_form">
                   <tr>
-                    <td width="22%"><b><?=gettext("L2TP settings"); ?></b></td>
-                    <td width="78%" align="right">
+                    <td style="width:22%"><b><?=gettext("L2TP settings"); ?></b></td>
+                    <td style="width:78%; text-align:right">
                       <small><?=gettext("full help"); ?> </small>
                       <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                     </td>
@@ -330,7 +330,7 @@ include("head.inc");
                   </tr>
                   <tr>
                     <td></td>
-                    <td width="78%">
+                    <td style="width:78%">
                       <input id="submit" name="Submit" type="submit" class="btn btn-primary" value="<?=gettext("Save"); ?>" />
                     </td>
                   </tr>

--- a/net/l2tp/src/www/vpn_l2tp_users_edit.php
+++ b/net/l2tp/src/www/vpn_l2tp_users_edit.php
@@ -152,10 +152,10 @@ include("head.inc");
                <div class="table-responsive">
                 <table class="table table-striped opnsense_standard_table_form">
                   <tr>
-                    <td width="22%">
+                    <td style="width:22%">
                       <strong><?=gettext("Edit User");?></strong>
                     </td>
-                    <td width="78%" align="right">
+                    <td style="width:78%; text-align:right">
                       <small><?=gettext("full help"); ?> </small>
                       <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page"></i>
                     </td>

--- a/net/pppoe/src/www/vpn_pppoe_edit.php
+++ b/net/pppoe/src/www/vpn_pppoe_edit.php
@@ -266,8 +266,8 @@ legacy_html_escape_form_data($pconfig);
               <div class="table-responsive">
                 <table class="table table-striped opnsense_standard_table_form">
                   <tr>
-                    <td width="22%"><strong><?=gettext("PPPoE server configuration");?></strong></td>
-                    <td width="78%" align="right">
+                    <td style="width:22%"><strong><?=gettext("PPPoE server configuration");?></strong></td>
+                    <td style="width:78%; text-align:right">
                       <small><?=gettext("full help"); ?> </small>
                       <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                     </td>
@@ -530,8 +530,8 @@ legacy_html_escape_form_data($pconfig);
                     </td>
                   </tr>
                   <tr>
-                    <td width="22%" valign="top">&nbsp;</td>
-                    <td width="78%">
+                    <td style="width:22%; vertical-align:top">&nbsp;</td>
+                    <td style="width:78%">
 <?php
                     if (isset($id)) {
                         echo "<input type=\"hidden\" name=\"id\" id=\"id\" value=\"" . htmlspecialchars($id, ENT_QUOTES | ENT_HTML401) . "\" />";

--- a/net/pptp/src/www/vpn_pptp.php
+++ b/net/pptp/src/www/vpn_pptp.php
@@ -196,8 +196,8 @@ include("head.inc");
                 <div class="table-responsive">
                   <table class="table table-striped opnsense_standard_table_form">
                     <tr>
-                      <td width="22%"><b><?=gettext("PPTP settings"); ?></b></td>
-                      <td width="78%" align="right">
+                      <td style="width:22%"><b><?=gettext("PPTP settings"); ?></b></td>
+                      <td style="width:78%; text-align:right">
                         <small><?=gettext("full help"); ?> </small>
                         <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                       </td>

--- a/net/pptp/src/www/vpn_pptp_users_edit.php
+++ b/net/pptp/src/www/vpn_pptp_users_edit.php
@@ -154,10 +154,10 @@ include("head.inc");
               <div class="table-responsive">
                 <table class="table table-striped opnsense_standard_table_form">
                   <tr>
-                    <td width="22%">
+                    <td style="width:22%">
                       <strong><?=gettext("Edit User");?></strong>
                     </td>
-                    <td width="78%" align="right">
+                    <td style="width:78%; text-align:right">
                       <small><?=gettext("full help"); ?> </small>
                       <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page"></i>
                     </td>

--- a/net/relayd/src/www/load_balancer_monitor_edit.php
+++ b/net/relayd/src/www/load_balancer_monitor_edit.php
@@ -223,8 +223,8 @@ $types = array("icmp" => gettext("ICMP"), "tcp" => gettext("TCP"), "http" => get
                 <div class="table-responsive">
                   <table class="table table-striped opnsense_standard_table_form">
                     <tr>
-                      <td width="22%"><strong><?=gettext("Edit Monitor entry"); ?></strong></td>
-                      <td width="78%" align="right">
+                      <td style="width:22%"><strong><?=gettext("Edit Monitor entry"); ?></strong></td>
+                      <td style="width:78%; text-align:right">
                         <small><?=gettext("full help"); ?> </small>
                         <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                       </td>
@@ -316,8 +316,8 @@ $types = array("icmp" => gettext("ICMP"), "tcp" => gettext("TCP"), "http" => get
                       </td>
                   </tr>
                   <tr>
-                    <td valign="top">&nbsp;</td>
-                    <td width="78%">
+                    <td style="vertical-align:top">&nbsp;</td>
+                    <td style="width:78%">
                       <input name="Submit" type="submit" class="btn btn-primary" value="<?=gettext("Save"); ?>" />
                       <input type="button" class="btn btn-default" value="<?=gettext("Cancel");?>" onclick="window.location.href='/load_balancer_monitor.php'" />
                       <?php if (isset($id)): ?>

--- a/net/relayd/src/www/load_balancer_pool_edit.php
+++ b/net/relayd/src/www/load_balancer_pool_edit.php
@@ -233,7 +233,7 @@ include("head.inc");
                     <td>
                       <strong><?=gettext("Add/edit - Pool entry"); ?></strong>
                     </td>
-                    <td align="right">
+                    <td style="text-align:right">
                       <small><?=gettext("full help"); ?> </small>
                       <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                     </td>
@@ -365,7 +365,7 @@ include("head.inc");
                   </tr>
                   <tr>
                     <td>&nbsp;</td>
-                    <td width="78%">
+                    <td style="width:78%">
                       <br />
                       <input id="save" name="save" type="submit" class="btn btn-primary" value="<?=gettext("Save"); ?>"/>
                       <input type="button" class="btn btn-default" value="<?=gettext("Cancel");?>" onclick="window.location.href='/load_balancer_pool.php'" />

--- a/net/relayd/src/www/load_balancer_setting.php
+++ b/net/relayd/src/www/load_balancer_setting.php
@@ -108,10 +108,10 @@ include("head.inc");
                 <div class="table-responsive">
                   <table class="table table-striped opnsense_standard_table_form">
                     <tr>
-                      <td width="22%">
+                      <td style="width:22%">
                         <strong><?=gettext("Global settings"); ?></strong>
                       </td>
-                      <td width="78%" align="right">
+                      <td style="width:78%; text-align:right">
                         <small><?=gettext("full help"); ?> </small>
                         <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                       </td>

--- a/net/relayd/src/www/load_balancer_virtual_server_edit.php
+++ b/net/relayd/src/www/load_balancer_virtual_server_edit.php
@@ -195,10 +195,10 @@ include("head.inc");
                 <div class="table-responsive">
                   <table class="table table-striped opnsense_standard_table_form">
                     <tr>
-                      <td width="22%">
+                      <td style="width:22%">
                         <strong><?=gettext("Add/edit - Virtual Server entry"); ?></strong>
                       </td>
-                      <td width="78%" align="right">
+                      <td style="width:78%; text-align:right">
                         <small><?=gettext("full help"); ?> </small>
                         <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                       </td>

--- a/net/relayd/src/www/status_lb_vs.php
+++ b/net/relayd/src/www/status_lb_vs.php
@@ -111,8 +111,8 @@ include("head.inc");
                       }
                       ?>
                     <td>
-                      <table border="0" cellpadding="3" cellspacing="2" summary="status">
-                        <tr><td bgcolor="<?=$bgcolor?>"><?=$rdr_a[$vsent['name']]['status']?> </td></tr>
+                      <table style="border:0; cellpadding:3; cellspacing:2">
+                        <tr><td style="background-color:<?=$bgcolor?>"><?=$rdr_a[$vsent['name']]['status']?> </td></tr>
                       </table>
                       <?=!empty($rdr_a[$vsent['name']]['total']) ?  "Total Sessions: {$rdr_a[$vsent['name']]['total']}" : "";?>
                       <?=!empty($rdr_a[$vsent['name']]['last']) ? "<br />Last: {$rdr_a[$vsent['name']]['last']}" : "";?>

--- a/net/relayd/src/www/widgets/widgets/load_balancer_status.widget.php
+++ b/net/relayd/src/www/widgets/widgets/load_balancer_status.widget.php
@@ -52,9 +52,9 @@ $nentries = isset($config['syslog']['nentries']) ? $config['syslog']['nentries']
 <table class="table table-striped table-condensed">
   <thead>
     <tr>
-      <th width="10%" class="listhdrr"><?= gettext('Server') ?></th>
-      <th width="10%" class="listhdrr"><?= gettext('Pool') ?></th>
-      <th width="30%" class="listhdr"><?= gettext('Description') ?></th>
+      <th style="width:10%" class="listhdrr"><?= gettext('Server') ?></th>
+      <th style="width:10%" class="listhdrr"><?= gettext('Pool') ?></th>
+      <th style="width:30%" class="listhdr"><?= gettext('Description') ?></th>
     </tr>
   </thead>
   <?php $i = 0; foreach ($a_vs as $vsent) :
@@ -80,7 +80,7 @@ $nentries = isset($config['syslog']['nentries']) ? $config['syslog']['nentries']
       <span style="background-color: <?=$bgcolor?>; display: block"><i><?= $rdr_a[$vsent['name']]['status'] ?></i></span>
       <?=$vsent['ipaddr'].":".$vsent['port'];?><br />
     </td>
-    <td class="listr" align="center" >
+    <td class="listr" style="text-align:center" >
     <table>
     <?php
         foreach ($a_pool as $pool) {
@@ -115,7 +115,7 @@ $nentries = isset($config['syslog']['nentries']) ? $config['syslog']['nentries']
                                 $checked = "checked";
                         }
                         echo "<tr>";
-                        echo "<td bgcolor=\"{$bgcolor}\">&nbsp;{$server['ip']['addr']}:{$pool['port']}&nbsp;</td><td bgcolor=\"{$bgcolor}\">&nbsp;";
+                        echo "<td style=\"background-color:{$bgcolor}\">&nbsp;{$server['ip']['addr']}:{$pool['port']}&nbsp;</td><td style=\"background-color:{$bgcolor}\">&nbsp;";
                         if ($server['ip']['avail']) {
                             echo " ({$server['ip']['avail']}) ";
                         }

--- a/net/upnp/src/www/services_upnp.php
+++ b/net/upnp/src/www/services_upnp.php
@@ -175,10 +175,10 @@ include("head.inc");
                 <table class="table table-striped opnsense_standard_table_form">
                   <thead>
                     <tr>
-                      <td width="22%">
+                      <td style="width:22%">
                         <strong><?=gettext("UPnP and NAT-PMP Settings");?></strong>
                       </td>
-                      <td width="78%" align="right">
+                      <td style="width:78%; text-align:right">
                         <small><?=gettext("full help"); ?> </small>
                         <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page" type="button"></i>
                         &nbsp;&nbsp;
@@ -314,8 +314,8 @@ include("head.inc");
                   </thead>
                   <tbody>
                     <tr>
-                      <td width="22%"><a id="help_for_permuser1" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Set 1");?></td>
-                      <td width="78%">
+                      <td style="width:22%"><a id="help_for_permuser1" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Set 1");?></td>
+                      <td style="width:78%">
                         <input name="permuser1" type="text" value="<?=$pconfig['permuser1'];?>" />
                         <div class="hidden" for="help_for_permuser1">
                           <?=gettext("Format: [allow or deny] [ext port or range] [int ipaddr or ipaddr/cdir] [int port or range]");?><br/>
@@ -361,8 +361,8 @@ include("head.inc");
                 <table class="table table-striped">
                   <tbody>
                     <tr>
-                     <td width="22%" valign="top">&nbsp;</td>
-                     <td width="78%">
+                     <td style="width:22%; vertical-align:top">&nbsp;</td>
+                     <td style="width:78%">
                        <input name="Submit" type="submit" class="btn btn-primary" value="<?=gettext("Save");?>" />
                      </td>
                     </tr>

--- a/net/wol/src/www/services_wol.php
+++ b/net/wol/src/www/services_wol.php
@@ -142,10 +142,10 @@ include("head.inc");
                   <table class="table table-striped opnsense_standard_table_form">
                     <thead>
                       <tr>
-                        <td width="22%">
+                        <td style="width:22%">
                           <strong><?=gettext("Wake on LAN");?></strong>
                         </td>
-                        <td width="78%" align="right">
+                        <td style="width:78%; text-align:right">
                           <small><?=gettext("full help"); ?> </small>
                           <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page"></i>
                           &nbsp;&nbsp;

--- a/net/wol/src/www/services_wol_edit.php
+++ b/net/wol/src/www/services_wol_edit.php
@@ -105,10 +105,10 @@ legacy_html_escape_form_data($pconfig);
               <div class="table-responsive">
                 <table class="table table-striped opnsense_standard_table_form">
                   <tr>
-                    <td width="22%">
+                    <td style="width:22%">
                       <strong><?=gettext("Edit WOL entry");?></strong>
                     </td>
-                    <td width="78%" align="right">
+                    <td style="width:78%; text-align:right">
                       <small><?=gettext("full help"); ?> </small>
                       <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page"></i>
                     </td>

--- a/net/zerotier/src/opnsense/mvc/app/views/OPNsense/Zerotier/overview.volt
+++ b/net/zerotier/src/opnsense/mvc/app/views/OPNsense/Zerotier/overview.volt
@@ -56,13 +56,13 @@ POSSIBILITY OF SUCH DAMAGE.
                 {% for key, value in information %}
                 {% set value = value | default('null') %}
                 <tr>
-                    <td width="22%">{{ key | e }}</td>
+                    <td style="width:22%">{{ key | e }}</td>
                     {% if value is type ('boolean') %}
-                        <td width="78%">{{ value ? 'true' : 'false' }}</td>
+                        <td style="width:78%">{{ value ? 'true' : 'false' }}</td>
                     {% elseif key == "config" %}
                         {% set config = value %}
                         {% set settings = config["settings"] %}
-                        <td width="78%">
+                        <td style="width:78%">
                             <table class="table">
                                 <tr>
                                     <td><b>{{ lang._("physical") }}</b></td>
@@ -85,7 +85,7 @@ POSSIBILITY OF SUCH DAMAGE.
                             </table>
                         </td>
                     {% else %}
-                        <td width="78%">{{ value | e}}</td>
+                        <td style="width:78%">{{ value | e}}</td>
                     {% endif %}
                 </tr>
                 {% elsefor %}
@@ -124,11 +124,11 @@ POSSIBILITY OF SUCH DAMAGE.
                                     {% for key, value in network %}
                                     {% set value = value | default('null') %}
                                     <tr>
-                                        <td width="22%">{{ key | e }}</td>
+                                        <td style="width:22%">{{ key | e }}</td>
                                         {% if value is type('boolean') %}
-                                            <td width="78%">{{ value == true ? 'true' : 'false' }}</td>
+                                            <td style="width:78%">{{ value == true ? 'true' : 'false' }}</td>
                                         {% elseif value is iterable %}
-                                            <td width="78%">
+                                            <td style="width:78%">
                                                 <table class="table">
                                                     {% if key == "assignedAddresses" %}
                                                         <thead>
@@ -177,7 +177,7 @@ POSSIBILITY OF SUCH DAMAGE.
                                                 </table>
                                             </td>
                                         {% else %}
-                                            <td width="78%">{{ value | e }}</td>
+                                            <td style="width:78%">{{ value | e }}</td>
                                         {% endif %}
                                     </tr>
                                     {% endfor %}
@@ -222,11 +222,11 @@ POSSIBILITY OF SUCH DAMAGE.
                                     {% for key, value in peer %}
                                     {% set value = value | default('null') %}
                                     <tr>
-                                        <td width="22%">{{ key | e }}</td>
+                                        <td style="width:22%">{{ key | e }}</td>
                                         {% if value is type('boolean') %}
-                                            <td width="78%">{{ value == true ? 'true' : 'false' }}</td>
+                                            <td style="width:78%">{{ value == true ? 'true' : 'false' }}</td>
                                         {% elseif value is iterable %}
-                                            <td width="78%">
+                                            <td style="width:78%">
                                                 <table class="table">
                                                     {% if key == "paths" %}
                                                         <thead>
@@ -266,7 +266,7 @@ POSSIBILITY OF SUCH DAMAGE.
                                                 </table>
                                             </td>
                                         {% else %}
-                                            <td width="78%">{{ value | e }}</td>
+                                            <td style="width:78%">{{ value | e }}</td>
                                         {% endif %}
                                     </tr>
                                     {% endfor %}

--- a/sysutils/smart/src/www/diag_smart.php
+++ b/sysutils/smart/src/www/diag_smart.php
@@ -145,7 +145,7 @@ switch($action) {
               <form action="<?= $_SERVER['PHP_SELF']?>" method="post" name="iform" id="iform">
                 <table class="table table-striped __nomb">
                    <tr>
-                     <th colspan="2" valign="top" class="listtopic"><?=gettext('Info'); ?></th>
+                     <th colspan="2" style="vertical-align:top" class="listtopic"><?=gettext('Info'); ?></th>
                     </tr>
                     <tr>
                       <td><?=gettext("Info type"); ?></td>
@@ -172,8 +172,8 @@ switch($action) {
                     </td>
                   </tr>
                   <tr>
-                    <td width="22%" valign="top">&nbsp;</td>
-                    <td width="78%">
+                    <td style="width:22%" style="vertical-align:top">&nbsp;</td>
+                    <td style="width:78%">
                       <input type="hidden" name="action" value="info" />
                       <input type="submit" name="submit" class="btn btn-primary" value="<?=gettext("View"); ?>" />
                     </td>
@@ -190,7 +190,7 @@ switch($action) {
               <form action="<?= $_SERVER['PHP_SELF']?>" method="post" name="test" id="iform">
                 <table class="table table-striped __nomb">
                    <tr>
-                     <th colspan="2" valign="top" class="listtopic"><?=gettext('Perform Self-tests'); ?></th>
+                     <th colspan="2" style="vertical-align:top" class="listtopic"><?=gettext('Perform Self-tests'); ?></th>
                     </tr>
                     <tr>
                       <td><?=gettext("Test type"); ?></td>
@@ -217,8 +217,8 @@ switch($action) {
                     </td>
                   </tr>
                   <tr>
-                    <td width="22%" valign="top">&nbsp;</td>
-                    <td width="78%">
+                    <td style="width:22%; vertical-align:top">&nbsp;</td>
+                    <td style="width:78%">
                       <input type="hidden" name="action" value="test" />
                       <input type="submit" name="submit" class="btn btn-primary" value="<?=gettext("Test"); ?>" />
                     </td>
@@ -234,7 +234,7 @@ switch($action) {
               <form action="<?= $_SERVER['PHP_SELF']?>" method="post" name="logs" id="iform">
                 <table class="table table-striped __nomb">
                    <tr>
-                     <th colspan="2" valign="top" class="listtopic"><?=gettext('View Logs'); ?></th>
+                     <th colspan="2" style="vertical-align:top" class="listtopic"><?=gettext('View Logs'); ?></th>
                     </tr>
                     <tr>
                       <td><?=gettext("Log type"); ?></td>
@@ -259,8 +259,8 @@ switch($action) {
                     </td>
                   </tr>
                   <tr>
-                    <td width="22%" valign="top">&nbsp;</td>
-                    <td width="78%">
+                    <td style="width:22%; vertical-align:top">&nbsp;</td>
+                    <td style="width:78%">
                       <input type="hidden" name="action" value="logs" />
                       <input type="submit" name="submit" class="btn btn-primary" value="<?=gettext("View"); ?>" />
                     </td>
@@ -276,7 +276,7 @@ switch($action) {
               <form action="<?= $_SERVER['PHP_SELF']?>" method="post" name="abort" id="iform">
                 <table class="table table-striped __nomb">
                    <tr>
-                     <th colspan="2" valign="top" class="listtopic"><?=gettext('Abort tests'); ?></th>
+                     <th colspan="2" style="vertical-align:top" class="listtopic"><?=gettext('Abort tests'); ?></th>
                     </tr>
                   <tr>
                     <td><?=gettext("Device: /dev/"); ?></td>
@@ -292,8 +292,8 @@ switch($action) {
                     </td>
                   </tr>
                   <tr>
-                    <td width="22%" valign="top">&nbsp;</td>
-                    <td width="78%">
+                    <td style="width:22%; vertical-align:top">&nbsp;</td>
+                    <td style="width:78%">
                       <input type="hidden" name="action" value="logs" />
                       <input type="submit" name="submit" value="<?=gettext("Abort"); ?>" class="btn btn-primary" onclick="return confirm('<?=gettext("Do you really want to abort the test?"); ?>')" />
                     </td>

--- a/sysutils/smart/src/www/widgets/widgets/smart_status.widget.php
+++ b/sysutils/smart/src/www/widgets/widgets/smart_status.widget.php
@@ -32,11 +32,11 @@ require_once("widgets/include/smart_status.inc");
 
 ?>
 
-<table class="table table-striped" width="100%" border="0" cellpadding="0" cellspacing="0" summary="smart status">
+<table class="table table-striped" style="width:100%; border:0; cellpadding:0; cellspacing:0">
 	<tr>
-		<td class="widgetsubheader" align="center"><b><?php echo gettext("Drive") ?></b></td>
-		<td class="widgetsubheader" align="center"><b><?php echo gettext("Ident") ?></b></td>
-		<td class="widgetsubheader" align="center"><b><?php echo gettext("SMART Status") ?></b></td>
+		<td class="widgetsubheader" style="text-align:center"><b><?php echo gettext("Drive") ?></b></td>
+		<td class="widgetsubheader" style="text-align:center"><b><?php echo gettext("Ident") ?></b></td>
+		<td class="widgetsubheader" style="text-align:center"><b><?php echo gettext("SMART Status") ?></b></td>
 	</tr>
 
 <?php
@@ -69,8 +69,8 @@ if (count($devs) > 0) {
 ?>
 		<tr>
 			<td class="listlr"><?php echo $dev; ?></td>
-			<td class="listr" align="center"><?php echo $dev_ident; ?></td>
-			<td class="listr" align="center"><span style="background-color:<?php echo $color; ?>">&nbsp;<?php echo $dev_state_translated ?>&nbsp;</span></td>
+			<td class="listr" style="text-align:center"><?php echo $dev_ident; ?></td>
+			<td class="listr" style="text-align:center"><span style="background-color:<?php echo $color; ?>">&nbsp;<?php echo $dev_state_translated ?>&nbsp;</span></td>
 		</tr>
 <?php
     }


### PR DESCRIPTION
width, align, valign, cellpadding, cellspacing, border, summary, bgcolor

Error: The width attribute on the table element is obsolete. Use CSS instead.
Error: The align attribute on the table element is obsolete. Use CSS instead.
Error: The valign attribute on the table element is obsolete. Use CSS instead.
Error: The cellpadding attribute on the table element is obsolete. Use CSS instead.
Error: The cellspacing attribute on the table element is obsolete. Use CSS instead.
Error: The border attribute on the table element is obsolete. Use CSS instead.
Error: The summary attribute on the table element is obsolete. Consider describing the structure of the table in a caption element or in a figure element containing the table; or, simplify the structure of the table so that no description is needed.
Error: The bgcolor attribute on the table element is obsolete. Use CSS instead.
  