### PR TITLE
security/tor: DRY controller code and fix copyright statements

### DIFF
--- a/security/tor/Makefile
+++ b/security/tor/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=          tor
-PLUGIN_VERSION=       1.4
+PLUGIN_VERSION=       1.5
 PLUGIN_COMMENT=       The Onion Router
 PLUGIN_DEPENDS=       tor ruby
 PLUGIN_MAINTAINER=    franz.fabian.94@gmail.com

--- a/security/tor/src/opnsense/mvc/app/controllers/OPNsense/Tor/Api/ExitaclController.php
+++ b/security/tor/src/opnsense/mvc/app/controllers/OPNsense/Tor/Api/ExitaclController.php
@@ -1,8 +1,6 @@
 <?php
 
 /*
- *    Copyright (C) 2015-2017 Deciso B.V.
- *    Copyright (C) 2015 Jos Schellevis
  *    Copyright (C) 2017 Fabian Franz
  *    All rights reserved.
  *
@@ -41,129 +39,26 @@ class ExitaclController extends ApiMutableModelControllerBase
     static protected $internalModelClass = '\OPNsense\Tor\ACLExitPolicy';
     public function searchaclAction()
     {
-        $this->sessionClose();
-        $mdl = $this->getModel();
-        $grid = new UIModelGrid($mdl->policy);
-        return $grid->fetchBindRequest(
-            $this->request,
-            array('enabled', 'type', 'network', 'action', 'startport', 'endport')
-        );
+        return $this->searchBase('policy', array('enabled', 'type', 'network', 'action', 'startport', 'endport'));
     }
     public function getaclAction($uuid = null)
     {
-        $mdl = $this->getModel();
-        if ($uuid != null) {
-            $node = $mdl->getNodeByReference('policy.' . $uuid);
-            if ($node != null) {
-                // return node
-                return array('exitpolicy' => $node->getNodes());
-            }
-        } else {
-            $node = $mdl->policy->add();
-            return array('exitpolicy' => $node->getNodes());
-        }
-        return array();
+        return $this->getBase('exitpolicy', 'policy', $uuid);
     }
     public function addaclAction()
     {
-        $result = array('result' => 'failed');
-        if ($this->request->isPost() && $this->request->hasPost('exitpolicy')) {
-            $result = array('result' => 'failed', 'validations' => array());
-            $mdl = $this->getModel();
-            $node = $mdl->policy->Add();
-            $node->setNodes($this->request->getPost('exitpolicy'));
-            $valMsgs = $mdl->performValidation();
-
-            foreach ($valMsgs as $field => $msg) {
-                $fieldnm = str_replace($node->__reference, 'exitpolicy', $msg->getField());
-                $result['validations'][$fieldnm] = $msg->getMessage();
-            }
-
-            if (count($result['validations']) == 0) {
-                $mdl->serializeToConfig();
-                Config::getInstance()->save();
-                unset($result['validations']);
-                $result['result'] = 'saved';
-            }
-        }
-        return $result;
+        return $this->addBase('exitpolicy', 'policy');
     }
     public function delaclAction($uuid)
     {
-
-        $result = array('result' => 'failed');
-
-        if ($this->request->isPost()) {
-            $mdl = $this->getModel();
-            if ($uuid != null) {
-                if ($mdl->policy->del($uuid)) {
-                    $mdl->serializeToConfig();
-                    Config::getInstance()->save();
-                    $result['result'] = 'deleted';
-                } else {
-                    $result['result'] = 'not found';
-                }
-            }
-        }
-        return $result;
+        return $this->delBase('policy', $uuid);
     }
     public function setaclAction($uuid)
     {
-        if ($this->request->isPost() && $this->request->hasPost('exitpolicy')) {
-            $mdl = $this->getModel();
-            if ($uuid != null) {
-                $node = $mdl->getNodeByReference('policy.' . $uuid);
-                if ($node != null) {
-                    $result = array('result' => 'failed', 'validations' => array());
-                    $info = $this->request->getPost('exitpolicy');
-
-                    $node->setNodes($info);
-                    $valMsgs = $mdl->performValidation();
-                    foreach ($valMsgs as $field => $msg) {
-                        $fieldnm = str_replace($node->__reference, 'exitpolicy', $msg->getField());
-                        $result['validations'][$fieldnm] = $msg->getMessage();
-                    }
-
-                    if (count($result['validations']) == 0) {
-                        // save config if validated correctly
-                        $mdl->serializeToConfig();
-                        unset($result['validations']);
-                        Config::getInstance()->save();
-                        $result = array('result' => 'saved');
-                    }
-                    return $result;
-                }
-            }
-        }
-        return array('result' => 'failed');
+        return $this->setBase('exitpolicy', 'policy', $uuid);
     }
-    public function toggle_handler($uuid, $element)
-    {
-
-        $result = array('result' => 'failed');
-
-        if ($this->request->isPost()) {
-            $mdl = $this->getModel();
-            if ($uuid != null) {
-                $node = $mdl->getNodeByReference($element . '.' . $uuid);
-                if ($node != null) {
-                    if ($node->enabled->__toString() == '1') {
-                        $result['result'] = 'Disabled';
-                        $node->enabled = '0';
-                    } else {
-                        $result['result'] = 'Enabled';
-                        $node->enabled = '1';
-                    }
-                    $mdl->serializeToConfig();
-                    Config::getInstance()->save();
-                }
-            }
-        }
-        return $result;
-    }
-
     public function toggleaclAction($uuid)
     {
-        return $this->toggle_handler($uuid, 'policy');
+        return $this->toggleBase('policy', $uuid);
     }
 }

--- a/security/tor/src/opnsense/mvc/app/controllers/OPNsense/Tor/Api/ExitaclController.php
+++ b/security/tor/src/opnsense/mvc/app/controllers/OPNsense/Tor/Api/ExitaclController.php
@@ -39,10 +39,12 @@ class ExitaclController extends ApiMutableModelControllerBase
     static protected $internalModelClass = '\OPNsense\Tor\ACLExitPolicy';
     public function searchaclAction()
     {
+        $this->sessionClose();
         return $this->searchBase('policy', array('enabled', 'type', 'network', 'action', 'startport', 'endport'));
     }
     public function getaclAction($uuid = null)
     {
+        $this->sessionClose();
         return $this->getBase('exitpolicy', 'policy', $uuid);
     }
     public function addaclAction()

--- a/security/tor/src/opnsense/mvc/app/controllers/OPNsense/Tor/Api/GeneralController.php
+++ b/security/tor/src/opnsense/mvc/app/controllers/OPNsense/Tor/Api/GeneralController.php
@@ -77,11 +77,13 @@ class GeneralController extends ApiMutableModelControllerBase
 
     public function searchhidservauthAction()
     {
+        $this->sessionClose();
         return $this->searchBase('client_authentications.client_auth', array('enabled', 'onion_service', 'auth_cookie'));
     }
 
     public function gethidservauthAction($uuid = null)
     {
+        $this->sessionClose();
         return $this->getBase('client_auth', 'client_authentications.client_auth', $uuid);
     }
 

--- a/security/tor/src/opnsense/mvc/app/controllers/OPNsense/Tor/Api/GeneralController.php
+++ b/security/tor/src/opnsense/mvc/app/controllers/OPNsense/Tor/Api/GeneralController.php
@@ -2,6 +2,8 @@
 
 /*
  * Copyright (C) 2017 Fabian Franz
+ * Copyright (C) 2015 Jos Schellevis
+ * Copyright (C) 2015-2017 Deciso B.V.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -75,135 +77,31 @@ class GeneralController extends ApiMutableModelControllerBase
 
     public function searchhidservauthAction()
     {
-        $this->sessionClose();
-        $mdl = $this->getModel();
-        $grid = new UIModelGrid($mdl->client_authentications->client_auth);
-        return $grid->fetchBindRequest(
-            $this->request,
-            array('enabled', 'onion_service', 'auth_cookie')
-        );
+        return $this->searchBase('client_authentications.client_auth', array('enabled', 'onion_service', 'auth_cookie'));
     }
 
     public function gethidservauthAction($uuid = null)
     {
-        $mdl = $this->getModel();
-        if ($uuid != null) {
-            $node = $mdl->getNodeByReference('client_authentications.client_auth.' . $uuid);
-            if ($node != null) {
-                // return node
-                return array('client_auth' => $node->getNodes());
-            }
-        } else {
-            $node = $mdl->client_authentications->client_auth->add();
-            return array('client_auth' => $node->getNodes());
-        }
-        return array();
+        return $this->getBase('client_auth', 'client_authentications.client_auth', $uuid);
     }
 
     public function addhidservauthAction()
     {
-        $result = array('result' => 'failed');
-        if ($this->request->isPost() && $this->request->hasPost('client_auth')) {
-            $result = array('result' => 'failed', 'validations' => array());
-            $mdl = $this->getModel();
-            $node = $mdl->client_authentications->client_auth->Add();
-            $node->setNodes($this->request->getPost('client_auth'));
-            $valMsgs = $mdl->performValidation();
-
-            foreach ($valMsgs as $field => $msg) {
-                $fieldnm = str_replace($node->__reference, 'client_auth', $msg->getField());
-                $result['validations'][$fieldnm] = $msg->getMessage();
-            }
-
-            if (count($result['validations']) == 0) {
-                // save config if validated correctly
-                $mdl->serializeToConfig();
-                Config::getInstance()->save();
-                unset($result['validations']);
-                $result['result'] = 'saved';
-            }
-        }
-        return $result;
+        return $this->addBase('client_auth', 'client_authentications.client_auth');
     }
 
     public function delhidservauthAction($uuid)
     {
-
-        $result = array('result' => 'failed');
-
-        if ($this->request->isPost()) {
-            $mdl = $this->getModel();
-            if ($uuid != null) {
-                if ($mdl->client_authentications->client_auth->del($uuid)) {
-                    $mdl->serializeToConfig();
-                    Config::getInstance()->save();
-                    $result['result'] = 'deleted';
-                } else {
-                    $result['result'] = 'not found';
-                }
-            }
-        }
-        return $result;
+        return $this->delBase('client_authentications.client_auth', $uuid);
     }
 
     public function sethidservauthAction($uuid)
     {
-        if ($this->request->isPost() && $this->request->hasPost('client_auth')) {
-            $mdl = $this->getModel();
-            if ($uuid != null) {
-                $node = $mdl->getNodeByReference('client_authentications.client_auth.' . $uuid);
-                if ($node != null) {
-                    $result = array('result' => 'failed', 'validations' => array());
-                    $info = $this->request->getPost('client_auth');
-
-                    $node->setNodes($info);
-                    $valMsgs = $mdl->performValidation();
-                    foreach ($valMsgs as $field => $msg) {
-                        $fieldnm = str_replace($node->__reference, 'client_auth', $msg->getField());
-                        $result['validations'][$fieldnm] = $msg->getMessage();
-                    }
-
-                    if (count($result['validations']) == 0) {
-                        // save config if validated correctly
-                        $mdl->serializeToConfig();
-                        unset($result['validations']);
-                        Config::getInstance()->save();
-                        $result = array('result' => 'saved');
-                    }
-                    return $result;
-                }
-            }
-        }
-        return array('result' => 'failed');
-    }
-
-    public function toggle_handler($uuid, $element)
-    {
-
-        $result = array('result' => 'failed');
-
-        if ($this->request->isPost()) {
-            $mdl = $this->getModel();
-            if ($uuid != null) {
-                $node = $mdl->getNodeByReference($element . '.' . $uuid);
-                if ($node != null) {
-                    if ($node->enabled->__toString() == '1') {
-                        $result['result'] = 'Disabled';
-                        $node->enabled = '0';
-                    } else {
-                        $result['result'] = 'Enabled';
-                        $node->enabled = '1';
-                    }
-                    $mdl->serializeToConfig();
-                    Config::getInstance()->save();
-                }
-            }
-        }
-        return $result;
+        return $this->setBase('client_auth', 'client_authentications.client_auth', $uuid);
     }
 
     public function togglehidservauthAction($uuid)
     {
-        return $this->toggle_handler($uuid, 'client_authentications.client_auth');
+        return $this->toggleBase('client_authentications.client_auth', $uuid);
     }
 }

--- a/security/tor/src/opnsense/mvc/app/controllers/OPNsense/Tor/Api/HiddenserviceController.php
+++ b/security/tor/src/opnsense/mvc/app/controllers/OPNsense/Tor/Api/HiddenserviceController.php
@@ -36,10 +36,12 @@ class HiddenserviceController extends ApiMutableModelControllerBase
     static protected $internalModelClass = '\OPNsense\Tor\HiddenService';
     public function searchserviceAction()
     {
+        $this->sessionClose();
         return $this->searchBase('service', array('enabled', 'name'));
     }
     public function getserviceAction($uuid = null)
     {
+        $this->sessionClose();
         return $this->getBase('hiddenservice', 'service', $uuid);
     }
     public function addserviceAction()

--- a/security/tor/src/opnsense/mvc/app/controllers/OPNsense/Tor/Api/HiddenserviceController.php
+++ b/security/tor/src/opnsense/mvc/app/controllers/OPNsense/Tor/Api/HiddenserviceController.php
@@ -1,8 +1,6 @@
 <?php
 
 /*
- *    Copyright (C) 2015-2017 Deciso B.V.
- *    Copyright (C) 2015 Jos Schellevis
  *    Copyright (C) 2017 Fabian Franz
  *    All rights reserved.
  *
@@ -30,10 +28,7 @@
 
 namespace OPNsense\Tor\Api;
 
-use \OPNsense\Tor\HiddenService;
-use \OPNsense\Core\Config;
 use \OPNsense\Base\ApiMutableModelControllerBase;
-use \OPNsense\Base\UIModelGrid;
 
 class HiddenserviceController extends ApiMutableModelControllerBase
 {
@@ -41,131 +36,27 @@ class HiddenserviceController extends ApiMutableModelControllerBase
     static protected $internalModelClass = '\OPNsense\Tor\HiddenService';
     public function searchserviceAction()
     {
-        $this->sessionClose();
-        $mdl = $this->getModel();
-        $grid = new UIModelGrid($mdl->service);
-        return $grid->fetchBindRequest(
-            $this->request,
-            array('enabled', 'name')
-        );
+        return $this->searchBase('service', array('enabled', 'name'));
     }
     public function getserviceAction($uuid = null)
     {
-        $mdl = $this->getModel();
-        if ($uuid != null) {
-            $node = $mdl->getNodeByReference('service.' . $uuid);
-            if ($node != null) {
-                // return node
-                return array('hiddenservice' => $node->getNodes());
-            }
-        } else {
-            $node = $mdl->service->add();
-            return array('hiddenservice' => $node->getNodes());
-        }
-        return array();
+        return $this->getBase('hiddenservice', 'service', $uuid);
     }
     public function addserviceAction()
     {
-        $result = array('result' => 'failed');
-        if ($this->request->isPost() && $this->request->hasPost('hiddenservice')) {
-            $result = array('result' => 'failed', 'validations' => array());
-            $mdl = $this->getModel();
-            $node = $mdl->service->Add();
-            $node->setNodes($this->request->getPost('hiddenservice'));
-            $valMsgs = $mdl->performValidation();
-
-            foreach ($valMsgs as $field => $msg) {
-                $fieldnm = str_replace($node->__reference, 'hiddenservice', $msg->getField());
-                $result['validations'][$fieldnm] = $msg->getMessage();
-            }
-
-            if (count($result['validations']) == 0) {
-                // save config if validated correctly
-                $mdl->serializeToConfig();
-                Config::getInstance()->save();
-                unset($result['validations']);
-                $result['result'] = 'saved';
-            }
-        }
-        return $result;
+        return $this->addBase('hiddenservice', 'service');
     }
     public function delserviceAction($uuid)
     {
-
-        $result = array('result' => 'failed');
-
-        if ($this->request->isPost()) {
-            $mdl = $this->getModel();
-            if ($uuid != null) {
-                if ($mdl->service->del($uuid)) {
-                    $mdl->serializeToConfig();
-                    Config::getInstance()->save();
-                    $result['result'] = 'deleted';
-                } else {
-                    $result['result'] = 'not found';
-                }
-            }
-        }
-        return $result;
+        return $this->delBase('service', $uuid);
     }
     public function setserviceAction($uuid)
     {
-        if ($this->request->isPost() && $this->request->hasPost('hiddenservice')) {
-            $mdl = $this->getModel();
-            if ($uuid != null) {
-                $node = $mdl->getNodeByReference('service.' . $uuid);
-                if ($node != null) {
-                    $result = array('result' => 'failed', 'validations' => array());
-                    $info = $this->request->getPost('hiddenservice');
-
-                    $node->setNodes($info);
-                    $valMsgs = $mdl->performValidation();
-                    foreach ($valMsgs as $field => $msg) {
-                        $fieldnm = str_replace($node->__reference, 'hiddenservice', $msg->getField());
-                        $result['validations'][$fieldnm] = $msg->getMessage();
-                    }
-
-                    if (count($result['validations']) == 0) {
-                        // save config if validated correctly
-                        $mdl->serializeToConfig();
-                        unset($result['validations']);
-                        Config::getInstance()->save();
-                        $result = array('result' => 'saved');
-                    }
-                    return $result;
-                }
-            }
-        }
-        return array('result' => 'failed');
-    }
-    public function toggle_handler($uuid, $element)
-    {
-
-        $result = array('result' => 'failed');
-
-        if ($this->request->isPost()) {
-            $mdl = $this->getModel();
-            if ($uuid != null) {
-                $node = $mdl->getNodeByReference($element . '.' . $uuid);
-                if ($node != null) {
-                    if ($node->enabled->__toString() == '1') {
-                        $result['result'] = 'Disabled';
-                        $node->enabled = '0';
-                    } else {
-                        $result['result'] = 'Enabled';
-                        $node->enabled = '1';
-                    }
-                    // if item has toggled, serialize to config and save
-                    $mdl->serializeToConfig();
-                    Config::getInstance()->save();
-                }
-            }
-        }
-        return $result;
+        return $this->setBase('hiddenservice', 'service', $uuid);
     }
 
     public function toggleserviceAction($uuid)
     {
-        return $this->toggle_handler($uuid, 'service');
+        return $this->toggleBase('service', $uuid);
     }
 }

--- a/security/tor/src/opnsense/mvc/app/controllers/OPNsense/Tor/Api/HiddenserviceaclController.php
+++ b/security/tor/src/opnsense/mvc/app/controllers/OPNsense/Tor/Api/HiddenserviceaclController.php
@@ -1,8 +1,6 @@
 <?php
 
 /*
- *    Copyright (C) 2015-2017 Deciso B.V.
- *    Copyright (C) 2015 Jos Schellevis
  *    Copyright (C) 2017 Fabian Franz
  *    All rights reserved.
  *
@@ -30,10 +28,7 @@
 
 namespace OPNsense\Tor\Api;
 
-use \OPNsense\Tor\HiddenServiceACL;
-use \OPNsense\Core\Config;
 use \OPNsense\Base\ApiMutableModelControllerBase;
-use \OPNsense\Base\UIModelGrid;
 
 class HiddenserviceaclController extends ApiMutableModelControllerBase
 {
@@ -41,130 +36,27 @@ class HiddenserviceaclController extends ApiMutableModelControllerBase
     static protected $internalModelClass = '\OPNsense\Tor\HiddenServiceACL';
     public function searchaclAction()
     {
-        $this->sessionClose();
-        $mdl = $this->getModel();
-        $grid = new UIModelGrid($mdl->hiddenserviceacl);
-        return $grid->fetchBindRequest(
-            $this->request,
-            array('enabled', 'hiddenservice', 'port', 'target_host', 'target_port')
-        );
+        return $this->searchBase('hiddenserviceacl', array('enabled', 'hiddenservice', 'port', 'target_host', 'target_port'));
     }
     public function getaclAction($uuid = null)
     {
-        $mdl = $this->getModel();
-        if ($uuid != null) {
-            $node = $mdl->getNodeByReference('hiddenserviceacl.' . $uuid);
-            if ($node != null) {
-                // return node
-                return array('hiddenserviceacl' => $node->getNodes());
-            }
-        } else {
-            $node = $mdl->hiddenserviceacl->add();
-            return array('hiddenserviceacl' => $node->getNodes());
-        }
-        return array();
+        return $this->getBase('hiddenserviceacl', 'hiddenserviceacl', $uuid);
     }
     public function addaclAction()
     {
-        $result = array('result' => 'failed');
-        if ($this->request->isPost() && $this->request->hasPost('hiddenserviceacl')) {
-            $result = array('result' => 'failed', 'validations' => array());
-            $mdl = $this->getModel();
-            $node = $mdl->hiddenserviceacl->Add();
-            $node->setNodes($this->request->getPost('hiddenserviceacl'));
-            $valMsgs = $mdl->performValidation();
-
-            foreach ($valMsgs as $field => $msg) {
-                $fieldnm = str_replace($node->__reference, 'hiddenserviceacl', $msg->getField());
-                $result['validations'][$fieldnm] = $msg->getMessage();
-            }
-
-            if (count($result['validations']) == 0) {
-                // save config if validated correctly
-                $mdl->serializeToConfig();
-                Config::getInstance()->save();
-                unset($result['validations']);
-                $result['result'] = 'saved';
-            }
-        }
-        return $result;
+        return $this->addBase('hiddenserviceacl', 'hiddenserviceacl');
     }
     public function delaclAction($uuid)
     {
-
-        $result = array('result' => 'failed');
-
-        if ($this->request->isPost()) {
-            $mdl = $this->getModel();
-            if ($uuid != null) {
-                if ($mdl->hiddenserviceacl->del($uuid)) {
-                    $mdl->serializeToConfig();
-                    Config::getInstance()->save();
-                    $result['result'] = 'deleted';
-                } else {
-                    $result['result'] = 'not found';
-                }
-            }
-        }
-        return $result;
+        return $this->delBase('hiddenserviceacl', $uuid);
     }
     public function setaclAction($uuid)
     {
-        if ($this->request->isPost() && $this->request->hasPost('hiddenserviceacl')) {
-            $mdl = $this->getModel();
-            if ($uuid != null) {
-                $node = $mdl->getNodeByReference('hiddenserviceacl.' . $uuid);
-                if ($node != null) {
-                    $result = array('result' => 'failed', 'validations' => array());
-                    $info = $this->request->getPost('hiddenserviceacl');
-
-                    $node->setNodes($info);
-                    $valMsgs = $mdl->performValidation();
-                    foreach ($valMsgs as $field => $msg) {
-                        $fieldnm = str_replace($node->__reference, 'hiddenserviceacl', $msg->getField());
-                        $result['validations'][$fieldnm] = $msg->getMessage();
-                    }
-
-                    if (count($result['validations']) == 0) {
-                        // save config if validated correctly
-                        $mdl->serializeToConfig();
-                        unset($result['validations']);
-                        Config::getInstance()->save();
-                        $result = array('result' => 'saved');
-                    }
-                    return $result;
-                }
-            }
-        }
-        return array('result' => 'failed');
-    }
-    public function toggle_handler($uuid, $element)
-    {
-
-        $result = array('result' => 'failed');
-
-        if ($this->request->isPost()) {
-            $mdl = $this->getModel();
-            if ($uuid != null) {
-                $node = $mdl->getNodeByReference($element . '.' . $uuid);
-                if ($node != null) {
-                    if ($node->enabled->__toString() == '1') {
-                        $result['result'] = 'Disabled';
-                        $node->enabled = '0';
-                    } else {
-                        $result['result'] = 'Enabled';
-                        $node->enabled = '1';
-                    }
-                    $mdl->serializeToConfig();
-                    Config::getInstance()->save();
-                }
-            }
-        }
-        return $result;
+        return $this->setBase('hiddenserviceacl', 'hiddenserviceacl', $uuid);
     }
 
     public function toggleaclAction($uuid)
     {
-        return $this->toggle_handler($uuid, 'hiddenserviceacl');
+        return $this->toggleBase('hiddenserviceacl', $uuid);
     }
 }

--- a/security/tor/src/opnsense/mvc/app/controllers/OPNsense/Tor/Api/HiddenserviceaclController.php
+++ b/security/tor/src/opnsense/mvc/app/controllers/OPNsense/Tor/Api/HiddenserviceaclController.php
@@ -36,10 +36,12 @@ class HiddenserviceaclController extends ApiMutableModelControllerBase
     static protected $internalModelClass = '\OPNsense\Tor\HiddenServiceACL';
     public function searchaclAction()
     {
+        $this->sessionClose();
         return $this->searchBase('hiddenserviceacl', array('enabled', 'hiddenservice', 'port', 'target_host', 'target_port'));
     }
     public function getaclAction($uuid = null)
     {
+        $this->sessionClose();
         return $this->getBase('hiddenserviceacl', 'hiddenserviceacl', $uuid);
     }
     public function addaclAction()

--- a/security/tor/src/opnsense/mvc/app/controllers/OPNsense/Tor/Api/SocksaclController.php
+++ b/security/tor/src/opnsense/mvc/app/controllers/OPNsense/Tor/Api/SocksaclController.php
@@ -1,8 +1,6 @@
 <?php
 
 /*
- *    Copyright (C) 2015-2017 Deciso B.V.
- *    Copyright (C) 2015 Jos Schellevis
  *    Copyright (C) 2017 Fabian Franz
  *    All rights reserved.
  *
@@ -30,10 +28,7 @@
 
 namespace OPNsense\Tor\Api;
 
-use \OPNsense\Tor\ACLSocksPolicy;
-use \OPNsense\Core\Config;
 use \OPNsense\Base\ApiMutableModelControllerBase;
-use \OPNsense\Base\UIModelGrid;
 
 class SocksaclController extends ApiMutableModelControllerBase
 {
@@ -41,129 +36,27 @@ class SocksaclController extends ApiMutableModelControllerBase
     static protected $internalModelClass = '\OPNsense\Tor\ACLSocksPolicy';
     public function searchaclAction()
     {
-        $this->sessionClose();
-        $mdl = $this->getModel();
-        $grid = new UIModelGrid($mdl->policy);
-        return $grid->fetchBindRequest(
-            $this->request,
-            array('enabled', 'type', 'network', 'action')
-        );
+        return $this->searchBase('policy', array('enabled', 'type', 'network', 'action'));
     }
     public function getaclAction($uuid = null)
     {
-        $mdl = $this->getModel();
-        if ($uuid != null) {
-            $node = $mdl->getNodeByReference('policy.' . $uuid);
-            if ($node != null) {
-                // return node
-                return array('policy' => $node->getNodes());
-            }
-        } else {
-            $node = $mdl->policy->add();
-            return array('policy' => $node->getNodes());
-        }
-        return array();
+        return $this->getBase('policy', 'policy', $uuid);
     }
     public function addaclAction()
     {
-        $result = array('result' => 'failed');
-        if ($this->request->isPost() && $this->request->hasPost('policy')) {
-            $result = array('result' => 'failed', 'validations' => array());
-            $mdl = $this->getModel();
-            $node = $mdl->policy->Add();
-            $node->setNodes($this->request->getPost('policy'));
-            $valMsgs = $mdl->performValidation();
-
-            foreach ($valMsgs as $field => $msg) {
-                $fieldnm = str_replace($node->__reference, 'policy', $msg->getField());
-                $result['validations'][$fieldnm] = $msg->getMessage();
-            }
-
-            if (count($result['validations']) == 0) {
-                $mdl->serializeToConfig();
-                Config::getInstance()->save();
-                unset($result['validations']);
-                $result['result'] = 'saved';
-            }
-        }
-        return $result;
+        return $this->addBase('policy', 'policy');
     }
     public function delaclAction($uuid)
     {
-
-        $result = array('result' => 'failed');
-
-        if ($this->request->isPost()) {
-            $mdl = $this->getModel();
-            if ($uuid != null) {
-                if ($mdl->policy->del($uuid)) {
-                    $mdl->serializeToConfig();
-                    Config::getInstance()->save();
-                    $result['result'] = 'deleted';
-                } else {
-                    $result['result'] = 'not found';
-                }
-            }
-        }
-        return $result;
+        return $this->delBase('policy', $uuid);
     }
     public function setaclAction($uuid)
     {
-        if ($this->request->isPost() && $this->request->hasPost('policy')) {
-            $mdl = $this->getModel();
-            if ($uuid != null) {
-                $node = $mdl->getNodeByReference('policy.' . $uuid);
-                if ($node != null) {
-                    $result = array('result' => 'failed', 'validations' => array());
-                    $info = $this->request->getPost('policy');
-
-                    $node->setNodes($info);
-                    $valMsgs = $mdl->performValidation();
-                    foreach ($valMsgs as $field => $msg) {
-                        $fieldnm = str_replace($node->__reference, 'policy', $msg->getField());
-                        $result['validations'][$fieldnm] = $msg->getMessage();
-                    }
-
-                    if (count($result['validations']) == 0) {
-                        // save config if validated correctly
-                        $mdl->serializeToConfig();
-                        unset($result['validations']);
-                        Config::getInstance()->save();
-                        $result = array('result' => 'saved');
-                    }
-                    return $result;
-                }
-            }
-        }
-        return array('result' => 'failed');
-    }
-    public function toggle_handler($uuid, $element)
-    {
-
-        $result = array('result' => 'failed');
-
-        if ($this->request->isPost()) {
-            $mdl = $this->getModel();
-            if ($uuid != null) {
-                $node = $mdl->getNodeByReference($element . '.' . $uuid);
-                if ($node != null) {
-                    if ($node->enabled->__toString() == '1') {
-                        $result['result'] = 'Disabled';
-                        $node->enabled = '0';
-                    } else {
-                        $result['result'] = 'Enabled';
-                        $node->enabled = '1';
-                    }
-                    $mdl->serializeToConfig();
-                    Config::getInstance()->save();
-                }
-            }
-        }
-        return $result;
+        return $this->setBase('policy', 'policy', $uuid);
     }
 
     public function toggleaclAction($uuid)
     {
-        return $this->toggle_handler($uuid, 'policy');
+        return $this->toggleBase('policy', $uuid);
     }
 }

--- a/security/tor/src/opnsense/mvc/app/controllers/OPNsense/Tor/Api/SocksaclController.php
+++ b/security/tor/src/opnsense/mvc/app/controllers/OPNsense/Tor/Api/SocksaclController.php
@@ -36,10 +36,12 @@ class SocksaclController extends ApiMutableModelControllerBase
     static protected $internalModelClass = '\OPNsense\Tor\ACLSocksPolicy';
     public function searchaclAction()
     {
+        $this->sessionClose();
         return $this->searchBase('policy', array('enabled', 'type', 'network', 'action'));
     }
     public function getaclAction($uuid = null)
     {
+        $this->sessionClose();
         return $this->getBase('policy', 'policy', $uuid);
     }
     public function addaclAction()


### PR DESCRIPTION
the new code does not contain any "foreign code" except the function left
in general as well as the servicecontroller (code originally borrowed from IDS which is now gone).