### PR TITLE
net-mgmt/lldp: Ability to set interfaces

### DIFF
--- a/net-mgmt/lldpd/Makefile
+++ b/net-mgmt/lldpd/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		lldpd
-PLUGIN_VERSION=		1.0
+PLUGIN_VERSION=		1.1
 PLUGIN_COMMENT=		LLDP allows you to know exactly on which port is a server
 PLUGIN_DEPENDS=		lldpd
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net-mgmt/lldpd/src/opnsense/mvc/app/controllers/OPNsense/Lldpd/forms/general.xml
+++ b/net-mgmt/lldpd/src/opnsense/mvc/app/controllers/OPNsense/Lldpd/forms/general.xml
@@ -29,4 +29,10 @@
         <type>checkbox</type>
         <help>This will activate the SONMP Protocol by Nortel.</help>
     </field>
+    <field>
+        <id>general.interface</id>
+        <label>Interface Configuration</label>
+        <type>text</type>
+        <help>Select the interfaces you want or you do not want LLDPd send and receive packets. Default is to use every interface. You can set very complex rules here, but be sure to use correct syntax or LLDPd will not start. For example, with igb*,!igb1,!igb2 lldpd will only use interfaces starting by igb with the exception of igb1 and igb2. While with *,!igb*,!!igb1 lldpd will use all interfaces, except interfaces starting by igb with the exception of igb1.</help>
+    </field>
 </form>

--- a/net-mgmt/lldpd/src/opnsense/mvc/app/controllers/OPNsense/Lldpd/forms/general.xml
+++ b/net-mgmt/lldpd/src/opnsense/mvc/app/controllers/OPNsense/Lldpd/forms/general.xml
@@ -33,6 +33,6 @@
         <id>general.interface</id>
         <label>Interface Configuration</label>
         <type>text</type>
-        <help>Select the interfaces you want or you do not want LLDPd send and receive packets. Default is to use every interface. You can set very complex rules here, but be sure to use correct syntax or LLDPd will not start. For example, with igb*,!igb1,!igb2 lldpd will only use interfaces starting by igb with the exception of igb1 and igb2. While with *,!igb*,!!igb1 lldpd will use all interfaces, except interfaces starting by igb with the exception of igb1.</help>
+        <help>Select the interfaces you want or you do not want LLDPd send and receive packets. Be sure to set the physical names and not the interface name set via the UI. Default is to use every interface. You can set very complex rules here, but be sure to use correct syntax or LLDPd will not start. For example, with igb*,!igb1,!igb2 lldpd will only use interfaces starting by igb with the exception of igb1 and igb2. While with *,!igb*,!!igb1 lldpd will use all interfaces, except interfaces starting by igb with the exception of igb1.</help>
     </field>
 </form>

--- a/net-mgmt/lldpd/src/opnsense/mvc/app/models/OPNsense/Lldpd/General.xml
+++ b/net-mgmt/lldpd/src/opnsense/mvc/app/models/OPNsense/Lldpd/General.xml
@@ -23,5 +23,8 @@
             <default>0</default>
             <Required>Y</Required>
         </sonmp>
+        <interface type="TextField">
+            <Required>N</Required>
+        </interface>
     </items>
 </model>

--- a/net-mgmt/lldpd/src/opnsense/service/templates/OPNsense/Lldpd/lldpd
+++ b/net-mgmt/lldpd/src/opnsense/service/templates/OPNsense/Lldpd/lldpd
@@ -1,6 +1,6 @@
 {% if helpers.exists('OPNsense.lldpd.general.enabled') and OPNsense.lldpd.general.enabled == '1' %}
 lldpd_enable="YES"
-lldpd_flags="{% if helpers.exists('OPNsense.lldpd.general.cdp') and OPNsense.lldpd.general.cdp == '1' %}-c{% endif %}{% if helpers.exists('OPNsense.lldpd.general.fdp') and OPNsense.lldpd.general.fdp == '1' %} -f{% endif %}{% if helpers.exists('OPNsense.lldpd.general.edp') and OPNsense.lldpd.general.edp == '1' %} -e{% endif %}{% if helpers.exists('OPNsense.lldpd.general.sonmp') and OPNsense.lldpd.general.sonmp == '1' %} -s{% endif %}"
+lldpd_flags="{% if helpers.exists('OPNsense.lldpd.general.cdp') and OPNsense.lldpd.general.cdp == '1' %}-c{% endif %}{% if helpers.exists('OPNsense.lldpd.general.fdp') and OPNsense.lldpd.general.fdp == '1' %} -f{% endif %}{% if helpers.exists('OPNsense.lldpd.general.edp') and OPNsense.lldpd.general.edp == '1' %} -e{% endif %}{% if helpers.exists('OPNsense.lldpd.general.sonmp') and OPNsense.lldpd.general.sonmp == '1' %} -s{% endif %}{% if helpers.exists('OPNsense.lldpd.general.interface') and OPNsense.lldpd.general.interface != '' %} -I {{ OPNsense.lldpd.general.interface }}{% endif %}"
 {% else %}
 lldpd_enable="NO"
 {% endif %}


### PR DESCRIPTION
Requested here: https://forum.opnsense.org/index.php?topic=7558.0


First I took select_multiple to allow the user to choose interfaces, but this is not really compatible with complex configurations (like described in help text). I think for such a little daemon it's ok to not use validation and only offer a text field.

