### PR TITLE
www/nginx: misleading help attribute for upstream.tls_enable

### DIFF
--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/upstream.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/upstream.xml
@@ -20,7 +20,7 @@
   <field>
     <id>upstream.tls_enable</id>
     <label>Enable TLS (HTTPS)</label>
-    <help>Authenticate on the Server using a client certificate.</help>
+    <help>Use TLS (HTTPS) to connect to the Server.</help>
     <type>checkbox</type>
   </field>
   <field>

--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/upstream.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/upstream.xml
@@ -20,7 +20,7 @@
   <field>
     <id>upstream.tls_enable</id>
     <label>Enable TLS (HTTPS)</label>
-    <help>Use TLS (HTTPS) to connect to the Server.</help>
+    <help>Use TLS (HTTPS) to connect to the server.</help>
     <type>checkbox</type>
   </field>
   <field>


### PR DESCRIPTION
fixes #1189 