### PR TITLE
net/haproxy: bring back tokenizer

### DIFF
--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogBackend.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogBackend.xml
@@ -283,6 +283,7 @@
         <id>backend.linkedActions</id>
         <label>Select Rules</label>
         <type>select_multiple</type>
+        <style>tokenize</style>
         <help><![CDATA[Choose rules to be included in this Backend Pool.]]></help>
         <hint>Choose rules.</hint>
     </field>

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogFrontend.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogFrontend.xml
@@ -328,6 +328,7 @@
         <id>frontend.linkedActions</id>
         <label>Select Rules</label>
         <type>select_multiple</type>
+        <style>tokenize</style>
         <help><![CDATA[Choose rules to be included in this Public Service.]]></help>
         <hint>Choose rules.</hint>
     </field>


### PR DESCRIPTION
The tokenizer was removed for _some_ fields in https://github.com/opnsense/plugins/commit/701b3812f32c2b5ecc7c05ba42aaad205e3a85f2. For certain fields, the sort order is important. Without using tokenizer, the sort order is no longer visible to the user. This effectively breaks functionality.

@AdSchellevis @fichtner Is there a replacement/alternative for tokenizer in 18.7?