### PR TITLE
net/frr: add carp failover option

### DIFF
--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/general.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/general.xml
@@ -6,6 +6,12 @@
         <help>This will activate the routing service.</help>
     </field>
     <field>
+        <id>general.enablecarp</id>
+        <label>Enable CARP Failover</label>
+        <type>checkbox</type>
+        <help>This will activate the routing service only on the master device.</help>
+    </field>
+    <field>
         <id>general.enablelogfile</id>
         <label>Create a logfile</label>
         <type>checkbox</type>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/General.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/General.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/quagga/general</mount>
     <description>Quagga Routing configuration</description>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <items>
         <enabled type="BooleanField">
             <default>0</default>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/General.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/General.xml
@@ -7,6 +7,10 @@
             <default>0</default>
             <Required>Y</Required>
         </enabled>
+        <enablecarp type="BooleanField">
+            <default>0</default>
+            <Required>Y</Required>
+        </enablecarp>
         <enablelogfile type="BooleanField">
             <default>0</default>
             <Required>Y</Required>


### PR DESCRIPTION
As discussed with @fichtner in IRC, added carpfailover.

Franco will add the carp syshook and a config loader 