### PR TITLE
net/haproxy: Release 2.5

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		haproxy
-PLUGIN_VERSION=		2.4
+PLUGIN_VERSION=		2.5
 PLUGIN_COMMENT=		Reliable, high performance TCP/HTTP load balancer
 PLUGIN_DEPENDS=		haproxy
 PLUGIN_MAINTAINER=	opnsense@moov.de

--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -1,7 +1,7 @@
 PLUGIN_NAME=		haproxy
 PLUGIN_VERSION=		2.5
 PLUGIN_COMMENT=		Reliable, high performance TCP/HTTP load balancer
-PLUGIN_DEPENDS=		haproxy
+PLUGIN_DEPENDS=		haproxy-devel
 PLUGIN_MAINTAINER=	opnsense@moov.de
 
 .include "../../Mk/plugins.mk"

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogBackend.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogBackend.xml
@@ -32,6 +32,13 @@
         <hint>Choose a load balancing algorithm.</hint>
     </field>
     <field>
+        <id>backend.proxyProtocol</id>
+        <label>Proxy Protocol</label>
+        <type>dropdown</type>
+        <help><![CDATA[Enforces use of the PROXY protocol over any connection established to the configured servers. The PROXY protocol informs the other end about the layer 3/4 addresses of the incoming connection, so that it can know the client's address or the public address it accessed to, whatever the upper layer protocol. This setting must not be used if the servers are not aware of the PROXY protocol. See the <a target="_blank" href="http://cbonte.github.io/haproxy-dconv/1.8/configuration.html#send-proxy">HAProxy documentation</a> for a full description.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
         <id>backend.linkedServers</id>
         <label>Servers</label>
         <type>select_multiple</type>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -623,8 +623,8 @@
                 <proxyProtocol type="OptionField">
                     <Required>N</Required>
                     <OptionValues>
-                        <v1>PROXY protocol version 1</v1>
-                        <v2>PROXY protocol version 2</v2>
+                        <v1>Version 1</v1>
+                        <v2>Version 2</v2>
                     </OptionValues>
                 </proxyProtocol>
                 <linkedServers type="ModelRelationField">

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -620,6 +620,13 @@
                         <uri>URI Hash (only HTTP mode)</uri>
                     </OptionValues>
                 </algorithm>
+                <proxyProtocol type="OptionField">
+                    <Required>N</Required>
+                    <OptionValues>
+                        <v1>PROXY protocol version 1</v1>
+                        <v2>PROXY protocol version 2</v2>
+                    </OptionValues>
+                </proxyProtocol>
                 <linkedServers type="ModelRelationField">
                     <Model>
                         <template>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/HAProxy</mount>
-    <version>2.1.0</version>
+    <version>2.2.0</version>
     <description>
         the HAProxy load balancer
     </description>

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -1056,8 +1056,10 @@ backend {{backend.name}}
 {#           # PROXY protocol #}
 {%           if backend.proxyProtocol|default("") == "v1" %}
 {%             do server_options.append('send-proxy') %}
+{%             do server_options.append('check-send-proxy') %}
 {%           elif backend.proxyProtocol|default("") == "v2" %}
 {%             do server_options.append('send-proxy-v2') %}
+{%             do server_options.append('check-send-proxy') %}
 {%           endif %}
 {#           # server advanced options #}
 {%           if server_data.advanced|default("") != "" %}

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -1053,6 +1053,12 @@ backend {{backend.name}}
 {%           elif server_data.source|default("") != "" %}
 {%             do server_options.append('source ' ~ server_data.source) %}
 {%           endif %}
+{#           # PROXY protocol #}
+{%           if backend.proxyProtocol|default("") == "v1" %}
+{%             do server_options.append('send-proxy') %}
+{%           elif backend.proxyProtocol|default("") == "v2" %}
+{%             do server_options.append('send-proxy-v2') %}
+{%           endif %}
 {#           # server advanced options #}
 {%           if server_data.advanced|default("") != "" %}
 {%             do server_options.append(server_data.advanced) %}


### PR DESCRIPTION
## New features
- add support for the PROXY protocol (i.e. in combination with postfix or dovecot)
- switch to HAProxy 1.8.4

## Bugfixes
none

## Enhancements
none