### PR TITLE
Make nginx support multiple servers entries

### DIFF
--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/http.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/http.conf
@@ -44,11 +44,13 @@ limit_req_zone ${{ zone.key }} zone={{ zone['@uuid'].replace('-', '') }}:{{ zone
 {%   set single_servername = server.servername.split(",")[0] %}
 server {
 {%   if server.listen_http_port is defined %}
-    listen  [::]:{{ server.listen_http_port }}{% if server.listen_https_port not in listen_list%} ipv6only=off{% endif %};
+    listen  {{ server.listen_http_port }};
+    listen  [::]:{{ server.listen_http_port }};
 {% do listen_list.append(server.listen_http_port) %}
 {%   endif %}
 {%   if server.listen_https_port is defined and server.certificate is defined %}
-    listen  [::]:{{ server.listen_https_port }}{% if server.listen_https_port not in listen_list%} ipv6only=off{% endif %} http2 ssl;
+    listen  {{ server.listen_https_port }} http2 ssl;
+    listen  [::]:{{ server.listen_https_port }} http2 ssl;
 {% do listen_list.append(server.listen_https_port) %}
 {%     if server.ca is defined %}
     ssl_client_certificate /usr/local/etc/nginx/key/{{ single_servername }}_ca.pem;


### PR DESCRIPTION
Currently the code [::]:80 ipv6only=off does not supported when running multiple servers in nginx.conf
More details in
https://unix.stackexchange.com/questions/321879/remove-ipv6only-option-from-puppet-nginx-module
https://serverfault.com/questions/638367/do-you-need-separate-ipv4-and-ipv6-listen-directives-in-nginx
http://nginx.org/en/docs/http/ngx_http_core_module.html#listen
https://forum.opnsense.org/index.php?topic=8877.msg44610#msg44610

This fix works as expected.