### PR TITLE
net/haproxy: release 2.15

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		haproxy
-PLUGIN_VERSION=		2.14
+PLUGIN_VERSION=		2.15
 PLUGIN_COMMENT=		Reliable, high performance TCP/HTTP load balancer
 PLUGIN_DEPENDS=		haproxy
 PLUGIN_MAINTAINER=	opnsense@moov.de

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/Api/SettingsController.php
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/Api/SettingsController.php
@@ -123,9 +123,14 @@ class SettingsController extends ApiMutableModelControllerBase
         return $this->delBase('servers.server', $uuid);
     }
 
+    public function toggleServerAction($uuid, $enabled = null)
+    {
+        return $this->toggleBase('servers.server', $uuid);
+    }
+
     public function searchServersAction()
     {
-        return $this->searchBase('servers.server', array('name', 'address', 'port', 'description'), 'name');
+        return $this->searchBase('servers.server', array('enabled', 'name', 'address', 'port', 'description'), 'name');
     }
 
     public function getHealthcheckAction($uuid = null)

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogAction.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogAction.xml
@@ -335,6 +335,17 @@
     <field>
         <label>Parameters</label>
         <type>header</type>
+        <style>type_table table_tcp-request_inspect-delay</style>
+    </field>
+    <field>
+        <id>action.tcp_request_inspect_delay</id>
+        <label>TCP inspection delay</label>
+        <type>text</type>
+        <help><![CDATA[Set the maximum allowed time to wait for data during content inspection. Defaults to milliseconds. You may also enter a number followed by one of the supported suffixes "d" (days), "h" (hour), "m" (minute), "s" (seconds), "ms" (miliseconds).]]></help>
+    </field>
+    <field>
+        <label>Parameters</label>
+        <type>header</type>
         <style>type_table table_tcp-response_content_lua</style>
     </field>
     <field>
@@ -342,6 +353,17 @@
         <label>Lua function</label>
         <type>text</type>
         <help><![CDATA[Execute the specified Lua function. You will most likely need to include/load your Lua code first.]]></help>
+    </field>
+    <field>
+        <label>Parameters</label>
+        <type>header</type>
+        <style>type_table table_tcp-response_inspect-delay</style>
+    </field>
+    <field>
+        <id>action.tcp_response_inspect_delay</id>
+        <label>TCP inspection delay</label>
+        <type>text</type>
+        <help><![CDATA[Set the maximum allowed time to wait for a response during content inspection. Defaults to milliseconds. You may also enter a number followed by one of the supported suffixes "d" (days), "h" (hour), "m" (minute), "s" (seconds), "ms" (miliseconds).]]></help>
     </field>
     <field>
         <label>Parameters</label>

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogBackend.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogBackend.xml
@@ -316,6 +316,7 @@
         <label>Select Rules</label>
         <type>select_multiple</type>
         <style>tokenize</style>
+        <sortable>true</sortable>
         <help><![CDATA[Choose rules to be included in this Backend Pool.]]></help>
         <hint>Choose rules.</hint>
     </field>

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogFrontend.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogFrontend.xml
@@ -95,6 +95,7 @@
         <type>select_multiple</type>
         <style>tokenize</style>
         <allownew>true</allownew>
+        <sortable>true</sortable>
         <help><![CDATA[Used to enforce or disable certain SSL options.]]></help>
     </field>
     <field>
@@ -401,6 +402,7 @@
         <label>Select Rules</label>
         <type>select_multiple</type>
         <style>tokenize</style>
+        <sortable>true</sortable>
         <help><![CDATA[Choose rules to be included in this Public Service.]]></help>
         <hint>Choose rules.</hint>
     </field>

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogServer.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogServer.xml
@@ -1,5 +1,11 @@
 <form>
     <field>
+        <id>server.enabled</id>
+        <label>Enabled</label>
+        <type>checkbox</type>
+        <help>Enable this server.</help>
+    </field>
+    <field>
         <id>server.name</id>
         <label>Name</label>
         <type>text</type>

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogServer.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogServer.xml
@@ -35,7 +35,6 @@
         <label>Mode</label>
         <type>dropdown</type>
         <help><![CDATA[Sets the operation mode to use for this server.]]></help>
-        <advanced>true</advanced>
     </field>
     <field>
         <id>server.ssl</id>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/HAProxy</mount>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <description>the HAProxy load balancer</description>
     <items>
         <general>
@@ -398,6 +398,7 @@
                 <ssl_bindOptions type="OptionField">
                     <Required>N</Required>
                     <default>no-sslv3,no-tlsv10,no-tls-tickets</default>
+                    <Sorted>Y</Sorted>
                     <Multiple>Y</Multiple>
                     <OptionValues>
                         <no-sslv3>no-sslv3</no-sslv3>
@@ -667,6 +668,7 @@
                         </template>
                     </Model>
                     <ValidationMessage>Related action item not found</ValidationMessage>
+                    <Sorted>Y</Sorted>
                     <multiple>Y</multiple>
                     <Required>N</Required>
                 </linkedActions>
@@ -983,6 +985,7 @@
                         </template>
                     </Model>
                     <ValidationMessage>Related action item not found</ValidationMessage>
+                    <Sorted>Y</Sorted>
                     <multiple>Y</multiple>
                     <Required>N</Required>
                 </linkedActions>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -1763,10 +1763,12 @@
                         <tcp-request_content_reject>tcp-request content reject</tcp-request_content_reject>
                         <tcp-request_content_lua>tcp-request content lua script</tcp-request_content_lua>
                         <tcp-request_content_use-service>tcp-request content use-service</tcp-request_content_use-service>
+                        <tcp-request_inspect-delay>tcp-request inspect-delay</tcp-request_inspect-delay>
                         <tcp-response_content_accept>tcp-response content accept</tcp-response_content_accept>
                         <tcp-response_content_close>tcp-response content close</tcp-response_content_close>
                         <tcp-response_content_reject>tcp-response content reject</tcp-response_content_reject>
                         <tcp-response_content_lua>tcp-response content lua script</tcp-response_content_lua>
+                        <tcp-response_inspect-delay>tcp-response inspect-delay</tcp-response_inspect-delay>
                         <custom>Custom rule (option pass-through)</custom>
                     </OptionValues>
                 </type>
@@ -1909,10 +1911,18 @@
                     <mask>/^.{1,4096}$/u</mask>
                     <Required>N</Required>
                 </tcp_request_content_use_service>
+                <tcp_request_inspect_delay type="TextField">
+                    <mask>/^.{1,32}$/u</mask>
+                    <Required>N</Required>
+                </tcp_request_inspect_delay>
                 <tcp_response_content_lua type="TextField">
                     <mask>/^.{1,4096}$/u</mask>
                     <Required>N</Required>
                 </tcp_response_content_lua>
+                <tcp_response_inspect_delay type="TextField">
+                    <mask>/^.{1,32}$/u</mask>
+                    <Required>N</Required>
+                </tcp_response_inspect_delay>
                 <custom type="TextField">
                     <mask>/^.{1,4096}$/u</mask>
                     <Required>N</Required>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -1008,6 +1008,10 @@
                 <id type="UniqueIdField">
                     <Required>Y</Required>
                 </id>
+                <enabled type="BooleanField">
+                    <default>1</default>
+                    <Required>Y</Required>
+                </enabled>
                 <name type="TextField">
                     <mask>/^([0-9a-zA-Z._]){1,255}$/u</mask>
                     <ValidationMessage>Should be a string between 1 and 255 characters.</ValidationMessage>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/Migrations/M2_7_0.php
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/Migrations/M2_7_0.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ *    Copyright (C) 2019 Frank Wall
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+namespace OPNsense\HAProxy\Migrations;
+
+use OPNsense\Base\BaseModelMigration;
+
+class M2_7_0 extends BaseModelMigration
+{
+    public function run($model)
+    {
+        // Servers have an 'enabled' field now 
+        foreach ($model->getNodeByReference('servers.servers')->iterateItems() as $server) {
+            $server->enabled = '1';
+        }
+    }
+}

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/Migrations/M2_7_0.php
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/Migrations/M2_7_0.php
@@ -35,7 +35,7 @@ class M2_7_0 extends BaseModelMigration
     public function run($model)
     {
         // Servers have an 'enabled' field now 
-        foreach ($model->getNodeByReference('servers.servers')->iterateItems() as $server) {
+        foreach ($model->getNodeByReference('servers.server')->iterateItems() as $server) {
             $server->enabled = '1';
         }
     }

--- a/net/haproxy/src/opnsense/mvc/app/views/OPNsense/HAProxy/index.volt
+++ b/net/haproxy/src/opnsense/mvc/app/views/OPNsense/HAProxy/index.volt
@@ -79,6 +79,7 @@ POSSIBILITY OF SUCH DAMAGE.
                 set:'/api/haproxy/settings/setServer/',
                 add:'/api/haproxy/settings/addServer/',
                 del:'/api/haproxy/settings/delServer/',
+                toggle:'/api/haproxy/settings/toggleServer/',
                 options: {
                     rowCount:[10,25,50,100,500,1000]
                 }
@@ -716,6 +717,7 @@ POSSIBILITY OF SUCH DAMAGE.
         <table id="grid-servers" class="table table-condensed table-hover table-striped table-responsive" data-editDialog="DialogServer">
             <thead>
             <tr>
+                <th data-column-id="enabled" data-width="6em" data-type="string" data-formatter="rowtoggle">{{ lang._('Enabled') }}</th>
                 <th data-column-id="serverid" data-type="number"  data-visible="false">{{ lang._('Server ID') }}</th>
                 <th data-column-id="name" data-type="string">{{ lang._('Server Name') }}</th>
                 <th data-column-id="address" data-type="string">{{ lang._('Server Address') }}</th>

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -541,7 +541,7 @@
 {%             set acl_line = [action_data.testType, action_acls|join(join_operator)]|join(' ') %}
 {%           else %}
 {%             set acl_line = '' %}
-{%             set comment_lines = ['# NOTE: actions with no ACLs/conditions will always match'] + comment_lines %}
+{%             set comment_lines = comment_lines + ['    # NOTE: actions with no ACLs/conditions will always match'] %}
 {%           endif %}
 {%           if action_options|length > 0 %}
 {%             do global_action_options.append(comment_lines|join('\n')) %}

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -490,6 +490,13 @@
 {%             set action_enabled = '0' %}
     # ERROR: missing parameters
 {%           endif %}
+{%         elif action_data.type == 'tcp-request_inspect-delay' %}
+{%           if action_data.tcp_request_inspect_delay|default("") != "" %}
+{%             do action_options.append('tcp-request inspect-delay ' ~ action_data.tcp_request_inspect_delay) %}
+{%           else %}
+{%             set action_enabled = '0' %}
+    # ERROR: missing parameters
+{%           endif %}
 {%         elif action_data.type == 'tcp-response_content_accept' %}
 {%           do action_options.append('tcp-response content accept') %}
 {%         elif action_data.type == 'tcp-response_content_close' %}
@@ -499,6 +506,13 @@
 {%         elif action_data.type == 'tcp-response_content_lua' %}
 {%           if action_data.tcp_response_content_lua|default("") != "" %}
 {%             do action_options.append('tcp-response content lua.' ~ action_data.tcp_response_content_lua) %}
+{%           else %}
+{%             set action_enabled = '0' %}
+    # ERROR: missing parameters
+{%           endif %}
+{%         elif action_data.type == 'tcp-response_inspect-delay' %}
+{%           if action_data.tcp_response_inspect_delay|default("") != "" %}
+{%             do action_options.append('tcp-response inspect-delay ' ~ action_data.tcp_response_inspect_delay) %}
 {%           else %}
 {%             set action_enabled = '0' %}
     # ERROR: missing parameters

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -1373,7 +1373,10 @@ backend {{backend.name}}
 {%           if server_data.advanced|default("") != "" %}
 {%             do server_options.append(server_data.advanced) %}
 {%           endif %}
+{#           # server enabled? #}
+{%           if server_data.enabled == '1' %}
     server {{server_data.name}} {{server_data.address}}:{% if backend.tuning_noport != '1' %}{% if server_data.port|default("") != "" %}{{server_data.port}}{% endif %}{% endif %} {{server_options|join(' ')}}
+{%           endif %}
 {%         endif %}
 {%       endfor %}
 


### PR DESCRIPTION
## New features
- rules can finally be sorted by using drag'n'drop (#582)
- added "enabled" field to servers (#1208)
- TCP inspection delays are supported in rules (#1188)

## Bugfixes
none

## Enhancements
- server option "mode" is always visible, no longer requires "advanced mode" (#1208)
- most dropdown fields finally have alphanumeric sorting (#687, https://github.com/opnsense/core/issues/3251)
- rules: align indentation of comments in haproxy.conf