### PR TITLE
 security/acme-client: Fix ECC Certs renewal and add support for OCSP

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogCertificate.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogCertificate.xml
@@ -45,6 +45,12 @@
         <help><![CDATA[Specify the domain key length: 2048, 3072, 4096, 8192 or ec-256, ec-384.]]></help>
     </field>
     <field>
+        <id>certificate.ocsp</id>
+        <label>OCSP Must Staple</label>
+        <type>checkbox</type>
+        <help>Generate and add OCSP Must Staple extension to the certificate.</help>
+    </field>
+    <field>
         <id>certificate.restartActions</id>
         <label>Restart Actions</label>
         <type>select_multiple</type>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -214,6 +214,10 @@
                         <key_ec384>ec-384</key_ec384>
                     </OptionValues>
                 </keyLength>
+                <ocsp type="BooleanField">
+                    <default>0</default>
+                    <Required>N</Required>
+                </ocsp>
                 <restartActions type="ModelRelationField">
                     <Model>
                         <actions>

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -799,7 +799,13 @@ function run_acme_validation($certObj, $valObj, $acctObj)
     // Get the chosen key length from xml and trim the parameter before passing to acme client
     $key_length = (string) $certObj->keyLength;
     $key_length = substr($key_length, 4);
+
     if ($key_length == 'ec256' || $key_length == 'ec384') {
+
+        if ($acme_action == "renew") {
+            // if it's renew then pass --ecc to acme client to locate the correct cert directory
+            $acme_args[] = "--ecc";
+        }
         $key_length = substr_replace($key_length, '-', 2, 0);
     }
 

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -809,6 +809,11 @@ function run_acme_validation($certObj, $valObj, $acctObj)
         $key_length = substr_replace($key_length, '-', 2, 0);
     }
 
+    // if OCSP Extension is turned on pass --ocsp parameter to acme client
+    if (isset($certObj->ocsp)) {
+        $acme_args[] = "--ocsp";
+    }
+
     // Run acme client
     // NOTE: We "export" certificates to our own directory, so we don't have to deal
     // with domain names in filesystem, but instead can use the ID of our certObj.


### PR DESCRIPTION
Added the ability to generate OCSP when issuing certificates.

Also Fixed ECC certs renewal bug, as --ecc must be passed to acme client in order to get the directory located, else the renewal will fail.

In the future, I would consider moving some blocks to functions and reorder the logic, as it begun to look a bit chaotic and non-semantic, but for now I would leave it that way.

If you have any suggestion, you are free to suggest, else I would like if the ecc bug got merged asap before the people hit the renewal time xD