### PR TITLE
correct regex error to allow domains

### DIFF
--- a/dns/dyndns/src/www/services_dyndns_edit.php
+++ b/dns/dyndns/src/www/services_dyndns_edit.php
@@ -38,7 +38,7 @@ function is_dyndns_username($uname)
 {
     if (!is_string($uname)) {
         return false;
-    } elseif (preg_match("/[^a-z0-9\-.@_:+]/i", $uname)) {
+    } elseif (preg_match("/[^a-z0-9\-\.@_:+]/i", $uname)) {
         return false;
     } else {
         return true;


### PR DESCRIPTION
not escaping the dot makes it so ACTUAL dots are not allowed as hostnames, which makes no sense at all.