### PR TITLE
net/haproxy: release 2.6

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		haproxy
-PLUGIN_VERSION=		2.5
+PLUGIN_VERSION=		2.6
 PLUGIN_COMMENT=		Reliable, high performance TCP/HTTP load balancer
 PLUGIN_DEPENDS=		haproxy-devel
 PLUGIN_MAINTAINER=	opnsense@moov.de

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogAction.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogAction.xml
@@ -286,6 +286,23 @@
     <field>
         <label>Parameters</label>
         <type>header</type>
+        <style>type_table table_http-response_set-status</style>
+    </field>
+    <field>
+        <id>action.http_response_set_status_code</id>
+        <label>HTTP Status Code</label>
+        <type>text</type>
+        <help><![CDATA[Replaces the response status code. Must be an integer between 100 and 999.]]></help>
+    </field>
+    <field>
+        <id>action.http_response_set_status_reason</id>
+        <label>HTTP Reason Text</label>
+        <type>text</type>
+        <help><![CDATA[An optional custom reason text for the HTTP status code. If empty the default reason for the specified code will be used.]]></help>
+    </field>
+    <field>
+        <label>Parameters</label>
+        <type>header</type>
         <style>type_table table_tcp-request_content_lua</style>
     </field>
     <field>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -1528,6 +1528,7 @@
                         <http-response_del-header>http-response header delete</http-response_del-header>
                         <http-response_replace-header>http-response header replace</http-response_replace-header>
                         <http-response_replace-value>http-response header replace value</http-response_replace-value>
+                        <http-response_set-status>Set HTTP status code in response</http-response_set-status>
                         <tcp-request_connection_accept>tcp-request connection accept</tcp-request_connection_accept>
                         <tcp-request_connection_reject>tcp-request connection reject</tcp-request_connection_reject>
                         <tcp-request_content_accept>tcp-request content accept</tcp-request_content_accept>
@@ -1658,6 +1659,16 @@
                     <mask>/^.{1,4096}$/u</mask>
                     <Required>N</Required>
                 </http_response_replace_value_regex>
+                <http_response_set_status_code type="IntegerField">
+                    <MinimumValue>100</MinimumValue>
+                    <MaximumValue>999</MaximumValue>
+                    <ValidationMessage>Please specify a value between 100 and 999.</ValidationMessage>
+                    <Required>N</Required>
+                </http_response_set_status_code>
+                <http_response_set_status_reason type="TextField">
+                    <mask>/^.{1,4096}$/u</mask>
+                    <Required>N</Required>
+                </http_response_set_status_reason>
                 <tcp_request_content_lua type="TextField">
                     <mask>/^.{1,4096}$/u</mask>
                     <Required>N</Required>

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -420,6 +420,18 @@
 {%             set action_enabled = '0' %}
     # ERROR: missing parameters
 {%           endif %}
+{%         elif action_data.type == 'http-response_set-status' %}
+{%           if action_data.http_response_set_status_code|default("") != "" %}
+{%             if action_data.http_response_set_status_reason|default("") != "" %}
+{%               set status_reason = ' reason "' ~ action_data.http_response_set_status_reason ~ '"' %}
+{%             else %}
+{%               set status_reason = '' %}
+{%             endif %}
+{%             do action_options.append('http-response set-status ' ~ action_data.http_response_set_status_code ~ status_reason) %}
+{%           else %}
+{%             set action_enabled = '0' %}
+    # ERROR: missing parameters
+{%           endif %}
 {%         elif action_data.type == 'tcp-request_connection_accept' %}
 {%           do action_options.append('tcp-request connection accept') %}
 {%         elif action_data.type == 'tcp-request_connection_reject' %}

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -215,7 +215,8 @@
 {%               do acl_options.append('') %}
 {%               if acl_data.nbsrv|default("") != "" %}
 {%                 if acl_data.nbsrv_backend|default("") != "" %}
-{%                   do acl_options.append('nbsrv(backend_' ~ acl_data.nbsrv_backend ~ ') ge ' ~ acl_data.nbsrv) %}
+{%                   set nbsrv_backend_data = helpers.getUUID(acl_data.nbsrv_backend) %}
+{%                   do acl_options.append('nbsrv(' ~ nbsrv_backend_data.name ~ ') ge ' ~ acl_data.nbsrv) %}
 {%                 else %}
 {%                   do acl_options.append('nbsrv ge ' ~ acl_data.nbsrv) %}
 {%                 endif %}


### PR DESCRIPTION
## New features
- add support for `http-response set-status` to manipulate HTTP status codes

## Bugfixes
- fix invalid backend name when using `nbsrv` in ACLs

## Enhancements
none