### PR TITLE
Updates to the scp-backup plugin.

### DIFF
--- a/sysutils/scp-backup/src/opnsense/mvc/app/controllers/OPNsense/ScpBackup/Api/GeneralController.php
+++ b/sysutils/scp-backup/src/opnsense/mvc/app/controllers/OPNsense/ScpBackup/Api/GeneralController.php
@@ -47,11 +47,6 @@ class GeneralController extends ApiMutableModelControllerBase
         $result = array();
         if ($this->request->isGet()) {
             $mdlGeneral = $this->getModel();
-            $publicKey = fopen("/conf/sshd/ssh_host_rsa_key.pub", "r");
-            if ($publicKey) {
-                $mdlGeneral->publickey = fread($publicKey, filesize("/conf/sshd/ssh_host_rsa_key.pub"));
-                fclose($publicKey);
-            }
             $result['general'] = $mdlGeneral->getNodes();
         }
         return $result;
@@ -65,7 +60,6 @@ class GeneralController extends ApiMutableModelControllerBase
             $backend = new Backend();
             $mdlCron = new Cron();
             $mdlGeneral->setNodes($this->request->getPost("general"));
-            $mdlGeneral->publickey = null;
             $valMsgs = $mdlGeneral->performValidation();
             foreach ($valMsgs as $field => $msg) {
                 if (!array_key_exists("validation", $result)) {

--- a/sysutils/scp-backup/src/opnsense/mvc/app/controllers/OPNsense/ScpBackup/forms/general.xml
+++ b/sysutils/scp-backup/src/opnsense/mvc/app/controllers/OPNsense/ScpBackup/forms/general.xml
@@ -30,10 +30,22 @@
     <help>Set the remote directory to backup the config file to.</help>
   </field>
   <field>
-    <id>general.publickey</id>
-    <label>Local Root's Public Key</label>
+    <id>general.privatekey</id>
+    <label>SSH Private Key</label>
     <type>textbox</type>
-    <help>The public key of the local root user. This public key must be added to the remote user's authorized_keys - otherwise backups will fail.</help>
-    <readonly>true</readonly>
+    <help>The private key of the user. The paired public key must be added to the remote user's authorized_keys otherwise backups will fail.</help>
+    <height>10</height>
+  </field>
+  <field>
+    <id>general.stricthostkeycheck</id>
+    <label>Enable StrictHostKeyCheck</label>
+    <type>checkbox</type>
+    <help>If enabled, SSH will never automatically add host keys. The host key value must be provided below.</help>
+  </field>
+  <field>
+    <id>general.hostkey</id>
+    <label>Host Key</label>
+    <type>text</type>
+    <help>The host key to use for connection, only used if StrictHostKeyCheck is enabled.</help>
   </field>
 </form>

--- a/sysutils/scp-backup/src/opnsense/mvc/app/models/OPNsense/ScpBackup/General.xml
+++ b/sysutils/scp-backup/src/opnsense/mvc/app/models/OPNsense/ScpBackup/General.xml
@@ -33,11 +33,20 @@
           <Required>Y</Required>
           <ValidationMessage>Please provide a remote directory.</ValidationMessage>
         </remotedirectory>
-        <publickey type="TextField">
-          <Required>N</Required>
-        </publickey>
+        <privatekey type="TextField">
+          <Required>Y</Required>
+          <ValidationMessage>Please provide a private SSH key. This key must pair with the public key added to the remote authorized_keys file.</ValidationMessage>
+        </privatekey>
         <cronuuid type="TextField">
           <Required>N</Required>
         </cronuuid>
+        <stricthostkeycheck type="BooleanField">
+          <default>0</default>
+          <Required>Y</Required>
+        </stricthostkeycheck>
+        <hostkey type="TextField">
+          <Required>N</Required>
+          <ValidationMessage>Please provide a valid SSH host key.</ValidationMessage>
+        </hostkey>
     </items>
 </model>


### PR DESCRIPTION
A private key is now stored along with the config that is the other side of
the public/private keypair for the remote host. The public key must be added
to the remote authorized_keys file.

It now also optionally will perform a StrictHostKeyCheck for connections to
the remote host. If StrictHostKeyCheck is enabled, then a HostKey needs to be
provided which is used to verify the remote host (same format as the entry in
the known_hosts file).

Both the private key and the host key are stored as entries in the config and
wrote out as tempoary files to initiate the connection. The temporary files
are removed after the backup has been performed.

-=david=-