### PR TITLE
Check if charset is defined

### DIFF
--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/http.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/http.conf
@@ -86,7 +86,9 @@ server {
     sendfile {% if server.sendfile is defined and server.sendfile == '1' %}On{% else %}Off{% endif %};
 {%   endif %}
     server_name  {{ server.servername.replace(',', ' ') }};
+{% if server.charset is defined %}
     charset {{ server.charset }};
+{% endif %}
     access_log  /var/log/nginx/{{ server.servername }}.access.log {{ server.access_log_format }};
     error_log  /var/log/nginx/{{ server.servername }}.error.log;
 {% if server.root is defined and server.root != '' %}


### PR DESCRIPTION
Check if charset is defined in http section, currently when choosed charset to "none", the code add **charset** option without value, and nginx service fail.

According http://nginx.org/en/docs/http/ngx_http_charset_module.html