### PR TITLE
FreeRadius: Fix help message on User dialog

### DIFF
--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/dialogEditFreeRADIUSUser.xml
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/dialogEditFreeRADIUSUser.xml
@@ -3,19 +3,19 @@
         <id>user.enabled</id>
         <label>Enabled</label>
         <type>checkbox</type>
-        <help>This will enable or disable the user account. Allowed characters are 0-9, a-z, A-Z, and ._-</help>
+        <help>This will enable or disable the user account.</help>
     </field>
     <field>
         <id>user.username</id>
         <label>Username</label>
         <type>text</type>
-        <help>Set the unique username for the user. Allowed characters are 0-9, a-z, A-Z, and ,._-!$%/()+#= with up to 128 characters.</help>
+        <help>Set the unique username for the user. Allowed characters are 0-9, a-z, A-Z, and ._-</help>
     </field>
     <field>
         <id>user.password</id>
         <label>Password</label>
         <type>password</type>
-        <help>Set the password for the user.</help>
+        <help>Set the password for the user. Allowed characters are 0-9, a-z, A-Z, and ,._-!$%/()+#= with up to 128 characters.</help>
     </field>
     <field>
         <id>user.description</id>


### PR DESCRIPTION
The help message on the Freeradius User form is off for the enabled, username and password fields.
Username and Password have regex mask validation patterns, but the help message was placed on the wrong field.
Fixed this by moving the 'Allowed characters' text to the correct help field.