### PR TITLE
net/frr: make 'set' in route-maps optional

### DIFF
--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/quagga/bgp</mount>
     <description>BGP Routing configuration</description>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <items>
         <enabled type="BooleanField">
             <default>0</default>
@@ -232,8 +232,7 @@
                                 <Required>N</Required>
                         </match2>
                         <set type="TextField">
-                                <default></default>
-                                <Required>Y</Required>
+                                <Required>N</Required>
                         </set>
                 </routemap>
         </routemaps>


### PR DESCRIPTION
As requested here:
https://github.com/opnsense/plugins/pull/1002#issuecomment-447898515

