### PR TITLE
Fixing net-snmp IPv6 compatibility

### DIFF
--- a/net-mgmt/net-snmp/Makefile
+++ b/net-mgmt/net-snmp/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		net-snmp
-PLUGIN_VERSION=		1.0
+PLUGIN_VERSION=		1.1
 PLUGIN_REVISION=        1
 PLUGIN_COMMENT=		Net-SNMP is a daemon for the SNMP protocol
 PLUGIN_DEPENDS=		net-snmp

--- a/net-mgmt/net-snmp/Makefile
+++ b/net-mgmt/net-snmp/Makefile
@@ -1,6 +1,5 @@
 PLUGIN_NAME=		net-snmp
 PLUGIN_VERSION=		1.1
-PLUGIN_REVISION=        1
 PLUGIN_COMMENT=		Net-SNMP is a daemon for the SNMP protocol
 PLUGIN_DEPENDS=		net-snmp
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net-mgmt/net-snmp/src/opnsense/service/templates/OPNsense/Netsnmp/snmpd.conf
+++ b/net-mgmt/net-snmp/src/opnsense/service/templates/OPNsense/Netsnmp/snmpd.conf
@@ -15,6 +15,7 @@ agentAddress udp:161,udp6:[::1]:161
 
 {% if helpers.exists('OPNsense.netsnmp.general.community') and OPNsense.netsnmp.general.community != '' %}
 rocommunity {{ OPNsense.netsnmp.general.community }}
+rocommunity6 {{ OPNsense.netsnmp.general.community }}
 {% endif %}
 
 {% if helpers.exists('OPNsense.netsnmp.user.users.user') %}


### PR DESCRIPTION
'rocommunity6' is necessary to be able to fetch information via IPv6.