### PR TITLE
Add nginx path_prefix in proxy_pass

### DIFF
--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/Api/SettingsController.php
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/Api/SettingsController.php
@@ -147,7 +147,7 @@ class SettingsController extends ApiMutableModelControllerBase
     // Location
     public function searchlocationAction()
     {
-        return $this->searchBase('location', array('description','urlpattern', 'matchtype', 'enable_secrules', 'force_https'));
+        return $this->searchBase('location', array('description','urlpattern', 'path_prefix', 'matchtype', 'enable_secrules', 'force_https'));
     }
 
     public function getlocationAction($uuid = null)

--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/location.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/location.xml
@@ -62,6 +62,12 @@
     <help>Select an upstream to proxy to or connect via FastCGI if chosen.</help>
   </field>
   <field>
+    <id>location.path_prefix</id>
+    <label>Path prefix</label>
+    <type>text</type>
+    <help>Define an optional path prefix for this location.</help>
+  </field>
+  <field>
     <id>location.limit_request_connections</id>
     <label>Limit Requests</label>
     <type>select_multiple</type>

--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/location.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/location.xml
@@ -63,9 +63,9 @@
   </field>
   <field>
     <id>location.path_prefix</id>
-    <label>Path prefix</label>
+    <label>Path Prefix</label>
     <type>text</type>
-    <help>Define an optional path prefix for this location.</help>
+    <help>Define an optional path prefix for this location. It will be prepended to the path so http://www.example.com/index.php will be sent to http://www.example.com/app/index.php on your upstream if you choose "/app" as path prefix.</help>
   </field>
   <field>
     <id>location.cache_path</id>

--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
@@ -205,6 +205,9 @@
         <Required>N</Required>
         <multiple>N</multiple>
       </upstream>
+      <path_prefix type="TextField">
+        <Required>N</Required>
+      </path_prefix>
       <root type="TextField">
         <Required>N</Required>
       </root>

--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
@@ -207,6 +207,7 @@
       </upstream>
       <path_prefix type="TextField">
         <Required>N</Required>
+        <mask>/^[^" \t]+$/i</mask>
       </path_prefix>
       <root type="TextField">
         <Required>N</Required>

--- a/www/nginx/src/opnsense/mvc/app/views/OPNsense/Nginx/index.volt
+++ b/www/nginx/src/opnsense/mvc/app/views/OPNsense/Nginx/index.volt
@@ -190,6 +190,7 @@ $( document ).ready(function() {
             <tr>
                 <th data-column-id="description" data-type="string" data-sortable="true"  data-visible="true">{{ lang._('Description') }}</th>
                 <th data-column-id="urlpattern" data-type="string" data-sortable="true"  data-visible="true">{{ lang._('URL Pattern') }}</th>
+                <th data-column-id="path_prefix" data-type="string" data-sortable="true"  data-visible="true">{{ lang._('URL Path Prefix') }}</th>
                 <th data-column-id="matchtype" data-type="string" data-sortable="true"  data-visible="true">{{ lang._('Match Type') }}</th>
                 <th data-column-id="enable_secrules" data-type="boolean" data-sortable="true"  data-visible="true">{{ lang._('WAF Enabled') }}</th>
                 <th data-column-id="force_https" data-type="boolean" data-sortable="true"  data-visible="true">{{ lang._('Force HTTPS') }}</th>

--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/location.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/location.conf
@@ -87,7 +87,11 @@ location {{ location.matchtype }} {{ location.urlpattern }} {
 {% if location.upstream is defined and (location.php_enable is not defined or location.php_enable != '1') %}
 {% set upstream = helpers.getUUID(location.upstream) %}
     proxy_set_header Host $host;
+{% if location.path_prefix is defined and location.path_prefix != '' %}   
+    proxy_pass http{% if upstream.tls_enable == '1' %}s{% endif %}://upstream{{ location.upstream.replace('-','') }}{{ location.path_prefix }};
+{% else %}
     proxy_pass http{% if upstream.tls_enable == '1' %}s{% endif %}://upstream{{ location.upstream.replace('-','') }};
+{% endif %}
 {%   if upstream.tls_enable == '1' %}
 {%     if upstream.tls_client_certificate is defined and upstream.tls_client_certificate != '' %}
     proxy_ssl_certificate_key /usr/local/etc/nginx/key/{{ upstream.tls_client_certificate }}.key;


### PR DESCRIPTION
Add optional support to url prefix in proxy_pass module according module documentation. 

http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass

![image](https://user-images.githubusercontent.com/1812609/46084071-2cb40900-c179-11e8-9a6d-0ab5d1501f46.png)

![image](https://user-images.githubusercontent.com/1812609/46084128-4c4b3180-c179-11e8-9614-2bdf831dfe44.png)
