### PR TITLE
fix pf configuration in telegraf plugin

### DIFF
--- a/net-mgmt/telegraf/Makefile
+++ b/net-mgmt/telegraf/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		telegraf
-PLUGIN_VERSION=		1.7.3
+PLUGIN_VERSION=		1.7.4
 PLUGIN_COMMENT=		Agent for collecting metrics and data
 PLUGIN_DEPENDS=		telegraf
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
+++ b/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
@@ -173,6 +173,7 @@
 
 {% if helpers.exists('OPNsense.telegraf.input.pf') and OPNsense.telegraf.input.pf == '1' %}
 [[inputs.pf]]
+use_sudo = true
 {% endif %}
 
 {% if helpers.exists('OPNsense.telegraf.input.ping') and OPNsense.telegraf.input.ping == '1' %}


### PR DESCRIPTION
The current configuration for the pf input in telegraf.conf doesn't work because you don't set the "use_sudo" parameter.

https://github.com/influxdata/telegraf/tree/master/plugins/inputs/pf#configuration

This commit fix the problem :)