### PR TITLE
Allow wildcard for Google Domains.

### DIFF
--- a/dns/dyndns/src/www/services_dyndns_edit.php
+++ b/dns/dyndns/src/www/services_dyndns_edit.php
@@ -102,8 +102,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     do_input_validation($pconfig, $reqdfields, $reqdfieldsn, $input_errors);
 
     if (isset($pconfig['host']) && in_array('host', $reqdfields)) {
-        /* Namecheap can have a @. or *. in hostname */
-        if ($pconfig['type'] == "namecheap" && (substr($pconfig['host'], 0, 2) == '@.' || substr($pconfig['host'], 0, 2) == '*.')) {
+        /* Multiple vendors can have a @. or *. in hostname */
+        $wildcard_vendors = array(
+          "googledomains",
+          "namecheap"
+        );
+        if (in_array($pconfig['type'], $wildcard_vendors) && (substr($pconfig['host'], 0, 2) == '@.' || substr($pconfig['host'], 0, 2) == '*.')) {
             $host_to_check = substr($pconfig['host'], 2);
         } else {
             $host_to_check = $pconfig['host'];


### PR DESCRIPTION
Fix for #1280 

Google Domains allows for wildcard Dynamic DNS entries, however the opnsense dynamic dns plugin only allows NameCheap to use wildcard domains. This request allows Google Domains to use wildcards and makes it easier to add additional vendors in the future.