### PR TITLE
www/nginx: remove workaround for njs encoding bug; release 1.6

### DIFF
--- a/www/nginx/Makefile
+++ b/www/nginx/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		nginx
-PLUGIN_VERSION=		1.5
+PLUGIN_VERSION=		1.6
 PLUGIN_COMMENT=		Nginx HTTP server and reverse proxy
 PLUGIN_DEPENDS=		nginx
 PLUGIN_MAINTAINER=	franz.fabian.94@gmail.com

--- a/www/nginx/src/opnsense/scripts/nginx/ngx_functions.js
+++ b/www/nginx/src/opnsense/scripts/nginx/ngx_functions.js
@@ -1,15 +1,6 @@
 var fs = require('fs');
 var tls_fingerprints = JSON.parse(fs.readFileSync('/usr/local/etc/nginx/tls_fingerprints.json'));
 
-function customArrayIndexOf(haystack, needle) {
-  var element, element_id;
-  for (element_id in haystack) {
-    element = haystack[element_id];
-    if (element == needle) return element_id;
-  }
-  return -1;
-}
-
 function check_cipher_array(r, browser_ciphers, fingerprint_ciphers, result) {
   if (result.status == 'Intercepted') {
     return;
@@ -25,7 +16,7 @@ function check_cipher_array(r, browser_ciphers, fingerprint_ciphers, result) {
   var current_index;
   for (browser_cipher_index in browser_ciphers) {
     browser_cipher = browser_ciphers[browser_cipher_index];
-    current_index = customArrayIndexOf(fingerprint_ciphers, browser_cipher);
+    current_index = fingerprint_ciphers.indexOf(browser_cipher);
     if (current_index === -1 || current_index <= last_index) {
       // a cipher has been found, which is not supported by the browser
       // such a connection is definitly intercepted

--- a/www/nginx/src/opnsense/scripts/nginx/ngx_functions.js
+++ b/www/nginx/src/opnsense/scripts/nginx/ngx_functions.js
@@ -21,7 +21,6 @@ function check_cipher_array(r, browser_ciphers, fingerprint_ciphers, result) {
       // a cipher has been found, which is not supported by the browser
       // such a connection is definitly intercepted
       result.status = "Intercepted";
-      //result.status = JSON.stringify(fingerprint_ciphers[0].toBytes().toString('hex'));
       return;
     }
     last_index = current_index;


### PR DESCRIPTION
cleanup: this is not needed since the utf-8 / raw compare is fixed in nginx now.