### PR TITLE
Remove wrong class for HTTP(S) settings

### DIFF
--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogFrontend.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogFrontend.xml
@@ -200,7 +200,7 @@
     <field>
         <label>HTTP(S) settings</label>
         <type>header</type>
-        <style>mode_table table_http table_ssl</style>
+        <style>mode_table table_http</style>
     </field>
     <field>
         <id>frontend.forwardFor</id>


### PR DESCRIPTION
The section is not visible when the dialog is first loaded. Only after switching from http to SSL(TCP) or TCP and back made the option visible.

As of the moment there it only one option in this section and it is related to http mode.
Using it in SSL (TCP) mode does not work:
```[WARNING] 130/221244 (37870) : config : 'option forwardfor' ignored for frontend '<FE>' as it requires HTTP mode.```

Therefore the easiest option seems to remove the unnecessary class from the view.

Best regards,
Fabian