### PR TITLE
net/freeradius: fix certificate generation

### DIFF
--- a/net/freeradius/Makefile
+++ b/net/freeradius/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		freeradius
-PLUGIN_VERSION=		1.9.1
+PLUGIN_VERSION=		1.9.2
 PLUGIN_COMMENT=		RADIUS Authentication, Authorization and Accounting Server
 PLUGIN_DEPENDS=		freeradius3
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/eap.xml
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/eap.xml
@@ -15,7 +15,7 @@
         <id>eap.ca</id>
         <label>Root Certificate</label>
         <type>dropdown</type>
-        <help>Choose the Root CA.</help>
+        <help>Choose the Root CA. This CA will be trusted to issue client certificates for authentication.</help>
     </field>
     <field>
         <id>eap.certificate</id>

--- a/net/freeradius/src/opnsense/scripts/Freeradius/generate_certs.php
+++ b/net/freeradius/src/opnsense/scripts/Freeradius/generate_certs.php
@@ -87,7 +87,7 @@ if (isset($configObj->OPNsense->freeradius)) {
                     )));
 
                     $pem_content .= "\n";
-                    $cert_pem_content .= $pem_content;
+                    $ca_pem_content .= $pem_content;
                 }
             }
         }

--- a/net/freeradius/src/opnsense/scripts/Freeradius/generate_certs.php
+++ b/net/freeradius/src/opnsense/scripts/Freeradius/generate_certs.php
@@ -68,14 +68,32 @@ if (isset($configObj->OPNsense->freeradius)) {
                     // generate ca pem file
                     if (!empty($cert->caref)) {
                         $cert = (array)$cert;
-                        $ca_pem_content .= ca_chain($cert);
+                        $cert_pem_content .= ca_chain($cert);
                     }
                 }
             }
         }
 
+        $cert_refid = (string)$find_cert->ca;
+        // if eap has a ca-certificate attached, search for its contents
+        if ($cert_refid != "") {
+            foreach ($configObj->ca as $ca) {
+                if ($cert_refid == (string)$ca->refid) {
+                    // generate cert pem file
+                    $pem_content = trim(str_replace("\n\n", "\n", str_replace(
+                        "\r",
+                        "",
+                        base64_decode((string)$ca->crt)
+                    )));
+
+                    $pem_content .= "\n";
+                    $cert_pem_content .= $pem_content;
+                }
+            }
+        }
+
         $cert_refid = (string)$find_cert->crl;
-        // if eap has a certificate attached, search for its contents
+        // if eap has a crl attached, search for its contents
         if ($cert_refid != "") {
             foreach ($configObj->crl as $crl) {
                 if ($cert_refid == (string)$crl->refid && !empty((string)$crl->text)) {


### PR DESCRIPTION
Certificate files were not properly generated. There was a mixup between service cert and ca cert. Also added elaboration on what the purpose of the `Root CA` is. I run this already in production.