### PR TITLE
frr: Add OSPF interface net type to ospfd.conf

### DIFF
--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
@@ -22,6 +22,9 @@ log syslog {{ OPNsense.quagga.general.sysloglevel }}
 {%   for interface in helpers.toList('OPNsense.quagga.ospf.interfaces.interface') %}
 {%     if interface.enabled == '1' %}
 interface {{ physical_interface(interface.interfacename) }}
+{% if interface.networktype %}
+{{       cline("network",interface.networktype)
+}}{% endif %}
 {{       cline("authentication",interface.authtype)
 }}{% if interface.authtype and interface.authtype == 'message-digest'
 %}{{       cline("message-digest-key 1 md5",interface.authkey)


### PR DESCRIPTION
When adding network type for ospf in frr it's only reflected in the UI and not actually written to ospfd.conf. With this PR the ospf network type is added to ospfd.conf if it's set for an interface.