### PR TITLE
Finishing work on Freeradius CCD support for openvpn 

### DIFF
--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/Api/CcdController.php
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/Api/CcdController.php
@@ -25,13 +25,12 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-
 namespace OPNsense\Freeradius\Api;
 
 use \OPNsense\Base\ApiControllerBase;
-use OPNsense\Freeradius\common\CCD;
-use OPNsense\Freeradius\common\OpenVpn;
-use OPNsense\Freeradius\User;
+use \OPNsense\Freeradius\common\CCD;
+use \OPNsense\Freeradius\common\OpenVpn;
+use \OPNsense\Freeradius\User;
 
 /**
  * Class CcdController

--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/Api/CcdController.php
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/Api/CcdController.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * Copyright (C) 2018 EugenMayer
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Freeradius\Api;
+
+use \OPNsense\Base\ApiControllerBase;
+use OPNsense\Freeradius\common\CCD;
+use OPNsense\Freeradius\common\OpenVpn;
+use OPNsense\Freeradius\User;
+
+/**
+ * Class CcdController
+ * @property mixed request
+ * @package OPNsense\Freeradius
+ */
+class CcdController extends ApiControllerBase
+{
+    /**
+     * regenerates all CCDs for the configred users
+     */
+    public function regenerateAction()
+    {
+        if ($this->request->isPost()) {
+            $dynamicCCDs = $this->getFreeradiusUsersAsCCDs();
+            if (count($dynamicCCDs)) {
+                OpenVpn::generateCCDconfigurationOnDisk($dynamicCCDs);
+            }
+            return array("status" => "ok", "generated_count" => count($dynamicCCDs));
+        } else {
+            return array("status" => "failed");
+        }
+    }
+
+    /**
+     * @return object[] array of all users
+     */
+    private function getFreeradiusUsers()
+    {
+        $usersMdl = new User();
+
+        $users = [];
+        foreach ($usersMdl->getNodes() as $user) {
+            $users[] = (object)array_pop($user['user']);
+        }
+
+        return $users;
+    }
+
+    /**
+     * @return CCD[]
+     */
+    private function getFreeradiusUsersAsCCDs()
+    {
+        $users = $this->getFreeradiusUsers();
+        $ccds = [];
+
+        foreach ($users as $user) {
+            $ccds[] = CCD::fromFreeradiusUsers($user);
+        }
+        return $ccds;
+    }
+
+}

--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/Api/UserController.php
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/Api/UserController.php
@@ -149,7 +149,6 @@ class UserController extends ApiMutableModelControllerBase
 
                     $ccd = CCD::fromFreeradiusUsers((object)$userToBeDeleted);
                     OpenVpn::resetToStaticOrDelete($ccd);
-                    // TODO: regenerate CCDs
                 } else {
                     $result['result'] = 'not found';
                 }
@@ -216,8 +215,6 @@ class UserController extends ApiMutableModelControllerBase
                     // if item has toggled, serialize to config and save
                     $mdlSetting->serializeToConfig();
                     Config::getInstance()->save();
-
-                    // TODO: regenerate CCDs
                 }
             }
         }

--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/common/CCD.php
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/common/CCD.php
@@ -66,7 +66,7 @@ class CCD
 
         if (isset($user->ip) && isset($user->subnet)) {
             $ip = $user->ip->__toString();
-            $prefix = self::netmaskToCidrPrefix($user->subnet->__toString());
+            $prefix = self::netmaskToCIDRprefix($user->subnet->__toString());
             $ccd->tunnel_network = "$ip/$prefix";
         }
         return $ccd;
@@ -76,7 +76,7 @@ class CCD
      * @param string $netmask netmask as 255.255.255.0
      * @return int prefix like 24 for the above
      */
-    static public function netmaskToCidrPrefix($netmask) {
+    static public function netmaskToCIDRprefix($netmask) {
         $long = ip2long($netmask);
         $base = ip2long('255.255.255.255');
         return 32-log(($long ^ $base)+1,2);

--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/common/CCD.php
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/common/CCD.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * Copyright (C) 2018 EugenMayer
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Freeradius\common;
+
+
+class CCD
+{
+    public $common_name;
+    // CIDR
+    public $tunnel_network;
+    // CIDR
+    public $tunnel_networkv6;
+    // CIDR
+    public $local_network;
+    // CIDR
+    public $local_networkv6;
+    // CIDR
+    public $remote_network;
+    // CIDR
+    public $remote_network6;
+    // redirect gateway
+    public $gwredir;
+    /**
+     * if not empty, push will be reset. We aren`t using a boolean due to the legacy code
+     */
+    public $push_reset;
+    /**
+     * if not empty, client will be blocked. We aren`t using a boolean due to the legacy code
+     */
+    public $block = NULL;
+
+
+    /**
+     * @return CCD
+     */
+    static public function fromFreeradiusUsers($user)
+    {
+        $ccd = new CCD();
+        $ccd->common_name = $user->username->__toString();
+
+        if (isset($user->ip) && isset($user->subnet)) {
+            $ip = $user->ip->__toString();
+            $prefix = self::netmaskToCidrPrefix($user->subnet->__toString());
+            $ccd->tunnel_network = "$ip/$prefix";
+        }
+        return $ccd;
+    }
+
+    /**
+     * @param string $netmask netmask as 255.255.255.0
+     * @return int prefix like 24 for the above
+     */
+    static public function netmaskToCidrPrefix($netmask) {
+        $long = ip2long($netmask);
+        $base = ip2long('255.255.255.255');
+        return 32-log(($long ^ $base)+1,2);
+    }
+
+}

--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/common/OpenVpn.php
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/common/OpenVpn.php
@@ -1,0 +1,213 @@
+<?php
+
+/*
+ * Copyright (C) 2018 Eugen Mayer
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Freeradius\common;
+// yeah, why should plugins.inc.d/openvpn.inc include all the symbols it is using..
+require_once("util.inc");
+require_once("plugins.inc.d/openvpn.inc");
+
+use \OPNsense\Core\Config;
+
+/**
+ * Handles all kind of OpenVPN based operations
+ * Class OpenVpn
+ * @package OPNsense\Freeradius\common
+ */
+class OpenVpn
+{
+
+    /**
+     * @param CCD $dynamicCDD
+     * @param null $servers
+     */
+    static public function resetToStaticOrDelete(CCD $dynamicCDD, $servers = null)
+    {
+        if ($servers == NULL) {
+            $servers = self::getDynamicCCDopenVPNServers();
+        }
+        $staticCCDs = self::getOpenVpnCCD();
+        if (isset($staticCCDs[$dynamicCDD->common_name])) {
+            $ccd = $staticCCDs[$dynamicCDD->common_name];
+            foreach ($servers as $server) {
+                // thats a openvpn legacy tool to create CCDs for a specific server
+                // lets use this to ensure compatibility
+                $ccdConfigAsString = openvpn_csc_conf(self::ccdToLegacyStructure($ccd), $server);
+                // this will override - reset the overlayed one with the original from static
+                self::writeCCDforServer($ccd->common_name, $ccdConfigAsString, $server['vpnid']);
+            }
+        } else {
+            // since the CCD does not exist in static, remove it. This is already more then the current core implementation does
+            // it does nothing in this case
+            foreach ($servers as $server) {
+                self::deleteCCDforServer($dynamicCDD->common_name, $server['vpnid']);
+            }
+        }
+
+    }
+
+    /**
+     * @param CCD[] $dynamicCDDs
+     * @param null $servers if null, it means all
+     */
+    static public function generateCCDconfigurationOnDisk($dynamicCDDs, $servers = null, $reset = false)
+    {
+        if ($servers == NULL) {
+            $servers = self::getDynamicCCDopenVPNServers();
+        }
+
+        $staticCCDs = self::getOpenVpnCCD();
+        // since this whole thing should only "override" or generate those one, we defined
+        // we do not work through the openvpn staticCCD but only ours
+        // and either generate new ones or overwrite existing ones
+
+        foreach ($dynamicCDDs as $dynamicCCD) {
+            $ccd = $dynamicCCD;
+            /**
+             * if an openVPN static_ccd exists, rather use our
+             * dynamicCCD as a overlay, so use all fields from openVPN except some few
+             * we offer in the dynamicCCD
+             */
+            if (array_key_exists($dynamicCCD->common_name, $staticCCDs)) {
+                $ccd = self::overlayCcd($staticCCDs[$dynamicCCD->common_name], $dynamicCCD);
+            }
+
+            // now generate that CCD for every server
+            foreach ($servers as $server) {
+                // thats a openvpn legacy tool to create CCDs for a specific server
+                // lets use this to ensure compatibility
+                $ccdConfigAsString = openvpn_csc_conf(self::ccdToLegacyStructure($ccd), $server);
+
+                self::writeCCDforServer($ccd->common_name, $ccdConfigAsString, $server['vpnid']);
+            }
+        }
+    }
+
+    /**
+     * Writes the ccd configuration we created using the legacy method to the disk at the correct location for a specific server
+     * @param string $common_name
+     * @param string $ccdConfigAsString
+     * @param string $openvpn_id
+     */
+    static function writeCCDforServer($common_name, $ccdConfigAsString, $openvpn_id)
+    {
+        openvpn_create_dirs();
+        // 'stolen' from openvpn_configure_csc - we cannot reuse this function since its not designed to
+        $target_filename = "/var/etc/openvpn-csc/{$openvpn_id}/{$common_name}";
+        file_put_contents($target_filename, $ccdConfigAsString);
+        chown($target_filename, 'nobody');
+        chgrp($target_filename, 'nobody');
+    }
+
+    /**
+     * This method is missing in the legacy API completely
+     * @param string $common_name
+     * @param string $openvpn_id
+     */
+    static function deleteCCDforServer($common_name, $openvpn_id)
+    {
+        $target_filename = "/var/etc/openvpn-csc/{$openvpn_id}/{$common_name}";
+        @unlink($target_filename);
+    }
+
+    static function ccdToLegacyStructure(CCD $ccd)
+    {
+        return (array)$ccd;
+    }
+
+    /**
+     * returns a CCD, which is based on your static(default) ccd and has been overlayed by the dynamic CCD
+     * @param CCD $static
+     * @param CCD $dynamic
+     * @return CCD
+     */
+    static function overlayCcd(CCD $static, CCD $dynamic)
+    {
+        // lets keep the reference intact
+        $ccd = clone($static);
+
+        $overridable_attribs = ['tunnel_network', 'tunnel_network6'];
+        foreach ($overridable_attribs as $attrib) {
+            if (isset($dynamic->{$attrib})) {
+                $ccd->{$attrib} = $dynamic->{$attrib};
+            }
+        }
+        return $ccd;
+    }
+
+    /**
+     * @return array an array of VPN-Servers ( stdClass ) which have the feature dynamic-ccd-lookup enabled
+     */
+    static function getDynamicCCDopenVPNServers()
+    {
+        $configObj = Config::getInstance()->object();
+        $servers = array();
+
+        if (isset($configObj->openvpn)) {
+            /** @var \SimpleXMLElement $root */
+            $root = $configObj->openvpn;
+            foreach ($root->children() as $name => $vpnServer) {
+                // if that VPN server has dynamic ccd enabled
+                if ($vpnServer->{'dynamic-ccd-lookup'} == '1') {
+                    // convert that one to an assoc array for easier usage in the toolchain
+                    $servers[$name] = json_decode(json_encode($vpnServer), true);
+                }
+            }
+        }
+
+        return $servers;
+    }
+
+    /**
+     * @return CCD[]
+     */
+    static function getOpenVpnCCD()
+    {
+        $configObj = Config::getInstance()->object();
+
+        if (isset($configObj->openvpn) && isset($configObj->openvpn->{'openvpn-csc'})) {
+            $ccds = array();
+            $ccd_attributes = array_keys(get_class_vars('OPNsense\Freeradius\common\CCD'));
+            // odd need of parsing them here, otherwise the result gets oddly transpiled
+
+            foreach ($configObj->openvpn->{'openvpn-csc'} as $ccdXml) {
+                $obj = json_decode(json_encode($ccdXml));
+                $ccd = new CCD();
+
+                // map all our legacy attributes on our helper class
+                foreach ($ccd_attributes as $attr) {
+                    if (isset($obj->{$attr})) {
+                        $ccd->{$attr} = $obj->{$attr};
+                    }
+                }
+                $ccds[$ccd->common_name] = $ccd;
+            }
+            return $ccds;
+        }
+        return NULL;
+    }
+}

--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/common/OpenVpn.php
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/common/OpenVpn.php
@@ -170,11 +170,14 @@ class OpenVpn
         if (isset($configObj->openvpn)) {
             /** @var \SimpleXMLElement $root */
             $root = $configObj->openvpn;
-            foreach ($root->children() as $name => $vpnServer) {
+            foreach ($root->children() as $tag => $vpnServer) {
                 // if that VPN server has dynamic ccd enabled
-                if ($vpnServer->{'dynamic-ccd-lookup'} == '1') {
-                    // convert that one to an assoc array for easier usage in the toolchain
-                    $servers[$name] = json_decode(json_encode($vpnServer), true);
+                if ($tag == 'openvpn-server') {
+                    if ($vpnServer->{'dynamic-ccd-lookup'} == '1') {
+                        // ensured thats actually a openvpn server and now openvpn-csc .. they are in the same root node
+                        $server = json_decode(json_encode($vpnServer), true);
+                        $servers[$server['description']] = $server;
+                    }
                 }
             }
         }

--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/common/OpenVpn.php
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/common/OpenVpn.php
@@ -61,8 +61,8 @@ class OpenVpn
                 self::writeCCDforServer($ccd->common_name, $ccdConfigAsString, $server['vpnid']);
             }
         } else {
-            // since the CCD does not exist in static, remove it. This is already more then the current core implementation does
-            // it does nothing in this case
+            // since the CCD does not exist in static, remove it. This is already more then the current
+            //  core implementation does it does nothing in this case
             foreach ($servers as $server) {
                 self::deleteCCDforServer($dynamicCDD->common_name, $server['vpnid']);
             }

--- a/net/freeradius/src/opnsense/mvc/app/views/OPNsense/Freeradius/user.volt
+++ b/net/freeradius/src/opnsense/mvc/app/views/OPNsense/Freeradius/user.volt
@@ -81,7 +81,7 @@ POSSIBILITY OF SUCH DAMAGE.
                 if (status != "success" || data['status'] != 'ok') {
                     BootstrapDialog.show({
                         type: BootstrapDialog.TYPE_WARNING,
-                        title: "{{ lang._('Error regenerated CCD`s') }}",
+                        title: "{{ lang._('Error regenerated CCD\'s') }}",
                         message: data['status'],
                         draggable: true
                     });

--- a/net/freeradius/src/opnsense/mvc/app/views/OPNsense/Freeradius/user.volt
+++ b/net/freeradius/src/opnsense/mvc/app/views/OPNsense/Freeradius/user.volt
@@ -70,6 +70,25 @@ POSSIBILITY OF SUCH DAMAGE.
             });
         });
 
+        /**
+         * Regenerate CCD
+         */
+        $("#regenerateCCDAct").click(function(){
+            $("#regenerateCCDAct_progress").addClass("fa fa-spinner fa-pulse");
+            ajaxCall(url="/api/freeradius/ccd/regenerate", sendData={}, callback=function(data,status) {
+                $("#regenerateCCDAct_progress").removeClass("fa fa-spinner fa-pulse");
+
+                if (status != "success" || data['status'] != 'ok') {
+                    BootstrapDialog.show({
+                        type: BootstrapDialog.TYPE_WARNING,
+                        title: "{{ lang._('Error regenerated CCD`s') }}",
+                        message: data['status'],
+                        draggable: true
+                    });
+                }
+            });
+        });
+
       /*************************************************************************************************************
        * context driven input dialogs
        *************************************************************************************************************/
@@ -134,6 +153,7 @@ POSSIBILITY OF SUCH DAMAGE.
     <div class="col-md-12">
         <hr/>
         <button class="btn btn-primary" id="reconfigureAct" type="button"><b>{{ lang._('Apply') }}</b> <i id="reconfigureAct_progress" class=""></i></button>
+        <button class="btn btn-primary" id="regenerateCCDAct" type="button"><b>{{ lang._('Regenerate CCDs') }}</b> <i id="regenerateCCDAct_progress" class=""></i></button>
         <br/><br/>
     </div>
 </div>


### PR DESCRIPTION
requires http://github.com/opnsense/core/pull/2084 on core

## Implemented as we have defined in:
https://github.com/opnsense/core/issues/2076 so Freeradius does generate / regenerate CCDs on every time a user gets a CRUD. Will also work transparent through the REST api.

## Added support for merged/overrides:
If a openvpn ccd ( client specific override ) exists, the FreeRadius CCD will only override the tunnel_nework ( radius plugin has no support for tunnel_network6 yet) nothing else. So its merged

## Tested this cases:

**Tested on Freeradius->Users:**
 - create, edit, delete user in FreeRadius and ensure things get synced properly. Delete works as a reset to static ( openvpn ccd ) or if non existent, a delete
 - enabled (overload static) and disabled ( reset to static or delete )
 - regenerate all
 - tested CCDs only existing in as Freeradius user ( no static ) are generate

**On OpenVPN side:**
 - tested CCDs only exist in openvpn ( static ) are generated
 - tested that servers not having "dynamic ccds" enabled, are not manipulated ( no overloading )
 - tested all other fields then the expected overloaded ( ip/netmask ) are preserved

### Missing:
 - i did not implement any event handling on openVPN side, that said, if someone creates a openVPN static ccd, this will be generated without looking at the freeradius CCDs. I simply have no events here
 - openvpn does not handle deleting its ccds when they are deleted - i did not add that code. I did add that code to Freeradius though, if a dynamicCCD is deleted, everything is properly cleand up