### PR TITLE
sysutils/monit: allow parameter in path options

### DIFF
--- a/sysutils/monit/Makefile
+++ b/sysutils/monit/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		monit
-PLUGIN_VERSION=		1.5
+PLUGIN_VERSION=		1.6
 PLUGIN_COMMENT=		Proactive system monitoring
 PLUGIN_MAINTAINER=	frank.brendel@eurolog.com
 PLUGIN_DEPENDS=		monit

--- a/sysutils/monit/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.xml
+++ b/sysutils/monit/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.xml
@@ -198,7 +198,7 @@
          </match>
          <path type="TextField">
             <Required>N</Required>
-            <mask>/^(\/[^\/ ]*)+\/? .*$/</mask>
+            <mask>/^(\/[^\/ ]*)+\/?.*$/</mask>
             <ValidationMessage>Should be a valid absolute file or folder path.</ValidationMessage>
          </path>
          <address type="TextField">
@@ -261,7 +261,7 @@
          </action>
          <path type="TextField">
             <Required>N</Required>
-            <mask>/^(\/[^\/ ]*)+\/? .*$/</mask>
+            <mask>/^(\/[^\/ ]*)+\/?.*$/</mask>
             <ValidationMessage>Should be a valid absolute file path.</ValidationMessage>
          </path>
       </test>

--- a/sysutils/monit/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.xml
+++ b/sysutils/monit/src/opnsense/mvc/app/models/OPNsense/Monit/Monit.xml
@@ -1,6 +1,6 @@
 <model>
    <mount>//OPNsense/monit</mount>
-   <version>1.0.2</version>
+   <version>1.0.3</version>
    <description>Monit settings</description>
    <items>
       <general>
@@ -198,7 +198,7 @@
          </match>
          <path type="TextField">
             <Required>N</Required>
-            <mask>/^(\/[^\/ ]*)+\/?$/</mask>
+            <mask>/^(\/[^\/ ]*)+\/? .*$/</mask>
             <ValidationMessage>Should be a valid absolute file or folder path.</ValidationMessage>
          </path>
          <address type="TextField">
@@ -261,7 +261,7 @@
          </action>
          <path type="TextField">
             <Required>N</Required>
-            <mask>/^(\/[^\/ ]*)+?$/</mask>
+            <mask>/^(\/[^\/ ]*)+\/? .*$/</mask>
             <ValidationMessage>Should be a valid absolute file path.</ValidationMessage>
          </path>
       </test>


### PR DESCRIPTION
Allow parameter in path option for services and tests with 'Execute' action.
Fix for #585 