### PR TITLE
Problem with multiple Upstream servers

### DIFF
--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/upstream.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/upstream.conf
@@ -6,8 +6,8 @@
 {%   endif %}
 {% endfor %}
 {% for upstream_uuid, upstream in upstreamlist.items() %}
-{%   for upstream_serveruuid in upstream.serverentries.split(',') %}
 upstream upstream{{ upstream_uuid.replace('-','') }} {
+{%   for upstream_serveruuid in upstream.serverentries.split(',') %}
 {%     set upstream_server = helpers.getUUID(upstream_serveruuid) %}
 server {% if ':' in upstream_server.server %}[{% endif %}{{ upstream_server.server }}{% if ':' in upstream_server.server %}]{% endif
        %}{% if upstream_server.port is defined %}:{{ upstream_server.port }}{% endif


### PR DESCRIPTION

I've some trouble while trying with multiple upstream servers:

```
nginx: [emerg] "upstream" directive is not allowed here in /usr/local/etc/nginx/nginx.conf:56
nginx: configuration file /usr/local/etc/nginx/nginx.conf test failed
```

I've made a small change to make it work.