### PR TITLE
Fixes #1299 by changing CloudFlare zone ID lookup behavior

### DIFF
--- a/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
+++ b/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
@@ -726,24 +726,22 @@ class updatedns
                     'Content-Type: application/json'
                 ));
 
-                // Get zone ID
+                // Get all zone info
                 $zonesUrl = "$baseUrl/zones";
-                // First, try removing the first part of the FQDN,
-                // under the assumption that it is probably the hostname,
-                // and look up the zone from what's left
-                $fqdnParts = explode('.', $fqdn);
-                $hostName = array_shift($fqdnParts);
-                $domainName = implode('.', $fqdnParts);
-                $getZoneId = "$zonesUrl/?name=$domainName";
-                curl_setopt($ch, CURLOPT_URL, $getZoneId);
+                curl_setopt($ch, CURLOPT_URL, $zonesUrl);
                 $output = json_decode(curl_exec($ch));
-                $zoneId = $output->result[0]->id;
-                if (empty($zoneId)) {
-                    // now try the full "hostname" as provided by the UI
-                    $getZoneId = "$zonesUrl/?name=$fqdn";
-                    curl_setopt($ch, CURLOPT_URL, $getZoneId);
-                    $output = json_decode(curl_exec($ch));
-                    $zoneId = $output->result[0]->id;
+
+                // Iterate zone objects, check if $fqdn is equal to or ends with zone name
+                foreach ($output->result as $key => $zoneObj) {
+                    if (preg_match("/^{$zoneObj->name}$|\.{$zoneObj->name}$/", $fqdn)) {
+                        // Found matching zone
+                        $zoneId = $zoneObj->id;
+                        // Get $hostName from $fqdn, set $domainName
+                        // These are only really used for log messages.
+                        $hostName = preg_replace ("/\.?{$zoneObj->name}$/", '', $fqdn);
+                        $domainName = $zoneObj->name;
+                        break;
+                    }
                 }
 
                 if ($zoneId) { // If zone ID was found get host ID

--- a/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
+++ b/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
@@ -76,8 +76,8 @@
  *  SelfHost            - Last Tested: 26 December 2011
  *  Amazon Route53      - Last Tested: 01 April 2012
  *  DNS-O-Matic         - Last Tested: 9 September 2010
- *  CloudFlare          - Last Tested: 19 September 2018
- *  CloudFlare IPv6     - Last Tested: 19 September 2018
+ *  CloudFlare          - Last Tested: 16 April 2019
+ *  CloudFlare IPv6     - Last Tested: 16 April 2019
  *  Eurodns             - Last Tested: 25 July 2018
  *  GratisDNS           - Last Tested: 15 August 2012
  *  OVH DynHOST         - Last Tested: NEVER
@@ -730,7 +730,8 @@ class updatedns
                 $zonesUrl = "$baseUrl/zones";
                 curl_setopt($ch, CURLOPT_URL, $zonesUrl);
                 $output = json_decode(curl_exec($ch));
-
+                $zoneId = null; // Set default value
+                
                 // Iterate zone objects, check if $fqdn is equal to or ends with zone name
                 foreach ($output->result as $key => $zoneObj) {
                     if (preg_match("/^{$zoneObj->name}$|\.{$zoneObj->name}$/", $fqdn)) {


### PR DESCRIPTION
Fixes updates to hosts with multiple levels of subdomains as mentioned in #1299.

Changes zone ID lookup for CloudFlare DDNS so that instead of guessing at hostname & domain parts of FQDN using array_push and testing with an API call, we instead request a list of zones and compare to $fqdn for an exact match, or one that matches the ending of $fqdn. This is reliable for multi-level subdomains of unrestricted depth.

Also eliminates an API call to check for an exact $fqdn match since this will also work in that scenario.