### PR TITLE
net/vnstat: new plugin

### DIFF
--- a/net/vnstat/Makefile
+++ b/net/vnstat/Makefile
@@ -1,0 +1,8 @@
+PLUGIN_NAME=		vnstat
+PLUGIN_VERSION=		0.1
+PLUGIN_COMMENT=		vnStat is a console-based network traffic monitor
+PLUGIN_DEPENDS=		vnstat
+PLUGIN_MAINTAINER=	m.muenz@gmail.com
+PLUGIN_DEVEL=       yes
+
+.include "../../Mk/plugins.mk"

--- a/net/vnstat/pkg-descr
+++ b/net/vnstat/pkg-descr
@@ -1,0 +1,8 @@
+vnStat is a console-based network traffic monitor for Linux
+and BSD that keeps a log of network traffic for the selected
+interface(s). It uses the network interface statistics
+provided by the kernel as information source. This means
+that vnStat won't actually be sniffing any traffic and also
+ensures light use of system resources.
+
+WWW: https://humdi.net/vnstat/

--- a/net/vnstat/src/etc/inc/plugins.inc.d/vnstat.inc
+++ b/net/vnstat/src/etc/inc/plugins.inc.d/vnstat.inc
@@ -1,0 +1,55 @@
+<?php
+
+/*
+    Copyright (C) 2018 Michael Muenz
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+
+function vnstat_enabled()
+{
+    $model = new \OPNsense\Vnstat\General();
+    return (string)$model->enabled == '1';
+}
+
+function vnstat_services()
+{
+    $services = array();
+
+    if (!vnstat_enabled()) {
+        return $services;
+    }
+
+    $services[] = array(
+        'description' => gettext('vnStat Daemon'),
+        'configd' => array(
+            'restart' => array('vnstat restart'),
+            'start' => array('vnstat start'),
+            'stop' => array('vnstat stop'),
+        ),
+        'name' => 'vnstatd',
+        'pidfile' => '/var/run/vnstat/vnstat.pid'
+    );
+
+    return $services;
+}

--- a/net/vnstat/src/opnsense/mvc/app/controllers/OPNsense/Vnstat/Api/GeneralController.php
+++ b/net/vnstat/src/opnsense/mvc/app/controllers/OPNsense/Vnstat/Api/GeneralController.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ *    Copyright (C) 2018 Michael Muenz
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+namespace OPNsense\Vnstat\Api;
+
+use OPNsense\Base\ApiMutableModelControllerBase;
+
+class GeneralController extends ApiMutableModelControllerBase
+{
+    static protected $internalModelClass = '\OPNsense\Vnstat\General';
+    static protected $internalModelName = 'general';
+}

--- a/net/vnstat/src/opnsense/mvc/app/controllers/OPNsense/Vnstat/Api/ServiceController.php
+++ b/net/vnstat/src/opnsense/mvc/app/controllers/OPNsense/Vnstat/Api/ServiceController.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ *    Copyright (C) 2018 Michael Muenz
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+namespace OPNsense\Vnstat\Api;
+
+use OPNsense\Base\ApiMutableServiceControllerBase;
+use OPNsense\Core\Backend;
+use OPNsense\Vnstat\General;
+
+/**
+ * Class ServiceController
+ * @package OPNsense\Vnstat
+ */
+class ServiceController extends ApiMutableServiceControllerBase
+{
+    static protected $internalServiceClass = '\OPNsense\Vnstat\General';
+    static protected $internalServiceTemplate = 'OPNsense/Vnstat';
+    static protected $internalServiceEnabled = 'enabled';
+    static protected $internalServiceName = 'vnstat';
+    
+    /**
+     * list hourly statistics
+     * @return array
+     */
+    public function hourlyAction()
+    {
+        $backend = new Backend();
+        $response = $backend->configdRun("vnstat hourly");
+        return array("response" => $response);
+    }
+
+    /**
+     * list daily statistics
+     * @return array
+     */
+    public function hourlyAction()
+    {
+        $backend = new Backend();
+        $response = $backend->configdRun("vnstat daily");
+        return array("response" => $response);
+    }
+
+    /**
+     * list weekly statistics
+     * @return array
+     */
+    public function hourlyAction()
+    {
+        $backend = new Backend();
+        $response = $backend->configdRun("vnstat weekly");
+        return array("response" => $response);
+    }
+
+    /**
+     * list monthly statistics
+     * @return array
+     */
+    public function hourlyAction()
+    {
+        $backend = new Backend();
+        $response = $backend->configdRun("vnstat monthly");
+        return array("response" => $response);
+    }
+}

--- a/net/vnstat/src/opnsense/mvc/app/controllers/OPNsense/Vnstat/Api/ServiceController.php
+++ b/net/vnstat/src/opnsense/mvc/app/controllers/OPNsense/Vnstat/Api/ServiceController.php
@@ -60,7 +60,7 @@ class ServiceController extends ApiMutableServiceControllerBase
      * list daily statistics
      * @return array
      */
-    public function hourlyAction()
+    public function dailyAction()
     {
         $backend = new Backend();
         $response = $backend->configdRun("vnstat daily");
@@ -71,7 +71,7 @@ class ServiceController extends ApiMutableServiceControllerBase
      * list weekly statistics
      * @return array
      */
-    public function hourlyAction()
+    public function weeklyAction()
     {
         $backend = new Backend();
         $response = $backend->configdRun("vnstat weekly");
@@ -82,7 +82,7 @@ class ServiceController extends ApiMutableServiceControllerBase
      * list monthly statistics
      * @return array
      */
-    public function hourlyAction()
+    public function monthlyAction()
     {
         $backend = new Backend();
         $response = $backend->configdRun("vnstat monthly");

--- a/net/vnstat/src/opnsense/mvc/app/controllers/OPNsense/Vnstat/GeneralController.php
+++ b/net/vnstat/src/opnsense/mvc/app/controllers/OPNsense/Vnstat/GeneralController.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+    Copyright (C) 2018 Michael Muenz
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+
+namespace OPNsense\Vnstat;
+
+class GeneralController extends \OPNsense\Base\IndexController
+{
+    public function indexAction()
+    {
+        $this->view->generalForm = $this->getForm("general");
+        $this->view->pick('OPNsense/Vnstat/general');
+    }
+}

--- a/net/vnstat/src/opnsense/mvc/app/controllers/OPNsense/Vnstat/forms/general.xml
+++ b/net/vnstat/src/opnsense/mvc/app/controllers/OPNsense/Vnstat/forms/general.xml
@@ -1,0 +1,14 @@
+<form>
+    <field>
+        <id>general.enabled</id>
+        <label>Enable vnstat daemon</label>
+        <type>checkbox</type>
+        <help>This will activate the vnstat daemon.</help>
+    </field>
+    <field>
+        <id>general.interface</id>
+        <label>Interface</label>
+        <type>dropdown</type>
+        <help>Set the interface to listen on.</help>
+    </field>
+</form>

--- a/net/vnstat/src/opnsense/mvc/app/models/OPNsense/Vnstat/ACL/ACL.xml
+++ b/net/vnstat/src/opnsense/mvc/app/models/OPNsense/Vnstat/ACL/ACL.xml
@@ -1,0 +1,9 @@
+<acl>
+   <page-services-vnstat>
+      <name>Services: Vnstat</name>
+      <patterns>
+         <pattern>ui/vnstat/*</pattern>
+         <pattern>api/vnstat/*</pattern>
+      </patterns>
+   </page-services-vnstat>
+</acl>

--- a/net/vnstat/src/opnsense/mvc/app/models/OPNsense/Vnstat/General.php
+++ b/net/vnstat/src/opnsense/mvc/app/models/OPNsense/Vnstat/General.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+    Copyright (C) 2018 Michael Muenz
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+
+namespace OPNsense\Vnstat;
+
+use OPNsense\Base\BaseModel;
+
+class General extends BaseModel
+{
+}

--- a/net/vnstat/src/opnsense/mvc/app/models/OPNsense/Vnstat/General.xml
+++ b/net/vnstat/src/opnsense/mvc/app/models/OPNsense/Vnstat/General.xml
@@ -1,0 +1,14 @@
+<model>
+    <mount>//OPNsense/vnstat/general</mount>
+    <description>Vnstat configuration</description>
+    <version>0.0.1</version>
+    <items>
+        <enabled type="BooleanField">
+            <default>0</default>
+            <Required>Y</Required>
+        </enabled>
+        <interface type="InterfaceField">
+            <Required>N</Required>
+        </interface>
+    </items>
+</model>

--- a/net/vnstat/src/opnsense/mvc/app/models/OPNsense/Vnstat/Menu/Menu.xml
+++ b/net/vnstat/src/opnsense/mvc/app/models/OPNsense/Vnstat/Menu/Menu.xml
@@ -1,0 +1,5 @@
+<menu>
+  <Services>
+    <Vnstat cssClass="fa fa-metric" url="/ui/vnstat/general/index" />
+  </Services>
+</menu>

--- a/net/vnstat/src/opnsense/mvc/app/models/OPNsense/Vnstat/Menu/Menu.xml
+++ b/net/vnstat/src/opnsense/mvc/app/models/OPNsense/Vnstat/Menu/Menu.xml
@@ -1,5 +1,5 @@
 <menu>
   <Services>
-    <Vnstat cssClass="fa fa-metric" url="/ui/vnstat/general/index" />
+    <Vnstat cssClass="fa fa-bar-chart" url="/ui/vnstat/general/index" />
   </Services>
 </menu>

--- a/net/vnstat/src/opnsense/mvc/app/views/OPNsense/Vnstat/general.volt
+++ b/net/vnstat/src/opnsense/mvc/app/views/OPNsense/Vnstat/general.volt
@@ -1,0 +1,117 @@
+{#
+
+OPNsense® is Copyright © 2014 – 2018 by Deciso B.V.
+This file is Copyright © 2018 by Michael Muenz
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1.  Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+2.  Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+#}
+
+<!-- Navigation bar -->
+<ul class="nav nav-tabs" data-tabs="tabs" id="maintabs">
+    <li class="active"><a data-toggle="tab" href="#general">{{ lang._('General') }}</a></li>
+    <li><a data-toggle="tab" href="#hourly">{{ lang._('Hourly Statistics') }}</a></li>
+    <li><a data-toggle="tab" href="#daily">{{ lang._('Daily Statistics') }}</a></li>
+    <li><a data-toggle="tab" href="#weekly">{{ lang._('Weekly Statistics') }}</a></li>
+    <li><a data-toggle="tab" href="#monthly">{{ lang._('Monthly Statistics') }}</a></li>
+</ul>
+
+<div class="tab-content content-box tab-content">
+    <div id="general" class="tab-pane fade in active">
+        <div class="content-box" style="padding-bottom: 1.5em;">
+            {{ partial("layout_partials/base_form",['fields':generalForm,'id':'frm_general_settings'])}}
+            <div class="col-md-12">
+                <hr />
+                <button class="btn btn-primary"  id="saveAct" type="button"><b>{{ lang._('Save') }}</b><i id="saveAct_progress"></i></button>
+            </div>
+        </div>
+    </div>
+    <div id="hourly" class="tab-pane fade in">
+      <pre id="listhourly"></pre>
+    </div>
+    <div id="daily" class="tab-pane fade in">
+      <pre id="listdaily"></pre>
+    </div>
+    <div id="weekly" class="tab-pane fade in">
+      <pre id="listweekly"></pre>
+    </div>
+    <div id="monthly" class="tab-pane fade in">
+      <pre id="listmonthly"></pre>
+    </div>
+</div>
+
+<script>
+
+// Put API call into a function, needed for auto-refresh    
+function update_hourly() {
+    ajaxCall(url="/api/vnstat/service/hourly", sendData={}, callback=function(data,status) {
+        $("#listhourly").text(data['response']);
+    });
+}
+function update_daily() {
+    ajaxCall(url="/api/vnstat/service/daily", sendData={}, callback=function(data,status) {
+        $("#listdaily").text(data['response']);
+    });
+}
+function update_weekly() {
+    ajaxCall(url="/api/vnstat/service/weekly", sendData={}, callback=function(data,status) {
+        $("#listweekly").text(data['response']);
+    });
+}
+function update_monthly() {
+    ajaxCall(url="/api/vnstat/service/monthly", sendData={}, callback=function(data,status) {
+        $("#listmonthly").text(data['response']);
+    });
+}
+
+$( document ).ready(function() {
+    var data_get_map = {'frm_general_settings':"/api/vnstat/general/get"};
+    mapDataToFormUI(data_get_map).done(function(data){
+        formatTokenizersUI();
+        $('.selectpicker').selectpicker('refresh');
+    });
+
+    ajaxCall(url="/api/vnstat/service/status", sendData={}, callback=function(data,status) {
+        updateServiceStatusUI(data['status']);
+    });
+
+    // Call function update_neighbor with a auto-refresh of 3 seconds
+    setInterval(update_hourly, 30000);
+    setInterval(update_daily, 30000);
+    setInterval(update_weekly, 30000);
+    setInterval(update_monthly, 30000);
+    
+    $("#saveAct").click(function(){
+        saveFormToEndpoint(url="/api/vnstat/general/set", formid='frm_general_settings',callback_ok=function(){
+        $("#saveAct_progress").addClass("fa fa-spinner fa-pulse");
+            ajaxCall(url="/api/vnstat/service/reconfigure", sendData={}, callback=function(data,status) {
+                ajaxCall(url="/api/vnstat/service/status", sendData={}, callback=function(data,status) {
+                    updateServiceStatusUI(data['status']);
+                });
+                $("#saveAct_progress").removeClass("fa fa-spinner fa-pulse");
+            });
+        });
+    });
+
+});
+</script>

--- a/net/vnstat/src/opnsense/mvc/app/views/OPNsense/Vnstat/general.volt
+++ b/net/vnstat/src/opnsense/mvc/app/views/OPNsense/Vnstat/general.volt
@@ -96,10 +96,10 @@ $( document ).ready(function() {
     });
 
     // Call function update_neighbor with a auto-refresh of 3 seconds
-    setInterval(update_hourly, 30000);
-    setInterval(update_daily, 30000);
-    setInterval(update_weekly, 30000);
-    setInterval(update_monthly, 30000);
+    setInterval(update_hourly, 3000);
+    setInterval(update_daily, 3000);
+    setInterval(update_weekly, 3000);
+    setInterval(update_monthly, 3000);
     
     $("#saveAct").click(function(){
         saveFormToEndpoint(url="/api/vnstat/general/set", formid='frm_general_settings',callback_ok=function(){

--- a/net/vnstat/src/opnsense/scripts/OPNsense/Vnstat/setup.sh
+++ b/net/vnstat/src/opnsense/scripts/OPNsense/Vnstat/setup.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+mkdir -p /var/run/vnstat
+chown -R vnstat:vnstat /var/run/vnstat
+chmod 755 /var/run/vnstat
+
+mkdir -p /var/lib/vnstat
+chown -R vnstat:vnstat /var/lib/vnstat
+chmod 755 /var/lib/vnstat

--- a/net/vnstat/src/opnsense/service/conf/actions.d/actions_vnstat.conf
+++ b/net/vnstat/src/opnsense/service/conf/actions.d/actions_vnstat.conf
@@ -41,7 +41,7 @@ type:script_output
 message:request Vnstat weekly status
 
 [monthly]
-command:/usr/local/bin/vnstat -w
+command:/usr/local/bin/vnstat -m
 parameters:
 type:script_output
 message:request Vnstat weekly status

--- a/net/vnstat/src/opnsense/service/conf/actions.d/actions_vnstat.conf
+++ b/net/vnstat/src/opnsense/service/conf/actions.d/actions_vnstat.conf
@@ -22,7 +22,7 @@ parameters:
 type:script_output
 message:request Vnstat status
 
-[houry]
+[hourly]
 command:/usr/local/bin/vnstat -h
 parameters:
 type:script_output

--- a/net/vnstat/src/opnsense/service/conf/actions.d/actions_vnstat.conf
+++ b/net/vnstat/src/opnsense/service/conf/actions.d/actions_vnstat.conf
@@ -1,0 +1,47 @@
+[start]
+command:/usr/local/opnsense/scripts/OPNsense/Vnstat/setup.sh;/usr/local/etc/rc.d/vnstat start
+parameters:
+type:script
+message:starting Vnstat
+
+[stop]
+command:/usr/local/etc/rc.d/vnstat stop; exit 0
+parameters:
+type:script
+message:stopping Vnstat
+
+[restart]
+command:/usr/local/opnsense/scripts/OPNsense/Vnstat/setup.sh;/usr/local/etc/rc.d/vnstat restart
+parameters:
+type:script
+message:restarting Vnstat
+
+[status]
+command:/usr/local/etc/rc.d/vnstat status;exit 0
+parameters:
+type:script_output
+message:request Vnstat status
+
+[houry]
+command:/usr/local/bin/vnstat -h
+parameters:
+type:script_output
+message:request Vnstat hourly status
+
+[daily]
+command:/usr/local/bin/vnstat -d
+parameters:
+type:script_output
+message:request Vnstat daily status
+
+[weekly]
+command:/usr/local/bin/vnstat -w
+parameters:
+type:script_output
+message:request Vnstat weekly status
+
+[monthly]
+command:/usr/local/bin/vnstat -w
+parameters:
+type:script_output
+message:request Vnstat weekly status

--- a/net/vnstat/src/opnsense/service/templates/OPNsense/Vnstat/+TARGETS
+++ b/net/vnstat/src/opnsense/service/templates/OPNsense/Vnstat/+TARGETS
@@ -1,0 +1,2 @@
+vnstat:/etc/rc.conf.d/vnstat
+vnstat.conf:/usr/local/etc/vnstat.conf

--- a/net/vnstat/src/opnsense/service/templates/OPNsense/Vnstat/vnstat
+++ b/net/vnstat/src/opnsense/service/templates/OPNsense/Vnstat/vnstat
@@ -1,0 +1,6 @@
+{% if helpers.exists('OPNsense.vnstat.general.enabled') and OPNsense.vnstat.general.enabled == '1' %}
+vnstat_var_script="/usr/local/opnsense/scripts/OPNsense/Vnstat/setup.sh"
+vnstat_enable="YES"
+{% else %}
+vnstat_enable="NO"
+{% endif %}

--- a/net/vnstat/src/opnsense/service/templates/OPNsense/Vnstat/vnstat.conf
+++ b/net/vnstat/src/opnsense/service/templates/OPNsense/Vnstat/vnstat.conf
@@ -1,0 +1,153 @@
+{% if helpers.exists('OPNsense.vnstat.general.enabled') and OPNsense.vnstat.general.enabled == '1' %}
+{% from 'OPNsense/Macros/interface.macro' import physical_interface %}
+
+{%   if helpers.exists('OPNsense.vnstat.general.interface') and OPNsense.vnstat.general.interface != '' %}
+# default interface
+Interface "{{ OPNsense.vnstat.general.interface }}"
+{%   endif %}
+
+# location of the database directory
+DatabaseDir "/var/lib/vnstat"
+
+# locale (LC_ALL) ("-" = use system locale)
+Locale "-"
+
+# on which day should months change
+MonthRotate 1
+
+# date output formats for -d, -m, -t and -w
+# see 'man date' for control codes
+DayFormat    "%x"
+MonthFormat  "%b '%y"
+TopFormat    "%x"
+
+# characters used for visuals
+RXCharacter       "%"
+TXCharacter       ":"
+RXHourCharacter   "r"
+TXHourCharacter   "t"
+
+# how units are prefixed when traffic is shown
+# 0 = IEC standard prefixes (KiB/MiB/GiB/TiB)
+# 1 = old style binary prefixes (KB/MB/GB/TB)
+UnitMode 0
+
+# output style
+# 0 = minimal & narrow, 1 = bar column visible
+# 2 = same as 1 except rate in summary and weekly
+# 3 = rate column visible
+OutputStyle 3
+
+# used rate unit (0 = bytes, 1 = bits)
+RateUnit 1
+
+# try to detect interface maximum bandwidth, 0 = disable feature
+# MaxBandwidth will be used as fallback value when enabled
+BandwidthDetection 1
+
+# maximum bandwidth (Mbit) for all interfaces, 0 = disable feature
+# (unless interface specific limit is given)
+MaxBandwidth 1000
+
+# interface specific limits
+#  example 8Mbit limit for 'ethnone':
+MaxBWethnone 8
+
+# how many seconds should sampling for -tr take by default
+Sampletime 5
+
+# default query mode
+# 0 = normal, 1 = days, 2 = months, 3 = top10
+# 4 = exportdb, 5 = short, 6 = weeks, 7 = hours
+QueryMode 0
+
+# filesystem disk space check (1 = enabled, 0 = disabled)
+CheckDiskSpace 1
+
+# database file locking (1 = enabled, 0 = disabled)
+UseFileLocking 1
+
+# how much the boot time can variate between updates (seconds)
+BootVariation 15
+
+# log days without traffic to daily list (1 = enabled, 0 = disabled)
+TrafficlessDays 1
+
+
+# vnstatd
+##
+
+# switch to given user when started as root (leave empty to disable)
+DaemonUser ""
+
+# switch to given user when started as root (leave empty to disable)
+DaemonGroup ""
+
+# how often (in seconds) interface data is updated
+UpdateInterval 30
+
+# how often (in seconds) interface status changes are checked
+PollInterval 5
+
+# how often (in minutes) data is saved to file
+SaveInterval 5
+
+# how often (in minutes) data is saved when all interface are offline
+OfflineSaveInterval 30
+
+# how often (in minutes) bandwidth detection is redone when
+# BandwidthDetection is enabled (0 = disabled)
+BandwidthDetectionInterval 5
+
+# force data save when interface status changes (1 = enabled, 0 = disabled)
+SaveOnStatusChange 1
+
+# enable / disable logging (0 = disabled, 1 = logfile, 2 = syslog)
+UseLogging 2
+
+# create dirs if needed (1 = enabled, 0 = disabled)
+CreateDirs 1
+
+# update ownership of files if needed (1 = enabled, 0 = disabled)
+UpdateFileOwner 1
+
+# file used for logging if UseLogging is set to 1
+LogFile "/var/log/vnstat/vnstat.log"
+
+# file used as daemon pid / lock file
+PidFile "/var/run/vnstat/vnstat.pid"
+
+
+# vnstati
+##
+
+# title timestamp format
+HeaderFormat "%x %H:%M"
+
+# show hours with rate (1 = enabled, 0 = disabled)
+HourlyRate 1
+
+# show rate in summary (1 = enabled, 0 = disabled)
+SummaryRate 1
+
+# layout of summary (1 = with monthly, 0 = without monthly)
+SummaryLayout 1
+
+# transparent background (1 = enabled, 0 = disabled)
+TransparentBg 0
+
+# image colors
+CBackground     "FFFFFF"
+CEdge           "AEAEAE"
+CHeader         "606060"
+CHeaderTitle    "FFFFFF"
+CHeaderDate     "FFFFFF"
+CText           "000000"
+CLine           "B0B0B0"
+CLineL          "-"
+CRx             "92CF00"
+CTx             "606060"
+CRxD            "-"
+CTxD            "-"
+
+{% endif %}

--- a/net/vnstat/src/opnsense/service/templates/OPNsense/Vnstat/vnstat.conf
+++ b/net/vnstat/src/opnsense/service/templates/OPNsense/Vnstat/vnstat.conf
@@ -3,7 +3,7 @@
 
 {%   if helpers.exists('OPNsense.vnstat.general.interface') and OPNsense.vnstat.general.interface != '' %}
 # default interface
-Interface "{{ OPNsense.vnstat.general.interface }}"
+Interface "{{ physical_interface(OPNsense.vnstat.general.interface) }}"
 {%   endif %}
 
 # location of the database directory


### PR DESCRIPTION
I read a couple of times users (e.g. Dominian) need a method to count monthly traffic, beginning from e.g. 01.09. 00:00:01 to 30.09 23:59:59. This plugin would easy monitor usage by hour/day/week/month incl. future predictions which might be quite nice for LTE connections where traffic is billed by MB. 

EDIT: I kept the options at a minimum for beginning and wait for feedback if users need more.