### PR TITLE
Added check for RR type

### DIFF
--- a/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
+++ b/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
@@ -653,12 +653,25 @@ class updatedns
 
                 /* Get IP for your hostname in Route 53 */
                 if (false !== ($a_result = SearchRecords($records['ResourceRecordSets'], "$hostname"))) {
-                    $OldTTL=$a_result[0][TTL];
-                    $OldIP=$a_result[0][ResourceRecords][0];
+                    /**
+                     * if hostname for ipv4 and ipv6 is the same, a_result contains more than 1 item
+                     * we need to get the item that corresponds to the record type
+                     */
+                    $oldTTLResult = null;
+                    $oldIPResult = null;
+                    foreach ($a_result as $resultItem) {
+                        if ($RecordType === $resultItem['Type']) {
+                            $oldTTLResult = $resultItem[TTL];
+                            $oldIPResult = $resultItem[ResourceRecords][0];
+                        }
+                    }
+
+                    $OldTTL=$oldTTLResult;
+                    $OldIP=$oldIPResult;
                 } else {
                     $OldIP="";
                 }
-
+                
                 /* Check if we need to update DNS Record */
                 if ($OldIP !== $NewIP) {
                     if (!empty($OldIP)) {


### PR DESCRIPTION
Now, if the RR for a hostname has both IPv4 and IPv6 addresses, the correct RR is chosen by the current RR type.