### PR TITLE
net/haproxy: Add support for HTTP/2

### DIFF
--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogFrontend.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogFrontend.xml
@@ -105,6 +105,12 @@
         <help><![CDATA[It sets the default string describing the list of cipher algorithms ("cipher suite") that are negotiated during the SSL/TLS handshake.]]></help>
     </field>
     <field>
+        <id>frontend.ssl_http2Enabled</id>
+        <label>Enable HTTP/2</label>
+        <type>checkbox</type>
+        <help><![CDATA[Enable support for HTTP/2.]]></help>
+    </field>
+    <field>
         <id>frontend.ssl_hstsEnabled</id>
         <label>Enable HSTS</label>
         <type>checkbox</type>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -416,6 +416,10 @@
                     <default>ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256</default>
                     <Required>N</Required>
                 </ssl_cipherList>
+                <ssl_http2Enabled type="BooleanField">
+                    <default>0</default>
+                    <Required>N</Required>
+                </ssl_http2Enabled>
                 <ssl_hstsEnabled type="BooleanField">
                     <default>1</default>
                     <Required>Y</Required>

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -967,6 +967,10 @@ frontend {{frontend.name}}
 {%           if frontend.ssl_cipherList|default("") != "" %}
 {%             do ssl_options.append('ciphers ' ~ frontend.ssl_cipherList) %}
 {%           endif %}
+{#           # HTTP/2 #}
+{%           if frontend.ssl_http2Enabled|default("") == '1' and frontend.mode == 'http' %}
+{%             do ssl_options.append('alpn h2,http/1.1') %}
+{%           endif %}
 {#           # HSTS #}
 {%           if frontend.ssl_hstsEnabled|default("") == '1' and frontend.mode == 'http' %}
 {%             set hsts_options = [] %}


### PR DESCRIPTION
Hi, I was looking to enable **HTTP/2** support in haproxy but could not find it. I added a checkbox under the advanced SSL options and added `alpn h2,http/1.1` to the SSL bind options in the template. Wanted to add it as a selectable SSL bind option in the GUI first, but it became too complex because the options string is split on commas. Therefore I decided to add it as a checkbox instead. 

Tested on my installation of Opnsense 18.7.8 (haproxy plugin 2.10, haproxy 1.8.14):

![image](https://user-images.githubusercontent.com/2611439/49551620-2f0caf00-f8f0-11e8-9599-f7497fa994d1.png)
