### PR TITLE
add All-Inkl.com to DynDns services

### DIFF
--- a/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns.inc
+++ b/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns.inc
@@ -132,6 +132,7 @@ function dyndns_list()
         'selfhost' => 'SelfHost',
         'strato' => 'STRATO',
         'zoneedit' => 'ZoneEdit',
+        'all-inkl' => 'All-Inkl.com',
     );
 }
 


### PR DESCRIPTION
All-Inkl is one of the biggest european providers and offers a DynDns service. The code was tested extensively and checks the result for its correctness. The code is a fork from https://github.com/pfsense/pfsense/pull/3223