### PR TITLE
nv.d3.css - legend fix color

### DIFF
--- a/misc/theme-cicada/src/opnsense/www/themes/cicada/build/css/nv.d3.css
+++ b/misc/theme-cicada/src/opnsense/www/themes/cicada/build/css/nv.d3.css
@@ -316,11 +316,10 @@ svg.nvd3-svg {
     cursor: pointer;
 }
 
-.nv-legend-symbol {
+.nv-controlsWrap.nvd3-svg circle.nv-legend-symbol {
   stroke-width: 1 !important;
-  fill: rgb(255, 255, 255) !important;
-  fill-opacity: 1;
-  stroke: rgb(255, 255, 255) !important;
+  fill: rgb(143, 143, 143) !important;
+  stroke: rgb(143, 143, 143) !important;
 }
 
 .nvd3 .nv-legend .nv-disabled circle {


### PR DESCRIPTION
@fichtner 
when I split the main.css, the colors in cicada for the reporting have been lost. This is unfortunately too late for this release but would still be great if you could at least merge it for the next release. sorry it was my mistake. best regards rené