### PR TITLE
www/nginx: some bugfixes; add a rule for the upcoming naxsi release; add restart action to acme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 */*/work
 *.pyc
+.idea/
+

--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		haproxy
-PLUGIN_VERSION=		2.7
+PLUGIN_VERSION=		2.8
 PLUGIN_REVISION=	2
 PLUGIN_COMMENT=		Reliable, high performance TCP/HTTP load balancer
 PLUGIN_DEPENDS=		haproxy-devel

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -677,7 +677,7 @@
                     <OptionValues>
                         <restart_gui>Restart OPNsense Web UI</restart_gui>
                         <restart_haproxy>Restart HAProxy (OPNsense plugin)</restart_haproxy>
-                        <restart_nginx>Restart nginx (OPNsense plugin)</restart_nginx>
+                        <restart_nginx>Restart Nginx (OPNsense plugin)</restart_nginx>
                         <configd>System or Plugin Command (select below)</configd>
                     </OptionValues>
                 </type>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -677,6 +677,7 @@
                     <OptionValues>
                         <restart_gui>Restart OPNsense Web UI</restart_gui>
                         <restart_haproxy>Restart HAProxy (OPNsense plugin)</restart_haproxy>
+                        <restart_nginx>Restart nginx (OPNsense plugin)</restart_nginx>
                         <configd>System or Plugin Command (select below)</configd>
                     </OptionValues>
                 </type>

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -1056,8 +1056,8 @@ function import_certificate($certObj, $modelObj)
 
     // Write changes to config
     // TODO: Legacy code, should be replaced with code from OPNsense framework
-    write_config("${import_log_message} Let's Encrypt SSL certificate: ${cert_cn}");
-    log_error("AcmeClient: ${import_log_message} Let's Encrypt SSL certificate: ${cert_cn}");
+    write_config("${import_log_message} Let's Encrypt X.509 certificate: ${cert_cn}");
+    log_error("AcmeClient: ${import_log_message} Let's Encrypt X.509 certificate: ${cert_cn}");
 
     // Update (acme) certificate object (through MVC framework)
     $uuid = $certObj->attributes()->uuid;
@@ -1137,6 +1137,9 @@ function run_restart_actions($certlist, $modelObj)
                     break;
                 case 'restart_haproxy':
                     $response = $backend->configdRun("haproxy restart");
+                    break;
+                case 'restart_nginx':
+                    $response = $backend->configdRun("nginx restart");
                     break;
                 case 'configd':
                     // Make sure a configd command was specified.

--- a/www/nginx/Makefile
+++ b/www/nginx/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=          nginx
-PLUGIN_VERSION=       0.2
+PLUGIN_VERSION=       0.3
 PLUGIN_COMMENT=       Nginx HTTP server and reverse proxy
 PLUGIN_DEPENDS=       nginx
 PLUGIN_MAINTAINER=    franz.fabian.94@gmail.com

--- a/www/nginx/src/etc/nginx/views/opnsense_error_404.html
+++ b/www/nginx/src/etc/nginx/views/opnsense_error_404.html
@@ -8,16 +8,52 @@
     <style>
         body {
             background-color: black;
+            max-width: 1000px;
+            margin: auto;
+            padding-top: 20px;
         }
-        h1, p {
+        h1, p, span, a, .footertext {
             text-align: center;
             color: white;
+            vertical-align: baseline;
+        }
+        @media screen and (min-width: 700px) {
+            .logo {
+                float: right;
+            }
+            .footertext {
+                text-align: left;
+                float: left;
+                position: absolute;
+                bottom: 0px;
+            }
+            footer {
+                height: 55px;
+                position: relative;
+            }
+            img {
+                float: right;
+            }
+        }
+        @media screen and (max-width: 699px) {
+            .footertext {
+                margin-bottom: 10px;
+            }
+            footer a {
+                display: block;
+                text-align: center;
+            }
         }
     </style>
 </head>
 <body>
-<h1>Not Found</h1>
-<p>The resource you want to access is not available.</p>
-<p>Please contact the webmaster if you think this is an error.</p>
+    <h1>Not Found</h1>
+    <p>The resource you want to access is not available.</p>
+    <p>Please contact the webmaster if you think this is an error.</p>
+    <hr />
+    <footer>
+          <div class="footertext">Web Application Protection by OPNsense</div>
+          <a href="https://opnsense.org/"><img class="logo" alt="OPNsense Logo" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAANYAAAAyCAYAAAAgNiW6AAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAFxGAABcRgEUlENBAAAAB3RJTUUH4gEeEjABrR1oTgAAELlJREFUeNrtnXuUXVV5wH/fuY95ZfIokASQh0IaHtEShAICRVcTXsbE0BZh4lKitGhgqZRlLeoqRVdUihRW0a5KsYjpBBCRV0l4pEUJRBawQBIwSQvIm0ACk0lmJjNz7zlf//j2uffOnXPO3JncmcmE81vrrrlzzj777L3v/vbj29/+tixZsgSAadOm0dHRcQLweeAUYB9AGF2ywIpJkyZdtnPnTlauXDngZpg2EUFVPwJ8FjgVmDbKaesHLgYeaW9vH3RzyZIlqCoiArA/sAD4ODAT8Ea5zDLAQ8ByIIhKX8r4k3V/cx0dHV8C/g74wBinYarnDa6LbW1tAKiqhwnUPwCHjVGaCsCkqBuhsHueh6qeDvwjcByQG8Mye2sM35UyArzp06cDfAm4mrEXKgBV1UEXgyAAQET+EvgXxk6oANR9BjFz5sww0WcDPwNOYmyFCiAY4/elDBPvnXfeOQHrqRrGOzEh5557LplMBuAA4JvAlPFOE1gvumXLFrAGaDk2DExJGUQWm1NV9lQ+sAZYiw2J6jmXEaAN+HBSoLC3Av4MmFNxS4HfAutcOuuBAtOB84GmxIDledVC4Jiq25uAJ12Z1ZtTgVmjEG/KKJHFfrRKHgKWAO/V+2VOCTGXIQQrn8+HXz+MTdZDNgOfA16sc9KOwoQlUbDcvCojItVl9jug7cwzz9z4wAMPEDW0HQnZbJYdO3bQ3Nz8U1LBmlBkMe1fJWtxQrV9+3ZaWlrq8qJcLoeqZqihB3S9AkD1y19R1dcAMplMZc+2u9SsyRORPKb9q+QhEdm4evXqyrTvNoVCgXXr1jFv3ry6xZkyNmQZXNELAE1NTdRTlRtq0+qAAKxYsWK80iUMFsRdqsrSpUuZP39+vfJJW1sbc+fOrVt8KWNHVEstAN3d3eOdtgnHtddeO95JSNlDGO3FzJSU9yWpYKWkjAKpYKWkjALZ3Y8iJeX9xXnnnRcaMMSSClZKyjBoa2urXg46GZgNFLH1zCeBYipYKSkjYzrwNWA78AzWSZ2J2Y7+WzrHSkkZJr7vC3AB8CxmBfSnmPXOA9hy1fmpYKWkDAMRIZPJ7I/1WPdgNqObgNeBvwDuBE5Kh4IpKcNnKtDled6uIAiywCIgD/wUeAfw0h4rJWX4vAe0BkHQgu02XwlswDbH7gf4qWClpAwDVeWss87aArwG/BXwNDbXuhkTqs8Cv0mHgikpw2T16tVggvQV4GB3OQccDrwM3J4K1l7I+vnQOBn8Qtm0RgER++Jj14+4p7b4Ni6ASc3Q3WtxqJrqS13EAhQFjq4xviieXwBZz6UzvCgQuPiT0rppoT1bDAamL0xkIQ/ZAhxxd21p2bQQfIWMlOMI49OulSxvbSNAOoAfAMdTXsdqD4Jgg+d5QSpYexGbF7ovAlqEjAdBQFbKPjn8/j76840V4QWCAI68d2Bcz54BjY2ukgr09EE2D36BPLb5VIGCZPBRW8RZ/0nIZwYKweZFtaVdnUR5AhrYO1QpeEIRYMu50NELR7q4NywybUGIr6YxUCWHkHUeS4pejkLO7enetMgEpODDnP8a+P7nz4ZsheeSrECxAJkcDYCHoKr0ixB8u2slGYVvtn6uL4f/KPBo+Fy4ePy+FqzQExQxjmMmCqGAANYVBRwCnKLK8SIcCkwWu9Odb2QL8BxWGZ7FJt9sWlgWiI2fKqu1+gvQkGcWcJpf4DjgIBFaAF+gA+UFnLuEhixbFROmXTvgmIdLSfxjrGWPKmcP2FD0eTaX5WOqnINwFNAk0AE8Dty+o48/qMLGhVBUc9CiQADiWfynqnIscJDAJFceXUGRN1w+16JsRPDzuYH53bSwJJSgZNz7P57NcQxwAEITUBDhXWwX+zpfePy7XT/vDDMxu6o3nGiCpapa9DyvnhsnAT7EwN3KPtA73pmtmfJW1SkEfBn4AubVKkk59R7CA8DVGY9nArUKBm7IaMxoyPMVzFXDIQlx9QPrgetRbkPoa5o84P584EdEC5YA38tlmQ98A9i36v5i4HyFizMe67ICGS1FNNODSzF/JQcNUUpbRLgLuEYDXmjIwu8XQCYDuWYo9ADwIYTLgHMYvEu8kl3AE8A1qtwnQrBp0cCh5kQTrA96nncZ9XNyo0Ar8BkG+rvYhml99ng2Lih9bcFc2P11jY/+EVYhj1O4UIRHwvmJ42DgJ5iZzlDkMd+KN4gwB/O12LOpPAyUqr/VnIMJbpzPkWOAHwKfLirvuGv7ufQtpDZmYm7+Pgos7fd5PrSjdUL1EeBGrGcdiibgNGCuCN9V5TqE4uZF5Z5rognWbOCqMXjPGlV9ebwzWwu5RlNSYBXsghFEMQv4J+DTqmxx1/KYcNQiVJU0AH8LbG3KcnVP7c3fETWEOR7z0Pwrp0+4gNqFqjqe5ZhavMtdm4rVq1qEqpLJwJUivAW0V/bH6TrWYP4XuE5EivV0DDNaFPtBlQzwKeIdh24BHsHmLFEcD3yi4v8TMfOcKAJsMXQ90Y5DM8Alu4ocOYzi63bpeyUhTBY4GkBtIXZBQtiXsTlknH+JecCxFf+f5a5FFjHwFDa3iqIZuAyYUdmIpII1kGeAi4D1QRDU0wvUqCECIkzGevMo+oFvqDIPG+pE4WFrMCGnY61xFG9gQ8jziB8uHwycMYxs3O3CX0Gyv8gZ7u9+wAdjwmwH/kaVM4B7Y8K0AIcCqOJhghU3ensOM1m6yMUdxRysNy1pQSfaUHAn1hrVU4sXYC36/wC3Aa+GjjmrD2nYg2nBhjNRdAG/E6EA/F9CHK0AquRFBjkjrWQbJlxFV25xSo0TVcmI1ORYdROmLPoD0If1ApFpdPPAqcT41nfpe16EHuClofIrwhQGOoWt5k1V3hbBw3r8qHLOAScAd4Rz1D1SsFQ1dI5ZLUBPYWPjvjq+LlDVHhHpA3MW2tfXN5GECmxOlI+5l6m4l1TJcwBOlX5AQrgC1hj5JP8Oh7q4dtSQ/h73t3+INOZdhWggvu7mKA+Jiwlxhc9PY7AmspL+irj6E8IdrpAVt+62RwpWUiZVdZuI9O9+VAMJggAR4aabbhrvPI4En/gK2Yrtcn0Ka83XR4TJYr0QQCPxvQHYaKGIUkQSD2eYBjULVigAAcmjES9jGS0SfzDEdGzO+Ap2KsvzEWXjubLApTHJA3KQFXz3zqS07Ssm8BNSsAQQVZ1oPcposxMbpkQNyzzgcqAH5XY1NXG1wwYR2EXZaCDJoUMrcAo2xEs6rKLRfWqh5qH9Ng+m+XS4PEe9vwkzNQpUWYkN76N0Cd1OuZIbIr/7+naGwFSSBbCFCuXRRBOslCqctcB28XgOYudGM4DrEc4QOxLpMcBPcDGfpM87AtvMB8kn1GRIrrAjYoqPh83tXiD+2KnDgJ+JcDvw494Onm6cNmCNbjicDKxyZZLUUGSoEOBUKzjB8QTEI8Aqe9KcpwFTod8N/AdWYTwRG18No855mHKhmSEEp05nQ0TRTVm442jFLFBWNU7jeuBPmhpKWtThHDCWwXqjZoaWl1KDlArWBMcvV95VmCXCUNV5KnZiy90i/DNwiI7OqoI3qsuAygrgFzWEnAFcAtzX288VmKqe5vqP1QbIUjoUnOAceU9p7aQX+Ba21vJVhj6sbx8X7hTgUhHW1vjKPuBtkht9D3jLKTjqjtsC04FyCcI2rGcaaj53IGZNcirwtT6f52p8XQ+wleQGK4Mpf0pKklSw9gK6emy/FNClypUiPA78PSY0Q41KPgr8O7YbdkMNr9uILXnspGRgHolPWfM2OghbVblUhEeBrwO1HM3y51jP/hnMAcxQrAWWUdYKxuW3QIUGNB0KTnA2LyoJlW3IMxX4asyw9VLiTXEqmQ1cVOPQrQ9TZb/qvn8g4nMQsD8y+g23CP3ALZhJ1xXUZjz9Mexk0Vro8c0o4VX3/0Ex+Z1BhTylPdbexEDBeBfTAN4LXIwZre6T8PRpquzL0HO0yvPBFgHXRjzjAW8onCnJ1g/15A3gO8CvsAblXJLX4+YB19USsRfucrOdA19n8MJzBvOCuwB3aGMqWHsHDcCXMXu/6qFKN3A95gPvKszANooZ2MS+k9qVhDkGn7oZ0iKjNCISZQrCV116K9MqmPuxy11+f0C85fzB2Dx0OKqbBuLnci1UNG17hGBNBCvyPZwcZhR7QsS9LuAOzHp8OfBLotefGrAW/l2STYFqFbqA4VXa2iIV1FNagKU4Q9oqXgd+ji0rHAD8a0xUTe5ToD4HxfuV+R2POVb1D5NKVQL3339/LcEC4tewfMpl/CrxWynC36WXsu1eFJW/V1L96aO+Np3lVErN+X2JZPs+XF5r3S2elN9e3DHDEN1jKVgvUuEToj5lYifOV29HKOzcufN92WstXrwYz/MQEZqamvB9v2SAXCwWERGWLVtGZ2dn9fBDQwt8RxHT0kWRpdxDJdniFYBdquwSKe3SjYsvrGBJc5gO4oV4xLgc9xEv/HnKpkVJ+e118RRcWuOsOHK4otbk/G6lQtijJDDn3OY21vnTIiKLMQfylbyqqhNi71O9mTRpEs3NzTQ0NJSMgD3nxSWbzQLkOzs7T8ft9algu+d5gaqiCrkc/ZSNaKtpAma7Gnk48XOi7UCH216ynnj2A2aq0gCJ20t+r1qTAe6wEJOtbijtdq5mCnCYa3NmE2/1vxXoVqUTW0KI40ARpqkZFR+VEG49UEjaNnKB53mnUf8hWjO276Vy4XIHNvZ/X/ZYrjGZi1lC9GJOSgqYlmkqNvE+kcHavPVhj7VvC7xrbffTMa/xgG+jzMd2zcZNvjcrbHO/wipsY19rRLgDgRtF2M7AXceV7ALuEKn/HMvRj2nhzoq41wz8UJWlmNlWXMXacOPddF1oi+v3YssTUfIwB/hPV44nxcS11cVRcsQTFdEs9xkL7lTVJ4EJb62+Gw3DLOycpVp5EVgT/vNaJzTbwGcNtpEx6rc7lOiJfkgA3CXQh3lAekyEXwBfjAjrYRU2idsVHhzlpvIeTP0dtZfqaPeJoxu458Kys5t7gQeBsyPC5jAvU0ncGChPiZQ9NY3nAvEjwHdEpG8v6K2KOnKL06TV/Gp2YJq9F1SV9vZ25q4qOdV8ETPZGYm1w22EdndSWnS9EqhJc1LFb4ArZBTdxymgyhPA9xn+PE6BG1T574prnZilypMjSM4vgWs8IajW6oylcCnWbd4AfB54SUTw/XpoO8eU6jLb3QwM9Rv0Yo4rvxAEwc1VigvAhCsIuAXzAbiG2irc28A1mM3gDgC/vzSceQ1TaV/lvg/VcnQCN7lnXh6mBbnEfI9/QAjUFsC/6MpmKEFWzGLkW6pc4RoPfB9aTbWzAbPG+AkkKm9CtrqyW4YtUQxw2pnFjiAZymCzHhRdxn6NOTssgM0zbr311rhn1mCalgCrfJupz5rD7hBgDkYaKLtBfx1g1apVI4nvXVcezZiiIe/e0YP9wBuxXuBh4O1QoNrb20sRHOEMcT0PBR5U5QkRPoE5aDkWmxeFSovQb8hjwF2qPBn6pfAVjloNz30ScjZJ2FL0uTyb4RbMquA0TAEyFZsH7gLexHYn36nwsECviLlkO/K+koHwU8D3iHfY+YT7/ibmGzFqnc3DPNpqxYNFrLf9NWZJcTrmH3CmK0vFBP5FV4Z37fRZ3+o2u2wvwAmrzLtuzgNfecEZ9t7s8nsy5rRmsktnD9bI/Bbzb7EuLLveKqX+/wPOlvw8NtrSyAAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxOC0wNi0yMlQyMDo1OTo0NiswMjowMCzFdxYAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTgtMDEtMzBUMTc6NDg6MDErMDE6MDBrpqImAAAAAElFTkSuQmCC" /></a>
+    </footer>
 </body>
 </html>

--- a/www/nginx/src/etc/nginx/views/opnsense_server_error.html
+++ b/www/nginx/src/etc/nginx/views/opnsense_server_error.html
@@ -8,16 +8,52 @@
     <style>
         body {
             background-color: black;
+            max-width: 1000px;
+            margin: auto;
+            padding-top: 20px;
         }
-        h1, p {
+        h1, p, span, a, .footertext {
             text-align: center;
             color: white;
+            vertical-align: baseline;
+        }
+        @media screen and (min-width: 700px) {
+            .logo {
+                float: right;
+            }
+            .footertext {
+                text-align: left;
+                float: left;
+                position: absolute;
+                bottom: 0px;
+            }
+            footer {
+                height: 55px;
+                position: relative;
+            }
+            img {
+                float: right;
+            }
+        }
+        @media screen and (max-width: 699px) {
+            .footertext {
+                margin-bottom: 10px;
+            }
+            footer a {
+                display: block;
+                text-align: center;
+            }
         }
     </style>
 </head>
 <body>
-<h1>Server Error</h1>
-<p>Sorry, but something went wrong on our side.</p>
-<p>There is nothing you can do except waiting until we fix the issue.</p>
+    <h1>Server Error</h1>
+    <p>Sorry, but something went wrong on our side.</p>
+    <p>There is nothing you can do except waiting until we fix the issue.</p>
+    <hr />
+    <footer>
+          <div class="footertext">Web Application Protection by OPNsense</div>
+          <a href="https://opnsense.org/"><img class="logo" alt="OPNsense Logo" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAANYAAAAyCAYAAAAgNiW6AAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAFxGAABcRgEUlENBAAAAB3RJTUUH4gEeEjABrR1oTgAAELlJREFUeNrtnXuUXVV5wH/fuY95ZfIokASQh0IaHtEShAICRVcTXsbE0BZh4lKitGhgqZRlLeoqRVdUihRW0a5KsYjpBBCRV0l4pEUJRBawQBIwSQvIm0ACk0lmJjNz7zlf//j2uffOnXPO3JncmcmE81vrrrlzzj777L3v/vbj29/+tixZsgSAadOm0dHRcQLweeAUYB9AGF2ywIpJkyZdtnPnTlauXDngZpg2EUFVPwJ8FjgVmDbKaesHLgYeaW9vH3RzyZIlqCoiArA/sAD4ODAT8Ea5zDLAQ8ByIIhKX8r4k3V/cx0dHV8C/g74wBinYarnDa6LbW1tAKiqhwnUPwCHjVGaCsCkqBuhsHueh6qeDvwjcByQG8Mye2sM35UyArzp06cDfAm4mrEXKgBV1UEXgyAAQET+EvgXxk6oANR9BjFz5sww0WcDPwNOYmyFCiAY4/elDBPvnXfeOQHrqRrGOzEh5557LplMBuAA4JvAlPFOE1gvumXLFrAGaDk2DExJGUQWm1NV9lQ+sAZYiw2J6jmXEaAN+HBSoLC3Av4MmFNxS4HfAutcOuuBAtOB84GmxIDledVC4Jiq25uAJ12Z1ZtTgVmjEG/KKJHFfrRKHgKWAO/V+2VOCTGXIQQrn8+HXz+MTdZDNgOfA16sc9KOwoQlUbDcvCojItVl9jug7cwzz9z4wAMPEDW0HQnZbJYdO3bQ3Nz8U1LBmlBkMe1fJWtxQrV9+3ZaWlrq8qJcLoeqZqihB3S9AkD1y19R1dcAMplMZc+2u9SsyRORPKb9q+QhEdm4evXqyrTvNoVCgXXr1jFv3ry6xZkyNmQZXNELAE1NTdRTlRtq0+qAAKxYsWK80iUMFsRdqsrSpUuZP39+vfJJW1sbc+fOrVt8KWNHVEstAN3d3eOdtgnHtddeO95JSNlDGO3FzJSU9yWpYKWkjAKpYKWkjALZ3Y8iJeX9xXnnnRcaMMSSClZKyjBoa2urXg46GZgNFLH1zCeBYipYKSkjYzrwNWA78AzWSZ2J2Y7+WzrHSkkZJr7vC3AB8CxmBfSnmPXOA9hy1fmpYKWkDAMRIZPJ7I/1WPdgNqObgNeBvwDuBE5Kh4IpKcNnKtDled6uIAiywCIgD/wUeAfw0h4rJWX4vAe0BkHQgu02XwlswDbH7gf4qWClpAwDVeWss87aArwG/BXwNDbXuhkTqs8Cv0mHgikpw2T16tVggvQV4GB3OQccDrwM3J4K1l7I+vnQOBn8Qtm0RgER++Jj14+4p7b4Ni6ASc3Q3WtxqJrqS13EAhQFjq4xviieXwBZz6UzvCgQuPiT0rppoT1bDAamL0xkIQ/ZAhxxd21p2bQQfIWMlOMI49OulSxvbSNAOoAfAMdTXsdqD4Jgg+d5QSpYexGbF7ovAlqEjAdBQFbKPjn8/j76840V4QWCAI68d2Bcz54BjY2ukgr09EE2D36BPLb5VIGCZPBRW8RZ/0nIZwYKweZFtaVdnUR5AhrYO1QpeEIRYMu50NELR7q4NywybUGIr6YxUCWHkHUeS4pejkLO7enetMgEpODDnP8a+P7nz4ZsheeSrECxAJkcDYCHoKr0ixB8u2slGYVvtn6uL4f/KPBo+Fy4ePy+FqzQExQxjmMmCqGAANYVBRwCnKLK8SIcCkwWu9Odb2QL8BxWGZ7FJt9sWlgWiI2fKqu1+gvQkGcWcJpf4DjgIBFaAF+gA+UFnLuEhixbFROmXTvgmIdLSfxjrGWPKmcP2FD0eTaX5WOqnINwFNAk0AE8Dty+o48/qMLGhVBUc9CiQADiWfynqnIscJDAJFceXUGRN1w+16JsRPDzuYH53bSwJJSgZNz7P57NcQxwAEITUBDhXWwX+zpfePy7XT/vDDMxu6o3nGiCpapa9DyvnhsnAT7EwN3KPtA73pmtmfJW1SkEfBn4AubVKkk59R7CA8DVGY9nArUKBm7IaMxoyPMVzFXDIQlx9QPrgetRbkPoa5o84P584EdEC5YA38tlmQ98A9i36v5i4HyFizMe67ICGS1FNNODSzF/JQcNUUpbRLgLuEYDXmjIwu8XQCYDuWYo9ADwIYTLgHMYvEu8kl3AE8A1qtwnQrBp0cCh5kQTrA96nncZ9XNyo0Ar8BkG+rvYhml99ng2Lih9bcFc2P11jY/+EVYhj1O4UIRHwvmJ42DgJ5iZzlDkMd+KN4gwB/O12LOpPAyUqr/VnIMJbpzPkWOAHwKfLirvuGv7ufQtpDZmYm7+Pgos7fd5PrSjdUL1EeBGrGcdiibgNGCuCN9V5TqE4uZF5Z5rognWbOCqMXjPGlV9ebwzWwu5RlNSYBXsghFEMQv4J+DTqmxx1/KYcNQiVJU0AH8LbG3KcnVP7c3fETWEOR7z0Pwrp0+4gNqFqjqe5ZhavMtdm4rVq1qEqpLJwJUivAW0V/bH6TrWYP4XuE5EivV0DDNaFPtBlQzwKeIdh24BHsHmLFEcD3yi4v8TMfOcKAJsMXQ90Y5DM8Alu4ocOYzi63bpeyUhTBY4GkBtIXZBQtiXsTlknH+JecCxFf+f5a5FFjHwFDa3iqIZuAyYUdmIpII1kGeAi4D1QRDU0wvUqCECIkzGevMo+oFvqDIPG+pE4WFrMCGnY61xFG9gQ8jziB8uHwycMYxs3O3CX0Gyv8gZ7u9+wAdjwmwH/kaVM4B7Y8K0AIcCqOJhghU3ensOM1m6yMUdxRysNy1pQSfaUHAn1hrVU4sXYC36/wC3Aa+GjjmrD2nYg2nBhjNRdAG/E6EA/F9CHK0AquRFBjkjrWQbJlxFV25xSo0TVcmI1ORYdROmLPoD0If1ApFpdPPAqcT41nfpe16EHuClofIrwhQGOoWt5k1V3hbBw3r8qHLOAScAd4Rz1D1SsFQ1dI5ZLUBPYWPjvjq+LlDVHhHpA3MW2tfXN5GECmxOlI+5l6m4l1TJcwBOlX5AQrgC1hj5JP8Oh7q4dtSQ/h73t3+INOZdhWggvu7mKA+Jiwlxhc9PY7AmspL+irj6E8IdrpAVt+62RwpWUiZVdZuI9O9+VAMJggAR4aabbhrvPI4En/gK2Yrtcn0Ka83XR4TJYr0QQCPxvQHYaKGIUkQSD2eYBjULVigAAcmjES9jGS0SfzDEdGzO+Ap2KsvzEWXjubLApTHJA3KQFXz3zqS07Ssm8BNSsAQQVZ1oPcposxMbpkQNyzzgcqAH5XY1NXG1wwYR2EXZaCDJoUMrcAo2xEs6rKLRfWqh5qH9Ng+m+XS4PEe9vwkzNQpUWYkN76N0Cd1OuZIbIr/7+naGwFSSBbCFCuXRRBOslCqctcB28XgOYudGM4DrEc4QOxLpMcBPcDGfpM87AtvMB8kn1GRIrrAjYoqPh83tXiD+2KnDgJ+JcDvw494Onm6cNmCNbjicDKxyZZLUUGSoEOBUKzjB8QTEI8Aqe9KcpwFTod8N/AdWYTwRG18No855mHKhmSEEp05nQ0TRTVm442jFLFBWNU7jeuBPmhpKWtThHDCWwXqjZoaWl1KDlArWBMcvV95VmCXCUNV5KnZiy90i/DNwiI7OqoI3qsuAygrgFzWEnAFcAtzX288VmKqe5vqP1QbIUjoUnOAceU9p7aQX+Ba21vJVhj6sbx8X7hTgUhHW1vjKPuBtkht9D3jLKTjqjtsC04FyCcI2rGcaaj53IGZNcirwtT6f52p8XQ+wleQGK4Mpf0pKklSw9gK6emy/FNClypUiPA78PSY0Q41KPgr8O7YbdkMNr9uILXnspGRgHolPWfM2OghbVblUhEeBrwO1HM3y51jP/hnMAcxQrAWWUdYKxuW3QIUGNB0KTnA2LyoJlW3IMxX4asyw9VLiTXEqmQ1cVOPQrQ9TZb/qvn8g4nMQsD8y+g23CP3ALZhJ1xXUZjz9Mexk0Vro8c0o4VX3/0Ex+Z1BhTylPdbexEDBeBfTAN4LXIwZre6T8PRpquzL0HO0yvPBFgHXRjzjAW8onCnJ1g/15A3gO8CvsAblXJLX4+YB19USsRfucrOdA19n8MJzBvOCuwB3aGMqWHsHDcCXMXu/6qFKN3A95gPvKszANooZ2MS+k9qVhDkGn7oZ0iKjNCISZQrCV116K9MqmPuxy11+f0C85fzB2Dx0OKqbBuLnci1UNG17hGBNBCvyPZwcZhR7QsS9LuAOzHp8OfBLotefGrAW/l2STYFqFbqA4VXa2iIV1FNagKU4Q9oqXgd+ji0rHAD8a0xUTe5ToD4HxfuV+R2POVb1D5NKVQL3339/LcEC4tewfMpl/CrxWynC36WXsu1eFJW/V1L96aO+Np3lVErN+X2JZPs+XF5r3S2elN9e3DHDEN1jKVgvUuEToj5lYifOV29HKOzcufN92WstXrwYz/MQEZqamvB9v2SAXCwWERGWLVtGZ2dn9fBDQwt8RxHT0kWRpdxDJdniFYBdquwSKe3SjYsvrGBJc5gO4oV4xLgc9xEv/HnKpkVJ+e118RRcWuOsOHK4otbk/G6lQtijJDDn3OY21vnTIiKLMQfylbyqqhNi71O9mTRpEs3NzTQ0NJSMgD3nxSWbzQLkOzs7T8ft9algu+d5gaqiCrkc/ZSNaKtpAma7Gnk48XOi7UCH216ynnj2A2aq0gCJ20t+r1qTAe6wEJOtbijtdq5mCnCYa3NmE2/1vxXoVqUTW0KI40ARpqkZFR+VEG49UEjaNnKB53mnUf8hWjO276Vy4XIHNvZ/X/ZYrjGZi1lC9GJOSgqYlmkqNvE+kcHavPVhj7VvC7xrbffTMa/xgG+jzMd2zcZNvjcrbHO/wipsY19rRLgDgRtF2M7AXceV7ALuEKn/HMvRj2nhzoq41wz8UJWlmNlWXMXacOPddF1oi+v3YssTUfIwB/hPV44nxcS11cVRcsQTFdEs9xkL7lTVJ4EJb62+Gw3DLOycpVp5EVgT/vNaJzTbwGcNtpEx6rc7lOiJfkgA3CXQh3lAekyEXwBfjAjrYRU2idsVHhzlpvIeTP0dtZfqaPeJoxu458Kys5t7gQeBsyPC5jAvU0ncGChPiZQ9NY3nAvEjwHdEpG8v6K2KOnKL06TV/Gp2YJq9F1SV9vZ25q4qOdV8ETPZGYm1w22EdndSWnS9EqhJc1LFb4ArZBTdxymgyhPA9xn+PE6BG1T574prnZilypMjSM4vgWs8IajW6oylcCnWbd4AfB54SUTw/XpoO8eU6jLb3QwM9Rv0Yo4rvxAEwc1VigvAhCsIuAXzAbiG2irc28A1mM3gDgC/vzSceQ1TaV/lvg/VcnQCN7lnXh6mBbnEfI9/QAjUFsC/6MpmKEFWzGLkW6pc4RoPfB9aTbWzAbPG+AkkKm9CtrqyW4YtUQxw2pnFjiAZymCzHhRdxn6NOTssgM0zbr311rhn1mCalgCrfJupz5rD7hBgDkYaKLtBfx1g1apVI4nvXVcezZiiIe/e0YP9wBuxXuBh4O1QoNrb20sRHOEMcT0PBR5U5QkRPoE5aDkWmxeFSovQb8hjwF2qPBn6pfAVjloNz30ScjZJ2FL0uTyb4RbMquA0TAEyFZsH7gLexHYn36nwsECviLlkO/K+koHwU8D3iHfY+YT7/ibmGzFqnc3DPNpqxYNFrLf9NWZJcTrmH3CmK0vFBP5FV4Z37fRZ3+o2u2wvwAmrzLtuzgNfecEZ9t7s8nsy5rRmsktnD9bI/Bbzb7EuLLveKqX+/wPOlvw8NtrSyAAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxOC0wNi0yMlQyMDo1OTo0NiswMjowMCzFdxYAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTgtMDEtMzBUMTc6NDg6MDErMDE6MDBrpqImAAAAAElFTkSuQmCC" /></a>
+    </footer>
 </body>
 </html>

--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/naxsirule.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/naxsirule.conf
@@ -47,15 +47,17 @@
 
 {% if naxsi_ruletype == 'basic' %}
 {# current policy in loop is available as custom_policy, the uuid as custom_policy_uuid #}
-{%   for naxsi_rule_uuid in custom_policy.naxsi_rules.split(',') %}
-{%     if naxsi_rule_uuid not in added_policies %}
-{%       set basic_rule = helpers.getUUID(naxsi_rule_uuid) %}
-{%       if basic_rule.ruletype == 'basic' %}
-{{         naxsi_rule(custom_policy_uuid, basic_rule, "BasicRule") }}
-{%         do added_policies.append(naxsi_rule_uuid) %}
+{%   if custom_policy.naxsi_rules is defined %}
+{%     for naxsi_rule_uuid in custom_policy.naxsi_rules.split(',') %}
+{%       if naxsi_rule_uuid not in added_policies %}
+{%         set basic_rule = helpers.getUUID(naxsi_rule_uuid) %}
+{%         if basic_rule.ruletype == 'basic' %}
+{{           naxsi_rule(custom_policy_uuid, basic_rule, "BasicRule") }}
+{%           do added_policies.append(naxsi_rule_uuid) %}
+{%         endif %}
 {%       endif %}
-{%     endif %}
-{%   endfor %}
+{%     endfor %}
+{%   endif %}
 {% endif %}
 {% if naxsi_ruletype == 'main' %}
 {{   naxsi_rule(custom_policy_uuid, main_rule, "MainRule") }}

--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/php-www.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/php-www.conf
@@ -3,6 +3,9 @@
 user = www
 group = www
 listen = /var/run/php-www.socket
+listen.owner = www
+listen.group = www
+listen.mode = 0660
 pm = dynamic
 pm.max_children = 5
 pm.start_servers = 2

--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/ruleset.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/ruleset.conf
@@ -1,3 +1,4 @@
+MainRule wl:19;
 {% set naxsi_ruletype = 'main' %}
 {% set main_policies = [] %}
 {% set main_rules = [] %}


### PR DESCRIPTION
www/nginx:

* add an if check for rules because it may not exist
* give the www php socket to www
* insert whitelist rule 19 (block if no rules loded) to lower the risk of an incorrectly configured system.
* theme for 404 and 50x

security/acme-client:

* rename SSL certificate to X.509 certificate - this is what is is correctly called - I hope nobody is still using SSL and X.509 is not bound to TLS (can probably be used for IKE as well)
* add the ability to restart nginx

global:

* add PhpStorm files to `.gitignore`