### PR TITLE
security/acme-client: add support to multiple dns api providers

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -21,7 +21,7 @@
         <id>validation.method</id>
         <label>Challenge Type</label>
         <type>dropdown</type>
-        <help><![CDATA[Set the Let's Encrypt challenge type. You'll have to add configuration for the selected challenge type below.]]></help>
+        <help>Set the Let's Encrypt challenge type. You'll have to add configuration for the selected challenge type below.</help>
     </field>
     <field>
         <label>HTTP-01</label>
@@ -92,7 +92,7 @@
         <id>validation.dns_sleep</id>
         <label>Sleep Time</label>
         <type>text</type>
-        <help><![CDATA[The time in seconds to wait for all the TXT records to take effect after adding them to the DNS API. Defaults to 120 seconds.]]></help>
+        <help>The time in seconds to wait for all the TXT records to take effect after adding them to the DNS API. Defaults to 120 seconds.</help>
     </field>
     <field>
         <label>Alwaysdata</label>
@@ -258,7 +258,7 @@
         <id>validation.dns_da_insecure</id>
         <label>Disable SSL Verification</label>
         <type>checkbox</type>
-        <help><![CDATA[Uncheck this box if you have a valid SSL certificate for your DirectAdmin installation]]></help>
+        <help>Uncheck this box if you have a valid SSL certificate for your DirectAdmin installation.</help>
     </field>
     <field>
         <label>DigitalOcean</label>
@@ -279,7 +279,7 @@
         <id>validation.dns_dnsimple_token</id>
         <label>OAuth Token</label>
         <type>text</type>
-        <help><![CDATA[Note that this is the account token not the user token.]]></help>
+        <help>Note that this is the account token not the user token.</help>
     </field>
     <field>
         <label>Domain-Offensive</label>
@@ -477,7 +477,7 @@
         <id>validation.dns_ispconfig_insecure</id>
         <label>Disable SSL Verification</label>
         <type>checkbox</type>
-        <help><![CDATA[Uncheck this box if you have a valid SSL certificate for your ISPConfig installation]]></help>
+        <help>Uncheck this box if you have a valid SSL certificate for your ISPConfig installation.</help>
     </field>
     <field>
         <label>KingHost</label>
@@ -503,13 +503,13 @@
         <id>validation.dns_knot_server</id>
         <label>Server</label>
         <type>text</type>
-        <help><![CDATA[Knot server address, like: dns.example.com]]></help>
+        <help>Knot server address, like: dns.example.com</help>
     </field>
     <field>
         <id>validation.dns_knot_key</id>
         <label>Key</label>
         <type>text</type>
-        <help><![CDATA[Specify the location of the generated TSIG Key inside the TSIG file using grep and cut, example: grep \# /etc/knot/acme.key | cut -d' ' -f2 ]]></help>
+        <help>Specify the location of the generated TSIG Key inside the TSIG file using grep and cut, example: grep \# /etc/knot/acme.key | cut -d' ' -f2</help>
     </field>
     <field>
         <label>lexicon</label>
@@ -620,7 +620,7 @@
         <id>validation.dns_nsupdate_key</id>
         <label>Secret Key</label>
         <type>textbox</type>
-        <help><![CDATA[Requires the the whole key file in a format that is compatible with nsupdate.]]></help>
+        <help>Requires the whole key file in a format that is compatible with nsupdate.</help>
     </field>
     <field>
         <label>OVH</label>
@@ -657,13 +657,13 @@
         <id>validation.dns_pdns_url</id>
         <label>URL</label>
         <type>text</type>
-        <help><![CDATA[Specify the URL for your PowerDNS server, i.e. http://ns.example.com:8081.]]></help>
+        <help>Specify the URL for your PowerDNS server, i.e. http://ns.example.com:8081.</help>
     </field>
     <field>
         <id>validation.dns_pdns_serverid</id>
         <label>Server ID</label>
         <type>text</type>
-        <help><![CDATA[Specify the Server ID of your PowerDNS server, i.e. localhost.]]></help>
+        <help>Specify the Server ID of your PowerDNS server, i.e. localhost.</help>
     </field>
     <field>
         <id>validation.dns_pdns_token</id>

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -120,6 +120,26 @@
         <type>text</type>
     </field>
     <field>
+        <label>autoDNS (InternetX)</label>
+        <type>header</type>
+        <style>table_dns table_dns_autodns</style>
+    </field>
+    <field>
+        <id>validation.dns_autodns_user</id>
+        <label>User</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_autodns_password</id>
+        <label>Password</label>
+        <type>password</type>
+    </field>
+    <field>
+        <id>validation.dns_autodns_context</id>
+        <label>Context</label>
+        <type>text</type>
+    </field>
+    <field>
         <label>AWS Route53</label>
         <type>header</type>
         <style>table_dns table_dns_aws</style>
@@ -132,6 +152,31 @@
     <field>
         <id>validation.dns_aws_secret</id>
         <label>AWS Secret</label>
+        <type>text</type>
+    </field>
+    <field>
+        <label>Azure DNS</label>
+        <type>header</type>
+        <style>table_dns table_dns_azure</style>
+    </field>
+    <field>
+        <id>validation.dns_azuredns_subscriptionid</id>
+        <label>Subscription ID</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_azuredns_tenantid</id>
+        <label>Tenant ID</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_azuredns_appid</id>
+        <label>APP ID</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_azuredns_clientsecret</id>
+        <label>Client Secret</label>
         <type>text</type>
     </field>
     <field>
@@ -200,6 +245,21 @@
         <type>password</type>
     </field>
     <field>
+        <label>DirectAdmin</label>
+        <type>header</type>
+        <style>table_dns table_dns_da</style>
+    </field>
+    <field>
+        <id>validation.dns_da_key</id>
+        <label>API Key</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_da_insecure</id>
+        <label>Disable SSL Verification</label>
+        <type>checkbox</type>
+    </field>
+    <field>
         <label>DigitalOcean</label>
         <type>header</type>
         <style>table_dns table_dns_dgon</style>
@@ -247,6 +307,16 @@
     <field>
         <id>validation.dns_dp_key</id>
         <label>Key</label>
+        <type>text</type>
+    </field>
+    <field>
+        <label>DreamHost</label>
+        <type>header</type>
+        <style>table_dns table_dns_dreamhost</style>
+    </field>
+    <field>
+        <id>validation.dns_dh_key</id>
+        <label>API Key</label>
         <type>text</type>
     </field>
     <field>
@@ -367,6 +437,21 @@
         <help>Enter either the IP address or FQDN of your Infoblox appliance.</help>
     </field>
     <field>
+        <label>INWX</label>
+        <type>header</type>
+        <style>table_dns table_dns_inwx</style>
+    </field>
+    <field>
+        <id>validation.dns_inwx_user</id>
+        <label>User</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_inws_password</id>
+        <label>Password</label>
+        <type>password</type>
+    </field>
+    <field>
         <label>IPSConfig</label>
         <type>header</type>
         <style>table_dns table_dns_ispconfig</style>
@@ -390,6 +475,36 @@
         <id>validation.dns_ispconfig_insecure</id>
         <label>Disable SSL Verification</label>
         <type>checkbox</type>
+    </field>
+    <field>
+        <label>KingHost</label>
+        <type>header</type>
+        <style>table_dns table_dns_kinghost</style>
+    </field>
+    <field>
+        <id>validation.dns_kinghost_username</id>
+        <label>Username</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_kinghost_password</id>
+        <label>Password</label>
+        <type>password</type>
+    </field>
+    <field>
+        <label>Knot</label>
+        <type>header</type>
+        <style>table_dns table_dns_knot</style>
+    </field>
+    <field>
+        <id>validation.dns_knot_server</id>
+        <label>Server</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_knot_key</id>
+        <label>Key</label>
+        <type>text</type>
     </field>
     <field>
         <label>lexicon</label>
@@ -467,6 +582,16 @@
         <type>text</type>
     </field>
     <field>
+        <label>Namesilo</label>
+        <type>header</type>
+        <style>table_dns table_dns_namesilo</style>
+    </field>
+    <field>
+        <id>validation.dns_namesilo_key</id>
+        <label>Key</label>
+        <type>text</type>
+    </field>
+    <field>
         <label>NS1.com</label>
         <type>header</type>
         <style>table_dns table_dns_nsone</style>
@@ -541,6 +666,46 @@
         <type>text</type>
     </field>
     <field>
+        <label>selectel</label>
+        <type>header</type>
+        <style>table_dns table_dns_selectel</style>
+    </field>
+    <field>
+        <id>validation.dns_sl_key</id>
+        <label>API Key</label>
+        <type>text</type>
+    </field>
+    <field>
+        <label>Servercow</label>
+        <type>header</type>
+        <style>table_dns table_dns_servercow</style>
+    </field>
+    <field>
+        <id>validation.dns_servercow_username</id>
+        <label>Username</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_servercow_password</id>
+        <label>Password</label>
+        <type>password</type>
+    </field>
+    <field>
+        <label>UnoEuro</label>
+        <type>header</type>
+        <style>table_dns table_dns_unoeuro</style>
+    </field>
+    <field>
+        <id>validation.dns_uno_key</id>
+        <label>API Key</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_uno_user</id>
+        <label>User</label>
+        <type>text</type>
+    </field>
+    <field>
         <label>Vscale</label>
         <type>header</type>
         <style>table_dns table_dns_vscale</style>
@@ -558,6 +723,26 @@
     <field>
         <id>validation.dns_yandex_token</id>
         <label>API Token</label>
+        <type>text</type>
+    </field>
+    <field>
+        <label>Zilore</label>
+        <type>header</type>
+        <style>table_dns table_dns_zilore</style>
+    </field>
+    <field>
+        <id>validation.dns_zilore_key</id>
+        <label>API Key</label>
+        <type>text</type>
+    </field>
+    <field>
+        <label>zonomi.com</label>
+        <type>header</type>
+        <style>table_dns table_dns_zonomi</style>
+    </field>
+    <field>
+        <id>validation.dns_zm_key</id>
+        <label>API Key</label>
         <type>text</type>
     </field>
 </form>

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -258,6 +258,7 @@
         <id>validation.dns_da_insecure</id>
         <label>Disable SSL Verification</label>
         <type>checkbox</type>
+        <help><![CDATA[Uncheck this box if you have a valid SSL certificate for your DirectAdmin installation]]></help>
     </field>
     <field>
         <label>DigitalOcean</label>
@@ -278,6 +279,7 @@
         <id>validation.dns_dnsimple_token</id>
         <label>OAuth Token</label>
         <type>text</type>
+        <help><![CDATA[Note that this is the account token not the user token.]]></help>
     </field>
     <field>
         <label>Domain-Offensive</label>
@@ -475,6 +477,7 @@
         <id>validation.dns_ispconfig_insecure</id>
         <label>Disable SSL Verification</label>
         <type>checkbox</type>
+        <help><![CDATA[Uncheck this box if you have a valid SSL certificate for your ISPConfig installation]]></help>
     </field>
     <field>
         <label>KingHost</label>
@@ -500,11 +503,13 @@
         <id>validation.dns_knot_server</id>
         <label>Server</label>
         <type>text</type>
+        <help><![CDATA[Knot server address, like: dns.example.com]]></help>
     </field>
     <field>
         <id>validation.dns_knot_key</id>
         <label>Key</label>
         <type>text</type>
+        <help><![CDATA[Specify the location of the generated TSIG Key inside the TSIG file using grep and cut, example: grep \# /etc/knot/acme.key | cut -d' ' -f2 ]]></help>
     </field>
     <field>
         <label>lexicon</label>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -338,16 +338,19 @@
                     <OptionValues>
                         <dns_ad>Alwaysdata.com API</dns_ad>
                         <dns_ali>aliyun.com API</dns_ali>
+                        <dns_autodns>autoDNS (InternetX) API</dns_autodns>
                         <dns_aws>AWS Route 53</dns_aws>
+                        <dns_azure>Azure DNS API</dns_azure>
                         <dns_cf>CloudFlare.com API</dns_cf>
                         <dns_cloudns>ClouDNS API</dns_cloudns>
                         <dns_cx>CloudXNS.com API</dns_cx>
                         <dns_cyon>cyon.ch API</dns_cyon>
+                        <dns_da>DirectAdmin API</dns_da>
                         <dns_dgon>DigitalOcean API</dns_dgon>
                         <dns_dnsimple>DNSimple API</dns_dnsimple>
-                        <dns_me>DNSMadeEasy.com API</dns_me>
                         <dns_do>Domain-Offensive/Resellerinterface/Domainrobot API</dns_do>
                         <dns_dp>DNSPod.cn API</dns_dp>
+                        <dns_dreamhost>DreamHost DNS API</dns_dreamhost>
                         <dns_duckdns>DuckDNS API</dns_duckdns>
                         <dns_dyn>Dyn Managed DNS API</dns_dyn>
                         <dns_dynu>Dynu API</dns_dynu>
@@ -356,17 +359,27 @@
                         <dns_gd>GoDaddy.com API</dns_gd>
                         <dns_he>Hurricane Electric</dns_he>
                         <dns_infoblox>Infoblox API</dns_infoblox>
+                        <dns_inwx>INWX XMLRPC API</dns_inwx>
                         <dns_ispconfig>ISPConfig 3.1+ API</dns_ispconfig>
+                        <dns_kinghost>KingHost DNS API</dns_kinghost>
+                        <dns_knot>Knot (knsupdate) DNS API</dns_knot>
                         <dns_lexicon>lexicon DNS API</dns_lexicon>
                         <dns_linode>Linode API</dns_linode>
                         <dns_lua>LuaDNS.com API</dns_lua>
+                        <dns_me>DNSMadeEasy.com API</dns_me>
                         <dns_namecom>Name.com API</dns_namecom>
+                        <dns_namesilo>Namesilo.com API</dns_namesilo>
                         <dns_nsone>NS1.com API</dns_nsone>
                         <dns_nsupdate>nsupdate (RFC 2136)</dns_nsupdate>
                         <dns_ovh>OVH, kimsufi, soyoustart and runabove API</dns_ovh>
                         <dns_pdns>PowerDNS.com API</dns_pdns>
+                        <dns_selectel>selectel.com / selectel.ru domain API</dns_selectel>
+                        <dns_servercow>Servercow API v1</dns_servercow>
+                        <dns_unoeuro>UnoEuro API</dns_unoeuro>
                         <dns_vscale>Vscale API</dns_vscale>
                         <dns_yandex>Yandex PDD API</dns_yandex>
+                        <dns_zilore>Zilore DNS API</dns_zilore>
+                        <dns_zonomi>zonomi.com domain API</dns_zonomi>
                     </OptionValues>
                 </dns_service>
                 <dns_sleep type="IntegerField">
@@ -385,12 +398,33 @@
                 <dns_ali_secret type="TextField">
                     <Required>N</Required>
                 </dns_ali_secret>
+                <dns_autodns_user type="TextField">
+                    <Required>N</Required>
+                </dns_autodns_user>
+                <dns_autodns_password type="TextField">
+                    <Required>N</Required>
+                </dns_autodns_password>
+                <dns_autodns_context type="TextField">
+                    <Required>N</Required>
+                </dns_autodns_context>
                 <dns_aws_id type="TextField">
                     <Required>N</Required>
                 </dns_aws_id>
                 <dns_aws_secret type="TextField">
                     <Required>N</Required>
                 </dns_aws_secret>
+                <dns_azuredns_subscriptionid type="TextField">
+                    <Required>N</Required>
+                </dns_azuredns_subscriptionid>
+                <dns_azuredns_tenantid type="TextField">
+                    <Required>N</Required>
+                </dns_azuredns_tenantid>
+                <dns_azuredns_appid type="TextField">
+                    <Required>N</Required>
+                </dns_azuredns_appid>
+                <dns_azuredns_clientsecret type="TextField">
+                    <Required>N</Required>
+                </dns_azuredns_clientsecret>
                 <dns_cf_email type="TextField">
                     <Required>N</Required>
                 </dns_cf_email>
@@ -418,6 +452,13 @@
                 <dns_cyon_password type="TextField">
                   <Required>N</Required>
                 </dns_cyon_password>
+                <dns_da_key type="TextField">
+                    <Required>N</Required>
+                </dns_da_key>
+                <dns_da_insecure type="BooleanField">
+                    <Required>N</Required>
+                    <default>1</default>
+                </dns_da_insecure>
                 <dns_dgon_key type="TextField">
                   <Required>N</Required>
                 </dns_dgon_key>
@@ -436,6 +477,9 @@
                 <dns_dp_key type="TextField">
                     <Required>N</Required>
                 </dns_dp_key>
+                <dns_dh_key type="TextField">
+                    <Required>N</Required>
+                </dns_dh_key>
                 <dns_duckdns_token type="TextField">
                     <Required>N</Required>
                 </dns_duckdns_token>
@@ -481,6 +525,12 @@
                 <dns_infoblox_server type="TextField">
                     <Required>N</Required>
                 </dns_infoblox_server>
+                <dns_inwx_user type="TextField">
+                    <Required>N</Required>
+                </dns_inwx_user>
+                <dns_inws_password type="TextField">
+                    <Required>N</Required>
+                </dns_inws_password>
                 <dns_ispconfig_user type="TextField">
                     <Required>N</Required>
                 </dns_ispconfig_user>
@@ -494,6 +544,18 @@
                     <Required>N</Required>
                     <default>1</default>
                 </dns_ispconfig_insecure>
+                <dns_kinghost_username type="TextField">
+                    <Required>N</Required>
+                </dns_kinghost_username>
+                <dns_kinghost_password type="TextField">
+                    <Required>N</Required>
+                </dns_kinghost_password>
+                <dns_knot_server type="TextField">
+                    <Required>N</Required>
+                </dns_knot_server>
+                <dns_knot_key type="TextField">
+                    <Required>N</Required>
+                </dns_knot_key>
                 <dns_lexicon_provider type="OptionField">
                     <Required>N</Required>
                     <default>cloudflare</default>
@@ -529,6 +591,9 @@
                 <dns_namecom_token type="TextField">
                     <Required>N</Required>
                 </dns_namecom_token>
+                <dns_namesilo_key type="TextField">
+                    <Required>N</Required>
+                </dns_namesilo_key>
                 <dns_nsone_key type="TextField">
                     <Required>N</Required>
                 </dns_nsone_key>
@@ -560,12 +625,33 @@
                 <dns_pdns_token type="TextField">
                     <Required>N</Required>
                 </dns_pdns_token>
+                <dns_sl_key type="TextField">
+                    <Required>N</Required>
+                </dns_sl_key>
+                <dns_servercow_username type="TextField">
+                    <Required>N</Required>
+                </dns_servercow_username>
+                <dns_servercow_password type="TextField">
+                    <Required>N</Required>
+                </dns_servercow_password>
+                <dns_uno_key type="TextField">
+                    <Required>N</Required>
+                </dns_uno_key>
+                <dns_uno_user type="TextField">
+                    <Required>N</Required>
+                </dns_uno_user>
                 <dns_vscale_key type="TextField">
                     <Required>N</Required>
                 </dns_vscale_key>
                 <dns_yandex_token type="TextField">
                     <Required>N</Required>
                 </dns_yandex_token>
+                <dns_zilore_key type="TextField">
+                    <Required>N</Required>
+                </dns_zilore_key>
+                <dns_zm_key type="TextField">
+                    <Required>N</Required>
+                </dns_zm_key>
             </validation>
         </validations>
         <actions>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -348,8 +348,9 @@
                         <dns_da>DirectAdmin API</dns_da>
                         <dns_dgon>DigitalOcean API</dns_dgon>
                         <dns_dnsimple>DNSimple API</dns_dnsimple>
-                        <dns_do>Domain-Offensive/Resellerinterface/Domainrobot API</dns_do>
+                        <dns_me>DNSMadeEasy.com API</dns_me>
                         <dns_dp>DNSPod.cn API</dns_dp>
+                        <dns_do>Domain-Offensive/Resellerinterface/Domainrobot API</dns_do>
                         <dns_dreamhost>DreamHost DNS API</dns_dreamhost>
                         <dns_duckdns>DuckDNS API</dns_duckdns>
                         <dns_dyn>Dyn Managed DNS API</dns_dyn>
@@ -366,7 +367,6 @@
                         <dns_lexicon>lexicon DNS API</dns_lexicon>
                         <dns_linode>Linode API</dns_linode>
                         <dns_lua>LuaDNS.com API</dns_lua>
-                        <dns_me>DNSMadeEasy.com API</dns_me>
                         <dns_namecom>Name.com API</dns_namecom>
                         <dns_namesilo>Namesilo.com API</dns_namesilo>
                         <dns_nsone>NS1.com API</dns_nsone>

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -600,9 +600,20 @@ function run_acme_validation($certObj, $valObj, $acctObj)
                 $proc_env['Ali_Key'] = (string)$valObj->dns_ali_key;
                 $proc_env['Ali_Secret'] = (string)$valObj->dns_ali_secret;
                 break;
+            case 'dns_autodns':
+                $proc_env['AUTODNS_USER'] = (string)$valObj->dns_autodns_user;
+                $proc_env['AUTODNS_PASSWORD'] = (string)$valObj->dns_autodns_password;
+                $proc_env['AUTODNS_CONTEXT'] = (string)$valObj->dns_autodns_context;
+                break;
             case 'dns_aws':
                 $proc_env['AWS_ACCESS_KEY_ID'] = (string)$valObj->dns_aws_id;
                 $proc_env['AWS_SECRET_ACCESS_KEY'] = (string)$valObj->dns_aws_secret;
+                break;
+            case 'dns_azure':
+                $proc_env['AZUREDNS_SUBSCRIPTIONID'] = (string)$valObj->dns_azuredns_subscriptionid;
+                $proc_env['AZUREDNS_TENANTID'] = (string)$valObj->dns_azuredns_tenantid;
+                $proc_env['AZUREDNS_APPID'] = (string)$valObj->dns_azuredns_appid;
+                $proc_env['AZUREDNS_CLIENTSECRET'] = (string)$valObj->dns_azuredns_clientsecret;
                 break;
             case 'dns_cf':
                 $proc_env['CF_Key'] = (string)$valObj->dns_cf_key;
@@ -621,6 +632,10 @@ function run_acme_validation($certObj, $valObj, $acctObj)
                 $proc_env['CY_Username'] = (string)$valObj->dns_cyon_user;
                 $proc_env['CY_Password'] = (string)$valObj->dns_cyon_user;
                 break;
+            case 'dns_da':
+                $proc_env['DA_Api'] = (string)$valObj->dns_da_key;
+                $proc_env['DA_Api_Insecure'] = (string)$valObj->dns_da_insecure;
+                break;
             case 'dns_dgon':
                 $proc_env['DO_API_KEY'] = (string)$valObj->dns_dgon_key;
                 break;
@@ -634,6 +649,9 @@ function run_acme_validation($certObj, $valObj, $acctObj)
             case 'dns_dp':
                 $proc_env['DP_Id'] = (string)$valObj->dns_dp_id;
                 $proc_env['DP_Key'] = (string)$valObj->dns_dp_key;
+                break;
+            case 'dns_dreamhost':
+                $proc_env['DH_API_KEY'] = (string)$valObj->dns_dh_key;
                 break;
             case 'dns_duckdns':
                 $proc_env['DuckDNS_Token'] = (string)$valObj->dns_duckdns_token;
@@ -666,11 +684,23 @@ function run_acme_validation($certObj, $valObj, $acctObj)
                 $proc_env['Infoblox_Creds'] = (string)$valObj->dns_infoblox_credentials;
                 $proc_env['Infoblox_Server'] = (string)$valObj->dns_infoblox_server;
                 break;
+            case 'dns_inwx':
+                $proc_env['INWX_User'] = (string)$valObj->dns_inwx_user;
+                $proc_env['INWX_Password'] = (string)$valObj->dns_inws_password;
+                break;
             case 'dns_ispconfig':
                 $proc_env['ISPC_User'] = (string)$valObj->dns_ispconfig_user;
                 $proc_env['ISPC_Password'] = (string)$valObj->dns_ispconfig_password;
                 $proc_env['ISPC_Api'] = (string)$valObj->dns_ispconfig_api;
                 $proc_env['ISPC_Api_Insecure'] = (string)$valObj->dns_ispconfig_insecure;
+                break;
+            case 'dns_kinghost':
+                $proc_env['KINGHOST_username'] = (string)$valObj->dns_kinghost_username;
+                $proc_env['KINGHOST_Password'] = (string)$valObj->dns_kinghost_password;
+                break;
+            case 'dns_knot':
+                $proc_env['KNOT_SERVER'] = (string)$valObj->dns_knot_server;
+                $proc_env['KNOT_KEY'] = (string)$valObj->dns_knot_key;
                 break;
             case 'dns_lexicon':
                 $proc_env['PROVIDER'] = (string)$valObj->dns_lexicon_provider;
@@ -699,6 +729,11 @@ function run_acme_validation($certObj, $valObj, $acctObj)
                 $proc_env['Namecom_Username'] = (string)$valObj->dns_namecom_user;
                 $proc_env['Namecom_Token'] = (string)$valObj->dns_namecom_token;
                 break;
+            case 'dns_namesilo':
+                $proc_env['Namesilo_Key'] = (string)$valObj->dns_namesilo_key;
+                // Namesilo applies changes to DNS records only every 15 minutes.
+                $acme_hook_options[] = "--dnssleep 960";
+                break;
             case 'dns_nsone':
                 $proc_env['NS1_Key'] = (string)$valObj->dns_nsone_key;
                 break;
@@ -706,7 +741,6 @@ function run_acme_validation($certObj, $valObj, $acctObj)
                 // Write secret key to filesystem
                 $secret_key_data = (string)$valObj->dns_nsupdate_key . "\n";
                 file_put_contents($secret_key_filename, $secret_key_data);
-
                 $proc_env['NSUPDATE_KEY'] = $secret_key_filename;
                 $proc_env['NSUPDATE_SERVER'] = (string)$valObj->dns_nsupdate_server;
                 break;
@@ -721,11 +755,28 @@ function run_acme_validation($certObj, $valObj, $acctObj)
                 $proc_env['PDNS_ServerId'] = (string)$valObj->dns_pdns_serverid;
                 $proc_env['PDNS_Token'] = (string)$valObj->dns_pdns_token;
                 break;
+            case 'dns_selectel':
+                $proc_env['SL_Key'] = (string)$valObj->dns_sl_key;
+                break;
+            case 'dns_servercow':
+                $proc_env['SERVERCOW_API_Username'] = (string)$valObj->dns_servercow_username;
+                $proc_env['SERVERCOW_API_Password'] = (string)$valObj->dns_servercow_password;
+                break;
+            case 'dns_unoeuro':
+                $proc_env['UNO_Key'] = (string)$valObj->dns_uno_key;
+                $proc_env['UNO_User'] = (string)$valObj->dns_uno_user;
+                break;
             case 'dns_vscale':
                 $proc_env['VSCALE_API_KEY'] = (string)$valObj->dns_vscale_key;
                 break;
             case 'dns_yandex':
                 $proc_env['PDD_Token'] = (string)$valObj->dns_yandex_token;
+                break;
+            case 'dns_zilore':
+                $proc_env['Zilore_Key'] = (string)$valObj->dns_zilore_key;
+                break;
+            case 'dns_zonomi':
+                $proc_env['ZM_Key'] = (string)$valObj->dns_zm_key;
                 break;
             default:
                 log_error("AcmeClient: invalid DNS-01 service specified: " . (string)$valObj->dns_service);


### PR DESCRIPTION
Add support to other DNS APIs:

autoDNS (InternetX)
Azure DNS
DirectAdmin 
DreamHost DNS
INWX 
KingHost DNS
Knot (knsupdate) DNS
Namesilo.com DNS
selectel.com / selectel.ru
Servercow 
UnoEuro
Zilore DNS
zonomi.com

