### PR TITLE
www/nginx: Fix upstream_server.xml description message.

### DIFF
--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/upstream_server.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/upstream_server.xml
@@ -1,7 +1,7 @@
 <form>
   <field>
     <id>upstream_server.description</id>
-    <label>Beschreibung</label>
+    <label>Description</label>
     <type>text</type>
   </field>
   <field>


### PR DESCRIPTION
The original text was in German, but all other messages were in English.