### PR TITLE
add wireguard persistent keepalive option

### DIFF
--- a/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardClient.xml
+++ b/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardClient.xml
@@ -43,4 +43,10 @@
         <type>text</type>
         <help>Set port the endpoint listens to.</help>
     </field>
+    <field>
+        <id>client.keepalive</id>
+        <label>Keepalive</label>
+        <type>text</type>
+        <help>Set persistent keepalive interval.</help>
+    </field>
 </form>

--- a/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Client.xml
+++ b/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Client.xml
@@ -35,6 +35,12 @@
                 <serverport type="PortField">
                     <Required>N</Required>
                 </serverport>
+                <keepalive type="IntegerField">
+                    <MinimumValue>1</MinimumValue>
+                    <MaximumValue>86400</MaximumValue>
+                    <ValidationMessage>Please specify a value between 1 and 86400.</ValidationMessage>
+                    <Required>N</Required>
+                </keepalive>
             </client>
         </clients>
     </items>

--- a/net/wireguard/src/opnsense/service/templates/OPNsense/Wireguard/wireguard-server.conf
+++ b/net/wireguard/src/opnsense/service/templates/OPNsense/Wireguard/wireguard-server.conf
@@ -27,6 +27,9 @@ AllowedIPs = {{ peerlist2_data.tunneladdress }}
 {%               if peerlist2_data.serveraddress|default('') != '' %}
 Endpoint = {{ peerlist2_data.serveraddress }}:{{ peerlist2_data.serverport }}
 {%               endif %}
+{%               if peerlist2_data.keepalive|default('') != '' %}
+PersistentKeepalive = {{ peerlist2_data.keepalive }}
+{%               endif %}
 {%             endif %}
 {%           endfor %}
 {%         endif %}


### PR DESCRIPTION
The PersistentKeepalive option is important for tunnels though a NAT.
Would be nice to have it configurable though the web interface.