### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ databases/redis -- Redis DB
 devel/debug -- Debugging Tools
 devel/helloworld -- A sample framework application
 dns/bind -- BIND domain name service
-dns/dnscrypt-proxy -- Flexible DNS proxy supportung DNSCrypt and DoH
+dns/dnscrypt-proxy -- Flexible DNS proxy supporting DNSCrypt and DoH
 dns/dyndns -- Dynamic DNS Support
 dns/rfc2136 -- RFC-2136 Support
 mail/postfix -- SMTP mail relay


### PR DESCRIPTION
Fix typo in README.

Typo in plugin description has already been fixed by #1071.