### PR TITLE
Fix "Collect cpu time" in telegraf plugin

### DIFF
--- a/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/input.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/input.xml
@@ -18,7 +18,7 @@
         <help>Whether to report total system CPU stats or not.</help>
     </field>
     <field>
-        <id>input.cpu_collect_cpu_time</id>
+        <id>input.collect_cpu_time</id>
         <label>Collect CPU Time</label>
         <type>checkbox</type>
         <help>If true, collect raw CPU time metrics.</help>


### PR DESCRIPTION
The checkbox for "Collect CPU Time" in telegraf doesn't work because there is a typo in input.xml