### PR TITLE
Use Route53 options for IPv6 as well

### DIFF
--- a/dns/dyndns/src/www/services_dyndns_edit.php
+++ b/dns/dyndns/src/www/services_dyndns_edit.php
@@ -188,6 +188,7 @@ include("head.inc");
                 $(".type_custom").show();
                 break;
               case "route53":
+              case "route53-v6":
                 $(".type_route53").show();
                 break;
               default:


### PR DESCRIPTION
Without it, when selecting Route53 v6, the options needed for Route53 would not be shown