### PR TITLE
Make nginx support multiple servers entries

### DIFF
--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/location.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/location.xml
@@ -62,6 +62,12 @@
     <help>Select an upstream to proxy to or connect via FastCGI if chosen.</help>
   </field>
   <field>
+    <id>location.new_urlpattern</id>
+    <label>New location path</label>
+    <type>text</type>
+    <help>Select a new path for upstream to proxy.</help>
+  </field>
+  <field>
     <id>location.limit_request_connections</id>
     <label>Limit Requests</label>
     <type>select_multiple</type>

--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
@@ -205,6 +205,9 @@
         <Required>N</Required>
         <multiple>N</multiple>
       </upstream>
+      <new_urlpattern type="TextField">
+        <Required>N</Required>
+      </new_urlpattern>
       <root type="TextField">
         <Required>N</Required>
       </root>

--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/http.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/http.conf
@@ -44,11 +44,13 @@ limit_req_zone ${{ zone.key }} zone={{ zone['@uuid'].replace('-', '') }}:{{ zone
 {%   set single_servername = server.servername.split(",")[0] %}
 server {
 {%   if server.listen_http_port is defined %}
-    listen  [::]:{{ server.listen_http_port }}{% if server.listen_https_port not in listen_list%} ipv6only=off{% endif %};
+    listen  {{ server.listen_http_port }};
+    listen  [::]:{{ server.listen_http_port }};
 {% do listen_list.append(server.listen_http_port) %}
 {%   endif %}
 {%   if server.listen_https_port is defined and server.certificate is defined %}
-    listen  [::]:{{ server.listen_https_port }}{% if server.listen_https_port not in listen_list%} ipv6only=off{% endif %} http2 ssl;
+    listen  {{ server.listen_https_port }} http2 ssl;
+    listen  [::]:{{ server.listen_https_port }} http2 ssl;
 {% do listen_list.append(server.listen_https_port) %}
 {%     if server.ca is defined %}
     ssl_client_certificate /usr/local/etc/nginx/key/{{ single_servername }}_ca.pem;

--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/location.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/location.conf
@@ -87,7 +87,7 @@ location {{ location.matchtype }} {{ location.urlpattern }} {
 {% if location.upstream is defined and (location.php_enable is not defined or location.php_enable != '1') %}
 {% set upstream = helpers.getUUID(location.upstream) %}
     proxy_set_header Host $host;
-    proxy_pass http{% if upstream.tls_enable == '1' %}s{% endif %}://upstream{{ location.upstream.replace('-','') }};
+    proxy_pass http{% if upstream.tls_enable == '1' %}s{% endif %}://upstream{{ location.upstream.replace('-','') }}{% if location.new_urlpattern != '' %}{{ location.new_urlpattern }};{% endif %}
 {%   if upstream.tls_enable == '1' %}
 {%     if upstream.tls_client_certificate is defined and upstream.tls_client_certificate != '' %}
     proxy_ssl_certificate_key /usr/local/etc/nginx/key/{{ upstream.tls_client_certificate }}.key;


### PR DESCRIPTION
Currently the code [::]:80 ipv6only=off does not supported when running multiple servers in nginx.conf
More details in
https://unix.stackexchange.com/questions/321879/remove-ipv6only-option-from-puppet-nginx-module
https://serverfault.com/questions/638367/do-you-need-separate-ipv4-and-ipv6-listen-directives-in-nginx
http://nginx.org/en/docs/http/ngx_http_core_module.html#listen
https://forum.opnsense.org/index.php?topic=8877.msg44610#msg44610

This fix works as expected.