### PR TITLE
net/haproxy: Release 2.11

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		haproxy
-PLUGIN_VERSION=		2.10
+PLUGIN_VERSION=		2.11
 PLUGIN_COMMENT=		Reliable, high performance TCP/HTTP load balancer
 PLUGIN_DEPENDS=		haproxy
 PLUGIN_MAINTAINER=	opnsense@moov.de

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -1395,7 +1395,7 @@ backend {{backend.name}}
 peers {{peers_name}}
     peer {{OPNsense.HAProxy.general.peers.name1}} {{OPNsense.HAProxy.general.peers.listen1}}:{{OPNsense.HAProxy.general.peers.port1}}
     peer {{OPNsense.HAProxy.general.peers.name2}} {{OPNsense.HAProxy.general.peers.listen2}}:{{OPNsense.HAProxy.general.peers.port2}}
-{%-   endif -%}
+{%   endif %}
 {%- endif -%}
 
 {# ############################### #}


### PR DESCRIPTION
## New features
none

## Bugfixes
- fix warning: a 'http-request' rule placed after a 'use_backend' rule will still be processed before (#999)
- fix wrong parameter name when using `tcp-request content lua` (#999)

## Enhancements
- internal: trim whitespace, remove empty lines in haproxy.conf (#999)