### PR TITLE
mail/rspamd: allow to set marking values and subject

### DIFF
--- a/mail/rspamd/Makefile
+++ b/mail/rspamd/Makefile
@@ -1,6 +1,5 @@
 PLUGIN_NAME=		rspamd
-PLUGIN_VERSION=		1.3
-PLUGIN_REVISION=    1
+PLUGIN_VERSION=		1.4
 PLUGIN_COMMENT=		Protect your network from spam
 PLUGIN_DEPENDS=		rspamd
 PLUGIN_MAINTAINER=	franz.fabian.94@gmail.com

--- a/mail/rspamd/src/opnsense/mvc/app/controllers/OPNsense/Rspamd/forms/settings.xml
+++ b/mail/rspamd/src/opnsense/mvc/app/controllers/OPNsense/Rspamd/forms/settings.xml
@@ -13,6 +13,30 @@
                 <type>checkbox</type>
                 <help>If you check this box, the local Redis server will be available to the modules (some do not work without it).</help>
             </field>
+            <field>
+                <id>rspamd.general.rejectscore</id>
+                <label>Reject Score</label>
+                <type>text</type>
+                <help>Set the value at which an e-mail is rejected.</help>
+            </field>
+            <field>
+                <id>rspamd.general.subjectscore</id>
+                <label>Subject Score</label>
+                <type>text</type>
+                <help>Set the value at which an e-mail is marked as spam in subject and header.</help>
+            </field>
+            <field>
+                <id>rspamd.general.greylistscore</id>
+                <label>Greylist Score</label>
+                <type>text</type>
+                <help>Set the value at which an e-mail is greylisted.</help>
+            </field>
+            <field>
+                <id>rspamd.general.rewritesubject</id>
+                <label>Rewrite Subject</label>
+                <type>text</type>
+                <help>Enter a prefix added to the subject when Subject Score is reached.</help>
+            </field>
         </subtab>
         <subtab id="rspamd-general-multimap" description="Multimap Settings">
             <field>

--- a/mail/rspamd/src/opnsense/mvc/app/controllers/OPNsense/Rspamd/forms/settings.xml
+++ b/mail/rspamd/src/opnsense/mvc/app/controllers/OPNsense/Rspamd/forms/settings.xml
@@ -20,10 +20,16 @@
                 <help>Set the value at which an e-mail is rejected.</help>
             </field>
             <field>
+                <id>rspamd.general.headerscore</id>
+                <label>Header Score</label>
+                <type>text</type>
+                <help>Set the value at which an e-mail is marked as spam in header.</help>
+            </field>
+            <field>
                 <id>rspamd.general.subjectscore</id>
                 <label>Subject Score</label>
                 <type>text</type>
-                <help>Set the value at which an e-mail is marked as spam in subject and header.</help>
+                <help>Set the value at which an e-mail is marked as spam in subject.</help>
             </field>
             <field>
                 <id>rspamd.general.greylistscore</id>

--- a/mail/rspamd/src/opnsense/mvc/app/controllers/OPNsense/Rspamd/forms/settings.xml
+++ b/mail/rspamd/src/opnsense/mvc/app/controllers/OPNsense/Rspamd/forms/settings.xml
@@ -17,25 +17,25 @@
                 <id>rspamd.general.rejectscore</id>
                 <label>Reject Score</label>
                 <type>text</type>
-                <help>Set the value at which an e-mail is rejected.</help>
+                <help>Set the value at which an e-mail is rejected. The value has to be higher than header, subject and greylist score.</help>
             </field>
             <field>
                 <id>rspamd.general.headerscore</id>
                 <label>Header Score</label>
                 <type>text</type>
-                <help>Set the value at which an e-mail is marked as spam in header.</help>
+                <help>Set the value at which an e-mail is marked as spam in header. The value has to be higher than greylist score.</help>
             </field>
             <field>
                 <id>rspamd.general.subjectscore</id>
                 <label>Subject Score</label>
                 <type>text</type>
-                <help>Set the value at which an e-mail is marked as spam in subject.</help>
+                <help>Set the value at which an e-mail is marked as spam in subject. The value has to be higher than header and greylist score.</help>
             </field>
             <field>
                 <id>rspamd.general.greylistscore</id>
                 <label>Greylist Score</label>
                 <type>text</type>
-                <help>Set the value at which an e-mail is greylisted.</help>
+                <help>Set the value at which an e-mail is greylisted. The value has to be lower than all other scores.</help>
             </field>
             <field>
                 <id>rspamd.general.rewritesubject</id>

--- a/mail/rspamd/src/opnsense/mvc/app/models/OPNsense/Rspamd/RSpamd.xml
+++ b/mail/rspamd/src/opnsense/mvc/app/models/OPNsense/Rspamd/RSpamd.xml
@@ -16,6 +16,11 @@
         <MinimumValue>1</MinimumValue>
         <MaximumValue>999</MaximumValue>
       </rejectscore>
+      <headerscore type="IntegerField">
+        <Required>N</Required>
+        <MinimumValue>1</MinimumValue>
+        <MaximumValue>999</MaximumValue>
+      </headerscore>
       <subjectscore type="IntegerField">
         <Required>N</Required>
         <MinimumValue>1</MinimumValue>

--- a/mail/rspamd/src/opnsense/mvc/app/models/OPNsense/Rspamd/RSpamd.xml
+++ b/mail/rspamd/src/opnsense/mvc/app/models/OPNsense/Rspamd/RSpamd.xml
@@ -11,6 +11,24 @@
         <default>0</default>
         <Required>Y</Required>
       </enable_redis_plugin>
+      <rejectscore type="IntegerField">
+        <Required>N</Required>
+        <MinimumValue>1</MinimumValue>
+        <MaximumValue>999</MaximumValue>
+      </rejectscore>
+      <subjectscore type="IntegerField">
+        <Required>N</Required>
+        <MinimumValue>1</MinimumValue>
+        <MaximumValue>999</MaximumValue>
+      </subjectscore>
+      <greylistscore type="IntegerField">
+        <Required>N</Required>
+        <MinimumValue>1</MinimumValue>
+        <MaximumValue>999</MaximumValue>
+      </greylistscore>
+      <rewritesubject type="TextField">
+        <Required>N</Required>
+      </rewritesubject>
     </general>
 
     <milter_headers>

--- a/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/+TARGETS
+++ b/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/+TARGETS
@@ -1,4 +1,5 @@
 rspamd:/etc/rc.conf.d/rspamd
+actions.conf:/usr/local/etc/rspamd/local.d/actions.conf
 antivirus.wl:/usr/local/etc/rspamd/local.d/antivirus.wl
 antivirus.conf:/usr/local/etc/rspamd/local.d/antivirus.conf
 bad_file_extensions-map:/usr/local/etc/rspamd/local.d/bad_file_extensions.map

--- a/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/2tld.inc.local
+++ b/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/2tld.inc.local
@@ -1,5 +1,5 @@
 {% if helpers.exists('OPNsense.Rspamd.general.enabled') and OPNsense.Rspamd.general.enabled == '1' and helpers.exists('OPNsense.Rspamd.surbl.exceptions') and OPNsense.Rspamd.surbl.exceptions != '' %}
-{% for host in OPNsense.Rspamd.surbl.exceptions.split(',') %}
+{%   for host in OPNsense.Rspamd.surbl.exceptions.split(',') %}
 {{ host }}
-{% endfor %}
+{%   endfor %}
 {% endif %}

--- a/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/actions.conf
+++ b/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/actions.conf
@@ -1,0 +1,18 @@
+#
+# Please don't modify this file as your changes might be overwritten with
+# the next update.
+#
+{% if helpers.exists('OPNsense.Rspamd.general.enabled') and OPNsense.Rspamd.general.enabled == '1' %}
+{%   if helpers.exists('OPNsense.Rspamd.general.rejectscore') and OPNsense.Rspamd.general.rejectscore != '' %}
+    reject = {{ OPNsense.Rspamd.general.rejectscore }};
+{%   endif %}
+{%   if helpers.exists('OPNsense.Rspamd.general.subjectscore') and OPNsense.Rspamd.general.subjectscore != '' %}
+    add_header = {{ OPNsense.Rspamd.general.subjectscore }};
+{%   endif %}
+{%   if helpers.exists('OPNsense.Rspamd.general.greylistscore') and OPNsense.Rspamd.general.greylistscore != '' %}
+    greylist = {{ OPNsense.Rspamd.general.greylistscore }};
+{%   endif %}
+{%   if helpers.exists('OPNsense.Rspamd.general.rewritesubject') and OPNsense.Rspamd.general.rewritesubject != '' %}
+    subject = "{{ OPNsense.Rspamd.general.rewritesubject }} %s"
+{%   endif %}
+{% endif %}

--- a/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/actions.conf
+++ b/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/actions.conf
@@ -7,7 +7,10 @@
     reject = {{ OPNsense.Rspamd.general.rejectscore }};
 {%   endif %}
 {%   if helpers.exists('OPNsense.Rspamd.general.subjectscore') and OPNsense.Rspamd.general.subjectscore != '' %}
-    add_header = {{ OPNsense.Rspamd.general.subjectscore }};
+    add_header = {{ OPNsense.Rspamd.general.headerscore }};
+{%   endif %}
+{%   if helpers.exists('OPNsense.Rspamd.general.subjectscore') and OPNsense.Rspamd.general.subjectscore != '' %}
+    rewrite_subject = {{ OPNsense.Rspamd.general.subjectscore }};
 {%   endif %}
 {%   if helpers.exists('OPNsense.Rspamd.general.greylistscore') and OPNsense.Rspamd.general.greylistscore != '' %}
     greylist = {{ OPNsense.Rspamd.general.greylistscore }};

--- a/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/antivirus.conf
+++ b/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/antivirus.conf
@@ -5,25 +5,25 @@
 {% if helpers.exists('OPNsense.Rspamd.general.enabled') and OPNsense.Rspamd.general.enabled == '1' and helpers.exists('OPNsense.Rspamd.av') %}
 
 clamav {
-{% if helpers.exists('OPNsense.Rspamd.av.force-reject') and OPNsense.Rspamd.av['force-reject'] == '1' %}
+{%   if helpers.exists('OPNsense.Rspamd.av.force-reject') and OPNsense.Rspamd.av['force-reject'] == '1' %}
     action = "reject";
-{% endif %}
-{% if helpers.exists('OPNsense.Rspamd.av.attachments-only') and OPNsense.Rspamd.av['attachments-only'] == '1' %}
+{%   endif %}
+{%   if helpers.exists('OPNsense.Rspamd.av.attachments-only') and OPNsense.Rspamd.av['attachments-only'] == '1' %}
     scan_mime_parts = true;
-{% else %}
+{%   else %}
     scan_mime_parts = false;
-{% endif %}
-{% if helpers.exists('OPNsense.Rspamd.av.max-size') and OPNsense.Rspamd.av['max-size'] != '' %}
+{%   endif %}
+{%   if helpers.exists('OPNsense.Rspamd.av.max-size') and OPNsense.Rspamd.av['max-size'] != '' %}
     # If `max_size` is set, messages > n bytes in size are not scanned
     max_size = {{ OPNsense.Rspamd.av['max-size'] }};
-{% endif %}
+{%   endif %}
     symbol = "CLAM_VIRUS";
     type = "clamav";
     #log_clean = true;
 
-{% if helpers.exists('OPNsense.clamav.general') and OPNsense.clamav.general.enabled == '1' %}
+{%   if helpers.exists('OPNsense.clamav.general') and OPNsense.clamav.general.enabled == '1' %}
     servers = "/var/run/clamav/clamd.sock";
-{% endif %}
+{%   endif %}
 }
 
 {% endif %}

--- a/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/antivirus.wl
+++ b/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/antivirus.wl
@@ -1,5 +1,5 @@
 {% if helpers.exists('OPNsense.Rspamd.general.enabled') and OPNsense.Rspamd.general.enabled == '1' and helpers.exists('OPNsense.Rspamd.av.whitelist') and OPNsense.Rspamd.av.whitelist != '' %}
-{% for host in OPNsense.Rspamd.av.whitelist.split(',') %}
+{%   for host in OPNsense.Rspamd.av.whitelist.split(',') %}
 {{ host }}
-{% endfor %}
+{%   endfor %}
 {% endif %}

--- a/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/bad_file_extensions-map
+++ b/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/bad_file_extensions-map
@@ -1,5 +1,5 @@
 {% if helpers.exists('OPNsense.Rspamd.general.enabled') and OPNsense.Rspamd.general.enabled == '1' and helpers.exists('OPNsense.Rspamd.multimap.badfileextension') and OPNsense.Rspamd.multimap.badfileextension != '' %}
-{% for extension in OPNsense.Rspamd.multimap.badfileextension.split(',') %}
+{%   for extension in OPNsense.Rspamd.multimap.badfileextension.split(',') %}
 {{ extension }}
-{% endfor %}
+{%   endfor %}
 {% endif %}

--- a/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/spamtrap-map
+++ b/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/spamtrap-map
@@ -1,5 +1,5 @@
 {% if helpers.exists('OPNsense.Rspamd.general.enabled') and OPNsense.Rspamd.general.enabled == '1' and helpers.exists('OPNsense.Rspamd.spamtrap.spam_recipients') %}
-{% for recipient in OPNsense.Rspamd.spamtrap.spam_recipients.split(',') %}
+{%   for recipient in OPNsense.Rspamd.spamtrap.spam_recipients.split(',') %}
 /{{ recipient }}/i
-{% endfor %}
+{%   endfor %}
 {% endif %}

--- a/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/spamtrap.conf
+++ b/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/spamtrap.conf
@@ -2,7 +2,6 @@
 # the next update.
 #
 
-
 {% if helpers.exists('OPNsense.Rspamd.general.enabled') and OPNsense.Rspamd.general.enabled == '1' and helpers.exists('OPNsense.Rspamd.spamtrap') %}
   # Optionally set an action
   #action = "no action";

--- a/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/surbl-whitelist.inc.local
+++ b/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/surbl-whitelist.inc.local
@@ -1,5 +1,5 @@
 {% if helpers.exists('OPNsense.Rspamd.general.enabled') and OPNsense.Rspamd.general.enabled == '1' and helpers.exists('OPNsense.Rspamd.surbl.whitelist') and OPNsense.Rspamd.surbl.whitelist != '' %}
-{% for host in OPNsense.Rspamd.surbl.whitelist.split(',') %}
+{%   for host in OPNsense.Rspamd.surbl.whitelist.split(',') %}
 {{ host }}
-{% endfor %}
+{%   endfor %}
 {% endif %}


### PR DESCRIPTION
- allow to set values when mail get's rejected, marked or greylisted
- allow to prepend a string to subject when marked as spam
- add some indents to templating

Working with rspamd is no real fun as there a many places for changes with different priorities. Also, when upgrading from 1.6 all the way to 1.8 the behavior is different. I reinstalled the plugin and removed db folder and got different scores (also without bayes).
When I reinstalled the plugin and removed /usr/local/etc/rspamd I got a warning that actions.conf was not readable. The files belong to root:whell and are 640 .. perhaps we shoud change them to 644?