### PR TITLE
net/vnstat: add multiple interfaces, ready for stable

### DIFF
--- a/net/vnstat/Makefile
+++ b/net/vnstat/Makefile
@@ -1,8 +1,7 @@
 PLUGIN_NAME=		vnstat
-PLUGIN_VERSION=		0.1
+PLUGIN_VERSION=		1.0
 PLUGIN_COMMENT=		vnStat is a console-based network traffic monitor
 PLUGIN_DEPENDS=		vnstat
 PLUGIN_MAINTAINER=	m.muenz@gmail.com
-PLUGIN_DEVEL=       yes
 
 .include "../../Mk/plugins.mk"

--- a/net/vnstat/src/opnsense/mvc/app/controllers/OPNsense/Vnstat/forms/general.xml
+++ b/net/vnstat/src/opnsense/mvc/app/controllers/OPNsense/Vnstat/forms/general.xml
@@ -8,7 +8,7 @@
     <field>
         <id>general.interface</id>
         <label>Interface</label>
-        <type>dropdown</type>
+        <type>select_multiple</type>
         <help>Set the interface to listen on.</help>
     </field>
 </form>

--- a/net/vnstat/src/opnsense/mvc/app/models/OPNsense/Vnstat/General.xml
+++ b/net/vnstat/src/opnsense/mvc/app/models/OPNsense/Vnstat/General.xml
@@ -9,6 +9,7 @@
         </enabled>
         <interface type="InterfaceField">
             <Required>N</Required>
+            <multiple>Y</multiple>
         </interface>
     </items>
 </model>

--- a/net/vnstat/src/opnsense/service/templates/OPNsense/Vnstat/vnstat
+++ b/net/vnstat/src/opnsense/service/templates/OPNsense/Vnstat/vnstat
@@ -1,4 +1,5 @@
 {% if helpers.exists('OPNsense.vnstat.general.enabled') and OPNsense.vnstat.general.enabled == '1' %}
+{% from 'OPNsense/Macros/interface.macro' import physical_interface %}
 vnstat_var_script="/usr/local/opnsense/scripts/OPNsense/Vnstat/setup.sh"
 vnstat_enable="YES"
 {%   if helpers.exists('OPNsense.vnstat.general.interface') and OPNsense.vnstat.general.interface != '' %}

--- a/net/vnstat/src/opnsense/service/templates/OPNsense/Vnstat/vnstat
+++ b/net/vnstat/src/opnsense/service/templates/OPNsense/Vnstat/vnstat
@@ -1,6 +1,13 @@
 {% if helpers.exists('OPNsense.vnstat.general.enabled') and OPNsense.vnstat.general.enabled == '1' %}
 vnstat_var_script="/usr/local/opnsense/scripts/OPNsense/Vnstat/setup.sh"
 vnstat_enable="YES"
+{%   if helpers.exists('OPNsense.vnstat.general.interface') and OPNsense.vnstat.general.interface != '' %}
+{%     set interfaces = [] %}
+{%     for interface in OPNsense.vnstat.general.interface.split(',') %}
+{%       interfaces.append(physical_interface(interface)) %}
+{%     endfor %}
+vnstat_additional_ifaces="{{ interfaces|join(' ') }}"
+{%   endif %}
 {% else %}
 vnstat_enable="NO"
 {% endif %}

--- a/net/vnstat/src/opnsense/service/templates/OPNsense/Vnstat/vnstat
+++ b/net/vnstat/src/opnsense/service/templates/OPNsense/Vnstat/vnstat
@@ -4,7 +4,7 @@ vnstat_enable="YES"
 {%   if helpers.exists('OPNsense.vnstat.general.interface') and OPNsense.vnstat.general.interface != '' %}
 {%     set interfaces = [] %}
 {%     for interface in OPNsense.vnstat.general.interface.split(',') %}
-{%       interfaces.append(physical_interface(interface)) %}
+{%       do interfaces.append(physical_interface(interface)) %}
 {%     endfor %}
 vnstat_additional_ifaces="{{ interfaces|join(' ') }}"
 {%   endif %}

--- a/net/vnstat/src/opnsense/service/templates/OPNsense/Vnstat/vnstat.conf
+++ b/net/vnstat/src/opnsense/service/templates/OPNsense/Vnstat/vnstat.conf
@@ -2,9 +2,13 @@
 {% from 'OPNsense/Macros/interface.macro' import physical_interface %}
 
 {%   if helpers.exists('OPNsense.vnstat.general.interface') and OPNsense.vnstat.general.interface != '' %}
-# default interface
-Interface "{{ physical_interface(OPNsense.vnstat.general.interface) }}"
+{%     set interfaces = [] %}
+{%     for interface in OPNsense.vnstat.general.interface.split(',') %}
+{%       do interfaces.append(physical_interface(interface)) %}
+{%     endfor %}
+Interface {{ interfaces|join('+') }}
 {%   endif %}
+
 
 # location of the database directory
 DatabaseDir "/var/lib/vnstat"


### PR DESCRIPTION
Add ability to monitor multiple interfaces, e.g. to sum 2 WANs together.