### PR TITLE
security/acme-client: fix node no longer exists error

### DIFF
--- a/security/acme-client/Makefile
+++ b/security/acme-client/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		acme-client
-PLUGIN_VERSION=		1.14
+PLUGIN_VERSION=		1.15
 PLUGIN_COMMENT=		Let's Encrypt client
 PLUGIN_MAINTAINER=	opnsense@moov.de
 PLUGIN_DEPENDS=		acme.sh bind911


### PR DESCRIPTION
Fixes #333.

This workaround solved the issue in an artificial test scenario. Let's hope it fixes this annoyance for everyone.