### PR TITLE
HTML Compliance - Attribute "type" on Element <script>

### DIFF
--- a/benchmarks/iperf/src/opnsense/mvc/app/views/OPNsense/iperf/index.volt
+++ b/benchmarks/iperf/src/opnsense/mvc/app/views/OPNsense/iperf/index.volt
@@ -26,7 +26,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #}
 
-<script type="text/javascript">
+<script>
 
 function table_tr_kv(key, value) {
     return "<tr><td>" + key + "</td><td>" + value + "</td></tr>";

--- a/databases/redis/src/opnsense/mvc/app/views/OPNsense/Redis/index.volt
+++ b/databases/redis/src/opnsense/mvc/app/views/OPNsense/Redis/index.volt
@@ -25,7 +25,7 @@
  # POSSIBILITY OF SUCH DAMAGE.
  #}
 
-<script type="text/javascript">
+<script>
 $( document ).ready(function() {
     var data_get_map = {'frm_redis':'/api/redis/settings/get'};
 

--- a/devel/helloworld/src/opnsense/mvc/app/views/OPNsense/HelloWorld/index.volt
+++ b/devel/helloworld/src/opnsense/mvc/app/views/OPNsense/HelloWorld/index.volt
@@ -26,7 +26,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #}
 
-<script type="text/javascript">
+<script>
     $( document ).ready(function() {
         var data_get_map = {'frm_GeneralSettings':"/api/helloworld/settings/get"};
         mapDataToFormUI(data_get_map).done(function(data){

--- a/dns/dyndns/src/www/services_dyndns.php
+++ b/dns/dyndns/src/www/services_dyndns.php
@@ -74,7 +74,7 @@ $main_buttons = array(
 
 ?>
 <body>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
     // delete service action
     $(".act_delete_service").click(function(event){

--- a/dns/dyndns/src/www/services_dyndns_edit.php
+++ b/dns/dyndns/src/www/services_dyndns_edit.php
@@ -178,7 +178,7 @@ include("head.inc");
 ?>
 <body>
 <?php include("fbegin.inc"); ?>
- <script type="text/javascript">
+ <script>
   $( document ).ready(function() {
       $("#type").change(function(){
           $(".opt_field").hide();

--- a/dns/dyndns/src/www/widgets/widgets/dyn_dns_status.widget.php
+++ b/dns/dyndns/src/www/widgets/widgets/dyn_dns_status.widget.php
@@ -138,7 +138,7 @@ if (!empty($_REQUEST['getdyndnsstatus'])) {
   endforeach;?>
   </tbody>
 </table>
-<script type="text/javascript">
+<script>
   function dyndns_getstatus()
   {
       scroll(0,0);

--- a/dns/rfc2136/src/www/services_rfc2136.php
+++ b/dns/rfc2136/src/www/services_rfc2136.php
@@ -72,7 +72,7 @@ $main_buttons = array(
 
 ?>
 <body>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
     // delete service action
     $(".act_delete_service").click(function(event){

--- a/dns/rfc2136/src/www/widgets/widgets/rfc2136.widget.php
+++ b/dns/rfc2136/src/www/widgets/widgets/rfc2136.widget.php
@@ -138,7 +138,7 @@ if (!empty($_REQUEST['getrfc2136status'])) {
   endforeach;?>
   </tbody>
 </table>
-<script type="text/javascript">
+<script>
   function rfc2136_getstatus()
   {
       scroll(0,0);

--- a/mail/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/domain.volt
+++ b/mail/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/domain.volt
@@ -27,7 +27,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #}
 
-<script type="text/javascript">
+<script>
 
     $( document ).ready(function() {
         /*************************************************************************************************************

--- a/mail/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/general.volt
+++ b/mail/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/general.volt
@@ -54,7 +54,7 @@ POSSIBILITY OF SUCH DAMAGE.
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
     $( document ).ready(function () {
         var data_get_map = {'frm_general_settings':"/api/postfix/general/get", 'frm_antispam_settings':"/api/postfix/antispam/get"};
         mapDataToFormUI(data_get_map).done(function (data) {

--- a/mail/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/recipient.volt
+++ b/mail/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/recipient.volt
@@ -27,7 +27,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #}
 
-<script type="text/javascript">
+<script>
 
     $( document ).ready(function() {
         /*************************************************************************************************************

--- a/mail/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/sender.volt
+++ b/mail/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/sender.volt
@@ -27,7 +27,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #}
 
-<script type="text/javascript">
+<script>
 
     $( document ).ready(function() {
         /*************************************************************************************************************

--- a/mail/rspamd/src/opnsense/mvc/app/views/OPNsense/Rspamd/index.volt
+++ b/mail/rspamd/src/opnsense/mvc/app/views/OPNsense/Rspamd/index.volt
@@ -25,7 +25,7 @@
  # POSSIBILITY OF SUCH DAMAGE.
  #}
 
-<script type="text/javascript">
+<script>
     window.redis_installed = {{ redis_installed ? 'true' : 'false' }};
     $( document ).ready(function() {
 

--- a/net-mgmt/collectd/src/opnsense/mvc/app/views/OPNsense/Collectd/general.volt
+++ b/net-mgmt/collectd/src/opnsense/mvc/app/views/OPNsense/Collectd/general.volt
@@ -34,7 +34,7 @@ POSSIBILITY OF SUCH DAMAGE.
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
     $( document ).ready(function() {
         var data_get_map = {'frm_general_settings':"/api/collectd/general/get"};
         mapDataToFormUI(data_get_map).done(function(data){

--- a/net-mgmt/lldpd/src/opnsense/mvc/app/views/OPNsense/Lldpd/general.volt
+++ b/net-mgmt/lldpd/src/opnsense/mvc/app/views/OPNsense/Lldpd/general.volt
@@ -43,7 +43,7 @@
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
 
 // Put API call into a function, needed for auto-refresh
 function update_neighbor() {

--- a/net-mgmt/snmp/src/www/services_snmp.php
+++ b/net-mgmt/snmp/src/www/services_snmp.php
@@ -127,7 +127,7 @@ include("head.inc");
 
 ?>
 <body>
-<script type="text/javascript">
+<script>
     $( document ).ready(function() {
         $("#hostres").change(function(){
             if ($('#hostres').prop('checked')) {

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/views/OPNsense/Telegraf/general.volt
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/views/OPNsense/Telegraf/general.volt
@@ -42,7 +42,7 @@ POSSIBILITY OF SUCH DAMAGE.
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
     $( document ).ready(function() {
         var data_get_map = {'frm_general_settings':"/api/telegraf/general/get"};
         mapDataToFormUI(data_get_map).done(function(data){

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/views/OPNsense/Telegraf/input.volt
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/views/OPNsense/Telegraf/input.volt
@@ -42,7 +42,7 @@ POSSIBILITY OF SUCH DAMAGE.
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
     $( document ).ready(function() {
         var data_get_map = {'frm_input_settings':"/api/telegraf/input/get"};
         mapDataToFormUI(data_get_map).done(function(data){

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/views/OPNsense/Telegraf/output.volt
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/views/OPNsense/Telegraf/output.volt
@@ -42,7 +42,7 @@ POSSIBILITY OF SUCH DAMAGE.
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
     $( document ).ready(function() {
         var data_get_map = {'frm_output_settings':"/api/telegraf/output/get"};
         mapDataToFormUI(data_get_map).done(function(data){

--- a/net-mgmt/zabbix-agent/src/opnsense/mvc/app/views/OPNsense/ZabbixAgent/index.volt
+++ b/net-mgmt/zabbix-agent/src/opnsense/mvc/app/views/OPNsense/ZabbixAgent/index.volt
@@ -25,7 +25,7 @@
  # POSSIBILITY OF SUCH DAMAGE.
  #}
 
-<script type="text/javascript">
+<script>
 $( document ).ready(function() {
     var data_get_map = {'frm_zabbixagent':"/api/zabbixagent/settings/get"};
 

--- a/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/views/OPNsense/Zabbixproxy/general.volt
+++ b/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/views/OPNsense/Zabbixproxy/general.volt
@@ -34,7 +34,7 @@ POSSIBILITY OF SUCH DAMAGE.
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
     $( document ).ready(function() {
         var data_get_map = {'frm_general_settings':"/api/zabbixproxy/general/get"};
         mapDataToFormUI(data_get_map).done(function(data){

--- a/net/arp-scan/src/opnsense/mvc/app/views/OPNsense/ARPscanner/index.volt
+++ b/net/arp-scan/src/opnsense/mvc/app/views/OPNsense/ARPscanner/index.volt
@@ -27,7 +27,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #}
 
 
-<script type="text/javascript">
+<script>
 
     function flush_table(){
         $('#netTable tr').slice(2).remove()

--- a/net/freeradius/src/opnsense/mvc/app/views/OPNsense/Freeradius/client.volt
+++ b/net/freeradius/src/opnsense/mvc/app/views/OPNsense/Freeradius/client.volt
@@ -27,7 +27,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #}
 
-<script type="text/javascript">
+<script>
 
     $( document ).ready(function() {
         /*************************************************************************************************************

--- a/net/freeradius/src/opnsense/mvc/app/views/OPNsense/Freeradius/eap.volt
+++ b/net/freeradius/src/opnsense/mvc/app/views/OPNsense/Freeradius/eap.volt
@@ -35,7 +35,7 @@ POSSIBILITY OF SUCH DAMAGE.
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
     $( document ).ready(function () {
         var data_get_map = {'frm_eap_settings':"/api/freeradius/eap/get"};
         mapDataToFormUI(data_get_map).done(function (data) {

--- a/net/freeradius/src/opnsense/mvc/app/views/OPNsense/Freeradius/general.volt
+++ b/net/freeradius/src/opnsense/mvc/app/views/OPNsense/Freeradius/general.volt
@@ -35,7 +35,7 @@ POSSIBILITY OF SUCH DAMAGE.
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
     $( document ).ready(function () {
         var data_get_map = {'frm_general_settings':"/api/freeradius/general/get"};
         mapDataToFormUI(data_get_map).done(function (data) {

--- a/net/freeradius/src/opnsense/mvc/app/views/OPNsense/Freeradius/ldap.volt
+++ b/net/freeradius/src/opnsense/mvc/app/views/OPNsense/Freeradius/ldap.volt
@@ -35,7 +35,7 @@ POSSIBILITY OF SUCH DAMAGE.
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
     $( document ).ready(function () {
         var data_get_map = {'frm_ldap_settings':"/api/freeradius/ldap/get"};
         mapDataToFormUI(data_get_map).done(function (data) {

--- a/net/freeradius/src/opnsense/mvc/app/views/OPNsense/Freeradius/user.volt
+++ b/net/freeradius/src/opnsense/mvc/app/views/OPNsense/Freeradius/user.volt
@@ -27,7 +27,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #}
 
-<script type="text/javascript">
+<script>
 
     $( document ).ready(function() {
         /*************************************************************************************************************

--- a/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/bgp.volt
+++ b/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/bgp.volt
@@ -159,7 +159,7 @@ POSSIBILITY OF SUCH DAMAGE.
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
 
 function quagga_update_status() {
     ajaxCall(url="/api/quagga/service/status", sendData={}, callback=function(data,status) {

--- a/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/diagnosticsbgp.volt
+++ b/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/diagnosticsbgp.volt
@@ -78,8 +78,8 @@ POSSIBILITY OF SUCH DAMAGE.
     </tbody>
   </table>
 </script>
-<script type="text/javascript" src="/ui/js/quagga/lodash.js"></script>
-<script type="text/javascript">
+<script src="/ui/js/quagga/lodash.js"></script>
+<script>
 function translate(x) {
   return x;
 }

--- a/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/diagnosticsgeneral.volt
+++ b/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/diagnosticsgeneral.volt
@@ -26,7 +26,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
 #}
-<script type="text/javascript" src="/ui/js/quagga/lodash.js"></script>
+<script src="/ui/js/quagga/lodash.js"></script>
 <script type="text/x-template" id="routestpl">
 <table>
   <thead>
@@ -58,7 +58,7 @@ POSSIBILITY OF SUCH DAMAGE.
 </table>
 </script>
 
-<script type="text/javascript">
+<script>
 function translate(content) {
   tr = {};
   tr['kernel route'] = '{{ lang._('Kernel Route') }}';

--- a/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/diagnosticsospf.volt
+++ b/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/diagnosticsospf.volt
@@ -375,7 +375,7 @@ POSSIBILITY OF SUCH DAMAGE.
   </table>
 <% }) %>
 </script>
-<script type="text/javascript" src="/ui/js/quagga/lodash.js"></script>
+<script src="/ui/js/quagga/lodash.js"></script>
 <script>
 
 function translate(data)

--- a/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/diagnosticsospfv3.volt
+++ b/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/diagnosticsospfv3.volt
@@ -263,7 +263,7 @@ POSSIBILITY OF SUCH DAMAGE.
   </table>
 <% }) %>
 </script>
-<script type="text/javascript" src="/ui/js/quagga/lodash.js"></script>
+<script src="/ui/js/quagga/lodash.js"></script>
 <script>
 
 function translate(data)

--- a/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/general.volt
+++ b/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/general.volt
@@ -34,7 +34,7 @@ POSSIBILITY OF SUCH DAMAGE.
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
     $( document ).ready(function() {
         var data_get_map = {'frm_general_settings':"/api/quagga/general/get"};
         mapDataToFormUI(data_get_map).done(function(data){

--- a/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/ospf.volt
+++ b/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/ospf.volt
@@ -129,7 +129,7 @@ POSSIBILITY OF SUCH DAMAGE.
     </div>
     </div>
 
-<script type="text/javascript">
+<script>
 
 function quagga_update_status() {
   ajaxCall(url="/api/quagga/service/status", sendData={}, callback=function(data,status) {

--- a/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/ospf6.volt
+++ b/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/ospf6.volt
@@ -74,7 +74,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
     </div>
 
-<script type="text/javascript">
+<script>
 
 function quagga_update_status() {
   ajaxCall(url="/api/quagga/service/status", sendData={}, callback=function(data,status) {

--- a/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/rip.volt
+++ b/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/rip.volt
@@ -35,7 +35,7 @@ POSSIBILITY OF SUCH DAMAGE.
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
 $(document).ready(function() {
   var data_get_map = {'frm_rip_settings':"/api/quagga/rip/get"};
   mapDataToFormUI(data_get_map).done(function(data){

--- a/net/ftp-proxy/src/opnsense/mvc/app/views/OPNsense/FtpProxy/index.volt
+++ b/net/ftp-proxy/src/opnsense/mvc/app/views/OPNsense/FtpProxy/index.volt
@@ -26,7 +26,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #}
 
-<script type="text/javascript">
+<script>
 
     $( document ).ready(function() {
         /**

--- a/net/haproxy/src/opnsense/mvc/app/views/OPNsense/HAProxy/index.volt
+++ b/net/haproxy/src/opnsense/mvc/app/views/OPNsense/HAProxy/index.volt
@@ -27,7 +27,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #}
 
-<script type="text/javascript">
+<script>
 
     $( document ).ready(function() {
 

--- a/net/haproxy/src/opnsense/mvc/app/views/OPNsense/HAProxy/statistics.volt
+++ b/net/haproxy/src/opnsense/mvc/app/views/OPNsense/HAProxy/statistics.volt
@@ -27,7 +27,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #}
 
-<script type="text/javascript">
+<script>
     $( document ).ready(function() {
         var gridopt = {
             ajax: false,

--- a/net/igmp-proxy/src/www/services_igmpproxy.php
+++ b/net/igmp-proxy/src/www/services_igmpproxy.php
@@ -60,7 +60,7 @@ $main_buttons = array(
 
 ?>
 <body>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
     // delete host action
     $(".act_delete_entry").click(function(event){

--- a/net/igmp-proxy/src/www/services_igmpproxy_edit.php
+++ b/net/igmp-proxy/src/www/services_igmpproxy_edit.php
@@ -104,7 +104,7 @@ include("head.inc");
 
 <body>
   <?php include("fbegin.inc"); ?>
-  <script type="text/javascript">
+  <script>
     $( document ).ready(function() {
       /**
        *  Aliases

--- a/net/l2tp/src/www/vpn_l2tp_users.php
+++ b/net/l2tp/src/www/vpn_l2tp_users.php
@@ -59,7 +59,7 @@ $main_buttons = array(
 
 ?>
 <body>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
     // delete host action
     $(".act_delete_user").click(function(event){

--- a/net/mdns-repeater/src/opnsense/mvc/app/views/OPNsense/MDNSRepeater/index.volt
+++ b/net/mdns-repeater/src/opnsense/mvc/app/views/OPNsense/MDNSRepeater/index.volt
@@ -26,7 +26,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #}
 
-<script type="text/javascript">
+<script>
 
 $( document ).ready(function() {
     var data_get_map = {'general': '/api/mdnsrepeater/settings/get'};

--- a/net/pppoe/src/www/vpn_pppoe.php
+++ b/net/pppoe/src/www/vpn_pppoe.php
@@ -78,7 +78,7 @@ $main_buttons = array(
 ?>
 
 <body>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
     // delete pppoe action
     $(".act_delete_pppoe").click(function(event){

--- a/net/pppoe/src/www/vpn_pppoe_edit.php
+++ b/net/pppoe/src/www/vpn_pppoe_edit.php
@@ -226,7 +226,7 @@ legacy_html_escape_form_data($pconfig);
 
 <body>
 <?php include("fbegin.inc"); ?>
-<script type="text/javascript">
+<script>
   $( document ).ready(function() {
     /**
      *  Aliases

--- a/net/pptp/src/www/vpn_pptp_users.php
+++ b/net/pptp/src/www/vpn_pptp_users.php
@@ -61,7 +61,7 @@ $main_buttons = array(
 ?>
 
 <body>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
     // delete host action
     $(".act_delete_user").click(function(event){

--- a/net/quagga/src/opnsense/mvc/app/views/OPNsense/Quagga/bgp.volt
+++ b/net/quagga/src/opnsense/mvc/app/views/OPNsense/Quagga/bgp.volt
@@ -155,7 +155,7 @@ POSSIBILITY OF SUCH DAMAGE.
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
 $(document).ready(function() {
   var data_get_map = {'frm_bgp_settings':"/api/quagga/bgp/get"};
   mapDataToFormUI(data_get_map).done(function(data){

--- a/net/quagga/src/opnsense/mvc/app/views/OPNsense/Quagga/diagnosticsbgp.volt
+++ b/net/quagga/src/opnsense/mvc/app/views/OPNsense/Quagga/diagnosticsbgp.volt
@@ -78,8 +78,8 @@ POSSIBILITY OF SUCH DAMAGE.
     </tbody>
   </table>
 </script>
-<script type="text/javascript" src="/ui/js/quagga/lodash.js"></script>
-<script type="text/javascript">
+<script src="/ui/js/quagga/lodash.js"></script>
+<script>
 function translate(x) {
   return x;
 }

--- a/net/quagga/src/opnsense/mvc/app/views/OPNsense/Quagga/diagnosticsgeneral.volt
+++ b/net/quagga/src/opnsense/mvc/app/views/OPNsense/Quagga/diagnosticsgeneral.volt
@@ -26,7 +26,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
 #}
-<script type="text/javascript" src="/ui/js/quagga/lodash.js"></script>
+<script src="/ui/js/quagga/lodash.js"></script>
 <script type="text/x-template" id="routestpl">
 <table>
   <thead>
@@ -58,7 +58,7 @@ POSSIBILITY OF SUCH DAMAGE.
 </table>
 </script>
 
-<script type="text/javascript">
+<script>
 function translate(content) {
   tr = {};
   tr['kernel route'] = '{{ lang._('Kernel Route') }}';

--- a/net/quagga/src/opnsense/mvc/app/views/OPNsense/Quagga/diagnosticsospf.volt
+++ b/net/quagga/src/opnsense/mvc/app/views/OPNsense/Quagga/diagnosticsospf.volt
@@ -375,7 +375,7 @@ POSSIBILITY OF SUCH DAMAGE.
   </table>
 <% }) %>
 </script>
-<script type="text/javascript" src="/ui/js/quagga/lodash.js"></script>
+<script src="/ui/js/quagga/lodash.js"></script>
 <script>
 
 function translate(data)

--- a/net/quagga/src/opnsense/mvc/app/views/OPNsense/Quagga/diagnosticsospfv3.volt
+++ b/net/quagga/src/opnsense/mvc/app/views/OPNsense/Quagga/diagnosticsospfv3.volt
@@ -263,7 +263,7 @@ POSSIBILITY OF SUCH DAMAGE.
   </table>
 <% }) %>
 </script>
-<script type="text/javascript" src="/ui/js/quagga/lodash.js"></script>
+<script src="/ui/js/quagga/lodash.js"></script>
 <script>
 
 function translate(data)

--- a/net/quagga/src/opnsense/mvc/app/views/OPNsense/Quagga/general.volt
+++ b/net/quagga/src/opnsense/mvc/app/views/OPNsense/Quagga/general.volt
@@ -34,7 +34,7 @@ POSSIBILITY OF SUCH DAMAGE.
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
     $( document ).ready(function() {
         var data_get_map = {'frm_general_settings':"/api/quagga/general/get"};
         mapDataToFormUI(data_get_map).done(function(data){

--- a/net/quagga/src/opnsense/mvc/app/views/OPNsense/Quagga/ospf.volt
+++ b/net/quagga/src/opnsense/mvc/app/views/OPNsense/Quagga/ospf.volt
@@ -126,7 +126,7 @@ POSSIBILITY OF SUCH DAMAGE.
     </div>
     </div>
 
-<script type="text/javascript">
+<script>
 $( document ).ready(function() {
   var data_get_map = {'frm_ospf_settings':"/api/quagga/ospfsettings/get"};
   mapDataToFormUI(data_get_map).done(function(data){

--- a/net/quagga/src/opnsense/mvc/app/views/OPNsense/Quagga/ospf6.volt
+++ b/net/quagga/src/opnsense/mvc/app/views/OPNsense/Quagga/ospf6.volt
@@ -73,7 +73,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
     </div>
 
-<script type="text/javascript">
+<script>
 $( document ).ready(function() {
   var data_get_map = {'frm_ospf6_settings':"/api/quagga/ospf6settings/get"};
   mapDataToFormUI(data_get_map).done(function(data){

--- a/net/quagga/src/opnsense/mvc/app/views/OPNsense/Quagga/rip.volt
+++ b/net/quagga/src/opnsense/mvc/app/views/OPNsense/Quagga/rip.volt
@@ -35,7 +35,7 @@ POSSIBILITY OF SUCH DAMAGE.
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
 $(document).ready(function() {
   var data_get_map = {'frm_rip_settings':"/api/quagga/rip/get"};
   mapDataToFormUI(data_get_map).done(function(data){

--- a/net/relayd/src/www/load_balancer_monitor.php
+++ b/net/relayd/src/www/load_balancer_monitor.php
@@ -77,7 +77,7 @@ $main_buttons = array(
 ?>
 
 <body>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
     // delete host action
     $(".act_delete").click(function(event){

--- a/net/relayd/src/www/load_balancer_monitor_edit.php
+++ b/net/relayd/src/www/load_balancer_monitor_edit.php
@@ -189,7 +189,7 @@ $types = array("icmp" => gettext("ICMP"), "tcp" => gettext("TCP"), "http" => get
 
 <body>
 <?php include("fbegin.inc"); ?>
-  <script type="text/javascript">
+  <script>
     $( document ).ready(function() {
         $("#monitor_type").change(function(){
             switch ($(this).val()) {

--- a/net/relayd/src/www/load_balancer_pool.php
+++ b/net/relayd/src/www/load_balancer_pool.php
@@ -84,7 +84,7 @@ $main_buttons = array(
 ?>
 
 <body>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
     // delete host action
     $(".act_delete").click(function(event){

--- a/net/relayd/src/www/load_balancer_pool_edit.php
+++ b/net/relayd/src/www/load_balancer_pool_edit.php
@@ -166,7 +166,7 @@ include("head.inc");
   </select>
 
 <?php include("fbegin.inc"); ?>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
       // init port type ahead
       var all_aliases = [];

--- a/net/relayd/src/www/load_balancer_virtual_server.php
+++ b/net/relayd/src/www/load_balancer_virtual_server.php
@@ -72,7 +72,7 @@ $main_buttons = array(
 ?>
 
 <body>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
     // delete host action
     $(".act_delete").click(function(event){

--- a/net/relayd/src/www/load_balancer_virtual_server_edit.php
+++ b/net/relayd/src/www/load_balancer_virtual_server_edit.php
@@ -143,7 +143,7 @@ include("head.inc");
 
 ?>
 <body>
-  <script type="text/javascript">
+  <script>
     $( document ).ready(function() {
       // collect all known aliases per type
       var all_aliases = {};

--- a/net/shadowsocks/src/opnsense/mvc/app/views/OPNsense/Shadowsocks/general.volt
+++ b/net/shadowsocks/src/opnsense/mvc/app/views/OPNsense/Shadowsocks/general.volt
@@ -34,7 +34,7 @@ POSSIBILITY OF SUCH DAMAGE.
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
     $( document ).ready(function() {
         var data_get_map = {'frm_general_settings':"/api/shadowsocks/general/get"};
         mapDataToFormUI(data_get_map).done(function(data){

--- a/net/siproxd/src/opnsense/mvc/app/views/OPNsense/Siproxd/general.volt
+++ b/net/siproxd/src/opnsense/mvc/app/views/OPNsense/Siproxd/general.volt
@@ -106,7 +106,7 @@ POSSIBILITY OF SUCH DAMAGE.
 {{ partial("layout_partials/base_dialog",['fields':formDialogEditSiproxdUser,'id':'dialogEditSiproxdUser','label':lang._('Edit User')])}}
 {{ partial("layout_partials/base_dialog",['fields':formDialogEditSiproxdDomain,'id':'dialogEditSiproxdDomain','label':lang._('Edit Outbound Domain')])}}
 
-<script type="text/javascript">
+<script>
 $( document ).ready(function() {
     var data_get_map = {'frm_general_settings':"/api/siproxd/general/get"};
     mapDataToFormUI(data_get_map).done(function(data){

--- a/net/wol/src/www/services_wol.php
+++ b/net/wol/src/www/services_wol.php
@@ -91,7 +91,7 @@ include("head.inc");
 ?>
 
 <body>
-  <script type="text/javascript">
+  <script>
   $( document ).ready(function() {
     // delete host action
     $(".act_delete_entry").click(function(event){

--- a/net/zerotier/src/opnsense/mvc/app/views/OPNsense/Zerotier/index.volt
+++ b/net/zerotier/src/opnsense/mvc/app/views/OPNsense/Zerotier/index.volt
@@ -27,7 +27,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
 #}
-<script type="text/javascript">
+<script>
 
     $(document).ready(function() {
 

--- a/net/zerotier/src/opnsense/mvc/app/views/OPNsense/Zerotier/overview.volt
+++ b/net/zerotier/src/opnsense/mvc/app/views/OPNsense/Zerotier/overview.volt
@@ -30,7 +30,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 {% set networksFirstRow = true, peersFirstRow = true %}
 
-<script type="text/javascript">
+<script>
     $(document).ready(function() {
         $("#network_details_collapse_all").click(function() {
             $(".network_details").collapse('toggle');

--- a/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/accounts.volt
+++ b/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/accounts.volt
@@ -27,7 +27,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #}
 
-<script type="text/javascript">
+<script>
 
     $( document ).ready(function() {
 

--- a/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/actions.volt
+++ b/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/actions.volt
@@ -27,7 +27,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #}
 
-<script type="text/javascript">
+<script>
 
     $( document ).ready(function() {
 

--- a/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/certificates.volt
+++ b/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/certificates.volt
@@ -30,7 +30,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #}
 
-<script type="text/javascript">
+<script>
 
     $( document ).ready(function() {
 

--- a/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/settings.volt
+++ b/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/settings.volt
@@ -27,7 +27,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #}
 
-<script type="text/javascript">
+<script>
 
     $( document ).ready(function() {
 

--- a/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/validations.volt
+++ b/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/validations.volt
@@ -27,7 +27,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #}
 
-<script type="text/javascript">
+<script>
 
     $( document ).ready(function() {
 

--- a/security/clamav/src/opnsense/mvc/app/views/OPNsense/ClamAV/general.volt
+++ b/security/clamav/src/opnsense/mvc/app/views/OPNsense/ClamAV/general.volt
@@ -54,7 +54,7 @@ POSSIBILITY OF SUCH DAMAGE.
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
 function timeoutCheck() {
     ajaxCall(url="/api/clamav/service/freshclam", sendData={}, callback=function(data,status) {
         if (data['status'] == 'done') {

--- a/security/openconnect/src/opnsense/mvc/app/views/OPNsense/Openconnect/general.volt
+++ b/security/openconnect/src/opnsense/mvc/app/views/OPNsense/Openconnect/general.volt
@@ -34,7 +34,7 @@ POSSIBILITY OF SUCH DAMAGE.
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
     $( document ).ready(function() {
         var data_get_map = {'frm_general_settings':"/api/openconnect/general/get"};
         mapDataToFormUI(data_get_map).done(function(data){

--- a/security/tinc/src/opnsense/mvc/app/views/OPNsense/Tinc/index.volt
+++ b/security/tinc/src/opnsense/mvc/app/views/OPNsense/Tinc/index.volt
@@ -26,7 +26,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #}
 
-<script type="text/javascript">
+<script>
 
     $( document ).ready(function() {
         /*************************************************************************************************************

--- a/security/tor/src/opnsense/mvc/app/views/OPNsense/Tor/diagnostics.volt
+++ b/security/tor/src/opnsense/mvc/app/views/OPNsense/Tor/diagnostics.volt
@@ -28,7 +28,7 @@
 #}
 
 
-<script type="text/javascript">
+<script>
 
 function tor_update_status() {
     ajaxCall(url='/api/tor/service/status', sendData={}, callback=function(data, status) {

--- a/security/tor/src/opnsense/mvc/app/views/OPNsense/Tor/general.volt
+++ b/security/tor/src/opnsense/mvc/app/views/OPNsense/Tor/general.volt
@@ -28,7 +28,7 @@
 #}
 
 
-<script type="text/javascript">
+<script>
 
 function tor_update_status() {
     ajaxCall(url="/api/tor/service/status", sendData={}, callback=function(data,status) {

--- a/security/tor/src/opnsense/mvc/app/views/OPNsense/Tor/info.volt
+++ b/security/tor/src/opnsense/mvc/app/views/OPNsense/Tor/info.volt
@@ -28,7 +28,7 @@
 #}
 
 
-<script type="text/javascript">
+<script>
 
 function tor_update_status() {
     ajaxCall(url="/api/tor/service/status", sendData={}, callback=function(data, status) {

--- a/sysutils/monit/src/opnsense/mvc/app/views/OPNsense/Monit/index.volt
+++ b/sysutils/monit/src/opnsense/mvc/app/views/OPNsense/Monit/index.volt
@@ -25,7 +25,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
 #}
-<script type="text/javascript">
+<script>
 
    $( document ).ready(function() {
 

--- a/sysutils/monit/src/opnsense/mvc/app/views/OPNsense/Monit/status.volt
+++ b/sysutils/monit/src/opnsense/mvc/app/views/OPNsense/Monit/status.volt
@@ -25,7 +25,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
 #}
-<script type="text/javascript">
+<script>
 
    $( document ).ready(function() {
 

--- a/sysutils/node_exporter/src/opnsense/mvc/app/views/OPNsense/NodeExporter/general.volt
+++ b/sysutils/node_exporter/src/opnsense/mvc/app/views/OPNsense/NodeExporter/general.volt
@@ -27,7 +27,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
 #}
-<script type="text/javascript">
+<script>
     $(document).ready(function() {
         var data_get_map = {'frm_general_settings':"/api/nodeexporter/general/get"};
         mapDataToFormUI(data_get_map).done(function(data) {

--- a/sysutils/nut/src/opnsense/mvc/app/views/OPNsense/Nut/index.volt
+++ b/sysutils/nut/src/opnsense/mvc/app/views/OPNsense/Nut/index.volt
@@ -25,7 +25,7 @@
  # POSSIBILITY OF SUCH DAMAGE.
  #}
 
-<script type="text/javascript">
+<script>
     $( document ).ready(function() {
 
         var data_get_map = {'frm_nut':'/api/nut/settings/get'};

--- a/sysutils/scp-backup/src/opnsense/mvc/app/views/OPNsense/ScpBackup/general.volt
+++ b/sysutils/scp-backup/src/opnsense/mvc/app/views/OPNsense/ScpBackup/general.volt
@@ -27,7 +27,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
 #}
-<script type="text/javascript">
+<script>
     $(document).ready(function() {
         var data_get_map = {'frm_general_settings':"/api/scpbackup/general/get"};
 

--- a/www/c-icap/src/opnsense/mvc/app/views/OPNsense/CICAP/general.volt
+++ b/www/c-icap/src/opnsense/mvc/app/views/OPNsense/CICAP/general.volt
@@ -54,7 +54,7 @@ POSSIBILITY OF SUCH DAMAGE.
     </div>
 </div>
 
-<script type="text/javascript">
+<script>
     $( document ).ready(function() {
         var data_get_map = {'frm_general_settings':"/api/cicap/general/get"};
         mapDataToFormUI(data_get_map).done(function(data){

--- a/www/web-proxy-sso/src/opnsense/mvc/app/views/OPNsense/ProxySSO/index.volt
+++ b/www/web-proxy-sso/src/opnsense/mvc/app/views/OPNsense/ProxySSO/index.volt
@@ -24,7 +24,7 @@
  # POSSIBILITY OF SUCH DAMAGE.
  #}
 
-<script type="text/javascript">
+<script>
     $( document ).ready(function() {
 
         /*************************************************************************************************************

--- a/www/web-proxy-useracl/src/opnsense/mvc/app/views/OPNsense/ProxyUserACL/index.volt
+++ b/www/web-proxy-useracl/src/opnsense/mvc/app/views/OPNsense/ProxyUserACL/index.volt
@@ -26,7 +26,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #}
 
-<script type="text/javascript">
+<script>
 
     $(document).ready(function () {
         grid = $("#grid-acl").UIBootgrid(


### PR DESCRIPTION
Warning: The type attribute is unnecessary for JavaScript resources.

HTML5: Edition for Web Authors
http://www.w3.org/TR/2014/REC-html5-20141028/scripting-1.html
The default, which is used if the attribute is absent, is "text/javascript".

The Script element
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script
HTML5 specification urges authors to omit the attribute rather than provide a redundant MIME type.