### PR TITLE
www/nginx proxy timeout

### DIFF
--- a/www/nginx/pkg-descr
+++ b/www/nginx/pkg-descr
@@ -17,6 +17,7 @@ Plugin Changelog
 * Alias support for downstream proxies (trust setting)
 * bugfix: deleting IP ACL
 * HSTS not sent automatically anymore if HTTP over TLS is configured (still available via security header)
+* add configuration directives for timeouts to location
 
 1.7
 

--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/location.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/location.xml
@@ -236,6 +236,20 @@
     <help>If you enable the WebSocket Support option, nginx will pass the upgrade header to the backed server.</help>
   </field>
   <field>
+    <id>location.proxy_read_timeout</id>
+    <label>Proxy Read Timeout</label>
+    <type>text</type>
+    <advanced>true</advanced>
+    <help>Enter a custom timout between data received from the client after which the connection is closed.</help>
+  </field>
+  <field>
+    <id>location.proxy_send_timeout</id>
+    <label>Proxy Send Timeout</label>
+    <type>text</type>
+    <advanced>true</advanced>
+    <help>Enter a custom timout between data it sent to the client after which the connection is closed. </help>
+  </field>
+  <field>
     <id>location.proxy_buffering</id>
     <label>Response Buffering</label>
     <type>checkbox</type>

--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
@@ -364,6 +364,14 @@
         <Required>Y</Required>
         <default>1</default>
       </proxy_buffering>
+      <proxy_read_timeout type="IntegerField">
+        <Required>N</Required>
+        <minValue>1</minValue>
+      </proxy_read_timeout>
+      <proxy_send_timeout type="IntegerField">
+        <Required>N</Required>
+        <minValue>1</minValue>
+      </proxy_send_timeout>
       <http2_push_preload type="BooleanField">
         <Required>Y</Required>
         <default>0</default>

--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/location.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/location.conf
@@ -139,6 +139,12 @@ location {{ location.matchtype }} {{ location.urlpattern }} {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-TLS-Client-Intercepted $tls_intercepted;
+{% if location.proxy_read_timeout is defined and location.proxy_read_timeout != '' %}
+    proxy_read_timeout {{ location.proxy_read_timeout }}s;
+{% endif %}
+{% if location.proxy_send_timeout is defined and location.proxy_send_timeout != '' %}
+    proxy_send_timeout {{ location.proxy_send_timeout }}s;
+{% endif %}
     proxy_ignore_client_abort {% if location.proxy_ignore_client_abort == '1' %}on{% else %}off{% endif %};
     proxy_request_buffering {% if location.proxy_request_buffering == '1' %}on{% else %}off{% endif %};
     proxy_buffering {% if location.proxy_buffering == '1' %}on{% else %}off{% endif %};


### PR DESCRIPTION
See https://forum.opnsense.org/index.php?topic=11799.0;topicseen

some websockets have no heartbeat and nginx considers the connection to be dead if no data is transferred.