### PR TITLE
Allow '+' in DDNS username

### DIFF
--- a/dns/dyndns/src/www/services_dyndns_edit.php
+++ b/dns/dyndns/src/www/services_dyndns_edit.php
@@ -38,7 +38,7 @@ function is_dyndns_username($uname)
 {
     if (!is_string($uname)) {
         return false;
-    } elseif (preg_match("/[^a-z0-9\-.@_:]/i", $uname)) {
+    } elseif (preg_match("/[^a-z0-9\-.@_:+]/i", $uname)) {
         return false;
     } else {
         return true;


### PR DESCRIPTION
Email addresses are often used as logins and the '+' character is a valid
character in email addresses. These are commonly found in gmail.com addresses,
for instance.