### PR TITLE
mail/postfix: add smarthost and smtp authentication

### DIFF
--- a/mail/postfix/Makefile
+++ b/mail/postfix/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		postfix
-PLUGIN_VERSION=		1.0
+PLUGIN_VERSION=		1.1
 PLUGIN_COMMENT=		SMTP mail relay
 PLUGIN_DEPENDS=		postfix-sasl
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
+++ b/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
@@ -80,6 +80,30 @@
         <help>Choose "none" to disable TLS for sending mail. Set encrypt to enforce TLS security, please do not use this for Internet wide communication as not every server supports TLS yet. Default is "may" which will use TLS when offered.</help>
     </field>
     <field>
+        <id>general.relayhost</id>
+        <label>Smart Host</label>
+        <type>text</type>
+        <help>Set the IP address where all outgoung mail are sent to.</help>
+    </field>    
+    <field>
+        <id>general.smtpauth_enabled</id>
+        <label>Enable SMTP Authentication</label>
+        <type>checkbox</type>
+        <help>Check this to enable authentication against your Smarthost.</help>
+    </field>
+    <field>
+        <id>general.smtpauth_user</id>
+        <label>Authentication Username</label>
+        <type>text</type>
+        <help>The username to use for SMTP authentication.</help>
+    </field>
+    <field>
+        <id>general.smtpauth_password</id>
+        <label>Authentication Password</label>
+        <type>password</type>
+        <help>The password to use for SMTP authentication.</help>
+    </field>
+    <field>
         <id>general.reject_unauth_pipelining</id>
         <label>Reject Unauthenticated Pipelining</label>
         <type>checkbox</type>

--- a/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
+++ b/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/postfix/general</mount>
     <description>Postfix configuration</description>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <items>
         <enabled type="BooleanField">
             <default>0</default>

--- a/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
+++ b/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
@@ -60,6 +60,21 @@
                 <encrypt>encrypt</encrypt>
             </OptionValues>
         </smtpclient_security>
+        <relayhost type="HostnameField">
+            <Required>N</Required>
+        </relayhost>
+        <smtpauth_enabled type="BooleanField">
+            <default>0</default>
+            <Required>Y</Required>
+        </smtpauth_enabled>
+        <smtpauth_user type="TextField">
+            <default></default>
+            <Required>N</Required>
+        </smtpauth_user>
+        <smtpauth_password type="TextField">
+            <default></default>
+            <Required>N</Required>
+        </smtpauth_password>
         <reject_unauth_pipelining type="BooleanField">
             <default>1</default>
             <Required>Y</Required>

--- a/mail/postfix/src/opnsense/scripts/OPNsense/Postfix/setup.sh
+++ b/mail/postfix/src/opnsense/scripts/OPNsense/Postfix/setup.sh
@@ -30,6 +30,7 @@ chown -R root:postfix /var/spool/postfix/pid
 postmap /usr/local/etc/postfix/transport
 postmap /usr/local/etc/postfix/recipient_access
 postmap /usr/local/etc/postfix/sender_access
+postmap /usr/local/etc/postfix/smtp_auth
 
 # Check for aliases
 if [ -f /usr/local/etc/postfix/aliases ]; then

--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/+TARGETS
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/+TARGETS
@@ -4,3 +4,4 @@ postfix:/etc/rc.conf.d/postfix
 transport:/usr/local/etc/postfix/transport
 recipient_access:/usr/local/etc/postfix/recipient_access
 sender_access:/usr/local/etc/postfix/sender_access
+smtp_auth:/usr/local/etc/postfix/smtp_auth

--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
@@ -88,6 +88,16 @@ smtpd_tls_cert_file = /usr/local/etc/postfix/cert_opn.pem
 smtpd_tls_CAfile = /usr/local/etc/postfix/ca_opn.pem
 {% endif %}
 
+{% if helpers.exists('OPNsense.postfix.general.relayhost') and OPNsense.postfix.general.relayhost != '' %}
+relayhost = {{ OPNsense.postfix.general.relayhost }}
+{% endif %}
+
+{% if helpers.exists('OPNsense.postfix.general.smtpauth_enabled') and OPNsense.postfix.general.smtpauth_enabled != '' %}
+smtp_sasl_auth_enable = yes  
+smtp_sasl_password_maps = hash:/usr/local/etc/postfix/smtp_auth  
+smtp_sasl_security_options = 
+{% endif %}
+
 {% if helpers.exists('OPNsense.postfix.antispam.enable_rspamd') and OPNsense.postfix.antispam.enable_rspamd == '1' %}
 smtpd_milters = inet:localhost:11332
 non_smtpd_milters = inet:localhost:11332

--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/smtp_auth
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/smtp_auth
@@ -1,0 +1,9 @@
+{% if helpers.exists('OPNsense.postfix.general.enabled') and OPNsense.postfix.general.enabled == '1' %}
+{%   if helpers.exists('OPNsense.postfix.general.smtpauth_enabled') and OPNsense.postfix.general.smtpauth_enabled == '1' %}
+{%     if helpers.exists('OPNsense.postfix.general.smtpauth_user') and OPNsense.postfix.general.smtpauth_user != '' %}
+{%       if helpers.exists('OPNsense.postfix.general.smtpauth_password') and OPNsense.postfix.general.smtpauth_password != '' %}
+{{ OPNsense.postfix.general.relayhost }} {{ OPNsense.postfix.general.smtpauth_user }}:{{ OPNsense.postfix.general.smtpauth_password }}
+{%       endif %}
+{%     endif %}
+{%   endif %}
+{% endif %}


### PR DESCRIPTION
- Add new field for relayhost / smarthost
- Add smtp authentication to authenticate local instance against a smarthost

Request from https://forum.opnsense.org/index.php?topic=7538.0