### PR TITLE
net/frr: change frr3 to frr5

### DIFF
--- a/net/frr/Makefile
+++ b/net/frr/Makefile
@@ -1,7 +1,7 @@
 PLUGIN_NAME=		frr
 PLUGIN_VERSION=		1.4
 PLUGIN_COMMENT=		The FRRouting Protocol Suite
-PLUGIN_DEPENDS=		frr3 ruby
+PLUGIN_DEPENDS=		frr5 ruby
 PLUGIN_CONFLICTS=	quagga
 PLUGIN_MAINTAINER=	franz.fabian.94@gmail.com
 


### PR DESCRIPTION
How do we handle highering the sysctl?

`sysctl kern.ipc.maxsockbuf=16777216`