### PR TITLE
dns/bind: daily dnsbl updates

### DIFF
--- a/dns/bind/src/opnsense/scripts/OPNsense/Bind/dnsbl.sh
+++ b/dns/bind/src/opnsense/scripts/OPNsense/Bind/dnsbl.sh
@@ -143,7 +143,7 @@ if [ $# -eq 0 -a -s "$DESTDIR/dnsbl.list" ]; then
 else
     DNSBLLIST=$1
 fi
-echo "$DNSBLLIST" > ${DESTDIR}/dnsbl.list
+printf "$DNSBLLIST" > ${DESTDIR}/dnsbl.list
 
 for CAT in $(echo ${DNSBLLIST} | tr ',' ' '); do
 	case "${CAT}" in

--- a/dns/bind/src/opnsense/scripts/OPNsense/Bind/dnsbl.sh
+++ b/dns/bind/src/opnsense/scripts/OPNsense/Bind/dnsbl.sh
@@ -138,7 +138,7 @@ install() {
 	rm -rf ${WORKDIR}
 }
 
-if [ $# -eq 0 ] && [ -s "$DESTDIR/dnsbl.list" ]; then
+if [ $# -eq 0 -a -s "$DESTDIR/dnsbl.list" ]; then
     DNSBLLIST=$(cat ${DESTDIR}/dnsbl.list)
 else
     DNSBLLIST=$1

--- a/dns/bind/src/opnsense/scripts/OPNsense/Bind/dnsbl.sh
+++ b/dns/bind/src/opnsense/scripts/OPNsense/Bind/dnsbl.sh
@@ -137,7 +137,14 @@ install() {
 	rm -rf ${WORKDIR}
 }
 
-for CAT in $(echo ${1} | tr ',' ' '); do
+if [ $# -eq 0 ] && [ -s "$DESTDIR/dnsbl.list" ]; then
+    DNSBLLIST=$(cat ${DESTDIR}/dnsbl.list)
+else
+    DNSBLLIST=$1
+fi
+echo "$DNSBLLIST" > ${DESTDIR}/dnsbl.list
+
+for CAT in $(echo ${DNSBLLIST} | tr ',' ' '); do
 	case "${CAT}" in
 	aa)
 		adaway

--- a/dns/bind/src/opnsense/scripts/OPNsense/Bind/dnsbl.sh
+++ b/dns/bind/src/opnsense/scripts/OPNsense/Bind/dnsbl.sh
@@ -2,6 +2,7 @@
 
 # Copyright (c) 2018 Michael Muenz <m.muenz@gmail.com>
 # Copyright (c) 2018 Franco Fichtner <franco@opnsense.org>
+# Copyright (c) 2018 Patrick Bestek <pabe-opnsense@phcn.de>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions


### PR DESCRIPTION
Closes #1022
if there is a file "$DESTDIR/dnsbl.list" and there are no arguments, use "$DESTDIR/dnsbl.list" instead of arguments
If there are arguments, use those and overwrite the content of "$DESTDIR/dnsbl.list" with the new arguments -> cron can run dnsbl.sh without arguments, remembers the selected lists and updates the lists