### PR TITLE
net/relayd: relayd.conf template failed with http checks

### DIFF
--- a/net/relayd/Makefile
+++ b/net/relayd/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		relayd
-PLUGIN_VERSION=		2.0
+PLUGIN_VERSION=		2.1
 PLUGIN_DEPENDS=		relayd
 PLUGIN_COMMENT=		Relayd Load Balancer
 PLUGIN_MAINTAINER=	frank.brendel@eurolog.com

--- a/net/relayd/src/opnsense/service/templates/OPNsense/Relayd/relayd.conf
+++ b/net/relayd/src/opnsense/service/templates/OPNsense/Relayd/relayd.conf
@@ -68,33 +68,28 @@ disable
 {%   set table = helpers.getUUID(virtualserver.transport_table) %}
 {%   set tablecheck = helpers.getUUID(virtualserver.transport_tablecheck) %}
 {%   set _tablecheck = '' %}
-{%   if tablecheck.type == 'http' %}
-{%    if tablecheck.path is defined %}
-{%     if tablecheck.ssl|default('0') == '1' %}
-{%      set _tablecheck = 'check ' ~ tablecheck.type ~ 's' %}
-{%     endif %}
-{%     set _tablecheck = _tablecheck ~ ' "' ~ tablecheck.path ~ '"' %}
-{%     if tablecheck.host is defined %}
-{%      set _tablecheck = _tablecheck ~ ' host ' ~ tablecheck.host %}
-{%     endif %}
-{%     if tablecheck.code is defined %}
-{%      set _tablecheck = _tablecheck ~ ' code ' ~ tablecheck.code %}
-{%     elif tablecheck.digest is defined %}
-{%      set _tablecheck = _tablecheck ~ ' digest "' ~ tablecheck.digest ~ '"' %}
-{%     else %}
-{%      set _tablecheck = '' %}
-{%     endif %}
+{%   if tablecheck.type == 'http' and tablecheck.path is defined %}
+{%    set _tablecheck = 'check ' ~ tablecheck.type %}
+{%    if tablecheck.ssl|default('0') == '1' %}
+{%     set _tablecheck = _tablecheck ~ 's' %}
 {%    endif %}
-{%   elif tablecheck.type == 'script' %}
-{%    if tablecheck.path is defined %}
-{%     set _tablecheck = 'check ' ~ tablecheck.type ~ ' "' ~ tablecheck.path ~ '"' %}
+{%    set _tablecheck = _tablecheck ~ ' "' ~ tablecheck.path ~ '"' %}
+{%    if tablecheck.host is defined %}
+{%     set _tablecheck = _tablecheck ~ ' host ' ~ tablecheck.host %}
 {%    endif %}
-{%   elif tablecheck.type == 'send' %}
-{%    if tablecheck.expect is defined %}
-{%     set _tablecheck = 'check ' ~ tablecheck.type ~ ' "' ~ tablecheck.data ~ '" expect "' ~ tablecheck.expect ~ '"' %}
-{%     if tablecheck.ssl|default('0') == '1' %}
-{%      set _tablecheck = _tablecheck ~ ' ssl' %}
-{%     endif %}
+{%    if tablecheck.code is defined %}
+{%     set _tablecheck = _tablecheck ~ ' code ' ~ tablecheck.code %}
+{%    elif tablecheck.digest is defined %}
+{%     set _tablecheck = _tablecheck ~ ' digest "' ~ tablecheck.digest ~ '"' %}
+{%    else %}
+{%     set _tablecheck = '' %}
+{%    endif %}
+{%   elif tablecheck.type == 'script' and tablecheck.path is defined %}
+{%    set _tablecheck = 'check ' ~ tablecheck.type ~ ' "' ~ tablecheck.path ~ '"' %}
+{%   elif tablecheck.type == 'send' and tablecheck.expect is defined %}
+{%    set _tablecheck = 'check ' ~ tablecheck.type ~ ' "' ~ tablecheck.data ~ '" expect "' ~ tablecheck.expect ~ '"' %}
+{%    if tablecheck.ssl|default('0') == '1' %}
+{%     set _tablecheck = _tablecheck ~ ' ssl' %}
 {%    endif %}
 {%   else %}
 {%    set _tablecheck = 'check ' ~ tablecheck.type %}
@@ -107,33 +102,28 @@ disable
 {%    set backuptable = helpers.getUUID(virtualserver.backuptransport_table) %}
 {%    set backuptablecheck = helpers.getUUID(virtualserver.backuptransport_tablecheck) if virtualserver.backuptransport_tablecheck is defined %}
 {%    set _backuptablecheck = '' %}
-{%    if backuptablecheck.type == 'http' %}
-{%     if backuptablecheck.path is defined %}
-{%      if backuptablecheck.ssl|default('0') == '1' %}
-{%       set _backuptablecheck = 'check ' ~ backuptablecheck.type ~ 's' %}
-{%      endif %}
-{%      set _backuptablecheck = _backuptablecheck ~ ' "' ~ backuptablecheck.path ~ '"' %}
-{%      if backuptablecheck.host is defined %}
-{%       set _backuptablecheck = _backuptablecheck ~ ' host ' ~ backuptablecheck.host %}
-{%      endif %}
-{%      if backuptablecheck.code is defined %}
-{%       set _backuptablecheck = _backuptablecheck ~ ' code ' ~ backuptablecheck.code %}
-{%      elif backuptablecheck.digest is defined %}
-{%       set _backuptablecheck = _backuptablecheck ~ ' digest "' ~ backuptablecheck.digest ~ '"' %}
-{%      else %}
-{%       set _backuptablecheck = '' %}
-{%      endif %}
+{%    if backuptablecheck.type == 'http' and backuptablecheck.path is defined%}
+{%     set _backuptablecheck = 'check ' ~ backuptablecheck.type ~ 's' %}
+{%     if backuptablecheck.ssl|default('0') == '1' %}
+{%      set _backuptablecheck = _backuptablecheck ~ 's' %}
 {%     endif %}
-{%    elif backuptablecheck.type == 'script' %}
-{%     if backuptablecheck.path is defined %}
-{%      set _backuptablecheck = 'check ' ~ backuptablecheck.type ~ ' "' ~ backuptablecheck.path ~ '"' %}
+{%     set _backuptablecheck = _backuptablecheck ~ ' "' ~ backuptablecheck.path ~ '"' %}
+{%     if backuptablecheck.host is defined %}
+{%      set _backuptablecheck = _backuptablecheck ~ ' host ' ~ backuptablecheck.host %}
 {%     endif %}
-{%    elif backuptablecheck.type == 'send' %}
-{%     if backuptablecheck.expect is defined %}
-{%      set _backuptablecheck = 'check ' ~ backuptablecheck.type ~ ' "' ~ backuptablecheck.data ~ '" expect "' ~ backuptablecheck.expect ~ '"' %}
-{%      if backuptablecheck.ssl|default('0') == '1' %}
-{%       set _backuptablecheck = _backuptablecheck ~ ' ssl' %}
-{%      endif %}
+{%     if backuptablecheck.code is defined %}
+{%      set _backuptablecheck = _backuptablecheck ~ ' code ' ~ backuptablecheck.code %}
+{%     elif backuptablecheck.digest is defined %}
+{%      set _backuptablecheck = _backuptablecheck ~ ' digest "' ~ backuptablecheck.digest ~ '"' %}
+{%     else %}
+{%      set _backuptablecheck = '' %}
+{%     endif %}
+{%    elif backuptablecheck.type == 'script' and backuptablecheck.path is defined %}
+{%     set _backuptablecheck = 'check ' ~ backuptablecheck.type ~ ' "' ~ backuptablecheck.path ~ '"' %}
+{%    elif backuptablecheck.type == 'send' and backuptablecheck.expect is defined %}
+{%     set _backuptablecheck = 'check ' ~ backuptablecheck.type ~ ' "' ~ backuptablecheck.data ~ '" expect "' ~ backuptablecheck.expect ~ '"' %}
+{%     if backuptablecheck.ssl|default('0') == '1' %}
+{%      set _backuptablecheck = _backuptablecheck ~ ' ssl' %}
 {%     endif %}
 {%    else %}
 {%     set _backuptablecheck = 'check ' ~ backuptablecheck.type %}


### PR DESCRIPTION
Fix failed syntax check of the relayd.conf with check type HTTP.

