### PR TITLE
net/vnstat: update setup.sh

### DIFF
--- a/net/vnstat/src/opnsense/scripts/OPNsense/Vnstat/setup.sh
+++ b/net/vnstat/src/opnsense/scripts/OPNsense/Vnstat/setup.sh
@@ -6,4 +6,5 @@ chmod 755 /var/run/vnstat
 
 mkdir -p /var/lib/vnstat
 chown -R vnstat:vnstat /var/lib/vnstat
-chmod -R 755 /var/lib/
+chmod 755 /var/lib/
+chmod -R 755 /var/lib/vnstat

--- a/net/vnstat/src/opnsense/scripts/OPNsense/Vnstat/setup.sh
+++ b/net/vnstat/src/opnsense/scripts/OPNsense/Vnstat/setup.sh
@@ -6,4 +6,4 @@ chmod 755 /var/run/vnstat
 
 mkdir -p /var/lib/vnstat
 chown -R vnstat:vnstat /var/lib/vnstat
-chmod 755 /var/lib/vnstat
+chmod -R 755 /var/lib/


### PR DESCRIPTION
On some systems /var/lib also doesn't exist, so permissions on /var/lib were 750 and then the user vnstat cannot reach subdir /var/lib/vnstat.