### PR TITLE
core/vpn/ipsec: allow easier override of colors in themes fix

### DIFF
--- a/misc/theme-cicada/src/opnsense/www/themes/cicada/assets/stylesheets/main.scss
+++ b/misc/theme-cicada/src/opnsense/www/themes/cicada/assets/stylesheets/main.scss
@@ -9565,14 +9565,14 @@ label > input {
 
 #ipsec {
   #ipsec-mobile, #ipsec-tunnel, #ipsec-overview {
-    background-color: #393939;
+    background-color: #393939 !important;
   }
   .ipsec-tab {
-    background-color: #3e3e3e;
-    color: #928873;
+    background-color: #3e3e3e !important;
+    color: #928873 !important;
     &.activetab {
-      background-color: #2a2a2a;
-      color: #ec6d12;
+      background-color: #2a2a2a !important;
+      color: #ec6d12 !important;
     }
   }
 }

--- a/misc/theme-cicada/src/opnsense/www/themes/cicada/build/css/main.css
+++ b/misc/theme-cicada/src/opnsense/www/themes/cicada/build/css/main.css
@@ -6297,17 +6297,17 @@ label > input[type="radio"] {
 }
 
 #ipsec #ipsec-mobile, #ipsec #ipsec-tunnel, #ipsec #ipsec-overview {
-	background-color: #393939;
+	background-color: #393939 !important;
 }
 
 #ipsec .ipsec-tab {
-	background-color: #3e3e3e;
-	color: #928873;
+	background-color: #3e3e3e !important;
+	color: #928873 !important;
 }
 
 #ipsec .ipsec-tab.activetab {
-	background-color: #2a2a2a;
-	color: #ec6d12;
+	background-color: #2a2a2a !important;
+	color: #ec6d12 !important;
 }
 .fw_pass {
   background-color: #365a38 !important;

--- a/misc/theme-tukan/src/opnsense/www/themes/tukan/assets/stylesheets/main.scss
+++ b/misc/theme-tukan/src/opnsense/www/themes/tukan/assets/stylesheets/main.scss
@@ -9580,14 +9580,14 @@ label > input {
 
 #ipsec {
   #ipsec-mobile, #ipsec-tunnel, #ipsec-overview {
-    background-color: #f0f0f0;
+    background-color: #f0f0f0 !important;
   }
   .ipsec-tab {
-    background-color: #839caa;
-    color: #FFF;
+    background-color: #839caa !important;
+    color: #FFF !important;
     &.activetab {
-      background-color: #315a71;
-      color: #FFF;
+      background-color: #315a71 !important;
+      color: #FFF !important;
     }
   }
 }

--- a/misc/theme-tukan/src/opnsense/www/themes/tukan/build/css/main.css
+++ b/misc/theme-tukan/src/opnsense/www/themes/tukan/build/css/main.css
@@ -6296,17 +6296,17 @@ label > input[type="radio"] {
 }
 
 #ipsec #ipsec-mobile, #ipsec #ipsec-tunnel, #ipsec #ipsec-overview {
-	background-color: #f0f0f0;
+	background-color: #f0f0f0 !important;
 }
 
 #ipsec .ipsec-tab {
-	background-color: #839caa;
-	color: #FFF;
+	background-color: #839caa !important;
+	color: #FFF !important;
 }
 
 #ipsec .ipsec-tab.activetab {
-	background-color: #315a71;
-	color: #FFF;
+	background-color: #315a71 !important;
+	color: #FFF !important;
 }
 .fw_pass {
   background-color: #295f2b !important;


### PR DESCRIPTION
see -> https://github.com/opnsense/core/pull/3286#issuecomment-469782949
@fichtner 
@AdSchellevis 