### PR TITLE
Check IP Services - Plugin

### DIFF
--- a/dns/checkip/Makefile
+++ b/dns/checkip/Makefile
@@ -1,0 +1,7 @@
+PLUGIN_NAME=		checkip
+PLUGIN_VERSION=		1.0
+PLUGIN_REVISION=	0
+PLUGIN_COMMENT=		Use alternate services to get current IP address (custom DynDNS and RFC2136).
+PLUGIN_MAINTAINER=	NOYB at github
+
+.include "../../Mk/plugins.mk"

--- a/dns/checkip/pkg-descr
+++ b/dns/checkip/pkg-descr
@@ -1,0 +1,3 @@
+Allow addition of check IP services to be used by custom Dynamic DNS 
+and RFC2136 entries that have the "Use public IP" option enabled, 
+to obtain the current IP address.

--- a/dns/checkip/src/opnsense/mvc/app/models/OPNsense/CheckIP/ACL/ACL.xml
+++ b/dns/checkip/src/opnsense/mvc/app/models/OPNsense/CheckIP/ACL/ACL.xml
@@ -1,0 +1,10 @@
+<acl>
+    <page-services-checkip>
+        <name>Services: Check IP</name>
+        <description>Allow access to the Check IP services module</description>
+        <patterns>
+            <pattern>services_checkip.php*</pattern>
+            <pattern>services_checkip_edit.php*</pattern>
+        </patterns>
+    </page-services-checkip>
+</acl>

--- a/dns/checkip/src/opnsense/mvc/app/models/OPNsense/CheckIP/Menu/Menu.xml
+++ b/dns/checkip/src/opnsense/mvc/app/models/OPNsense/CheckIP/Menu/Menu.xml
@@ -1,0 +1,7 @@
+<menu>
+    <Services>
+        <CheckIP VisibleName="Check IP" url="/services_checkip.php" cssClass="fa fa-tags fa-fw">
+            <Edit url="/services_checkip_edit.php*" visibility="hidden"/>
+        </CheckIP>
+    </Services>
+</menu>

--- a/dns/checkip/src/www/services_checkip.php
+++ b/dns/checkip/src/www/services_checkip.php
@@ -1,0 +1,193 @@
+<?php
+
+/*
+    Copyright (C) 2014-2016 Deciso B.V.
+    Copyright (C) 2008 Ermal Luçi
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+
+require_once("guiconfig.inc");
+require_once("services.inc");
+
+$a_checkipservices = &config_read_array('checkipservices', 'service');
+
+// Append the factory default check IP service to the list.
+$a_checkipservices[] = factory_default_checkipservice();
+$factory_default = count($a_checkipservices) - 1;
+
+// Is the factory default check IP service disabled?
+if (isset($config['checkipservices']['disable_factory_default'])) {
+    unset($a_checkipservices[$factory_default]['enable']);
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = $a_checkipservices[$_POST['id']]['name'];
+    if (isset($_POST['act']) && $_POST['act'] == "del" && isset($_POST['id'])) {
+        unset($a_checkipservices[$_POST['id']]);
+        $wc_msg = gettext("Deleted a check IP service: %s");
+    } elseif (isset($_POST['act']) && $_POST['act'] == "toggle" && isset($_POST['id'])) {
+        if ($a_checkipservices[$_POST['id']]) {
+            if (isset($a_checkipservices[$_POST['id']]['enable'])) {
+                unset($a_checkipservices[$_POST['id']]['enable']);
+                $wc_msg = gettext("Disabled a check IP service: %s");
+            } else {
+                $a_checkipservices[$_POST['id']]['enable'] = true;
+                $wc_msg = gettext("Enabled a check IP service: %s");
+            }
+            if ($_POST['id'] == $factory_default) {
+                if (isset($config['checkipservices']['disable_factory_default'])) {
+                    unset($config['checkipservices']['disable_factory_default']);
+                } else {
+                    $config['checkipservices']['disable_factory_default'] = true;
+                }
+            }
+        }
+    }
+    unset($a_checkipservices[$factory_default]);
+    write_config(sprintf($wc_msg, htmlspecialchars($name)));
+
+    header(url_safe('Location: /services_checkip.php'));
+    exit;
+}
+
+include("head.inc");
+
+legacy_html_escape_form_data($a_checkipservices);
+
+$main_buttons = array(
+        array('label' => gettext('Add'), 'href' => 'services_checkip_edit.php'),
+);
+
+?>
+<body>
+  <script>
+  $( document ).ready(function() {
+      // delete service action
+      $(".act_delete_service").click(function(event){
+          event.preventDefault();
+          var id = $(this).data("id");
+          BootstrapDialog.show({
+              type:BootstrapDialog.TYPE_DANGER,
+              title: "<?= gettext("Check IP Service");?>",
+              message: "<?=gettext("Do you really want to delete this entry?");?>",
+              buttons: [{
+                                  label: "<?= gettext("No");?>",
+                                  action: function(dialogRef) {
+                                          dialogRef.close();
+                                  }}, {
+                                  label: "<?= gettext("Yes");?>",
+                                  action: function(dialogRef) {
+                                      $.post(window.location, {act: 'del', id:id}, function(data) {
+                                              location.reload();
+                                      });
+                              }
+                          }]
+          });
+      });
+      // link toggle buttons
+      $(".act_toggle").click(function(event){
+              event.preventDefault();
+              $.post(window.location, {act: 'toggle', id:$(this).data("id")}, function(data) {
+                      location.reload();
+              });
+      });
+      // watch scroll position and set to last known on page load
+      watchScrollPosition();
+  });
+  </script>
+
+<?php include("fbegin.inc"); ?>
+  <section class="page-content-main"><h2 style="display:none"><?=gettext('Check IP Services')?></h2>
+    <div class="container-fluid">
+      <div class="row">
+        <section class="col-xs-12"><h3 style="display:none"><?=gettext('Services List')?></h3>
+          <div class="tab-content content-box col-xs-12">
+            <form method="post" name="iform" id="iform">
+              <div class="table-responsive">
+                <table class="table table-striped">
+                  <thead>
+                    <tr>
+                      <th></th>
+                      <th><?=gettext("Name")?></th>
+                      <th><?=gettext("URL")?></th>
+                      <th><?=gettext("Verify SSL Peer")?></th>
+                      <th><?=gettext("Description")?></th>
+                      <th></th>
+                    </tr>
+                    </thead>
+                  <tbody>
+<?php
+                    $i = 0;
+                    foreach ($a_checkipservices as $checkipservice):
+
+                      // Hide edit and delete controls on the factory default check IP service entry (last one; id = count-1), and retain layout positioning.
+                      $visibility = $i == $factory_default ? 'invisible' : 'visible';
+?>
+                    <tr>
+                      <td class="text-left" style="width:0px">
+                        <a href="#" class="act_toggle" data-id="<?=$i;?>" data-toggle="tooltip" title="<?=(!empty($checkipservice['enable'])) ? gettext("disable") : gettext("enable");?>">
+                          <i style="width:15px" class="glyphicon glyphicon-play <?=(!empty($checkipservice['enable'])) ? "text-success" : "text-muted";?>"></i>
+                        </a>
+                      </td>
+                      <td>
+                        <?=htmlspecialchars($checkipservice['name'])?>
+                      </td>
+                      <td>
+                        <a target="Check_IP" rel="noopener noreferrer" href="<?=$checkipservice['url']?>"><?=htmlspecialchars($checkipservice['url'])?></a>
+                      </td>
+                      <td class="text-center">
+                        <i<?=(isset($checkipservice['verifysslpeer'])) ? ' class="fa fa-check"' : '';?>></i>
+                      </td>
+                      <td>
+                        <?=htmlspecialchars($checkipservice['descr'])?>
+                      </td>
+                      <td>
+                        <a href="services_checkip_edit.php?id=<?=$i;?>" class="btn btn-default btn-xs <?=$visibility?>">
+                          <i class="glyphicon glyphicon-pencil"></i>
+                        </a>
+                        <a href="#" data-id="<?=$i;?>" class="act_delete_service btn btn-default btn-xs <?=$visibility?>">
+                          <i class="glyphicon glyphicon-trash"></i>
+                        </a>
+                      </td>
+                    </tr>
+<?php
+                      $i++;
+                    endforeach; ?>
+                    <tr>
+                      <td colspan=6>
+                        <?= htmlspecialchars(gettext('The first (highest in list) enabled check IP service will be used to check IP addresses for Dynamic DNS services, and RFC 2136 entries that have the "Use public IP" option enabled.')); ?><br /><br />
+                        <?= htmlspecialchars(gettext('The service must return an HTML body in the format of: "<body>Current IP Address: {IP_Address}</body>"')); ?><br />
+                        <?= htmlspecialchars(gettext('Example PHP: <html><head><title>Current IP Check</title></head><body>Current IP Address: <?=$_SERVER[\'REMOTE_ADDR\']?></body></html>')); ?>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </form>
+          </div>
+        </section>
+      </div>
+    </div>
+  </section>
+<?php include("foot.inc"); ?>

--- a/dns/checkip/src/www/services_checkip_edit.php
+++ b/dns/checkip/src/www/services_checkip_edit.php
@@ -1,0 +1,208 @@
+<?php
+
+/*
+    Copyright (C) 2014-2015 Deciso B.V.
+    Copyright (C) 2008 Ermal Luçi
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+
+require_once("guiconfig.inc");
+
+$a_checkipservices = &config_read_array('checkipservices', 'service');
+
+if ($_SERVER['REQUEST_METHOD'] === 'GET') {
+    if (isset($_GET['id']) && is_numericint($_GET['id'])) {
+        $id = $_GET['id'];
+    }
+    if (isset($id) && isset($a_checkipservices[$id])) {
+        $pconfig['enable'] = isset($a_checkipservices[$id]['enable']);
+        $pconfig['name'] = $a_checkipservices[$id]['name'];
+        $pconfig['url'] = $a_checkipservices[$id]['url'];
+        $pconfig['username'] = $a_checkipservices[$id]['username'];
+        $pconfig['password'] = $a_checkipservices[$id]['password'];
+        $pconfig['verifysslpeer'] = isset($a_checkipservices[$id]['verifysslpeer']);
+        $pconfig['descr'] = $a_checkipservices[$id]['descr'];
+    }
+} elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['id']) && is_numericint($_POST['id'])) {
+        $id = $_POST['id'];
+    }
+    $input_errors = array();
+    $pconfig = $_POST;
+
+    /* input validation */
+    $reqdfields = array();
+    $reqdfieldsn = array();
+    $reqdfields = array_merge($reqdfields, explode(" ", "name url"));
+    $reqdfieldsn = array_merge($reqdfieldsn, array(gettext("Name"), gettext("URL")));
+
+    do_input_validation($_POST, $reqdfields, $reqdfieldsn, $input_errors);
+
+    if (($_POST['name'] && !is_validaliasname($_POST['name']))) {
+        $input_errors[] = gettext("The Check IP Service name contains invalid characters.");
+    }
+    if (($_POST['url'] && !is_URL($_POST['url']))) {
+        $input_errors[] = gettext("The Check IP Service URL is not valid.");
+    }
+
+    if (count($input_errors) == 0) {
+        $checkip = array();
+        $checkip['enable'] = $_POST['enable'] ? true : false;
+        $checkip['name'] = $_POST['name'];
+        $checkip['url'] = $_POST['url'];
+        $checkip['username'] = $_POST['username'];
+        $checkip['password'] = $_POST['passwordfld'];
+        $checkip['verifysslpeer'] = $_POST['verifysslpeer'] ? true : false;
+        $checkip['descr'] = $_POST['descr'];
+
+        if (isset($id) && $a_checkipservices[$id]) {
+            $a_checkipservices[$id] = $checkip;
+        } else {
+            $a_checkipservices[] = $checkip;
+        }
+
+        write_config(sprintf(gettext("New/edited check IP service: %s"), $checkip['name']));
+
+        header(url_safe('Location: /services_checkip.php'));
+        exit;
+    }
+}
+
+legacy_html_escape_form_data($a_checkipservices);
+
+include("head.inc");
+
+?>
+<body>
+<?php include("fbegin.inc"); ?>
+  <section class="page-content-main"><h2 style="display:none">Check IP Service Add/Edit</h2>
+    <div class="container-fluid">
+      <div class="row">
+        <?php if (isset($input_errors) && count($input_errors) > 0) print_input_errors($input_errors); ?>
+        <section class="col-xs-12"><h3 style="display:none">Input Form</h3>
+          <div class="content-box">
+            <form method="post" name="iform" id="iform">
+              <div class="table-responsive">
+                <table class="table table-striped opnsense_standard_table_form">
+
+                  <tr>
+                    <td style="width:22%"><strong><?= gettext("Check IP Service") ?></strong></td>
+                    <td style="width:78%" class="text-right">
+                      <small><?= gettext("full help") ?> </small>
+                      <i class="fa fa-toggle-off text-danger" style="cursor: pointer;" id="show_all_help_page"></i>
+                    </td>
+                  </tr>
+
+                  <tr>
+                    <td><i class="fa fa-info-circle text-muted"></i> <?= gettext("Enable") ?></td>
+                    <td>
+                      <label for="enable">
+                        <input name="enable" type="checkbox" id="enable" value="<?= gettext("yes") ?>" <?= empty($pconfig['enable']) ? '' : 'checked="checked"' ?> />
+                        <?= gettext('Enable this service.');?>
+                      </label>
+                    </td>
+                  </tr>
+
+                  <tr>
+                    <td><a id="help_for_name" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext("Name") ?></td>
+                    <td>
+                      <input name="name" type="text" id="name" value="<?= $pconfig['name'] ?>" />
+                      <output class="hidden" for="help_for_name">
+                        <?= gettext('The service name may only consist of the characters "a-z, A-Z, 0-9 and _".');?>
+                      </output>
+                    </td>
+                  </tr>
+
+                  <tr>
+                    <td><a id="help_for_url" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext("URL") ?></td>
+                    <td>
+                      <input name="url" type="text" id="url" value="<?= $pconfig['url'] ?>" />
+                      <output class="hidden" for="help_for_url">
+                        <?= gettext('The service URL to use.');?>
+                      </output>
+                    </td>
+                  </tr>
+
+                  <tr>
+                    <td><a id="help_for_username" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext("User name") ?></td>
+                    <td>
+                      <input name="username" type="text" id="username" value="<?= $pconfig['username'] ?>" />
+                      <output class="hidden" for="help_for_username">
+                        <?= gettext('The user name to authenticate with the service.');?>
+                      </output>
+                    </td>
+                  </tr>
+
+                  <tr>
+                    <td><a id="help_for_password" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext("Password") ?></td>
+                    <td>
+                      <input name="passwordfld" type="password" id="passwordfld" value="<?= $pconfig['password'] ?>" />
+                      <output class="hidden" for="help_for_password">
+                        <?= gettext('The password to authenticate with the service.');?>
+                      </output>
+                    </td>
+                  </tr>
+
+                  <tr>
+                    <td><i class="fa fa-info-circle text-muted"></i> <?= gettext("Verify SSL Peer") ?></td>
+                    <td>
+                      <label for="verifysslpeer">
+                        <input name="verifysslpeer" type="checkbox" id="verifysslpeer" value="<?= gettext("yes") ?>" <?= empty($pconfig['verifysslpeer']) ? '' : 'checked="checked"' ?> />
+                        <?= gettext('Require SSL peer verification.');?>
+                      </label>
+                    </td>
+                  </tr>
+
+                  <tr>
+                    <td><a id="help_for_descr" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?= gettext("Description") ?></td>
+                    <td>
+                      <input name="descr" type="text" id="descr" value="<?= $pconfig['descr'] ?>" />
+                      <output class="hidden" for="help_for_descr">
+                        <?= gettext('A description for administrative reference (not parsed).');?>
+                      </output>
+                    </td>
+                  </tr>
+
+                  <tr>
+                    <td>&nbsp;</td>
+                    <td>
+                      <button name="submit" type="submit" class="btn btn-primary" value="save"><?= gettext('Save') ?></button>
+<?php
+                      if (isset($id) && $a_checkipservices[$id]): ?>
+                        <input name="id" type="hidden" value="<?= $id ?>" />
+<?php
+                      endif; ?>
+                      <a href="services_checkip.php" class="btn btn-default"><?= gettext('Cancel') ?></a>
+                    </td>
+                  </tr>
+
+                </table>
+              </div>
+            </form>
+          </div>
+        </section>
+      </div>
+    </div>
+  </section>
+<?php include("foot.inc"); ?>


### PR DESCRIPTION
Configurable check IP services.
Used by Dynamic DNS services to check IP addresses.
Configure as many check IP services as desired.  The first (highest in the list) that is enabled will be used as the default.
Include verify peer option.
A future possibility could be to add an option to the Dynamic DNS entires to use a specific check IP service.
Allows additional/private check IP services to be added and set as the default.

Note:
The new files "services_checkip.php" and "services_checkip_edit.php" are modeled after the OPNsense files "services_dyndns.php" and "services_dyndns_edit.php".