### PR TITLE
security/acme-client: Add the ability to specify domain key length

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogCertificate.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogCertificate.xml
@@ -39,6 +39,12 @@
         <help><![CDATA[Set the Let's Encrypt validation method for this certificate.]]></help>
     </field>
     <field>
+        <id>certificate.keyLength</id>
+        <label>Key Length</label>
+        <type>dropdown</type>
+        <help><![CDATA[Specify the domain key length: 2048, 3072, 4096, 8192 or ec-256, ec-384.]]></help>
+    </field>
+    <field>
         <id>certificate.restartActions</id>
         <label>Restart Actions</label>
         <type>select_multiple</type>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -205,6 +205,17 @@
                     <multiple>N</multiple>
                     <Required>Y</Required>
                 </validationMethod>
+                <keyLength type="OptionField">
+                    <Required>Y</Required>
+                    <default>key_4096</default>
+                    <OptionValues>
+                        <key_2048>2048 bit</key_2048>
+                        <key_3072>3072 bit</key_3072>
+                        <key_4096>4096 bit</key_4096>
+                        <key_ec256>ec-256</key_ec256>
+                        <key_ec384>ec-384</key_ec384>
+                    </OptionValues>
+                </keyLength>
                 <restartActions type="ModelRelationField">
                     <Model>
                         <actions>

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -828,7 +828,6 @@ function revoke_cert($certObj, $valObj, $acctObj)
       . "--revoke "
       . "--domain " . (string)$certObj->name . " "
       . "--home /var/etc/acme-client/home "
-      . "--keylength 4096 "
       . "--accountconf " . $account_conf_file . " "
       . $ecc_param;
     //echo "DEBUG: executing command: " . $acmecmd . "\n";

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -740,6 +740,13 @@ function run_acme_validation($certObj, $valObj, $acctObj)
     // Teach acme.sh about DNS API hook location
     $proc_env['_SCRIPT_HOME'] = '/usr/local/share/examples/acme.sh';
 
+    // Get the chosen key length from xml and trim the parameter before passing to acme client
+    $key_length = (string) $certObj->keyLength;
+    $key_length = substr($key_length, 4 );
+    if($key_length == 'ec256' || $key_length == 'ec384') {
+        $key_length = substr_replace($key_length, '-', 2,0);
+    }
+
     // Run acme client
     // NOTE: We "export" certificates to our own directory, so we don't have to deal
     // with domain names in filesystem, but instead can use the ID of our certObj.
@@ -750,7 +757,7 @@ function run_acme_validation($certObj, $valObj, $acctObj)
       . $altnames
       . $acme_validation . " "
       . "--home /var/etc/acme-client/home "
-      . "--keylength 4096 "
+      . "--keylength " . $key_length . " " 
       . "--accountconf " . $account_conf_file . " "
       . "--certpath ${cert_filename} "
       . "--keypath ${key_filename} "
@@ -806,6 +813,13 @@ function revoke_cert($certObj, $valObj, $acctObj)
     // Generate certificate filenames
     $cert_id = (string)$certObj->id;
 
+    // Check if EC certificate is used, if yes add the --ecc parameter to acme client
+    $key_length = (string) $certObj->keyLength;
+    $ecc_param =  " ";
+    if($key_length == 'key_ec256' || $key_length == 'key_ec384') {
+        $ecc_param =  "--ecc";
+    }
+
     // Run acme client
     // NOTE: We "export" certificates to our own directory, so we don't have to deal
     // with domain names in filesystem, but instead can use the ID of our certObj.
@@ -815,7 +829,8 @@ function revoke_cert($certObj, $valObj, $acctObj)
       . "--domain " . (string)$certObj->name . " "
       . "--home /var/etc/acme-client/home "
       . "--keylength 4096 "
-      . "--accountconf " . $account_conf_file;
+      . "--accountconf " . $account_conf_file . " "
+      . $ecc_param;
     //echo "DEBUG: executing command: " . $acmecmd . "\n";
     $result = mwexec($acmecmd);
 


### PR DESCRIPTION
Hello, 

I made few changes to add domain key length field to the GUI, giving the user the ability to specify the desired key length.

Also deleting --keylength paramter from acme client on revoke as it's not needed because the script will seek the cert installation path.

I tested on many scenarios and it's working properly.