### PR TITLE
www/nginx: reorder menu

### DIFF
--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Menu/Menu.xml
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Menu/Menu.xml
@@ -1,10 +1,10 @@
 <menu>
   <Services>
     <Nginx cssClass="fa fa-shield fa-fw">
-      <Configuration url="/ui/nginx" />
-      <Logs url="/ui/nginx/index/logs" />
-      <Banned url="/ui/nginx/index/ban" />
-      <TLSFingerprints VisibleName="TLS Fingerprints" url="/ui/nginx/index/tls_handshakes" />
+      <Configuration url="/ui/nginx" order="10"/>
+      <Banned url="/ui/nginx/index/ban" order="20"/>
+      <TLSFingerprints VisibleName="TLS Fingerprints" url="/ui/nginx/index/tls_handshakes" order="30"/>
+      <Logs url="/ui/nginx/index/logs" order="100"/>
     </Nginx>
   </Services>
 </menu>


### PR DESCRIPTION
I'll start now moving nginx in production and will do some more work on it. 
At first could we reorder the menu as within most menues the logs are at the bottom and configuration on the top?