### PR TITLE
net/relayd: add PHPunit API controller tests

### DIFF
--- a/net/relayd/Makefile
+++ b/net/relayd/Makefile
@@ -1,6 +1,6 @@
 PLUGIN_NAME=		relayd
 PLUGIN_VERSION=		2.0.d
-PLUGIN_REVISION=	4
+PLUGIN_REVISION=	5
 PLUGIN_DEPENDS=		relayd
 PLUGIN_COMMENT=		Relayd Load Balancer
 PLUGIN_MAINTAINER=	frank.brendel@eurolog.com

--- a/net/relayd/src/opnsense/mvc/tests/app/compound/OPNsense/Relayd/RelaydTest.php
+++ b/net/relayd/src/opnsense/mvc/tests/app/compound/OPNsense/Relayd/RelaydTest.php
@@ -1,0 +1,453 @@
+<?php
+
+/**
+ *    Copyright (C) 2018 EURO-LOG AG
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+namespace tests\OPNsense\Relayd\Api;
+
+require_once("config.inc");
+
+use \OPNsense\Core\Config;
+
+class RelaydTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * list with model node types
+     */ 
+    private $nodeTypes = array('host', 'tablecheck', 'table', 'protocol', 'virtualserver');
+    
+    // holds the SettingsController object
+    protected static $setRelayd;
+    
+    public static function setUpBeforeClass()
+    {
+        self::$setRelayd = new \OPNsense\Relayd\Api\SettingsController;
+    }
+    
+    private function cleanupNodes($nodeType = null)
+    {
+        $nodes = self::$setRelayd->mdlRelayd->$nodeType->getNodes();
+        foreach ($nodes as $nodeUuid => $node) {
+            self::$setRelayd->mdlRelayd->$nodeType->del($nodeUuid);
+        }
+    }
+    
+    /**
+     * test getAction
+     */
+    public function testGet()
+    {
+        $this->assertInstanceOf('\OPNsense\Relayd\Api\SettingsController', self::$setRelayd);
+        $this->expectException(Exception);
+        $response = self::$setRelayd->getAction('wrong_node_type');
+        $testConfig = [];
+        $response = self::$setRelayd->getAction('general');
+        $testConfig['general'] = $response['relayd']['general'];
+
+        $this->assertEquals($response['result'], 'ok');
+        $this->assertArrayHasKey('enabled', $response['relayd']['general']);
+
+        return $testConfig;
+    }
+    
+    /**
+     * test searchAction
+     * @depends testGet
+     */
+    public function testSearch($testConfig)
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST = array('current' => '1', 'rowCount' => '7');
+        
+        foreach ($this->nodeTypes as $nodeType) {
+            $response = self::$setRelayd->searchAction($nodeType);
+            $this->assertArrayHasKey('total', $response);
+            $testConfig[$nodeType] = $response['rows'];
+        }
+        
+        return $testConfig;
+    }
+    
+    /**
+     * test delAction
+     * not really a test if the config is empty, but we will delete something later
+     * @depends testSearch
+     */
+    public function testReset($testConfig)
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        foreach (array_reverse($this->nodeTypes) as $nodeType) {
+            foreach ($testConfig[$nodeType] as $node) {
+                $response = self::$setRelayd->delAction($nodeType, $node['uuid']);
+                $this->assertEquals($response['result'], 'ok');
+            }
+        }
+        // need an assertion here to succeed this test on empty config
+        $this->assertTrue(true);
+    }
+    
+    /**
+     * test setAction general
+     * @depends testReset
+     */
+    public function testSetGeneral()
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        
+        // interval too small
+        $_POST = array('relayd' => ['general' => ['interval' => '0']]);
+        $response = self::$setRelayd->setAction('general');
+        $this->assertCount(1, $response['validations']);
+        $this->assertEquals($response['result'], 'failed');
+        $this->assertEquals($response['validations']['relayd.general.interval'], 'Check interval must be greater than 0');
+        
+        // set correct interval and incorrect timeout (s. testServiceController)
+        $_POST = array('relayd' => ['general' => ['interval' => '10', 'timeout' => 86400, 'enabled' => '0']]);
+        $response = self::$setRelayd->setAction('general');
+        $this->assertEquals($response['response'], "OK\n\n");
+    }
+    
+    /**
+     * test setAction for hosts
+     * @depends testReset
+     */
+    public function testSetHost()
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        
+        // empty host name
+        $_POST = array('relayd' => ['host' => ['address' => '127.0.0.1']]);
+        $response = self::$setRelayd->setAction('host');
+        $this->assertCount(1, $response['validations']);
+        $this->assertEquals($response['result'], 'failed');
+        $this->assertEquals($response['validations']['relayd.host.name'], 'Should be a string between 1 and 255 characters. Allowed characters are letters and numbers as well as underscore, minus, dot and space.');
+        $this->cleanupNodes('host');
+        
+        // check mask
+        $_POST = array('relayd' => ['host' => ['name' => 'test$Host', 'address' => '127.0.0.$']]);
+        $response = self::$setRelayd->setAction('host');
+        $this->assertCount(2, $response['validations']);
+        $this->assertEquals($response['result'], 'failed');
+        $this->assertEquals($response['validations']['relayd.host.name'], 'Should be a string between 1 and 255 characters. Allowed characters are letters and numbers as well as underscore, minus, dot and space.');
+        $this->assertEquals($response['validations']['relayd.host.address'], 'Please specify a valid servername or IP address.');
+        $this->cleanupNodes('host');
+        
+        // create host for ServiceControllerTest
+        $_POST = array('relayd' => ['host' => ['name' => 'testHost', 'address' => '127.0.0.1']]);
+        $response = self::$setRelayd->setAction('host');
+        $this->assertEquals($response['result'], 'ok');
+    }
+    
+    /**
+     * test setAction for tables
+     * @depends testSetHost
+     */
+    public function testSetTable()
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+
+        // check mask and missing host
+        $_POST = array('relayd' => ['table' => ['name' => 'test$Table', 'hosts' => 'aaa-111-bbb-222']]);
+        $response = self::$setRelayd->setAction('table');
+        $this->assertCount(2, $response['validations']);
+        $this->assertEquals($response['result'], 'failed');
+        $this->assertEquals($response['validations']['relayd.table.name'], 'Should be a string between 1 and 255 characters. Allowed characters are letters and numbers as well as underscore, minus, dot and space.');
+        $this->assertEquals($response['validations']['relayd.table.hosts'], 'Host not found');
+        $this->cleanupNodes('table');
+        
+        // create table for ServiceControllerTest
+        $_POST = array('current' => '1', 'rowCount' => '7', 'searchPhrase' => 'testHost');
+        $response = self::$setRelayd->searchAction('host');
+        $this->assertArrayHasKey('total', $response);
+        $_POST = array('relayd' => ['table' => ['name' => 'testTable', 'enabled' => 1, 'hosts' => $response['rows'][0]['uuid']]]);
+        $response = self::$setRelayd->setAction('table');
+     }
+    
+    /**
+     * test setAction for tablechecks
+     * @depends testSearch
+     * @depends testReset
+     */
+    public function testSetTableCheck()
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        
+        // wrong option
+        $_POST = array('relayd' => ['tablecheck' => ['name' => 'test$Check', 'type' => 'ABCXYZ']]);
+        $response = self::$setRelayd->setAction('tablecheck');
+        $this->assertCount(2, $response['validations']);
+        $this->assertEquals($response['result'], 'failed');
+        $this->assertEquals($response['validations']['relayd.tablecheck.name'], 'Should be a string between 1 and 255 characters. Allowed characters are letters and numbers as well as underscore, minus, dot and space.');
+        $this->assertEquals($response['validations']['relayd.tablecheck.type'], 'option not in list');
+        $this->cleanupNodes('tablecheck');
+        
+        // type 'send' without 'expect'
+        $_POST = array('relayd' => ['tablecheck' => ['name' => 'testSend', 'type' => 'send']]);
+        $response = self::$setRelayd->setAction('tablecheck');
+        $this->assertCount(1, $response['validations']);
+        $this->assertEquals($response['result'], 'failed');
+        $this->assertEquals($response['validations']['relayd.tablecheck.expect'], 'Expect Pattern cannot be empty.');
+        $this->cleanupNodes('tablecheck');
+        
+        // type 'script' without 'path'
+        $_POST = array('relayd' => ['tablecheck' => ['name' => 'testScript', 'type' => 'script']]);
+        $response = self::$setRelayd->setAction('tablecheck');
+        $this->assertCount(1, $response['validations']);
+        $this->assertEquals($response['result'], 'failed');
+        $this->assertEquals($response['validations']['relayd.tablecheck.path'], 'Script path cannot be empty.');
+        $this->cleanupNodes('tablecheck');
+        
+        // type 'http' without 'code' and 'digest'
+        $_POST = array('relayd' => ['tablecheck' => ['name' => 'testTableCheck', 'type' => 'http', 'path' => 'http://www.example.com']]);
+        $response = self::$setRelayd->setAction('tablecheck');
+        $this->assertCount(2, $response['validations']);
+        $this->assertEquals($response['result'], 'failed');
+        $this->assertEquals($response['validations']['relayd.tablecheck.code'], 'Provide one of Response Code or Message Digest.');
+        $this->assertEquals($response['validations']['relayd.tablecheck.digest'], 'Provide one of Response Code or Message Digest.');
+        $this->cleanupNodes('tablecheck');
+        
+        // create tablecheck for ServiceControllerTest
+        $_POST = array('relayd' => [
+            'tablecheck' => [
+                'name' => 'testTableCheck', 
+                'type' => 'http', 
+                'path' => '/',
+                'host' => 'localhost',
+                'code' => '403',
+                'ssl' => '1']]);
+        $response = self::$setRelayd->setAction('tablecheck');
+        $this->assertEquals($response['result'], 'ok');
+    }
+    
+    /**
+     * test setAction for protocols
+     * @depends testSearch
+     * @depends testReset
+     */
+    public function testSetProtocol()
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        
+        // missing 'name' wrong 'type'
+        $_POST = array('relayd' => ['protocol' => ['name' => 'test$Protocol', 'type' => 'ABCXYZ']]);
+        $response = self::$setRelayd->setAction('protocol');
+        $this->assertCount(2, $response['validations']);
+        $this->assertEquals($response['result'], 'failed');
+        $this->assertEquals($response['validations']['relayd.protocol.name'], 'Should be a string between 1 and 255 characters. Allowed characters are letters and numbers as well as underscore, minus, dot and space.');
+        $this->assertEquals($response['validations']['relayd.protocol.type'], 'option not in list');
+        $this->cleanupNodes('protocol');
+        
+        // create protocol for ServiceControllerTest
+        $_POST = array('relayd' => ['protocol' => ['name' => 'testProtocol', 'type' => 'tcp', 'options' => 'nodelay, socket buffer 65536']]);
+        $response = self::$setRelayd->setAction('protocol');
+        $this->assertEquals($response['result'], 'ok');
+    }
+    
+    /**
+     * test setAction for virtualservers
+     * @depends testSearch
+     * @depends testReset
+     */
+    public function testSetVirtualServer()
+    {   
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        
+        // search table and tablecheck
+        $_POST = array('current' => '1', 'rowCount' => '7', 'searchPhrase' => 'testTable');
+        $response = self::$setRelayd->searchAction('table');
+        $this->assertArrayHasKey('total', $response);
+        $tableUuid = $response['rows'][0]['uuid'];
+        $_POST = array('current' => '1', 'rowCount' => '7', 'searchPhrase' => 'testTableCheck');
+        $response = self::$setRelayd->searchAction('tablecheck');
+        $this->assertArrayHasKey('total', $response);
+        $tableCheckUuid = $response['rows'][0]['uuid'];
+        $_POST = array('current' => '1', 'rowCount' => '7', 'searchPhrase' => 'testProtocol');
+        $response = self::$setRelayd->searchAction('protocol');
+        $this->assertArrayHasKey('total', $response);
+        $protocolUuid = $response['rows'][0]['uuid'];
+        
+        // check mask, misisng table, tablecheck, wrong/missing listen port/address
+        $_POST = array('relayd' => [
+            'virtualserver' => [
+                'name' => 'test{}VirtualServer',
+                'listen_startport' => '123456',
+            ]]);
+        $response = self::$setRelayd->setAction('virtualserver');
+        $this->assertCount(5, $response['validations']);
+        $this->assertEquals($response['result'], 'failed');
+        $this->assertEquals($response['validations']['relayd.virtualserver.name'], 'Should be a string between 1 and 255 characters. Allowed characters are letters and numbers as well as underscore, minus, dot and space.');
+        $this->assertEquals($response['validations']['relayd.virtualserver.listen_address'], 'Please specify a valid servername or IP address.');
+        $this->assertEquals($response['validations']['relayd.virtualserver.listen_startport'], 'A valid Port number must be specified.');
+        $this->assertEquals($response['validations']['relayd.virtualserver.transport_table'], 'Table not found');
+        $this->assertEquals($response['validations']['relayd.virtualserver.transport_tablecheck'], 'Table check not found');
+        $this->cleanupNodes('virtualserver');
+        
+        // wrong tablemodes, missing ModelRelationField targets
+        $_POST = array('relayd' => [
+            'virtualserver' => [
+                'name' => 'testVirtualServer',
+                'listen_address' => '127.0.0.1',
+                'listen_startport' => '444',
+                'transport_table' => $tableUuid,
+                'transport_tablemode' => 'least-states',
+                'transport_tablecheck' => $tableCheckUuid,
+            ]]);
+        $response = self::$setRelayd->setAction('virtualserver');
+        $this->assertCount(1, $response['validations']);
+        $this->assertEquals($response['result'], 'failed');
+        $this->assertEquals($response['validations']['relayd.virtualserver.transport_tablemode'], 'Scheduler \'least-states\' not supported for relays.');
+        $this->cleanupNodes('virtualserver');
+        
+        // wron scheduler, missing protocol
+        $_POST = array('relayd' => [
+            'virtualserver' => [
+                'name' => 'testVirtualServer',
+                'type' => 'redirect',
+                'listen_address' => '127.0.0.1',
+                'listen_startport' => '444',
+                'transport_table' => $tableUuid,
+                'transport_tablemode' => 'least-states',
+                'transport_tablecheck' => $tableCheckUuid,
+                'backuptransport_table' => $tableUuid,
+                'backuptransport_tablemode' => 'random',
+                'backuptransport_tablecheck' => $tableCheckUuid,
+                'protocol' => 'aaa-bbb-123-456'
+            ]]);
+        $response = self::$setRelayd->setAction('virtualserver');
+        $this->assertCount(2, $response['validations']);
+        $this->assertEquals($response['result'], 'failed');
+        $this->assertEquals($response['validations']['relayd.virtualserver.backuptransport_tablemode'], 'Scheduler \'random\' not supported for redirects.');
+        $this->assertEquals($response['validations']['relayd.virtualserver.protocol'], 'Protocol not found');
+        $this->cleanupNodes('virtualserver');
+
+        // create virtualserver for ServiceControllerTest
+        $_POST = array('relayd' => [
+            'virtualserver' => [
+                'name' => 'testVirtualServer',
+                'enabled' => '1',
+                'listen_address' => '127.0.0.1',
+                'listen_startport' => '444',
+                'transport_table' => $tableUuid,
+                'transport_port' => '443',
+                'transport_tablecheck' => $tableCheckUuid,
+                'protocol' => $protocolUuid
+            ]]);
+        $response = self::$setRelayd->setAction('virtualserver');
+        $this->assertEquals($response['result'], 'ok');
+    }
+    
+    /**
+     * ServiceControllerTest
+     * @depends testSetGeneral
+     * @depends testSetHost
+     * @depends testSetTable
+     * @depends testSetTableCheck
+     * @depends testSetProtocol
+     * @depends testSetVirtualServer
+     */
+    public function testServiceController()
+    {
+        $svcRelayd = new \OPNsense\Relayd\Api\ServiceController;
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        
+        // generate template and test it by Relayd
+        $response = $svcRelayd->configtestAction();
+        $this->assertEquals($response['template'], 'OK');
+        $this->assertEquals($response['result'], "global timeout exceeds interval\ntable timeout exceeds interval: testTable:443");
+        $_POST = array('relayd' => ['general' => ['timeout' => '200']]);
+        $response = self::$setRelayd->setAction('general');
+        $this->assertEquals($response['result'], 'ok');
+        $response = $svcRelayd->configtestAction();
+        $this->assertEquals($response['template'], 'OK');
+        $this->assertEquals($response['result'], 'configuration OK');
+        
+        // status
+        $response = $svcRelayd->statusAction();
+        $this->assertEquals($response['status'], 'disabled');
+        
+        // enable
+        $_POST = array('relayd' => ['general' => ['enabled' => '1']]);
+        $response = self::$setRelayd->setAction('general');
+        $this->assertEquals($response['result'], 'ok');
+        
+        // reconfigure
+        $response = $svcRelayd->reconfigureAction();
+        $this->assertEquals($response['status'], 'ok');
+        
+        // start
+        $response = $svcRelayd->startAction();
+        $this->assertEquals($response['response'], "OK\n\n");
+        
+        // status
+        $response = $svcRelayd->statusAction();
+        $this->assertEquals($response['status'], 'running');
+        
+    }
+    
+    /**
+     * StatusControllerTest
+     * @depends testServiceController
+     */
+    public function testStatusController()
+    {
+        $statRelayd = new \OPNsense\Relayd\Api\StatusController;
+        $response = $statRelayd->sumAction();
+        $this->assertEquals($response['result'], 'ok');
+        $this->assertEquals($response['rows'][0]['type'], 'relay');
+        $this->assertEquals($response['rows'][0]['name'], 'testVirtualServer');
+        $this->assertEquals($response['rows'][0]['tables'][1]['name'], 'testTable:443');
+        $this->assertEquals($response['rows'][0]['tables'][1]['status'], 'active (1 hosts)');
+        $this->assertEquals($response['rows'][0]['tables'][1]['hosts'][1]['name'], '127.0.0.1');
+        
+        $response = $statRelayd->toggleAction('table', 1, 'disable');
+        $this->assertEquals($response['result'], 'ok');
+        $this->assertEquals($response['output'], 'command succeeded');
+    }
+    
+    /**
+     * cleanup config
+     * @depends testStatusController
+     */
+    public function testCleanup()
+    {
+        $svcRelayd = new \OPNsense\Relayd\Api\ServiceController;
+        $response = $svcRelayd->stopAction();
+        $this->assertEquals($response['response'], "OK\n\n");
+        
+        foreach (array_reverse($this->nodeTypes) as $nodeType) {
+            $this->cleanupNodes($nodeType);
+        }
+        
+        $general = self::$setRelayd->mdlRelayd->getNodeByReference('general');
+        $general->setNodes(array('enabled' => '0'));
+        
+        self::$setRelayd->mdlRelayd->serializeToConfig();
+        Config::getInstance()->save();
+        $this->assertTrue(true);
+    }
+}

--- a/net/relayd/src/opnsense/service/conf/actions.d/actions_relayd.conf
+++ b/net/relayd/src/opnsense/service/conf/actions.d/actions_relayd.conf
@@ -4,7 +4,7 @@ type:script
 message:starting relayd
 
 [stop]
-command:/usr/local/etc/rc.d/relayd stop
+command:/usr/local/etc/rc.d/relayd stop; exit 0
 type:script
 message:stopping relayd
 

--- a/net/relayd/src/opnsense/service/templates/OPNsense/Relayd/relayd.conf
+++ b/net/relayd/src/opnsense/service/templates/OPNsense/Relayd/relayd.conf
@@ -38,8 +38,8 @@ table <{{ name }}>{{ disable }} {
 
 {% if helpers.exists('OPNsense.relayd.protocol') %}
 {%  for protocol in helpers.toList('OPNsense.relayd.protocol') %}
-{{ protocol.type }} protocol "{{protocol.name}}" {
-{{ protocol.options }}
+protocol "{{protocol.name}}" {
+{{ protocol.type }} { {{ protocol.options }} }
 }
 {%  endfor %}
 {% endif %}


### PR DESCRIPTION
This PR adds PHPunit tests for the plugin API controllers.
And it fixes some potential bugs that came up during testing. :slightly_smiling_face: 
The SettingsController uses a single model object now to avoid caching problems.

#### Running the tests
1. install PHPunit
   `# pkg install phpunit6-php71`
2. run phpunit
   :bangbang: The test will purge the relayd configuration. :bangbang:
   `# phpunit /usr/local/opnsense/mvc/tests/app/compound/OPNsense/Relayd/RelaydTest.php`

