### PR TITLE
net/haproxy: release 2.7

### DIFF
--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogAction.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogAction.xml
@@ -196,6 +196,17 @@
     <field>
         <label>Parameters</label>
         <type>header</type>
+        <style>type_table table_http-request_set-path</style>
+    </field>
+    <field>
+        <id>action.http_request_set_path</id>
+        <label>Set Path</label>
+        <type>text</type>
+        <help><![CDATA[Rewrites the request path. The query string, if any, is left intact. If a scheme and authority is found before the path, they are left intact as well.]]></help>
+    </field>
+    <field>
+        <label>Parameters</label>
+        <type>header</type>
         <style>type_table table_http-response_lua</style>
     </field>
     <field>

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogBackend.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogBackend.xml
@@ -78,6 +78,20 @@
         <help><![CDATA[Enable to log health check status updates.]]></help>
     </field>
     <field>
+        <id>backend.checkInterval</id>
+        <label>Check Interval</label>
+        <type>text</type>
+        <help><![CDATA[Sets the interval (in milliseconds) for running health checks on all configured servers. This setting takes precedence over default values in health monitors and real servers.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>backend.checkDownInterval</id>
+        <label>Down Interval</label>
+        <type>text</type>
+        <help><![CDATA[Sets the interval (in milliseconds) for running health checks on a configured server when the server state is DOWN. If it is not set HAProxy uses the check interval.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
         <id>backend.healthCheckFall</id>
         <label>Unhealthy Threshold</label>
         <type>text</type>

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogBackend.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogBackend.xml
@@ -78,6 +78,20 @@
         <help><![CDATA[Enable to log health check status updates.]]></help>
     </field>
     <field>
+        <id>backend.healthCheckFall</id>
+        <label>Unhealthy Threshold</label>
+        <type>text</type>
+        <help><![CDATA[The number of consecutive unsuccessful health checks before a server is considered as unavailable.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>backend.healthCheckRise</id>
+        <label>Healthy Threshold</label>
+        <type>text</type>
+        <help><![CDATA[The number of consecutive successful health checks before a server is considered as available.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
         <label>Stick-table persistence</label>
         <type>header</type>
     </field>

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogFrontend.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogFrontend.xml
@@ -200,7 +200,7 @@
     <field>
         <label>HTTP(S) settings</label>
         <type>header</type>
-        <style>mode_table table_http table_ssl</style>
+        <style>mode_table table_http</style>
     </field>
     <field>
         <id>frontend.forwardFor</id>

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogHealthcheck.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogHealthcheck.xml
@@ -21,7 +21,7 @@
         <id>healthcheck.interval</id>
         <label>Check interval</label>
         <type>text</type>
-        <help><![CDATA[Select interval (in milliseconds) between two consecutive health checks.]]></help>
+        <help><![CDATA[Select interval (in milliseconds) between two consecutive health checks. This value can be overriden in backend pool and real server configuration.]]></help>
     </field>
     <field>
         <id>healthcheck.checkport</id>

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogServer.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogServer.xml
@@ -77,7 +77,7 @@
         <id>server.checkInterval</id>
         <label>Check Interval</label>
         <type>text</type>
-        <help><![CDATA[Sets the interval (in milliseconds) for running health checks on this server. This setting takes precedence. If set, the interval in the healthcheck is ignored.]]></help>
+        <help><![CDATA[Sets the interval (in milliseconds) for running health checks on this server. This setting takes precedence over default values in health monitors. It can still be overwritten from the backend pool.]]></help>
         <advanced>true</advanced>
     </field>
     <field>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -1542,6 +1542,7 @@
                         <http-request_del-header>http-request header delete</http-request_del-header>
                         <http-request_replace-header>http-request header replace</http-request_replace-header>
                         <http-request_replace-value>http-request header replace value</http-request_replace-value>
+                        <http-request_set-path>http-request set-path</http-request_set-path>
                         <http-response_allow>http-response allow</http-response_allow>
                         <http-response_deny>http-response deny</http-response_deny>
                         <http-response_lua>http-response lua script</http-response_lua>
@@ -1641,6 +1642,10 @@
                     <mask>/^.{1,4096}$/u</mask>
                     <Required>N</Required>
                 </http_request_replace_value_regex>
+                <http_request_set_path type="TextField">
+                    <mask>/^.{1,4096}$/u</mask>
+                    <Required>N</Required>
+                </http_request_set_path>
                 <http_response_lua type="TextField">
                     <mask>/^.{1,4096}$/u</mask>
                     <Required>N</Required>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -664,6 +664,16 @@
                     <default>0</default>
                     <Required>N</Required>
                 </healthCheckLogStatus>
+                <checkInterval type="TextField">
+                    <mask>/^([0-9]{1,8}(?:us|ms|s|m|h|d)?)/u</mask>
+                    <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
+                    <Required>N</Required>
+                </checkInterval>
+                <checkDownInterval type="TextField">
+                    <mask>/^([0-9]{1,8}(?:us|ms|s|m|h|d)?)/u</mask>
+                    <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
+                    <Required>N</Required>
+                </checkDownInterval>
                 <healthCheckFall type="IntegerField">
                     <MinimumValue>1</MinimumValue>
                     <MaximumValue>100</MaximumValue>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -664,6 +664,18 @@
                     <default>0</default>
                     <Required>N</Required>
                 </healthCheckLogStatus>
+                <healthCheckFall type="IntegerField">
+                    <MinimumValue>1</MinimumValue>
+                    <MaximumValue>100</MaximumValue>
+                    <ValidationMessage>Please specify a value between 1 and 100.</ValidationMessage>
+                    <Required>N</Required>
+                </healthCheckFall>
+                <healthCheckRise type="IntegerField">
+                    <MinimumValue>1</MinimumValue>
+                    <MaximumValue>100</MaximumValue>
+                    <ValidationMessage>Please specify a value between 1 and 100.</ValidationMessage>
+                    <Required>N</Required>
+                </healthCheckRise>
                 <stickiness_pattern type="OptionField">
                     <Required>N</Required>
                     <default>sourceipv4</default>

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -1012,6 +1012,14 @@ backend {{backend.name}}
 {%             if server_data.checkDownInterval|default("") != "" %}
 {%               do server_options.append('downinter ' ~ server_data.checkDownInterval) %}
 {%             endif %}
+{#             # unhealthy threshold #}
+{%             if backend.healthCheckFall|default("") != "" %}
+{%               do server_options.append('fall ' ~ backend.healthCheckFall) %}
+{%             endif %}
+{#             # healthy threshold #}
+{%             if backend.healthCheckRise|default("") != "" %}
+{%               do server_options.append('rise ' ~ backend.healthCheckRise) %}
+{%             endif %}
 {#             # use a different port for health check #}
 {%             if healthcheck_data.checkport|default("") != "" %}
 {#               # prefer port from health check template #}

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -374,6 +374,13 @@
 {%             set action_enabled = '0' %}
     # ERROR: missing parameters
 {%           endif %}
+{%         elif action_data.type == 'http-request_set-path' %}
+{%           if action_data.http_request_set_path|default("") != "" %}
+{%             do action_options.append('http-request set-path ' ~ action_data.http_request_set_path) %}
+{%           else %}
+{%             set action_enabled = '0' %}
+    # ERROR: missing parameters
+{%           endif %}
 {%         elif action_data.type == 'http-response_allow' %}
 {%           do action_options.append('http-response allow') %}
 {%         elif action_data.type == 'http-response_deny' %}

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -1002,14 +1002,19 @@ backend {{backend.name}}
 {#           # check if health check is enabled #}
 {%           if healthcheck_enabled == '1' %}
 {%             do server_options.append('check') %}
-{#             # server settings take precedence over healthcheck settings #}
-{%             if server_data.checkInterval|default("") != "" %}
+{#             # This can be configured in multiple places. #}
+{#             # Priority for which value is used: backend > server > health check #}
+{%             if backend.checkInterval|default("") != "" %}
+{%               do server_options.append('inter ' ~ backend.checkInterval) %}
+{%             elif server_data.checkInterval|default("") != "" %}
 {%               do server_options.append('inter ' ~ server_data.checkInterval) %}
 {%             elif healthcheck_data.interval|default("") != "" %}
 {%               do server_options.append('inter ' ~ healthcheck_data.interval) %}
 {%             endif %}
 {#             # use a different interval when server is in DOWN state #}
-{%             if server_data.checkDownInterval|default("") != "" %}
+{%             if backend.checkDownInterval|default("") != "" %}
+{%               do server_options.append('downinter ' ~ backend.checkDownInterval) %}
+{%             elif server_data.checkDownInterval|default("") != "" %}
 {%               do server_options.append('downinter ' ~ server_data.checkDownInterval) %}
 {%             endif %}
 {#             # unhealthy threshold #}


### PR DESCRIPTION
## New features
- support rise/fall parameters in backends and health checks
- support set-path in ACLs

## Bugfixes
- fix X-Forwarded-For option disappeared (#647)

## Enhancements
none