### PR TITLE
fix acme operations when using multiple accounts

### DIFF
--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -319,10 +319,14 @@ function run_acme_account_registration($acctObj, $certObj, $modelObj)
     $account_conf_dir = "/var/etc/acme-client/accounts/" . $acctObj->id;
     $account_conf_file = $account_conf_dir . "/account.conf";
     $account_key_file = $account_conf_dir . "/account.key";
+    $account_json_file = $account_conf_dir . "/account.json";
+    $account_ca_file = $account_conf_dir . "/ca.conf";
     $acme_conf = array();
     $acme_conf[] = "CERT_HOME='/var/etc/acme-client/home'";
     $acme_conf[] = "LOG_FILE='/var/log/acme.sh.log'";
     $acme_conf[] = "ACCOUNT_KEY_PATH='" . $account_key_file . "'";
+    $acme_conf[] = "ACCOUNT_JSON_PATH='" . $account_json_file . "'";
+    $acme_conf[] = "CA_CONF='" . $account_ca_file . "'";
     if (!empty((string)$acctObj->email)) {
         $acme_conf[] = "ACCOUNT_EMAIL='" . (string)$acctObj->email . "'";
     }


### PR DESCRIPTION
acme.sh stores some account-related information in
/var/etc/acme-client/home/ca
this leads to "validation failed" messages every time a certificate
with a different account is validated
this is fixed by adding ACCOUNT_JSON_PATH and CA_CONF to account.conf