### PR TITLE
net/frr: cleaned up redistribute options

### DIFF
--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
@@ -22,10 +22,8 @@
                 <multiple>Y</multiple>
                 <default></default>
                 <OptionValues>
-                        <babel>Babel routing protocol (Babel)</babel>
                         <ospf>Open Shortest Path First (OSPF)</ospf>
                         <connected>Connected routes (directly attached subnet or host)</connected>
-                        <isis>Intermediate System to Intermediate System (IS-IS)</isis>
                         <kernel>Kernel routes (not installed via the zebra RIB)</kernel>
                         <rip>Routing Information Protocol (RIP)</rip>
                         <static>Statically configured routes</static>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF.xml
@@ -36,7 +36,6 @@
                         <bgp>Border Gateway Protocol (BGP)</bgp>
                         <connected>Connected routes (directly attached subnet or host)</connected>
                         <kernel>Kernel routes (not installed via the zebra RIB)</kernel>
-                        <ospf>Open Shortest Path First (OSPF)</ospf>
                         <rip>Routing Information Protocol (RIP)</rip>
                         <static>Statically configured routes</static>
                 </OptionValues>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF.xml
@@ -36,6 +36,7 @@
                         <bgp>Border Gateway Protocol (BGP)</bgp>
                         <connected>Connected routes (directly attached subnet or host)</connected>
                         <kernel>Kernel routes (not installed via the zebra RIB)</kernel>
+                        <ospf>Open Shortest Path First (OSPF)</ospf>
                         <rip>Routing Information Protocol (RIP)</rip>
                         <static>Statically configured routes</static>
                 </OptionValues>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF6.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF6.xml
@@ -13,6 +13,7 @@
                 <default></default>
                 <OptionValues>
                         <connected>Connected routes (directly attached subnet or host)</connected>
+                        <kernel>Kernel routes (not installed via the zebra RIB)</kernel>
                         <static>Statically configured routes</static>
                 </OptionValues>
         </redistribute>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/RIP.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/RIP.xml
@@ -32,12 +32,9 @@
                 <multiple>Y</multiple>
                 <default></default>
                 <OptionValues>
-                        <babel>Babel routing protocol (Babel)</babel>
                         <bgp>Border Gateway Protocol (BGP)</bgp>
                         <connected>Connected routes (directly attached subnet or host)</connected>
-                        <isis>Intermediate System to Intermediate System (IS-IS)</isis>
                         <kernel>Kernel routes (not installed via the zebra RIB)</kernel>
-                        <pim>Protocol Independent Multicast (PIM)</pim>
                         <ospf>Open Shortest Path First (OSPF)</ospf>
                         <static>Statically configured routes</static>
                 </OptionValues>


### PR DESCRIPTION
Fixes #607

Added missing options, removed invalid and non-implemented ones (Babel, PIM, IS-IS).