### PR TITLE
net/ssh-keys: add plugin to support known_hosts

### DIFF
--- a/security/ssh-keys/Makefile
+++ b/security/ssh-keys/Makefile
@@ -1,0 +1,7 @@
+PLUGIN_NAME=          ssh-keys
+PLUGIN_VERSION=       0.0.1
+PLUGIN_COMMENT=       Harden SSH connections
+PLUGIN_MAINTAINER=    franz.fabian.94@gmail.com
+
+.include "../../Mk/plugins.mk"
+

--- a/security/ssh-keys/pkg-descr
+++ b/security/ssh-keys/pkg-descr
@@ -1,0 +1,1 @@
+This plugin adds support to configure known_hosts for SSH script hardening.

--- a/security/ssh-keys/src/opnsense/mvc/app/controllers/OPNsense/Sshkeys/Api/SshController.php
+++ b/security/ssh-keys/src/opnsense/mvc/app/controllers/OPNsense/Sshkeys/Api/SshController.php
@@ -1,0 +1,150 @@
+<?php
+
+/*
+ *    Copyright (C) 2015-2017 Deciso B.V.
+ *    Copyright (C) 2015 Jos Schellevis
+ *    Copyright (C) 2017 Fabian Franz
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Sshkeys\Api;
+
+use OPNsense\Base\ApiMutableModelControllerBase;
+use OPNsense\Base\UIModelGrid;
+use OPNsense\Core\Backend;
+use OPNsense\Core\Config;
+use OPNsense\Sshkeys\SSH;
+
+class SshController extends ApiMutableModelControllerBase
+{
+    static protected $internalModelName = 'ssh';
+    static protected $internalModelClass = '\OPNsense\Sshkeys\SSH';
+    public function search_known_hostsAction()
+    {
+        $this->sessionClose();
+        $mdl = $this->getModel();
+        $grid = new UIModelGrid($mdl->known_host);
+        return $grid->fetchBindRequest(
+            $this->request,
+            array('key_type', 'host')
+        );
+    }
+    public function get_known_hostAction($uuid = null)
+    {
+        $mdl = $this->getModel();
+        if ($uuid != null) {
+            $node = $mdl->getNodeByReference('known_host.' . $uuid);
+            if ($node != null) {
+                // return node
+                return array('known_host' => $node->getNodes());
+            }
+        } else {
+            $node = $mdl->known_host->add();
+            return array('known_host' => $node->getNodes());
+        }
+        return array();
+    }
+    public function add_known_hostAction()
+    {
+        $result = array('result' => 'failed');
+        if ($this->request->isPost() && $this->request->hasPost('known_host')) {
+            $result = array('result' => 'failed', 'validations' => array());
+            $mdl = $this->getModel();
+            $node = $mdl->known_host->Add();
+            $node->setNodes($this->request->getPost('known_host'));
+            $valMsgs = $mdl->performValidation();
+
+            foreach ($valMsgs as $field => $msg) {
+                $fieldnm = str_replace($node->__reference, 'known_host', $msg->getField());
+                $result['validations'][$fieldnm] = $msg->getMessage();
+            }
+
+            if (count($result['validations']) == 0) {
+                // save config if validated correctly
+                $mdl->serializeToConfig();
+                Config::getInstance()->save();
+                unset($result['validations']);
+                $result['result'] = 'saved';
+                $this->refresh_template();
+            }
+        }
+        return $result;
+    }
+    public function del_known_hostAction($uuid)
+    {
+
+        $result = array('result' => 'failed');
+
+        if ($this->request->isPost()) {
+            $mdl = $this->getModel();
+            if ($uuid != null) {
+                if ($mdl->known_host->del($uuid)) {
+                    $mdl->serializeToConfig();
+                    Config::getInstance()->save();
+                    $result['result'] = 'deleted';
+                    $this->refresh_template();
+                } else {
+                    $result['result'] = 'not found';
+                }
+            }
+        }
+        return $result;
+    }
+    public function set_known_hostAction($uuid)
+    {
+        if ($this->request->isPost() && $this->request->hasPost('known_host')) {
+            $mdl = $this->getModel();
+            if ($uuid != null) {
+                $node = $mdl->getNodeByReference('known_host.' . $uuid);
+                if ($node != null) {
+                    $result = array('result' => 'failed', 'validations' => array());
+                    $info = $this->request->getPost('known_host');
+
+                    $node->setNodes($info);
+                    $valMsgs = $mdl->performValidation();
+                    foreach ($valMsgs as $field => $msg) {
+                        $fieldnm = str_replace($node->__reference, 'known_host', $msg->getField());
+                        $result['validations'][$fieldnm] = $msg->getMessage();
+                    }
+
+                    if (count($result['validations']) == 0) {
+                        // save config if validated correctly
+                        $mdl->serializeToConfig();
+                        unset($result['validations']);
+                        Config::getInstance()->save();
+                        $result = array('result' => 'saved');
+                        $this->refresh_template();
+                    }
+                    return $result;
+                }
+            }
+        }
+        return array('result' => 'failed');
+    }
+    private function refresh_template()
+    {
+        $backend = new Backend();
+        $backend->configdRun('template reload OPNsense/Sshkeys');
+    }
+}

--- a/security/ssh-keys/src/opnsense/mvc/app/controllers/OPNsense/Sshkeys/IndexController.php
+++ b/security/ssh-keys/src/opnsense/mvc/app/controllers/OPNsense/Sshkeys/IndexController.php
@@ -1,0 +1,45 @@
+<?php
+/*
+
+    Copyright (C) 2018 Fabian Franz
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+
+
+*/
+
+
+namespace OPNsense\Sshkeys;
+
+/**
+* Class IndexController
+* @package OPNsense/Sshkeys
+*/
+class IndexController extends \OPNsense\Base\IndexController
+{
+    public function indexAction()
+    {
+        $this->view->known_host_form = $this->getForm("known_host");
+        $this->view->pick('OPNsense/Sshkeys/index');
+    }
+}

--- a/security/ssh-keys/src/opnsense/mvc/app/controllers/OPNsense/Sshkeys/forms/known_host.xml
+++ b/security/ssh-keys/src/opnsense/mvc/app/controllers/OPNsense/Sshkeys/forms/known_host.xml
@@ -1,0 +1,20 @@
+<form>
+  <field>
+    <id>known_host.host</id>
+    <label>Host</label>
+    <type>text</type>
+    <help>Enter an IPv4- or IPv6 address or a hostname.</help>
+  </field>
+  <field>
+    <id>known_host.key_type</id>
+    <label>Key Type</label>
+    <type>dropdown</type>
+    <help>Select a key type - you need to add one entry per key type the server supports.</help>
+  </field>
+  <field>
+    <id>known_host.public_key</id>
+    <label>Public Key</label>
+    <type>text</type>
+    <help>Enter a Base64 encoded public key.</help>
+  </field>
+</form>

--- a/security/ssh-keys/src/opnsense/mvc/app/models/OPNsense/Sshkeys/ACL/ACL.xml
+++ b/security/ssh-keys/src/opnsense/mvc/app/models/OPNsense/Sshkeys/ACL/ACL.xml
@@ -1,0 +1,9 @@
+<acl>
+  <page-sshkeys>
+    <name>SSH Keys</name>
+    <patterns>
+      <pattern>ui/sshkeys/*</pattern>
+      <pattern>api/sshkeys/*</pattern>
+    </patterns>
+  </page-sshkeys>
+</acl>

--- a/security/ssh-keys/src/opnsense/mvc/app/models/OPNsense/Sshkeys/Menu/Menu.xml
+++ b/security/ssh-keys/src/opnsense/mvc/app/models/OPNsense/Sshkeys/Menu/Menu.xml
@@ -1,0 +1,7 @@
+<menu>
+  <System>
+    <Access>
+      <ssh-keys VisibleName="SSH Keys" url="/ui/sshkeys/" />
+    </Access>
+  </System>
+</menu>

--- a/security/ssh-keys/src/opnsense/mvc/app/models/OPNsense/Sshkeys/SSH.php
+++ b/security/ssh-keys/src/opnsense/mvc/app/models/OPNsense/Sshkeys/SSH.php
@@ -1,0 +1,34 @@
+<?php
+/*
+    Copyright (C) 2018 Fabian Franz
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+
+namespace OPNsense\Sshkeys;
+
+use OPNsense\Base\BaseModel;
+
+class SSH extends BaseModel
+{
+}

--- a/security/ssh-keys/src/opnsense/mvc/app/models/OPNsense/Sshkeys/SSH.xml
+++ b/security/ssh-keys/src/opnsense/mvc/app/models/OPNsense/Sshkeys/SSH.xml
@@ -1,0 +1,26 @@
+<model>
+  <mount>//OPNsense/ssh-keys</mount>
+  <description>Management of SSH Keys</description>
+  <items>
+    <known_host type="ArrayField">
+      <key_type type="OptionField">
+        <Required>Y</Required>
+        <default>ssh-ed25519</default>
+        <OptionValues>
+          <ecdsa-sha2-nistp256>ECDSA-SHA2-NISTP256</ecdsa-sha2-nistp256>
+          <ssh-ed25519>ED25519</ssh-ed25519>
+          <ssh-rsa>RSA</ssh-rsa>
+        </OptionValues>
+      </key_type>
+      <public_key type="TextField">
+        <Required>Y</Required>
+        <mask>/^(?:[A-Za-z0-9\+\/]{4})*(?:[A-Za-z0-9\+\/]{2}==|[A-Za-z0-9\+\/]{3}=)?$/</mask>
+        <ValidationMessage>This must be a valid base64 encoded public key.</ValidationMessage>
+      </public_key>
+      <host type="TextField">
+        <Required>Y</Required>
+        <mask>/^(((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|$)){4}|[a-fA-F0-9:]{2,40}$|[a-zA-Z][a-zA-Z0-9\-_\.]{3,}$)/</mask>
+      </host>
+    </known_host>
+  </items>
+</model>

--- a/security/ssh-keys/src/opnsense/mvc/app/views/OPNsense/Sshkeys/index.volt
+++ b/security/ssh-keys/src/opnsense/mvc/app/views/OPNsense/Sshkeys/index.volt
@@ -1,0 +1,106 @@
+{#
+
+    Copyright (C) 2018 Fabian Franz
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+
+
+#}
+
+
+{#
+
+    Copyright (C) 2017 Fabian Franz
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+
+
+#}
+
+
+<script type="text/javascript">
+$( document ).ready(function() {
+    $("#grid-known-hosts").UIBootgrid(
+        { 'search':'/api/sshkeys/ssh/search_known_hosts',
+          'get':'/api/sshkeys/ssh/get_known_host/',
+          'set':'/api/sshkeys/ssh/set_known_host/',
+          'add':'/api/sshkeys/ssh/add_known_host/',
+          'del':'/api/sshkeys/ssh/del_known_host/',
+          'options':{selection:false, multiSelect:false}
+        }
+    );
+});
+
+</script>
+<ul class="nav nav-tabs" data-tabs="tabs" id="maintabs">
+    <li class="active"><a data-toggle="tab" href="#known-hosts">{{ lang._('Known Hosts') }}</a></li>
+</ul>
+
+<div class="tab-content content-box tab-content" style="padding-bottom: 1.5em;">
+    <div id="known-hosts" class="tab-pane fade in active">
+        <div class="alert alert-info" role="alert">
+          {{ lang._('Known hosts can be used to harden SSH connections by whitelisting the public keys of servers (also known as certificate pinning).') }}
+        </div>
+        <table id="grid-known-hosts" class="table table-responsive" data-editDialog="knownhostdlg">
+          <thead>
+              <tr>
+                  <th data-column-id="host" data-type="string" data-visible="true">{{ lang._('Host') }}</th>
+                  <th data-column-id="key_type" data-type="string" data-visible="true">{{ lang._('Key Type') }}</th>
+                  <th data-column-id="commands" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
+              </tr>
+          </thead>
+          <tbody>
+          </tbody>
+          <tfoot>
+              <tr>
+                  <td colspan="1"></td>
+                  <td>
+                      <button data-action="add" type="button" class="btn btn-xs btn-default"><span class="fa fa-plus"></span></button>
+                  </td>
+              </tr>
+          </tfoot>
+      </table>
+    </div>
+</div>
+
+{{ partial("layout_partials/base_dialog",['fields': known_host_form,'id':'knownhostdlg', 'label':lang._('Edit Known Host')]) }}

--- a/security/ssh-keys/src/opnsense/service/templates/OPNsense/Sshkeys/+TARGETS
+++ b/security/ssh-keys/src/opnsense/service/templates/OPNsense/Sshkeys/+TARGETS
@@ -1,0 +1,1 @@
+os_known_hosts:/tmp/os_known_hosts

--- a/security/ssh-keys/src/opnsense/service/templates/OPNsense/Sshkeys/os_known_hosts
+++ b/security/ssh-keys/src/opnsense/service/templates/OPNsense/Sshkeys/os_known_hosts
@@ -1,0 +1,7 @@
+{% if helpers.exists('OPNsense.ssh-keys') %}
+{%   if helpers.exists('OPNsense.ssh-keys.known_host') %}
+{%     for key in helpers.toList('OPNsense.ssh-keys.known_host') %}
+{{ key.host }} {{ key.key_type }} {{ key.public_key }}
+{%     endfor %}
+{%   endif %}
+{% endif %}


### PR DESCRIPTION
this is information needed for hardening SSH connections (certificate pinning) - makes it easy to add it to scp backup.