### PR TITLE
Add IP support to ProxyUserACL

### DIFF
--- a/www/web-proxy-useracl/src/opnsense/mvc/app/controllers/OPNsense/ProxyUserACL/Api/SettingsController.php
+++ b/www/web-proxy-useracl/src/opnsense/mvc/app/controllers/OPNsense/ProxyUserACL/Api/SettingsController.php
@@ -57,7 +57,7 @@ class SettingsController extends ApiMutableModelControllerBase
         $grid = new UIModelGrid($mdlProxyUserACL->general->ACLs->ACL);
         return $grid->fetchBindRequest(
             $this->request,
-            array('Group', 'Name', 'Domains', 'Black', 'Priority', 'uuid'),
+            array('Group', 'ACLName', 'Name', 'Source', 'Domains', 'Black', 'Priority', 'uuid'),
             'Priority'
         );
     }
@@ -74,7 +74,11 @@ class SettingsController extends ApiMutableModelControllerBase
             $result = array("result" => "failed", "validations" => array());
             $mdlProxyUserACL = $this->getModel();
             $post = $this->request->getPost("ACL");
-            $post["Hex"] = $this->strToHex($post["Name"]);
+
+            if ($post["Name"])
+                $post["Hex"] = $this->strToHex($post["Name"]);
+            else
+                $post["Hex"] = $this->strToHex($post["Source"]);
 
             $count = count($mdlProxyUserACL->general->ACLs->ACL->getNodes());
             if ($post["Priority"] > $count) {
@@ -149,7 +153,12 @@ class SettingsController extends ApiMutableModelControllerBase
                 if ($node != null) {
                     $result = array("result" => "failed", "validations" => array());
                     $ACLInfo = $this->request->getPost("ACL");
-                    $ACLInfo["Hex"] = $this->strToHex($ACLInfo["Name"]);
+
+                    if ($ACLInfo["Name"])
+                        $ACLInfo["Hex"] = $this->strToHex($ACLInfo["Name"]);
+                    else
+                        $ACLInfo["Hex"] = $this->strToHex($ACLInfo["Source"]);
+
                     $old_priority = (string)$node->Priority;
                     $new_priority = $ACLInfo["Priority"];
 
@@ -284,6 +293,10 @@ class SettingsController extends ApiMutableModelControllerBase
 
     private function checkName($user, $search)
     {
+        if ($search == "ip") {
+            return true;
+        }
+
         $authFactory = new AuthenticationFactory();
         $servers = $authFactory->listServers();
 

--- a/www/web-proxy-useracl/src/opnsense/mvc/app/controllers/OPNsense/ProxyUserACL/forms/dialogACL.xml
+++ b/www/web-proxy-useracl/src/opnsense/mvc/app/controllers/OPNsense/ProxyUserACL/forms/dialogACL.xml
@@ -23,7 +23,7 @@
     </field>
     <field>
         <id>ACL.Source</id>
-        <label>IP sources</label>
+        <label>IP/Subnet</label>
         <type>select_multiple</type>
         <style>tokenize</style>
         <allownew>true</allownew>

--- a/www/web-proxy-useracl/src/opnsense/mvc/app/controllers/OPNsense/ProxyUserACL/forms/dialogACL.xml
+++ b/www/web-proxy-useracl/src/opnsense/mvc/app/controllers/OPNsense/ProxyUserACL/forms/dialogACL.xml
@@ -1,9 +1,8 @@
 <form>
     <field>
-        <id>ACL.Name</id>
+        <id>ACL.ACLName</id>
         <label>Name</label>
         <type>text</type>
-        <help>Enter a name of user/group. Group name is case sensitive.</help>
     </field>
     <field>
         <id>ACL.Priority</id>
@@ -13,9 +12,28 @@
     </field>
     <field>
         <id>ACL.Group</id>
-        <label>Group/User</label>
+        <label>Type</label>
         <type>dropdown</type>
-        <help>Group or User ACL</help>
+        <help>Group, User or IP ACL</help>
+    </field>
+    <field>
+        <id>ACL.Name</id>
+        <label>Group or User Name</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>ACL.Source</id>
+        <label>IP sources</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <allownew>true</allownew>
+        <help><![CDATA[Enter sources IP address.
+        <div class="alert alert-info">
+            <b>Examples:</b><br/>
+            <b class="text-primary">IP: 192.168.0.1</b><br/>
+            <b class="text-primary">Subnet: 192.168.0.0/24 or 192.168.1.0/255.255.255.0</b><br/>
+            <b class="text-primary">IP-Range: 192.168.1.1-192.168.1.10</b><br/>
+        </div>]]></help>
     </field>
     <field>
         <id>ACL.Black</id>

--- a/www/web-proxy-useracl/src/opnsense/mvc/app/models/OPNsense/ProxyUserACL/Menu/Menu.xml
+++ b/www/web-proxy-useracl/src/opnsense/mvc/app/models/OPNsense/ProxyUserACL/Menu/Menu.xml
@@ -1,7 +1,7 @@
 <menu>
-    <Services>
-        <WebProxy>
-            <ProxyUserACL VisibleName="Groups and Users" order="30" url="/ui/proxyuseracl"/>
-        </WebProxy>
-    </Services>
+	<Services>
+		<WebProxy>
+			<ProxyUserACL VisibleName="Groups, Users and IPs" order="30" url="/ui/proxyuseracl/"/>
+		</WebProxy>
+	</Services>
 </menu>

--- a/www/web-proxy-useracl/src/opnsense/mvc/app/models/OPNsense/ProxyUserACL/ProxyUserACL.xml
+++ b/www/web-proxy-useracl/src/opnsense/mvc/app/models/OPNsense/ProxyUserACL/ProxyUserACL.xml
@@ -2,20 +2,20 @@
     <mount>//OPNsense/ProxyUserACL</mount>
     <version>1.0.0</version>
     <description>
-        Group and User ACL settings
+        Group, User and IP ACL settings
     </description>
     <items>
         <general>
             <ACLs>
                 <ACL type="ArrayField">
-                    <Name type="TextField">
+                    <ACLName type="TextField">
                         <Required>Y</Required>
-                    </Name>
+                    </ACLName>
                     <Hex type="TextField">
                         <Required>Y</Required>
                     </Hex>
                     <Domains type="CSVListField">
-                        <Required>N</Required>
+                        <Required>Y</Required>
                     </Domains>
                     <Black type="OptionField">
                         <Required>Y</Required>
@@ -35,8 +35,13 @@
                         <OptionValues>
                             <group>Group</group>
                             <user>User</user>
+                            <ip>IP</ip>
                         </OptionValues>
                     </Group>
+                    <Name type="TextField">
+                    </Name>
+                    <Source type="CSVListField">
+                    </Source>
                 </ACL>
             </ACLs>
         </general>

--- a/www/web-proxy-useracl/src/opnsense/mvc/app/views/OPNsense/ProxyUserACL/index.volt
+++ b/www/web-proxy-useracl/src/opnsense/mvc/app/views/OPNsense/ProxyUserACL/index.volt
@@ -143,7 +143,7 @@
                             <th data-column-id="ACLName" data-type="string"
                                 data-sortable="false">{{ lang._('Description') }}</th>
                             <th data-column-id="Group" data-width="10em" data-type="string"
-                                data-sortable="false">{{ lang._('Source') }}</th>
+                                data-sortable="false">{{ lang._('Target Type') }}</th>
                             <th data-column-id="targets" data-width="10em" data-formatter="targets"
                                 data-sortable="false">{{ lang._('Targets') }}</th>
                             <th data-column-id="Black" data-width="10em" data-type="string"

--- a/www/web-proxy-useracl/src/opnsense/mvc/app/views/OPNsense/ProxyUserACL/index.volt
+++ b/www/web-proxy-useracl/src/opnsense/mvc/app/views/OPNsense/ProxyUserACL/index.volt
@@ -1,155 +1,180 @@
 {#
-Copyright (C) 2017 Smart-Soft
+    Copyright (C) 2017 Smart-Soft
 
-All rights reserved.
+    All rights reserved.
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice,
-   this list of conditions and the following disclaimer.
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright
-   notice, this list of conditions and the following disclaimer in the
-   documentation and/or other materials provided with the distribution.
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
 
-THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGE.
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
 
-#}
+    #}
 
-<script>
+    <script>
 
-    $(document).ready(function () {
-        grid = $("#grid-acl").UIBootgrid(
-            {
-                'search': '/api/proxyuseracl/settings/searchACL',
-                'get': '/api/proxyuseracl/settings/getACL/',
-                'set': '/api/proxyuseracl/settings/setACL/',
-                'add': '/api/proxyuseracl/settings/addACL/',
-                'del': '/api/proxyuseracl/settings/delACL/',
-                'toggle': '/api/proxyuseracl/settings/toggleACL/',
-                options: {
-                    formatters: {
-                        "commands": function (column, row) {
-                            return "<button type=\"button\" class=\"btn btn-xs btn-default command-edit\" data-row-id=\"" + row.uuid + "\"><span class=\"fa fa-pencil\"></span></button> " +
-                                "<button type=\"button\" class=\"btn btn-xs btn-default command-copy\" data-row-id=\"" + row.uuid + "\"><span class=\"fa fa-clone\"></span></button>" +
-                                "<button type=\"button\" class=\"btn btn-xs btn-default command-delete\" data-row-id=\"" + row.uuid + "\"><span class=\"fa fa-trash-o\"></span></button>";
-                        },
-                        "rowtoggle": function (column, row) {
-                            if (parseInt(row[column.id], 2) == 1) {
-                                return "<span style=\"cursor: pointer;\" class=\"fa fa-check-square-o command-toggle\" data-value=\"1\" data-row-id=\"" + row.uuid + "\"></span>";
-                            } else {
-                                return "<span style=\"cursor: pointer;\" class=\"fa fa-square-o command-toggle\" data-value=\"0\" data-row-id=\"" + row.uuid + "\"></span>";
-                            }
-                        },
-                        "boolean": function (column, row) {
-                            if (parseInt(row[column.id], 2) == 1) {
-                                return "<span class=\"fa fa-check\" data-value=\"1\" data-row-id=\"" + row.uuid + "\"></span>";
-                            } else {
-                                return "<span class=\"fa fa-times\" data-value=\"0\" data-row-id=\"" + row.uuid + "\"></span>";
-                            }
-                        },
-                        "updown": function (column, row) {
-                            return "<button type=\"button\" class=\"btn btn-xs btn-default command-updown\" data-row-id=\"" + row.uuid + "\" data-command=\"up\"><span class=\"fa fa-arrow-up\"></span></button> " +
-                                "<button type=\"button\" class=\"btn btn-xs btn-default command-updown\" data-row-id=\"" + row.uuid + "\" data-command=\"down\"><span class=\"fa fa-arrow-down\"></span></button>";
-                        },
+        $(document).ready(function () {
+            grid = $("#grid-acl").UIBootgrid(
+                {
+                    'search': '/api/proxyuseracl/settings/searchACL',
+                    'get': '/api/proxyuseracl/settings/getACL/',
+                    'set': '/api/proxyuseracl/settings/setACL/',
+                    'add': '/api/proxyuseracl/settings/addACL/',
+                    'del': '/api/proxyuseracl/settings/delACL/',
+                    'toggle': '/api/proxyuseracl/settings/toggleACL/',
+                    options: {
+                        formatters: {
+                            "commands": function (column, row) {
+                                return "<button type=\"button\" class=\"btn btn-xs btn-default command-edit\" data-row-id=\"" + row.uuid + "\"><span class=\"fa fa-pencil\"></span></button> " +
+                                    "<button type=\"button\" class=\"btn btn-xs btn-default command-copy\" data-row-id=\"" + row.uuid + "\"><span class=\"fa fa-clone\"></span></button>" +
+                                    "<button type=\"button\" class=\"btn btn-xs btn-default command-delete\" data-row-id=\"" + row.uuid + "\"><span class=\"fa fa-trash-o\"></span></button>";
+                            },
+                            "targets": function (column, row) {
+                                return row.Source ? row.Source : row.Name;
+                            },
+                            "updown": function (column, row) {
+                                return "<button type=\"button\" class=\"btn btn-xs btn-default command-updown\" data-row-id=\"" + row.uuid + "\" data-command=\"up\"><span class=\"fa fa-arrow-up\"></span></button> " +
+                                    "<button type=\"button\" class=\"btn btn-xs btn-default command-updown\" data-row-id=\"" + row.uuid + "\" data-command=\"down\"><span class=\"fa fa-arrow-down\"></span></button>";
+                            },
+                        }
                     }
                 }
-            }
-        );
+            );
 
-        grid.on("loaded.rs.jquery.bootgrid", function () {
-            grid.find(".command-updown").on("click", function () {
-                ajaxCall(url = "/api/proxyuseracl/settings/updownACL/" + $(this).data("row-id"), sendData = {"command": $(this).data("command")}, callback = function () {
-                    $("#grid-acl").bootgrid("reload");
-                });
-            }).end();
-
-            grid.find("*[data-action=add]").click(function () {
-                $("#btn_DialogACL_save_progress").removeClass("fa fa-spinner fa-pulse");
-                $("#btn_DialogACL_save").click(function () {
-                    $("#btn_DialogACL_save_progress").addClass("fa fa-spinner fa-pulse");
-                    var old_handleFormValidation = window.handleFormValidation;
-                    window.handleFormValidation = function (parent, validationErrors) {
-                        $("#btn_DialogACL_save_progress").removeClass("fa fa-spinner fa-pulse");
-                        window.handleFormValidation = old_handleFormValidation;
-                        handleFormValidation(parent, validationErrors);
-                    }
-                });
-            }).end();
-        });
-
-        $("#reconfigureAct").click(function () {
-            $("#reconfigureAct_progress").addClass("fa fa-spinner fa-pulse");
-            ajaxCall(url = "/api/proxy/service/reconfigure", sendData = {}, callback = function (data, status) {
-                // when done, disable progress animation.
-                $("#reconfigureAct_progress").removeClass("fa fa-spinner fa-pulse");
-
-                if (status != "success" || data['status'] != 'ok') {
-                    BootstrapDialog.show({
-                        type: BootstrapDialog.TYPE_WARNING,
-                        title: "Error reconfiguring proxy",
-                        message: data['status'],
-                        draggable: true
+            grid.on("loaded.rs.jquery.bootgrid", function () {
+                grid.find(".command-updown").on("click", function () {
+                    ajaxCall(url = "/api/proxyuseracl/settings/updownACL/" + $(this).data("row-id"), sendData = {"command": $(this).data("command")}, callback = function () {
+                        $("#grid-acl").bootgrid("reload");
                     });
-                }
+                }).end();
+
+                grid.find("*[data-action=add]").click(function () {
+                    $('#row_ACL\\.Source').hide();
+
+                    $("#btn_DialogACL_save_progress").removeClass("fa fa-spinner fa-pulse");
+                    $("#btn_DialogACL_save").click(function () {
+                        $("#btn_DialogACL_save_progress").addClass("fa fa-spinner fa-pulse");
+                        var old_handleFormValidation = window.handleFormValidation;
+                        window.handleFormValidation = function (parent, validationErrors) {
+                            $("#btn_DialogACL_save_progress").removeClass("fa fa-spinner fa-pulse");
+                            window.handleFormValidation = old_handleFormValidation;
+                            handleFormValidation(parent, validationErrors);
+                        }
+                    });
+                }).end();
+
+                $('.command-edit').click(function(event) {
+                    var checkExist = setInterval(function() {
+                        var text = $('span.filter-option.pull-left')[0].innerText
+                        if (text == "IP" || text == "Group" || text == "User") {
+                            clearInterval(checkExist);
+                            if(text == "IP") {
+                                $('#row_ACL\\.Name').hide();
+                                $('#row_ACL\\.Source').show();
+                            }
+                            else {
+                                $('#row_ACL\\.Source').hide();
+                                $('#row_ACL\\.Name').show();
+                                $($('#row_ACL\\.Name').find('td')[0]).find('div').find('b').text(text);
+                            }
+                        }
+                    }, 100);
+                });
+
+                $(document).click(function(event) {
+                    var text = $('span.filter-option.pull-left')[0].innerText;
+
+                    if(text == "IP") {
+                        $('#row_ACL\\.Name').hide();
+                        $('#row_ACL\\.Source').show();
+                    }
+                    else {
+                        $('#row_ACL\\.Source').hide();
+                        $('#row_ACL\\.Name').show();
+                        $($('#row_ACL\\.Name').find('td')[0]).find('div').find('b').text(text);
+                    }
+                });
+            });
+
+            $("#reconfigureAct").click(function () {
+                $("#reconfigureAct_progress").addClass("fa fa-spinner fa-pulse");
+                ajaxCall(url = "/api/proxy/service/reconfigure", sendData = {}, callback = function (data, status) {
+                    // when done, disable progress animation.
+                    $("#reconfigureAct_progress").removeClass("fa fa-spinner fa-pulse");
+
+                    if (status != "success" || data['status'] != 'ok') {
+                        BootstrapDialog.show({
+                            type: BootstrapDialog.TYPE_WARNING,
+                            title: "Error reconfiguring proxy",
+                            message: data['status'],
+                            draggable: true
+                        });
+                    }
+                });
             });
         });
-    });
-</script>
+    </script>
 
-<div id="acl">
-    <table id="acl-content">
-        <tr>
-            <td colspan="2">
-                <table id="grid-acl" class="table table-condensed table-hover table-striped table-responsive"
-                       data-editDialog="DialogACL">
-                    <thead>
-                    <tr>
-                        <th data-column-id="Priority" data-width="10em" data-type="string" data-sortable="false"
-                            data-visible="true">{{ lang._('Number') }}</th>
-                        <th data-column-id="Group" data-width="10em" data-type="string"
-                            data-sortable="false">{{ lang._('Group') }}</th>
-                        <th data-column-id="Black" data-width="10em" data-type="string"
-                            data-sortable="false">{{ lang._('Black') }}</th>
-                        <th data-column-id="Name" data-type="string"
-                            data-sortable="false">{{ lang._('Name') }}</th>
-                        <th data-column-id="Domains" data-type="string" data-sortable="false"
-                            data-visible="true">{{ lang._('Domains') }}</th>
-                        <th data-column-id="updown" data-width="7em" data-formatter="updown"
-                            data-sortable="false">{{ lang._('Priority') }}</th>
-                        <th data-column-id="commands" data-width="7em" data-formatter="commands"
-                            data-sortable="false">{{ lang._('Commands') }}</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    </tbody>
-                    <tfoot>
-                    <tr>
-                        <td></td>
-                        <td>
-                            <button data-action="add" type="button" class="btn btn-xs btn-default"><span
-                                        class="fa fa-plus"></span></button>
-                            <button data-action="deleteSelected" type="button" class="btn btn-xs btn-default"><span
-                                        class="fa fa-trash-o"></span></button>
-                        </td>
-                    </tr>
-                    </tfoot>
-                </table>
-            </td>
-        </tr>
-    </table>
-</div>
-<button class="btn btn-primary" id="reconfigureAct" type="button"><b>{{ lang._('Apply') }}</b><i
-            id="reconfigureAct_progress" class=""></i></button>
+    <div id="acl">
+        <table id="acl-content">
+            <tr>
+                <td colspan="2">
+                    <table id="grid-acl" class="table table-condensed table-hover table-striped table-responsive"
+                           data-editDialog="DialogACL">
+                        <thead>
+                        <tr>
+                            <th data-column-id="Priority" data-width="10em" data-type="string" data-sortable="false"
+                                data-visible="true">{{ lang._('Number') }}</th>
+                            <th data-column-id="ACLName" data-type="string"
+                                data-sortable="false">{{ lang._('Description') }}</th>
+                            <th data-column-id="Group" data-width="10em" data-type="string"
+                                data-sortable="false">{{ lang._('Source') }}</th>
+                            <th data-column-id="targets" data-width="10em" data-formatter="targets"
+                                data-sortable="false">{{ lang._('Targets') }}</th>
+                            <th data-column-id="Black" data-width="10em" data-type="string"
+                                data-sortable="false">{{ lang._('Type') }}</th>
+                            <th data-column-id="Domains" data-type="string" data-sortable="false"
+                                data-visible="true">{{ lang._('Domains') }}</th>
+                            <th data-column-id="updown" data-width="7em" data-formatter="updown"
+                                data-sortable="false">{{ lang._('Priority') }}</th>
+                            <th data-column-id="commands" data-width="7em" data-formatter="commands"
+                                data-sortable="false">{{ lang._('Commands') }}</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        </tbody>
+                        <tfoot>
+                        <tr>
+                            <td></td>
+                            <td>
+                                <button data-action="add" type="button" class="btn btn-xs btn-default"><span
+                                            class="fa fa-plus"></span></button>
+                                <button data-action="deleteSelected" type="button" class="btn btn-xs btn-default"><span
+                                            class="fa fa-trash-o"></span></button>
+                            </td>
+                        </tr>
+                        </tfoot>
+                    </table>
+                </td>
+            </tr>
+        </table>
+    </div>
+    <button class="btn btn-primary" id="reconfigureAct" type="button"><b>{{ lang._('Apply') }}</b><i
+                id="reconfigureAct_progress" class=""></i></button>
 
-{{ partial("layout_partials/base_dialog",['fields':formDialogACL,'id':'DialogACL','label':lang._('Edit user/group white and black lists')]) }}
+    {{ partial("layout_partials/base_dialog",['fields':formDialogACL,'id':'DialogACL','label':lang._('Edit user/group/ip white and black lists')]) }}

--- a/www/web-proxy-useracl/src/opnsense/mvc/app/views/OPNsense/ProxyUserACL/index.volt
+++ b/www/web-proxy-useracl/src/opnsense/mvc/app/views/OPNsense/ProxyUserACL/index.volt
@@ -1,180 +1,194 @@
 {#
-    Copyright (C) 2017 Smart-Soft
+Copyright (C) 2017 Smart-Soft
 
-    All rights reserved.
+All rights reserved.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice,
-       this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
 
-    2. Redistributions in binary form must reproduce the above copyright
-       notice, this list of conditions and the following disclaimer in the
-       documentation and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
 
-    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
 
-    #}
+#}
 
-    <script>
+<script>
 
-        $(document).ready(function () {
-            grid = $("#grid-acl").UIBootgrid(
-                {
-                    'search': '/api/proxyuseracl/settings/searchACL',
-                    'get': '/api/proxyuseracl/settings/getACL/',
-                    'set': '/api/proxyuseracl/settings/setACL/',
-                    'add': '/api/proxyuseracl/settings/addACL/',
-                    'del': '/api/proxyuseracl/settings/delACL/',
-                    'toggle': '/api/proxyuseracl/settings/toggleACL/',
-                    options: {
-                        formatters: {
-                            "commands": function (column, row) {
-                                return "<button type=\"button\" class=\"btn btn-xs btn-default command-edit\" data-row-id=\"" + row.uuid + "\"><span class=\"fa fa-pencil\"></span></button> " +
-                                    "<button type=\"button\" class=\"btn btn-xs btn-default command-copy\" data-row-id=\"" + row.uuid + "\"><span class=\"fa fa-clone\"></span></button>" +
-                                    "<button type=\"button\" class=\"btn btn-xs btn-default command-delete\" data-row-id=\"" + row.uuid + "\"><span class=\"fa fa-trash-o\"></span></button>";
-                            },
-                            "targets": function (column, row) {
-                                return row.Source ? row.Source : row.Name;
-                            },
-                            "updown": function (column, row) {
-                                return "<button type=\"button\" class=\"btn btn-xs btn-default command-updown\" data-row-id=\"" + row.uuid + "\" data-command=\"up\"><span class=\"fa fa-arrow-up\"></span></button> " +
-                                    "<button type=\"button\" class=\"btn btn-xs btn-default command-updown\" data-row-id=\"" + row.uuid + "\" data-command=\"down\"><span class=\"fa fa-arrow-down\"></span></button>";
-                            },
-                        }
+    $(document).ready(function () {
+        grid = $("#grid-acl").UIBootgrid(
+            {
+                'search': '/api/proxyuseracl/settings/searchACL',
+                'get': '/api/proxyuseracl/settings/getACL/',
+                'set': '/api/proxyuseracl/settings/setACL/',
+                'add': '/api/proxyuseracl/settings/addACL/',
+                'del': '/api/proxyuseracl/settings/delACL/',
+                'toggle': '/api/proxyuseracl/settings/toggleACL/',
+                options: {
+                    formatters: {
+                        "commands": function (column, row) {
+                            return "<button type=\"button\" class=\"btn btn-xs btn-default command-edit\" data-row-id=\"" + row.uuid + "\"><span class=\"fa fa-pencil\"></span></button> " +
+                                "<button type=\"button\" class=\"btn btn-xs btn-default command-copy\" data-row-id=\"" + row.uuid + "\"><span class=\"fa fa-clone\"></span></button>" +
+                                "<button type=\"button\" class=\"btn btn-xs btn-default command-delete\" data-row-id=\"" + row.uuid + "\"><span class=\"fa fa-trash-o\"></span></button>";
+                        },
+                        "rowtoggle": function (column, row) {
+                            if (parseInt(row[column.id], 2) == 1) {
+                                return "<span style=\"cursor: pointer;\" class=\"fa fa-check-square-o command-toggle\" data-value=\"1\" data-row-id=\"" + row.uuid + "\"></span>";
+                            } else {
+                                return "<span style=\"cursor: pointer;\" class=\"fa fa-square-o command-toggle\" data-value=\"0\" data-row-id=\"" + row.uuid + "\"></span>";
+                            }
+                        },
+                        "boolean": function (column, row) {
+                            if (parseInt(row[column.id], 2) == 1) {
+                                return "<span class=\"fa fa-check\" data-value=\"1\" data-row-id=\"" + row.uuid + "\"></span>";
+                            } else {
+                                return "<span class=\"fa fa-times\" data-value=\"0\" data-row-id=\"" + row.uuid + "\"></span>";
+                            }
+                        },
+                        "updown": function (column, row) {
+                            return "<button type=\"button\" class=\"btn btn-xs btn-default command-updown\" data-row-id=\"" + row.uuid + "\" data-command=\"up\"><span class=\"fa fa-arrow-up\"></span></button> " +
+                                "<button type=\"button\" class=\"btn btn-xs btn-default command-updown\" data-row-id=\"" + row.uuid + "\" data-command=\"down\"><span class=\"fa fa-arrow-down\"></span></button>";
+                        },
+                        "targets": function (column, row) {
+                            return row.Source ? row.Source : row.Name;
+                        },
                     }
                 }
-            );
+            }
+        );
 
-            grid.on("loaded.rs.jquery.bootgrid", function () {
-                grid.find(".command-updown").on("click", function () {
-                    ajaxCall(url = "/api/proxyuseracl/settings/updownACL/" + $(this).data("row-id"), sendData = {"command": $(this).data("command")}, callback = function () {
-                        $("#grid-acl").bootgrid("reload");
-                    });
-                }).end();
-
-                grid.find("*[data-action=add]").click(function () {
-                    $('#row_ACL\\.Source').hide();
-
-                    $("#btn_DialogACL_save_progress").removeClass("fa fa-spinner fa-pulse");
-                    $("#btn_DialogACL_save").click(function () {
-                        $("#btn_DialogACL_save_progress").addClass("fa fa-spinner fa-pulse");
-                        var old_handleFormValidation = window.handleFormValidation;
-                        window.handleFormValidation = function (parent, validationErrors) {
-                            $("#btn_DialogACL_save_progress").removeClass("fa fa-spinner fa-pulse");
-                            window.handleFormValidation = old_handleFormValidation;
-                            handleFormValidation(parent, validationErrors);
-                        }
-                    });
-                }).end();
-
-                $('.command-edit').click(function(event) {
-                    var checkExist = setInterval(function() {
-                        var text = $('span.filter-option.pull-left')[0].innerText
-                        if (text == "IP" || text == "Group" || text == "User") {
-                            clearInterval(checkExist);
-                            if(text == "IP") {
-                                $('#row_ACL\\.Name').hide();
-                                $('#row_ACL\\.Source').show();
-                            }
-                            else {
-                                $('#row_ACL\\.Source').hide();
-                                $('#row_ACL\\.Name').show();
-                                $($('#row_ACL\\.Name').find('td')[0]).find('div').find('b').text(text);
-                            }
-                        }
-                    }, 100);
+        grid.on("loaded.rs.jquery.bootgrid", function () {
+            grid.find(".command-updown").on("click", function () {
+                ajaxCall(url = "/api/proxyuseracl/settings/updownACL/" + $(this).data("row-id"), sendData = {"command": $(this).data("command")}, callback = function () {
+                    $("#grid-acl").bootgrid("reload");
                 });
+            }).end();
 
-                $(document).click(function(event) {
-                    var text = $('span.filter-option.pull-left')[0].innerText;
+            grid.find("*[data-action=add]").click(function () {
+                $('#row_ACL\\.Source').hide();
 
-                    if(text == "IP") {
-                        $('#row_ACL\\.Name').hide();
-                        $('#row_ACL\\.Source').show();
-                    }
-                    else {
-                        $('#row_ACL\\.Source').hide();
-                        $('#row_ACL\\.Name').show();
-                        $($('#row_ACL\\.Name').find('td')[0]).find('div').find('b').text(text);
+                $("#btn_DialogACL_save_progress").removeClass("fa fa-spinner fa-pulse");
+                $("#btn_DialogACL_save").click(function () {
+                    $("#btn_DialogACL_save_progress").addClass("fa fa-spinner fa-pulse");
+                    var old_handleFormValidation = window.handleFormValidation;
+                    window.handleFormValidation = function (parent, validationErrors) {
+                        $("#btn_DialogACL_save_progress").removeClass("fa fa-spinner fa-pulse");
+                        window.handleFormValidation = old_handleFormValidation;
+                        handleFormValidation(parent, validationErrors);
                     }
                 });
+            }).end();
+
+            $('.command-edit').click(function(event) {
+                var checkExist = setInterval(function() {
+                    var text = $('span.filter-option.pull-left')[0].innerText
+                    if (text == "IP" || text == "Group" || text == "User") {
+                        clearInterval(checkExist);
+                        if(text == "IP") {
+                            $('#row_ACL\\.Name').hide();
+                            $('#row_ACL\\.Source').show();
+                        }
+                        else {
+                            $('#row_ACL\\.Source').hide();
+                            $('#row_ACL\\.Name').show();
+                            $($('#row_ACL\\.Name').find('td')[0]).find('div').find('b').text(text);
+                        }
+                    }
+                }, 100);
             });
 
-            $("#reconfigureAct").click(function () {
-                $("#reconfigureAct_progress").addClass("fa fa-spinner fa-pulse");
-                ajaxCall(url = "/api/proxy/service/reconfigure", sendData = {}, callback = function (data, status) {
-                    // when done, disable progress animation.
-                    $("#reconfigureAct_progress").removeClass("fa fa-spinner fa-pulse");
+            $(document).click(function(event) {
+                var text = $('span.filter-option.pull-left')[0].innerText;
 
-                    if (status != "success" || data['status'] != 'ok') {
-                        BootstrapDialog.show({
-                            type: BootstrapDialog.TYPE_WARNING,
-                            title: "Error reconfiguring proxy",
-                            message: data['status'],
-                            draggable: true
-                        });
-                    }
-                });
+                if(text == "IP") {
+                    $('#row_ACL\\.Name').hide();
+                    $('#row_ACL\\.Source').show();
+                }
+                else {
+                    $('#row_ACL\\.Source').hide();
+                    $('#row_ACL\\.Name').show();
+                    $($('#row_ACL\\.Name').find('td')[0]).find('div').find('b').text(text);
+                }
             });
         });
-    </script>
 
-    <div id="acl">
-        <table id="acl-content">
-            <tr>
-                <td colspan="2">
-                    <table id="grid-acl" class="table table-condensed table-hover table-striped table-responsive"
-                           data-editDialog="DialogACL">
-                        <thead>
-                        <tr>
-                            <th data-column-id="Priority" data-width="10em" data-type="string" data-sortable="false"
-                                data-visible="true">{{ lang._('Number') }}</th>
-                            <th data-column-id="ACLName" data-type="string"
-                                data-sortable="false">{{ lang._('Description') }}</th>
-                            <th data-column-id="Group" data-width="10em" data-type="string"
-                                data-sortable="false">{{ lang._('Target Type') }}</th>
-                            <th data-column-id="targets" data-width="10em" data-formatter="targets"
-                                data-sortable="false">{{ lang._('Targets') }}</th>
-                            <th data-column-id="Black" data-width="10em" data-type="string"
-                                data-sortable="false">{{ lang._('Type') }}</th>
-                            <th data-column-id="Domains" data-type="string" data-sortable="false"
-                                data-visible="true">{{ lang._('Domains') }}</th>
-                            <th data-column-id="updown" data-width="7em" data-formatter="updown"
-                                data-sortable="false">{{ lang._('Priority') }}</th>
-                            <th data-column-id="commands" data-width="7em" data-formatter="commands"
-                                data-sortable="false">{{ lang._('Commands') }}</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        </tbody>
-                        <tfoot>
-                        <tr>
-                            <td></td>
-                            <td>
-                                <button data-action="add" type="button" class="btn btn-xs btn-default"><span
-                                            class="fa fa-plus"></span></button>
-                                <button data-action="deleteSelected" type="button" class="btn btn-xs btn-default"><span
-                                            class="fa fa-trash-o"></span></button>
-                            </td>
-                        </tr>
-                        </tfoot>
-                    </table>
-                </td>
-            </tr>
-        </table>
-    </div>
-    <button class="btn btn-primary" id="reconfigureAct" type="button"><b>{{ lang._('Apply') }}</b><i
-                id="reconfigureAct_progress" class=""></i></button>
+        $("#reconfigureAct").click(function () {
+            $("#reconfigureAct_progress").addClass("fa fa-spinner fa-pulse");
+            ajaxCall(url = "/api/proxy/service/reconfigure", sendData = {}, callback = function (data, status) {
+                // when done, disable progress animation.
+                $("#reconfigureAct_progress").removeClass("fa fa-spinner fa-pulse");
 
-    {{ partial("layout_partials/base_dialog",['fields':formDialogACL,'id':'DialogACL','label':lang._('Edit user/group/ip white and black lists')]) }}
+                if (status != "success" || data['status'] != 'ok') {
+                    BootstrapDialog.show({
+                        type: BootstrapDialog.TYPE_WARNING,
+                        title: "Error reconfiguring proxy",
+                        message: data['status'],
+                        draggable: true
+                    });
+                }
+            });
+        });
+    });
+</script>
+
+<div id="acl">
+    <table id="acl-content">
+        <tr>
+            <td colspan="2">
+                <table id="grid-acl" class="table table-condensed table-hover table-striped table-responsive"
+                        data-editDialog="DialogACL">
+                    <thead>
+                    <tr>
+                        <th data-column-id="Priority" data-width="10em" data-type="string" data-sortable="false"
+                            data-visible="true">{{ lang._('Number') }}</th>
+                        <th data-column-id="ACLName" data-type="string"
+                            data-sortable="false">{{ lang._('Description') }}</th>
+                        <th data-column-id="Group" data-width="10em" data-type="string"
+                            data-sortable="false">{{ lang._('Target Type') }}</th>
+                        <th data-column-id="targets" data-width="10em" data-formatter="targets"
+                            data-sortable="false">{{ lang._('Targets') }}</th>
+                        <th data-column-id="Black" data-width="10em" data-type="string"
+                            data-sortable="false">{{ lang._('Type') }}</th>
+                        <th data-column-id="Domains" data-type="string" data-sortable="false"
+                            data-visible="true">{{ lang._('Domains') }}</th>
+                        <th data-column-id="updown" data-width="7em" data-formatter="updown"
+                            data-sortable="false">{{ lang._('Priority') }}</th>
+                        <th data-column-id="commands" data-width="7em" data-formatter="commands"
+                            data-sortable="false">{{ lang._('Commands') }}</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    </tbody>
+                    <tfoot>
+                    <tr>
+                        <td></td>
+                        <td>
+                            <button data-action="add" type="button" class="btn btn-xs btn-default"><span
+                                        class="fa fa-plus"></span></button>
+                            <button data-action="deleteSelected" type="button" class="btn btn-xs btn-default"><span
+                                        class="fa fa-trash-o"></span></button>
+                        </td>
+                    </tr>
+                    </tfoot>
+                </table>
+            </td>
+        </tr>
+    </table>
+</div>
+<button class="btn btn-primary" id="reconfigureAct" type="button"><b>{{ lang._('Apply') }}</b><i
+            id="reconfigureAct_progress" class=""></i></button>
+
+{{ partial("layout_partials/base_dialog",['fields':formDialogACL,'id':'DialogACL','label':lang._('Edit user/group/ip white and black lists')]) }}

--- a/www/web-proxy-useracl/src/opnsense/scripts/OPNsense/ProxyUserACL/reload.php
+++ b/www/web-proxy-useracl/src/opnsense/scripts/OPNsense/ProxyUserACL/reload.php
@@ -39,7 +39,18 @@ $domain = strtoupper((string) Config::getInstance()->object()->system->domain);
 
 array_map('unlink', glob("/usr/local/etc/squid/ACL_useracl_*.txt"));
 foreach ($mdlProxyUserACL->getNodeByReference('general.ACLs.ACL')->getNodes() as $acl) {
-    file_put_contents("/usr/local/etc/squid/ACL_useracl_" .
-        $acl["Priority"] . ".txt", $acl["Name"] . "\n" .
-        ($acl["Group"]["user"]["selected"] == "1" ? $acl["Name"] . "@" . $domain . "\n" : ""));
+    file_put_contents("/test.txt", $acl["Group"]);
+    if ($acl["Group"]["ip"]["selected"] == "1") {
+        $sources = "";
+        foreach ($acl["Source"] as $source)
+            $sources = $sources . $source["value"] . "\n";
+
+        file_put_contents("/usr/local/etc/squid/ACL_useracl_" .
+            $acl["Priority"] . ".txt", $sources . "\n");
+    }
+    else {
+        file_put_contents("/usr/local/etc/squid/ACL_useracl_" .
+            $acl["Priority"] . ".txt", $acl["Name"] . "\n" .
+            ($acl["Group"]["user"]["selected"] == "1" ? $acl["Name"] . "@" . $domain . "\n" : ""));
+    }
 }

--- a/www/web-proxy-useracl/src/opnsense/service/templates/OPNsense/ProxyUserACL/ProxyUserACL.conf
+++ b/www/web-proxy-useracl/src/opnsense/service/templates/OPNsense/ProxyUserACL/ProxyUserACL.conf
@@ -39,7 +39,11 @@ external_acl_type ext_group_local_{{ ACL.Priority }} ttl=300 negative_ttl=60 %LO
 acl group_local_{{ACL.Priority}} external ext_group_local_{{ ACL.Priority }} "/usr/local/etc/squid/ACL_useracl_{{ ACL.Priority }}.txt"
 {%              endif %}
 {%          else %}
+{%              if  ACL.Group == "user" %}
 acl user_{{ACL.Priority}} proxy_auth "/usr/local/etc/squid/ACL_useracl_{{ ACL.Priority }}.txt"
+{%              else %}
+acl ip_{{ACL.Priority}} src "/usr/local/etc/squid/ACL_useracl_{{ ACL.Priority }}.txt"
+{%              endif %}
 {%          endif %}
 {%          if ldap|length == 1 or local|length == 1 %}
 {%              for element in ACL.Domains.split(",") %}
@@ -79,11 +83,19 @@ adaptation_access request_mod  {{ACL.Black}} group_local_{{ACL.Priority}} domain
 http_access {{ACL.Black}} group_local_{{ACL.Priority}} domains_{{ACL.Priority}}
 {%			            endif %}
 {%                  else %}
-{%	                if helpers.exists('OPNsense.proxy.forward.icap.enable') and OPNsense.proxy.forward.icap.enable == '1' %}
+{%                      if  ACL.Group == "user" %}
+{%	                        if helpers.exists('OPNsense.proxy.forward.icap.enable') and OPNsense.proxy.forward.icap.enable == '1' %}
 adaptation_access response_mod {{ACL.Black}} user_{{ACL.Priority}} domains_{{ACL.Priority}}
 adaptation_access request_mod  {{ACL.Black}} user_{{ACL.Priority}} domains_{{ACL.Priority}}
-{%		                endif %}
+{%		                    endif %}
 http_access {{ACL.Black}} user_{{ACL.Priority}} domains_{{ACL.Priority}}
+{%                      else %}
+{%	                        if helpers.exists('OPNsense.proxy.forward.icap.enable') and OPNsense.proxy.forward.icap.enable == '1' %}
+adaptation_access response_mod {{ACL.Black}} ip_{{ACL.Priority}} domains_{{ACL.Priority}}
+adaptation_access request_mod  {{ACL.Black}} ip_{{ACL.Priority}} domains_{{ACL.Priority}}
+{%		                    endif %}
+http_access {{ACL.Black}} ip_{{ACL.Priority}} domains_{{ACL.Priority}}
+{%		                endif %}
 {%		            endif %}
 {%                  break %}
 {%		        endif %}


### PR DESCRIPTION
ProxyUserACL only allowed creating squid rules based on groups and users. This Pull Request simply adds a new type of ACL where you can instead create rules based on IP addresses. The previous features, except the views, remains unchanged.

<img width="1413" alt="screen shot 2018-07-23 at 19 02 11" src="https://user-images.githubusercontent.com/21959383/43095360-7ea2737c-8ead-11e8-9a23-4378807b7108.png">

<img width="1415" alt="screen shot 2018-07-23 at 19 03 24" src="https://user-images.githubusercontent.com/21959383/43095361-7ed3bc16-8ead-11e8-8e15-ea672af62182.png">

<img width="1411" alt="screen shot 2018-07-23 at 19 03 40" src="https://user-images.githubusercontent.com/21959383/43095363-7efcf5a4-8ead-11e8-8fec-0f53c8a1b8be.png">


