### PR TITLE
www/nginx: fix rule 19 issue

### DIFF
--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/location.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/location.conf
@@ -13,6 +13,7 @@ location {{ location.matchtype }} {{ location.urlpattern }} {
     LibInjectionXss;
     CheckRule "$LIBINJECTION_XSS >= {{ location.xss_block_score }}" BLOCK;
 {% endif %}
+    BasicRule wl:19;
 {% set added_policies = [] %}
 {% if location.custom_policy is defined %}
 {%   for custom_policy_uuid in location.custom_policy.split(',') %}

--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/ruleset.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/ruleset.conf
@@ -1,4 +1,3 @@
-MainRule wl:19;
 {% set naxsi_ruletype = 'main' %}
 {% set main_policies = [] %}
 {% set main_rules = [] %}


### PR DESCRIPTION
root cause: even if MainRule is successfully parsed, it is currently
not supported. So it must be moved to a basic rule.