### PR TITLE
net/haproxy: add "http-reuse" option

### DIFF
--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogBackend.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogBackend.xml
@@ -276,6 +276,13 @@
         <advanced>true</advanced>
     </field>
     <field>
+        <id>backend.tuning_httpreuse</id>
+        <label>HTTP reuse</label>
+        <type>dropdown</type>
+        <help><![CDATA[Declare how idle HTTP connections may be shared between requests.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
         <label>Rules</label>
         <type>header</type>
     </field>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -838,6 +838,16 @@
                     <default>0</default>
                     <Required>Y</Required>
                 </tuning_noport>
+                <tuning_httpreuse type="OptionField">
+                    <Required>N</Required>
+                    <default>never</default>
+                    <OptionValues>
+                        <never>Never [default]</never>
+                        <safe>Safe</safe>
+                        <aggressive>Aggressive</aggressive>
+                        <always>Always</always>
+                    </OptionValues>
+                </tuning_httpreuse>
                 <linkedActions type="ModelRelationField">
                     <Model>
                         <template>

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -298,7 +298,7 @@
 {%             set action_enabled = '0' %}
     # ERROR: missing parameters
 {%           endif %}
-{%         elif action_data.type == 'use_server' %}
+{%         elif action_data.type == 'use_' %}
 {%           if action_data.use_server|default("") != "" %}
 {%             set server_data = helpers.getUUID(action_data.use_server) %}
 {%             do action_options.append('use-server ' ~ server_data.name) %}
@@ -1031,6 +1031,9 @@ backend {{backend.name}}
 {%         for customOpt in backend.customOptions.split("\n") %}
     {{customOpt}}
 {%         endfor %}
+{%       endif %}
+{%       if backend.tuning_httpreuse|default("") != "" %}
+    http-reuse {{backend.tuning_httpreuse}}
 {%       endif %}
 {%       if backend.tuning_defaultserver|default("") != "" %}
     default-server {{backend.tuning_defaultserver}}

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -298,7 +298,7 @@
 {%             set action_enabled = '0' %}
     # ERROR: missing parameters
 {%           endif %}
-{%         elif action_data.type == 'use_' %}
+{%         elif action_data.type == 'use_server' %}
 {%           if action_data.use_server|default("") != "" %}
 {%             set server_data = helpers.getUUID(action_data.use_server) %}
 {%             do action_options.append('use-server ' ~ server_data.name) %}

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -1032,7 +1032,7 @@ backend {{backend.name}}
     {{customOpt}}
 {%         endfor %}
 {%       endif %}
-{%       if backend.tuning_httpreuse|default("") != "" %}
+{%       if backend.tuning_httpreuse|default("") != "" and backend.mode == "http" %}
     http-reuse {{backend.tuning_httpreuse}}
 {%       endif %}
 {%       if backend.tuning_defaultserver|default("") != "" %}


### PR DESCRIPTION
This PR adds support for the "http-reuse" option (http://cbonte.github.io/haproxy-dconv/1.8/configuration.html#4-http-reuse) for a HAproxy backend.