### PR TITLE
net/wireguard: add DNS to server config

### DIFF
--- a/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardServer.xml
+++ b/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardServer.xml
@@ -36,6 +36,12 @@
         <help>Set port for this instance to listen on.</help>
     </field>
     <field>
+        <id>server.dns</id>
+        <label>DNS Server</label>
+        <type>text</type>
+        <help>Set the interface specific DNS server.</help>
+    </field>
+    <field>
         <id>server.tunneladdress</id>
         <label>Tunnel Address</label>
         <style>tokenize</style>

--- a/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardServer.xml
+++ b/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardServer.xml
@@ -38,7 +38,9 @@
     <field>
         <id>server.dns</id>
         <label>DNS Server</label>
-        <type>text</type>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <allownew>true</allownew>
         <help>Set the interface specific DNS server.</help>
     </field>
     <field>

--- a/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Server.xml
+++ b/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Server.xml
@@ -33,6 +33,9 @@
                 </port>
                 <dns type="CSVListField">
                     <Required>N</Required>
+                    <mask>/^([a-fA-F0-9\.:\[\]]*?,)*([a-fA-F0-9\.:\[\]]*)$/</mask>
+                    <ValidationMessage>Please use valid IPv4 or IPv6 addresses.</ValidationMessage>
+
                 </dns>
                 <tunneladdress type="NetworkField">
                     <default></default>

--- a/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Server.xml
+++ b/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Server.xml
@@ -31,6 +31,9 @@
                     <default>51820</default>
                     <Required>Y</Required>
                 </port>
+                <dns type="CSVListField">
+                    <Required>N</Required>
+                </dns>
                 <tunneladdress type="NetworkField">
                     <default></default>
                     <FieldSeparator>,</FieldSeparator>

--- a/net/wireguard/src/opnsense/service/templates/OPNsense/Wireguard/wireguard-server.conf
+++ b/net/wireguard/src/opnsense/service/templates/OPNsense/Wireguard/wireguard-server.conf
@@ -6,12 +6,15 @@
 {%       if server_list.enabled == '1' %}
 [Interface]
 Address = {{ server_list.tunneladdress }}
-PrivateKey = {{ server_list.privkey }}
+{%         if server_list.dns|default('') != '' %}
+DNS = {{ server_list.dns }}
+{%         endif %}
 ListenPort = {{ server_list.port }}
 {%         if server_list.peers|default('') != '' %}
 {%           for peerlist in server_list.peers.split(",") %}
 {%             set peerlist2_data = helpers.getUUID(peerlist) %}
 {%             if peerlist2_data != {} and peerlist2_data.enabled == '1' %}
+PrivateKey = {{ server_list.privkey }}
 [Peer]
 PublicKey = {{ peerlist2_data.pubkey }}
 AllowedIPs = {{ peerlist2_data.tunneladdress }}


### PR DESCRIPTION
Add DNS servers to interface via `resolvconf`
Now local DNS lookups work with AzireVPN.

No bump since 0.4 isn't released yet.