### PR TITLE
sysutils/nut: add blazer_usb driver

### DIFF
--- a/sysutils/nut/src/opnsense/mvc/app/controllers/OPNsense/Nut/forms/settings.xml
+++ b/sysutils/nut/src/opnsense/mvc/app/controllers/OPNsense/Nut/forms/settings.xml
@@ -64,6 +64,20 @@
                 <help>Set extra arguments for this UPS, e.g. "port=auto".</help>
             </field>
         </subtab>
+        <subtab id="nut-ups-blazerusb" description="BlazerUSB-Driver">
+            <field>
+                <id>nut.blazerusb.enable</id>
+                <label>Enable</label>
+                <type>checkbox</type>
+                <help>Enable the BlazerUSB driver.</help>
+            </field>
+            <field>
+                <id>nut.blazerusb.args</id>
+                <label>Extra Arguments</label>
+                <type>text</type>
+                <help>Set extra arguments for this UPS, e.g. "port=auto".</help>
+            </field>
+        </subtab>
         <subtab id="nut-ups-netclient" description="Netclient">
             <field>
                 <id>nut.netclient.enable</id>

--- a/sysutils/nut/src/opnsense/mvc/app/models/OPNsense/Nut/Nut.xml
+++ b/sysutils/nut/src/opnsense/mvc/app/models/OPNsense/Nut/Nut.xml
@@ -53,6 +53,16 @@
         <Required>N</Required>
       </args>
     </apcsmart>
+    <blazerusb>
+      <enable type="BooleanField">
+        <Required>Y</Required>
+        <default>0</default>
+      </enable>
+      <args type="TextField">
+        <default>port=auto</default>
+        <Required>N</Required>
+      </args>
+    </blazerusb>
     <netclient>
       <enable type="BooleanField">
         <Required>Y</Required>

--- a/sysutils/nut/src/opnsense/service/templates/OPNsense/Nut/ups.conf
+++ b/sysutils/nut/src/opnsense/service/templates/OPNsense/Nut/ups.conf
@@ -16,4 +16,11 @@ driver=apcsmart
 {{ OPNsense.Nut.apcsmart.args }}
 {%     endif %}
 {%   endif %}
+{%   if helpers.exists('OPNsense.Nut.blazerusb.enable') and OPNsense.Nut.blazerusb.enable == '1' %}
+[{{ OPNsense.Nut.general.name }}]
+driver=blazer_usb
+{%     if helpers.exists('OPNsense.Nut.blazerusb.args') and OPNsense.Nut.blazerusb.args != '' %}
+{{ OPNsense.Nut.blazerusb.args }}
+{%     endif %}
+{%   endif %}
 {% endif %}


### PR DESCRIPTION
Add blazer_usb driver, closes #905 

Current stable of nut is 1.0, with 1.1 I added apcsmart which sadly  wasn't verified yet, 1.2 splitted diagnostics for timeout reasons. Now I didn't touch the makefile, should we make 1.3 or how to handle this now? 

