### PR TITLE
misc/theme-cicada: Unify scrollbar colors to theme.

### DIFF
--- a/misc/theme-cicada/src/opnsense/www/themes/cicada/build/css/main.css
+++ b/misc/theme-cicada/src/opnsense/www/themes/cicada/build/css/main.css
@@ -6203,20 +6203,20 @@ padding-right: 15px; }
 
 ::-webkit-scrollbar-button {
   width: 8px;
-  height: 5px; }
+  height: 0px; }
 
 ::-webkit-scrollbar-track {
-  background: #f7f7f7;
+  background: #323232;
   box-shadow: 0px 0px 0px;
   border-radius: 0; }
 
 ::-webkit-scrollbar-thumb {
-  background: #e5e5e5;
-  border: thin solid #e5e5e5;
+  background: #424242;
+  border: thin solid #393939;
   border-radius: 0px; }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #e5e5e5; }
+  background: #ec6d12; }
 
 .widgetdiv {
   padding-top: 0px !important;


### PR DESCRIPTION
The scrollbar was showing up as a solid light colored bar which didn't actually show your position within the page.

* Change scrollbar to dark colors from within the theme.
* Remove arbitrary gap at top of scrollbar.
* On hover highlight as opnsense orange.

Please let me know if there is anything I missed about making a contribution,  I'm open to all corrections/suggestions.