### PR TITLE
Added non-inter option

### DIFF
--- a/security/openconnect/src/opnsense/service/templates/OPNsense/Openconnect/openconnect.conf
+++ b/security/openconnect/src/opnsense/service/templates/OPNsense/Openconnect/openconnect.conf
@@ -7,6 +7,7 @@ background
 quiet
 interface=tun30000
 syslog
+non-inter
 passwd-on-stdin
 {%   if helpers.exists('OPNsense.openconnect.general.servercert') and OPNsense.openconnect.general.servercert != '' %}
 servercert={{ OPNsense.openconnect.general.hash }}:{{ OPNsense.openconnect.general.servercert }}


### PR DESCRIPTION
When authentication fails, the default behavior for openconnect is to request different authentication credentials, which causes the process to "hang" waiting for input.  Adding the "non-inter" option to the configuration file causes the process to fail instantly if authentication fails.