### PR TITLE
Fix ngnix permissions issue with acme-client

### DIFF
--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/setup.sh
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/setup.sh
@@ -1,11 +1,17 @@
 #!/bin/sh
 
-ACME_DIRS="/var/etc/acme-client /var/etc/acme-client/certs /var/etc/acme-client/keys /var/etc/acme-client/configs /var/etc/acme-client/challenges /var/etc/acme-client/home"
+ACME_DIRS="/var/etc/acme-client /var/etc/acme-client/certs /var/etc/acme-client/keys /var/etc/acme-client/configs /var/etc/acme-client/home"
 
 for directory in ${ACME_DIRS}; do
     mkdir -p ${directory}
     chown -R root:wheel ${directory}
-    chmod -R 750 ${directory}
+    chmod -R 755 ${directory}
 done
+
+CHALLENGES_DIR="/var/etc/acme-client/challenges"
+
+mkdir -p ${CHALLENGES_DIR}
+chown -R www:www ${CHALLENGES_DIR}
+chmod -R 755 ${CHALLENGES_DIR}
 
 exit 0


### PR DESCRIPTION
This needs to be tested with HAProxy as well. 

Currently Nginx runs its workers as "www". Since the acme-client folder is created with 750 permissions and owned by root:wheel, Nginx throws an error 13: permission denied when attempting to validate using http. By setting permissions to 755 (like everything else in the etc directory), and then giving "www" ownership of the challenges directory, nginx can read and write to the directory without issue.

Note: it's probably not necessary to change ownership to www since we are allowing "www" to read the directory by changing permissions to 755.