### PR TITLE
net/wireguard: hotfix for latest master

### DIFF
--- a/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardClient.xml
+++ b/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardClient.xml
@@ -37,10 +37,4 @@
         <type>text</type>
         <help>Set port the endpoint listens to.</help>
     </field>
-    <field>
-        <id>client.disableroutes</id>
-        <label>Disable Routes</label>
-        <type>checkbox</type>
-        <help>This will prevent installing routes. Usually you only enable this to do own routing decisions via a local gateway and gateway rules.</help>
-    </field>
 </form>

--- a/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardServer.xml
+++ b/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardServer.xml
@@ -58,4 +58,10 @@
         <allownew>true</allownew>
         <help>List of peers for this server.</help>
     </field>
+    <field>
+        <id>server.disableroutes</id>
+        <label>Disable Routes</label>
+        <type>checkbox</type>
+        <help>This will prevent installing routes. Usually you only enable this to do own routing decisions via a local gateway and gateway rules.</help>
+    </field>
 </form>

--- a/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Client.xml
+++ b/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Client.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/wireguard/client</mount>
     <description>Wireguard Client configuration</description>
-    <version>0.0.3</version>
+    <version>0.0.4</version>
     <items>
         <clients>
             <client type="ArrayField">
@@ -30,10 +30,6 @@
                 <serverport type="PortField">
                     <Required>N</Required>
                 </serverport>
-                <disableroutes type="BooleanField">
-                    <default>0</default>
-                    <Required>Y</Required>
-                </disableroutes>
             </client>
         </clients>
     </items>

--- a/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Server.xml
+++ b/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Server.xml
@@ -35,7 +35,6 @@
                     <Required>N</Required>
                     <mask>/^([a-fA-F0-9\.:\[\]]*?,)*([a-fA-F0-9\.:\[\]]*)$/</mask>
                     <ValidationMessage>Please use valid IPv4 or IPv6 addresses.</ValidationMessage>
-
                 </dns>
                 <tunneladdress type="NetworkField">
                     <default></default>

--- a/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Server.xml
+++ b/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Server.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/wireguard/server</mount>
     <description>Wireguard Server configuration</description>
-    <version>0.0.1</version>
+    <version>0.0.2</version>
     <items>
         <servers>
             <server type="ArrayField">

--- a/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Server.xml
+++ b/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Server.xml
@@ -43,6 +43,10 @@
                     <Required>Y</Required>
                     <asList>Y</asList>
                 </tunneladdress>
+                <disableroutes type="BooleanField">
+                    <default>0</default>
+                    <Required>Y</Required>
+                </disableroutes>
                 <peers type="ModelRelationField">
                     <Model>
                         <template>

--- a/net/wireguard/src/opnsense/service/templates/OPNsense/Wireguard/wireguard-server.conf
+++ b/net/wireguard/src/opnsense/service/templates/OPNsense/Wireguard/wireguard-server.conf
@@ -10,14 +10,14 @@ Address = {{ server_list.tunneladdress }}
 DNS = {{ server_list.dns }}
 {%         endif %}
 ListenPort = {{ server_list.port }}
+PrivateKey = {{ server_list.privkey }}
+{%         if server_list.disableroutes == '1' %}
+Table = off
+{%         endif %}
 {%         if server_list.peers|default('') != '' %}
 {%           for peerlist in server_list.peers.split(",") %}
 {%             set peerlist2_data = helpers.getUUID(peerlist) %}
 {%             if peerlist2_data != {} and peerlist2_data.enabled == '1' %}
-{%               if peerlist2_data != {} and peerlist2_data.disableroutes == '1' %}
-Table = off
-{%               endif %}
-PrivateKey = {{ server_list.privkey }}
 [Peer]
 PublicKey = {{ peerlist2_data.pubkey }}
 AllowedIPs = {{ peerlist2_data.tunneladdress }}


### PR DESCRIPTION
- wrong templating when using multiple endpoints
- moved disable routes to server since it's a global configuration, not client related.