### PR TITLE
fixing use_redis in dkim_signing.conf

### DIFF
--- a/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/dkim_signing.conf
+++ b/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/dkim_signing.conf
@@ -15,7 +15,7 @@
   try_fallback = {% if helpers.exists('OPNsense.Rspamd.dkim.try_fallback') and OPNsense.Rspamd.dkim.try_fallback == '1' %}true{% else %}false{% endif %};
   use_domain = "{{ OPNsense.Rspamd.dkim.use_domain|default("header") }}";
   use_esld = {% if helpers.exists('OPNsense.Rspamd.dkim.use_esld') and OPNsense.Rspamd.dkim.use_esld == '1' %}true{% else %}false{% endif %};
-  use_redis = false;
+  use_redis = {% if helpers.exists('OPNsense.Rspamd.general.enable_redis_plugin') and OPNsense.Rspamd.general.enable_redis_plugin == '1' %}true{% else %}false{% endif %};
   # Hash for DKIM keys in Redis
   key_prefix = "DKIM_KEYS";
 


### PR DESCRIPTION
This fixes an issue here if you have redis in use in other places in rspamd did it is set to now use it by default in dkim_signing.conf. By adding the if else this makes it so that we can store the dkim keys in redis.