### PR TITLE
Add simple RTSP helper plugin

### DIFF
--- a/net/rtsphelper/Makefile
+++ b/net/rtsphelper/Makefile
@@ -1,0 +1,7 @@
+PLUGIN_NAME=		rtsphelper
+PLUGIN_VERSION=		1.0
+#PLUGIN_DEPENDS=		
+PLUGIN_COMMENT=		RTSP Port Forwarder Helper
+PLUGIN_MAINTAINER=	quentin.canel@o2r.fr
+
+.include "../../Mk/plugins.mk"

--- a/net/rtsphelper/Makefile
+++ b/net/rtsphelper/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		rtsphelper
-PLUGIN_VERSION=		1.0
+PLUGIN_VERSION=		1.2
 #PLUGIN_DEPENDS=		
 PLUGIN_COMMENT=		RTSP Port Forwarder Helper
 PLUGIN_MAINTAINER=	quentin.canel@o2r.fr

--- a/net/rtsphelper/pkg-descr
+++ b/net/rtsphelper/pkg-descr
@@ -1,0 +1,1 @@
+A simple helper script that opens ports to allow mis-configured RTSP servers to work behind NAT environment

--- a/net/rtsphelper/src/etc/inc/plugins.inc.d/rtsphelper.inc
+++ b/net/rtsphelper/src/etc/inc/plugins.inc.d/rtsphelper.inc
@@ -1,0 +1,137 @@
+<?php
+
+function rtsphelper_enabled()
+{
+    global $config;
+
+    return isset($config['installedpackages']['rtsphelper']['config'][0]['enable']);
+}
+
+function rtsphelper_firewall($fw)
+{
+    if (!rtsphelper_enabled()) {
+        return;
+    }
+
+    $fw->registerAnchor('rtsphelper', 'rdr');
+    $fw->registerAnchor('rtsphelper', 'fw');
+}
+
+function rtsphelper_services()
+{
+    $services = array();
+
+    if (!rtsphelper_enabled()) {
+        return $services;
+    }
+
+    $pconfig = array();
+    $pconfig['name'] = 'rtsphelper';
+    $pconfig['description'] = gettext('RTSP Helper');
+    $pconfig['php']['restart'] = array('rtsphelper_stop', 'rtsphelper_start');
+    $pconfig['php']['start'] = array('rtsphelper_start');
+    $pconfig['php']['stop'] = array('rtsphelper_stop');
+    $pconfig['pidfile'] = '/var/run/rtsphelper.pid';
+    $services[] = $pconfig;
+
+    return $services;
+}
+
+function rtsphelper_start()
+{
+    if (!rtsphelper_enabled()) {
+        return;
+    }
+
+    if (isvalidpid('/var/run/rtsphelper.pid')) {
+        return;
+    }
+
+    mwexec_bg('/usr/local/bin/python2.7 /usr/local/opnsense/scripts/net/rtsphelper/rtsphelper.py');
+}
+
+function rtsphelper_stop()
+{
+    killbypid('/var/run/rtsphelper.pid', 'TERM', true);
+    mwexec('/sbin/pfctl -artsphelper -Fr 2>&1 >/dev/null');
+    mwexec('/sbin/pfctl -artsphelper -Fn 2>&1 >/dev/null');
+}
+
+function rtsphelper_configure()
+{
+    return array('bootup' => array('rtsphelper_configure_do'));
+}
+
+function rtsphelper_permuser_list()
+{
+    $ret = array();
+    $count = 3;
+
+    for ($i = 1; $i <= $count; $i++) {
+        $ret[$i] = "permuser{$i}";
+    }
+
+    return $ret;
+}
+
+function rtsphelper_forward_list()
+{
+    $ret = array();
+    $count = 5;
+
+    for ($i = 1; $i <= $count; $i++) {
+        $ret[$i] = "forward{$i}";
+    }
+
+    return $ret;
+}
+
+function rtsphelper_configure_do($verbose = false)
+{
+    global $config;
+
+    rtsphelper_stop();
+
+    if (!rtsphelper_enabled()) {
+        return;
+    }
+
+    if ($verbose) {
+        echo 'Starting RTSP Helper...';
+        flush();
+    }
+
+    $rtsphelper_config = $config['installedpackages']['rtsphelper']['config'][0];
+
+    $ext_ifname = get_real_interface($rtsphelper_config['ext_iface']);
+    if ($ext_ifname == $rtsphelper_config['ext_iface']) {
+        if ($verbose) {
+            echo "failed.\n";
+        }
+        return;
+    }
+
+    $config_text = "ext_ifname={$ext_ifname}\n";
+
+    $ifaces_active = '';
+
+    /* RTSP Helper access restrictions */
+    foreach (rtsphelper_permuser_list() as $permuser) {
+        if (!empty($rtsphelper_config[$permuser])) {
+            $config_text .= "allow={$rtsphelper_config[$permuser]}\n";
+        }
+    }
+
+    foreach (rtsphelper_forward_list() as $forward) {
+        if (!empty($rtsphelper_config[$forward])) {
+            $config_text .= "forward={$rtsphelper_config[$forward]}\n";
+        }
+    }
+    /* write out the configuration */
+    file_put_contents('/var/etc/rtsphelper.conf', $config_text);
+    rtsphelper_start();
+
+    if ($verbose) {
+        echo "done.\n";
+    }
+}

--- a/net/rtsphelper/src/etc/inc/plugins.inc.d/rtsphelper.inc
+++ b/net/rtsphelper/src/etc/inc/plugins.inc.d/rtsphelper.inc
@@ -47,7 +47,7 @@ function rtsphelper_start()
         return;
     }
 
-    mwexec_bg('/usr/local/bin/python2.7 /usr/local/opnsense/scripts/net/rtsphelper/rtsphelper.py');
+    mwexec_bg('/usr/local/bin/python3 /usr/local/opnsense/scripts/net/rtsphelper/rtsphelper.py');
 }
 
 function rtsphelper_stop()

--- a/net/rtsphelper/src/opnsense/mvc/app/models/Net/RTSPHelper/ACL/ACL.xml
+++ b/net/rtsphelper/src/opnsense/mvc/app/models/Net/RTSPHelper/ACL/ACL.xml
@@ -1,0 +1,14 @@
+<acl>
+    <page-service-rtsphelper>
+        <name>Service: RTSP Helper</name>
+        <patterns>
+            <pattern>services_rtsphelper.php*</pattern>
+        </patterns>
+    </page-service-rtsphelper>
+    <page-status-rtsphelperstatus>
+        <name>Status: RTSP Helper</name>
+        <patterns>
+            <pattern>status_rtsphelper.php*</pattern>
+        </patterns>
+    </page-status-rtsphelperstatus>
+</acl>

--- a/net/rtsphelper/src/opnsense/mvc/app/models/Net/RTSPHelper/Menu/Menu.xml
+++ b/net/rtsphelper/src/opnsense/mvc/app/models/Net/RTSPHelper/Menu/Menu.xml
@@ -1,0 +1,10 @@
+<menu>
+    <Services>
+        <RTSPHelper VisibleName="RTSP Helper" cssClass="fa fa-plug fa-fw">
+            <Settings url="/services_rtsphelper.php">
+                <Edit url="/services_rtsphelper.php?*" visibility="hidden"/>
+            </Settings>
+            <Status url="/status_rtsphelper.php"/>
+        </RTSPHelper>
+    </Services>
+</menu>

--- a/net/rtsphelper/src/opnsense/scripts/net/rtsphelper/rtsphelper.py
+++ b/net/rtsphelper/src/opnsense/scripts/net/rtsphelper/rtsphelper.py
@@ -23,8 +23,8 @@ class Forward:
         try:
             self.forward.connect((host, port))
             return self.forward
-        except Exception, e:
-            print e
+        except Exception as e:
+            print(e)
             return False
 
 class ProxyServer:
@@ -62,7 +62,7 @@ class ProxyServer:
                     break
                 else:
                     self.on_recv()
-            except socket.error, e:
+            except socket.error as e:
                 self.on_close()
 
     def on_accept(self):
@@ -78,11 +78,11 @@ class ProxyServer:
                 self.channel[clientsock] = forward
                 self.channel[forward] = clientsock
             else:
-                print "Can't establish connection with remote server.",
-                print "Closing connection with client side", clientaddr
+                print("Can't establish connection with remote server.")
+                print("Closing connection with client side", clientaddr)
                 clientsock.close()
         else:
-            print "Forbidden client IP"
+            print("Forbidden client IP")
             clientsock.close()
 
     def on_close(self):
@@ -115,7 +115,7 @@ class ProxyServer:
 
     def parseData(self, data, client):
         for line in data.splitlines():
-            lineSplit = line.split(':', 1)
+            lineSplit = line.decode().split(':', 1)
             if lineSplit[0] == "Transport":
                 for transportOpt in lineSplit[1].split(';'):
                     if transportOpt.split('=')[0] == "client_port":
@@ -142,13 +142,13 @@ class PortManager:
         self.forwardedPorts[client] = []
 
     def updatePorts(self, client, ports):
-        print "Forwarding ports for client " + client[0] + ". New list of ports is: {0}".format(ports)
+        print("Forwarding ports for client " + client[0] + ". New list of ports is: {0}".format(ports))
         self.forwardedPorts[client] = ports
         self.applyRules()
 
 
     def removeClient(self, client):
-        print "Remove client: " + client[0]
+        print("Remove client: " + client[0])
         self.forwardedPorts.pop(client)
         self.applyRules()
 
@@ -176,7 +176,7 @@ class PortManager:
         for localBinding in self.localBindings:
             f.write(config_rule_1.format(localBinding[0], localBinding[1], '127.0.0.1', localBinding[2]))
 
-        for client,ports in self.forwardedPorts.iteritems():
+        for client,ports in self.forwardedPorts.items():
             ip = client[0]
             for port in ports:
                 f.write(rdr_rule.format(config['ext_if'], port, ip))
@@ -187,7 +187,7 @@ class PortManager:
             for network in self.allowedNets:
                 f.write(config_rule_3.format(network, '127.0.0.1', localBinding[2]))
 
-        for client,ports in self.forwardedPorts.iteritems():
+        for client,ports in self.forwardedPorts.items():
             ip = client[0]
             for port in ports:
                 f.write(pass_rule.format(config['ext_if'], ip, port, 'RTSP'))
@@ -272,7 +272,7 @@ if __name__ == '__main__':
         handle_exit()
 
     def handle_exit():
-        print "Exiting..."
+        print("Exiting...")
         pm.removeAll()
         sys.exit(0)
 
@@ -283,6 +283,6 @@ if __name__ == '__main__':
             for server in servers:
                 server.main_loop()
     except KeyboardInterrupt:
-        print "Ctrl C - Stopping server"
+        print("Ctrl C - Stopping server")
         handle_exit()
 sys.exit(1)

--- a/net/rtsphelper/src/opnsense/scripts/net/rtsphelper/rtsphelper.py
+++ b/net/rtsphelper/src/opnsense/scripts/net/rtsphelper/rtsphelper.py
@@ -1,0 +1,288 @@
+#!/usr/bin/python
+import socket
+import select
+import time
+import sys
+import os
+import signal
+import subprocess
+
+buffer_size = 4096
+delay = 0.0001
+
+config_file = '/var/etc/rtsphelper.conf'
+config = {}
+
+FNULL = open(os.devnull, 'w')
+
+class Forward:
+    def __init__(self):
+        self.forward = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+    def start(self, host, port):
+        try:
+            self.forward.connect((host, port))
+            return self.forward
+        except Exception, e:
+            print e
+            return False
+
+class ProxyServer:
+    input_list = []
+    channel = {}
+    clients = []
+
+    forward_to = []
+
+    perms = []
+
+    def __init__(self, remoteHost, remotePort, portManager, perms):
+        self.pm = portManager
+        self.forward_to = [remoteHost, remotePort]
+        self.perms = perms
+        self.server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.server.bind(('127.0.0.1', 0))
+        self.server.listen(200)
+        self.pm.addLocalBinding(remoteHost, remotePort, self.server.getsockname()[1])
+        self.input_list.append(self.server)
+
+    def main_loop(self):
+        ss = select.select
+        inputready, outputready, exceptready = ss(self.input_list, [], [])
+        for self.s in inputready:
+            if self.s == self.server:
+                self.on_accept()
+                break
+            
+            try:
+                self.data = self.s.recv(buffer_size)
+                if len(self.data) == 0:
+                    self.on_close()
+                    break
+                else:
+                    self.on_recv()
+            except socket.error, e:
+                self.on_close()
+
+    def on_accept(self):
+        clientsock, clientaddr = self.server.accept()
+        
+        if allowedIP(clientaddr[0], self.perms):
+            forward = Forward().start(self.forward_to[0], self.forward_to[1])
+            if forward:
+                self.clients.append([clientaddr,clientsock,forward])
+                self.pm.addClient(clientaddr)
+                self.input_list.append(clientsock)
+                self.input_list.append(forward)
+                self.channel[clientsock] = forward
+                self.channel[forward] = clientsock
+            else:
+                print "Can't establish connection with remote server.",
+                print "Closing connection with client side", clientaddr
+                clientsock.close()
+        else:
+            print "Forbidden client IP"
+            clientsock.close()
+
+    def on_close(self):
+        #remove objects from input_list
+        self.input_list.remove(self.s)
+        self.input_list.remove(self.channel[self.s])
+        out = self.channel[self.s]
+        # close the connection with client
+        self.channel[out].close()  # equivalent to do self.s.close()
+        # close the connection with remote server
+        self.channel[self.s].close()
+        # delete both objects from channel dict
+        del self.channel[out]
+        del self.channel[self.s]
+
+        for c in self.clients:
+            if c[1] == self.s:
+                break
+        self.clients.remove(c)
+        self.pm.removeClient(c[0])
+
+    def on_recv(self):
+        data = self.data
+        # here we can parse and/or modify the data before send forward
+        self.channel[self.s].send(data)
+        for c in self.clients:
+            if c[1] == self.s:
+                self.parseData(data, c)
+                break
+
+    def parseData(self, data, client):
+        for line in data.splitlines():
+            lineSplit = line.split(':', 1)
+            if lineSplit[0] == "Transport":
+                for transportOpt in lineSplit[1].split(';'):
+                    if transportOpt.split('=')[0] == "client_port":
+                        askedPorts = transportOpt.split('=')[1].split('-')
+                        allowedPorts = []
+                        for port in askedPorts:
+                            if allowedPortForward(client[0][0], port, self.perms):
+                                allowedPorts.append(port)
+                        self.pm.updatePorts(client[0], allowedPorts)
+
+class PortManager:
+    forwardedPorts = {}
+    localBindings = []
+    allowedNets = []
+
+    def __init__(self, perms):
+        for perm in perms:
+            network = perm[0]
+            self.allowedNets.append(network)
+        self.removeAll()
+        self.applyRules()
+
+    def addClient(self, client):
+        self.forwardedPorts[client] = []
+
+    def updatePorts(self, client, ports):
+        print "Forwarding ports for client " + client[0] + ". New list of ports is: {0}".format(ports)
+        self.forwardedPorts[client] = ports
+        self.applyRules()
+
+
+    def removeClient(self, client):
+        print "Remove client: " + client[0]
+        self.forwardedPorts.pop(client)
+        self.applyRules()
+
+    def removeAll(self):
+        f = open('/tmp/rtsphelper.rules', 'w')
+        f.close()
+        subprocess.call(['pfctl', '-a', 'rtsphelper', '-F', 'nat'], stdout=FNULL, stderr=subprocess.STDOUT)
+        subprocess.call(['pfctl', '-a', 'rtsphelper', '-F', 'rules'], stdout=FNULL, stderr=subprocess.STDOUT)
+        subprocess.call(['pfctl', '-k', 'label', '-k', 'RTSP'], stdout=FNULL, stderr=subprocess.STDOUT)
+
+    def addLocalBinding(self, ip, port, local_port):
+        self.localBindings.append([ip, port, local_port])
+        self.applyRules()
+
+    def applyRules(self):
+        config_rule_1 = 'rdr inet proto tcp from any to {} port {} -> {} port {}\n'
+        config_rule_2 = 'block in quick on {} proto tcp from any to {} port {}\n'
+        config_rule_3 = 'pass in quick proto tcp from {} to {} port {}\n'
+        
+        pass_rule = 'pass in quick on {} inet proto udp from any to {} port {} keep state label "{}"\n'
+        rdr_rule  = 'rdr on {} inet proto udp from any to any port {} -> {}\n'
+
+        f = open('/tmp/rtsphelper.rules', 'w')
+
+        for localBinding in self.localBindings:
+            f.write(config_rule_1.format(localBinding[0], localBinding[1], '127.0.0.1', localBinding[2]))
+
+        for client,ports in self.forwardedPorts.iteritems():
+            ip = client[0]
+            for port in ports:
+                f.write(rdr_rule.format(config['ext_if'], port, ip))
+
+        f.write('\n')
+        for localBinding in self.localBindings:
+            f.write(config_rule_2.format(config['ext_if'], '127.0.0.1', localBinding[2]))
+            for network in self.allowedNets:
+                f.write(config_rule_3.format(network, '127.0.0.1', localBinding[2]))
+
+        for client,ports in self.forwardedPorts.iteritems():
+            ip = client[0]
+            for port in ports:
+                f.write(pass_rule.format(config['ext_if'], ip, port, 'RTSP'))
+
+        f.close()
+        subprocess.call(['pfctl', '-a', 'rtsphelper', '-f', '/tmp/rtsphelper.rules'], stdout=FNULL)
+
+
+def writePidFile():
+    pid = str(os.getpid())
+    f = open('/var/run/rtsphelper.pid', 'w')
+    f.write(pid)
+    f.close()
+
+def ip_to_u32(ip):
+    return int(''.join('%02x' % int(d) for d in ip.split('.')), 16)
+
+def allowedIP(ipstr, perms):
+    ip = ip_to_u32(ipstr)
+    for perm in perms:
+        mask, net = perm[0]
+        if ip & mask == net:
+            return True
+    return False
+
+def allowedPortForward(ipstr, port, perms):
+    if not allowedIP(ipstr, perms):
+        return False
+    else:
+        ip = ip_to_u32(ipstr)
+        for perm in perms:
+            mask, net = perm[0]
+            ports = perm[1]
+            if ip & mask == net:
+                if int(port) >= int(ports[0]) and int(port) <= int(ports[1]):
+                    return True
+        return False
+
+def buildPerms(perms):
+    masks = [ ]
+    for perm in perms:
+        cidr = perm[0]
+        portRange = perm[1]
+        if '/' in cidr:
+            netstr, bits = cidr.split('/')
+            mask = (0xffffffff << (32 - int(bits))) & 0xffffffff
+            net = ip_to_u32(netstr) & mask
+        else:
+            mask = 0xffffffff
+            net = ip_to_u32(cidr)
+        masks.append(((mask, net), (min(portRange.split('-')[0],portRange.split('-')[1]),max(portRange.split('-')[0],portRange.split('-')[1]))))
+    return masks
+
+if __name__ == '__main__':
+    writePidFile()
+
+    config['forward_to'] = []
+    config['perms'] = []
+
+    with open(config_file, 'r') as cf:
+        line = cf.readline()
+        while line:
+            key,value = line.strip().split('=')
+            if key == 'ext_ifname':
+                config['ext_if'] = value
+            elif key == 'forward':
+                config['forward_to'].append([value.split(':')[0],int(value.split(':')[1])])
+            elif key == 'allow':
+                config['perms'].append(value.split(' '))
+
+            line = cf.readline()
+    
+    perms = buildPerms(config['perms'])
+    servers = []
+
+    pm = PortManager(config['perms'])
+
+    for forward in config['forward_to']:
+        servers.append(ProxyServer(forward[0], forward[1], pm, perms))
+
+    def handle_exit_signal(sig, frame):
+        handle_exit()
+
+    def handle_exit():
+        print "Exiting..."
+        pm.removeAll()
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, handle_exit_signal)
+    try:
+        while 1:
+            time.sleep(delay)
+            for server in servers:
+                server.main_loop()
+    except KeyboardInterrupt:
+        print "Ctrl C - Stopping server"
+        handle_exit()
+sys.exit(1)

--- a/net/rtsphelper/src/www/services_rtsphelper.php
+++ b/net/rtsphelper/src/www/services_rtsphelper.php
@@ -2,7 +2,6 @@
 
 require_once("guiconfig.inc");
 require_once("interfaces.inc");
-require_once("services.inc");
 require_once("filter.inc");
 require_once("system.inc");
 require_once("plugins.inc.d/rtsphelper.inc");

--- a/net/rtsphelper/src/www/services_rtsphelper.php
+++ b/net/rtsphelper/src/www/services_rtsphelper.php
@@ -1,0 +1,280 @@
+<?php
+
+require_once("guiconfig.inc");
+require_once("interfaces.inc");
+require_once("services.inc");
+require_once("filter.inc");
+require_once("system.inc");
+require_once("plugins.inc.d/rtsphelper.inc");
+
+function rtsphelper_validate_ip($ip)
+{
+    /* validate cidr */
+    $ip_array = array();
+    $ip_array = explode('/', $ip);
+    if (count($ip_array) == 2) {
+        if ($ip_array[1] < 1 || $ip_array[1] > 32) {
+            return false;
+        }
+    } elseif (count($ip_array) != 1) {
+        return false;
+    }
+
+    /* validate ip */
+    if (!is_ipaddr($ip_array[0])) {
+        return false;
+    }
+
+    return true;
+}
+
+function rtsphelper_validate_forward($forward)
+{
+    $fw_array = array();
+    $fw_array = explode(':', $forward);
+
+    if (!is_ipaddr($fw_array[0])) {
+        return false;
+    }
+
+    $sub = $fw_array[1];
+    if ($sub < 0 || $sub > 65535 || !is_numeric($sub)) {
+        return false;
+    }
+
+    return true;
+}
+
+function rtsphelper_validate_port($port)
+{
+    foreach (explode('-', $port) as $sub) {
+        if ($sub < 0 || $sub > 65535 || !is_numeric($sub)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'GET') {
+    $pconfig = array();
+
+    $copy_fields = array('enable', 'ext_iface');
+
+    foreach (rtsphelper_permuser_list() as $permuser) {
+        $copy_fields[] = $permuser;
+    }
+
+    foreach (rtsphelper_forward_list() as $forward) {
+        $copy_fields[] = $forward;
+    }
+
+    foreach ($copy_fields as $fieldname) {
+        if (isset($config['installedpackages']['rtsphelper']['config'][0][$fieldname])) {
+            $pconfig[$fieldname] = $config['installedpackages']['rtsphelper']['config'][0][$fieldname];
+        }
+    }
+} elseif ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $input_errors = array();
+    $pconfig = $_POST;
+
+    /* user permissions validation */
+    foreach (rtsphelper_permuser_list() as $i => $permuser) {
+        if (!empty($pconfig[$permuser])) {
+            $perm = explode(' ', $pconfig[$permuser]);
+            /* should explode to 2 args */
+            if (count($perm) != 2) {
+                $input_errors[] = sprintf(gettext("You must follow the specified format in the 'User specified permissions %s' field"), $i);
+            } else {
+              /* verify port or port range */
+              if (!rtsphelper_validate_port($perm[1]) ) {
+                  $input_errors[] = sprintf(gettext("You must specify a port or port range between 0 and 65535 in the 'User specified permissions %s' field"), $i);
+              }
+              /* verify ip address */
+              if (!rtsphelper_validate_ip($perm[0])) {
+                  $input_errors[] = sprintf(gettext("You must specify a valid ip address in the 'User specified permissions %s' field"), $i);
+              }
+            }
+        }
+    }
+
+    foreach (rtsphelper_forward_list() as $i => $forward) {
+        if (!empty($pconfig[$forward])) {
+            if (!rtsphelper_validate_forward($pconfig[$forward])) {
+                $input_errors[] = sprintf(gettext("You must specify a valid ip and port in the 'Hosts to enable %s' field"), $i);
+            }
+        }
+    }
+
+    if (count($input_errors) == 0) {
+        // save form data
+        $rtsp = array();
+        // boolean types
+        foreach (array('enable') as $fieldname) {
+            $rtsp[$fieldname] = !empty($pconfig[$fieldname]);
+        }
+        // text field types
+        foreach (array('ext_iface') as $fieldname) {
+            $rtsp[$fieldname] = $pconfig[$fieldname];
+        }
+        foreach (rtsphelper_permuser_list() as $fieldname) {
+            $rtsp[$fieldname] = $pconfig[$fieldname];
+        }
+        foreach (rtsphelper_forward_list() as $forward) {
+            $rtsp[$forward] = $pconfig[$forward];
+        }
+        // sync to config
+        $config['installedpackages']['rtsphelper']['config'] = $rtsp;
+
+        write_config('Modified RTSP Helper settings');
+        rtsphelper_configure_do();
+        filter_configure();
+        header(url_safe('Location: /services_rtsphelper.php'));
+        exit;
+    }
+}
+
+
+$service_hook = 'rtsphelper';
+legacy_html_escape_form_data($pconfig);
+include("head.inc");
+?>
+<body>
+<?php include("fbegin.inc"); ?>
+  <section class="page-content-main">
+    <div class="container-fluid">
+      <div class="row">
+        <?php if (isset($input_errors) && count($input_errors) > 0) print_input_errors($input_errors); ?>
+        <form method="post" name="iform" id="iform">
+          <section class="col-xs-12">
+            <div class="content-box">
+              <div class="table-responsive">
+                <table class="table table-striped opnsense_standard_table_form">
+                  <thead>
+                    <tr>
+                      <td style="width:22%">
+                        <strong><?=gettext("RTSP Helper Settings");?></strong>
+                      </td>
+                      <td style="width:78%; text-align:right">
+                        <small><?=gettext("full help"); ?> </small>
+                        <i class="fa fa-toggle-off text-danger"  style="cursor: pointer;" id="show_all_help_page"></i>
+                        &nbsp;&nbsp;
+                      </td>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td><i class="fa fa-info-circle text-muted"></i> <?=gettext("Enable");?></td>
+                      <td>
+                       <input name="enable" type="checkbox" value="yes" <?=!empty($pconfig['enable']) ? "checked=\"checked\"" : ""; ?> />
+                      </td>
+                    </tr>
+                    <tr>
+                      <td><a id="help_for_ext_iface" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("External Interface");?></td>
+                      <td>
+                       <select class="selectpicker" name="ext_iface">
+<?php
+                        foreach (get_configured_interface_with_descr() as $iface => $ifacename):?>
+                          <option value="<?=$iface;?>" <?=$pconfig['ext_iface'] == $iface ? "selected=\"selected\"" : "";?>>
+                            <?=htmlspecialchars($ifacename);?>
+                          </option>
+<?php
+                        endforeach;?>
+                       </select>
+                       <div class="hidden" data-for="help_for_ext_iface">
+                         <?=gettext("Select only your primary WAN interface (interface with your default route). Only one interface is allowed here, not multiple.");?>
+                       </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </section>
+          <section class="col-xs-12">
+            <div class="content-box">
+              <div class="table-responsive">
+                <table class="table table-striped opnsense_standard_table_form">
+                  <thead>
+                    <tr>
+                      <th colspan="2"><?=gettext("Hosts to enable");?></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+<?php foreach (rtsphelper_forward_list() as $i => $forward): ?>
+                    <tr>
+<?php if ($i == 1): ?>
+                      <td style="width:22%"><a id="help_for_forward" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Entry') . ' ' . $i ?></td>
+<?php else: ?>
+                      <td style="width:22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext('Entry') . ' ' . $i ?></td>
+<?php endif ?>
+                      <td style="width:78%">
+                        <input name="<?= html_safe($forward) ?>" type="text" value="<?= $pconfig[$forward] ?>" />
+<?php if ($i == 1): ?>
+                        <div class="hidden" data-for="help_for_forward">
+                          <?=gettext("Format: [ip:port]");?><br/>
+                          <?=gettext("Example: 1.2.3.4:554");?>
+                        </div>
+<?php endif ?>
+                      </td>
+                    </tr>
+<?php endforeach ?>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </section>
+          <section class="col-xs-12">
+            <div class="content-box">
+              <div class="table-responsive">
+                <table class="table table-striped opnsense_standard_table_form">
+                  <thead>
+                    <tr>
+                      <th colspan="2"><?=gettext("User specified permissions");?></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+<?php foreach (rtsphelper_permuser_list() as $i => $permuser): ?>
+                    <tr>
+<?php if ($i == 1): ?>
+                      <td style="width:22%"><a id="help_for_permuser" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext('Entry') . ' ' . $i ?></td>
+<?php else: ?>
+                      <td style="width:22%"><i class="fa fa-info-circle text-muted"></i> <?=gettext('Entry') . ' ' . $i ?></td>
+<?php endif ?>
+                      <td style="width:78%">
+                        <input name="<?= html_safe($permuser) ?>" type="text" value="<?= $pconfig[$permuser] ?>" />
+<?php if ($i == 1): ?>
+                        <div class="hidden" data-for="help_for_permuser">
+                          <?=gettext("Format: [int ipaddr or ipaddr/cdir] [int port or range]");?><br/>
+                          <?=gettext("Example: 192.168.0.0/24 1024-65535");?>
+                        </div>
+<?php endif ?>
+                      </td>
+                    </tr>
+<?php endforeach ?>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </section>
+          <section class="col-xs-12">
+            <div class="content-box">
+              <div class="table-responsive">
+                <table class="table table-striped">
+                  <tbody>
+                    <tr>
+                     <td style="width:22%; vertical-align:top">&nbsp;</td>
+                     <td style="width:78%">
+                       <input name="Submit" type="submit" class="btn btn-primary" value="<?=gettext("Save");?>" />
+                     </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </section>
+        </form>
+      </div>
+    </div>
+  </section>
+<?php include("foot.inc"); ?>

--- a/net/rtsphelper/src/www/status_rtsphelper.php
+++ b/net/rtsphelper/src/www/status_rtsphelper.php
@@ -1,7 +1,6 @@
 <?php
 
 require_once("guiconfig.inc");
-require_once("services.inc");
 require_once("interfaces.inc");
 require_once("plugins.inc.d/rtsphelper.inc");
 

--- a/net/rtsphelper/src/www/status_rtsphelper.php
+++ b/net/rtsphelper/src/www/status_rtsphelper.php
@@ -1,0 +1,81 @@
+<?php
+
+require_once("guiconfig.inc");
+require_once("services.inc");
+require_once("interfaces.inc");
+require_once("plugins.inc.d/rtsphelper.inc");
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!empty($_POST['clear'])) {
+        rtsphelper_stop();
+        rtsphelper_start();
+        header(url_safe('Location: /status_rtsphelper.php'));
+        exit;
+    }
+}
+
+$rdr_entries = array();
+exec("/sbin/pfctl -artsphelper -sn", $rdr_entries, $pf_ret);
+
+$service_hook = 'rtsphelper';
+include("head.inc");
+?>
+<body>
+<?php include("fbegin.inc"); ?>
+
+<section class="page-content-main">
+  <div class="container-fluid">
+    <div class="row">
+      <section class="col-xs-12">
+        <div class="content-box">
+<?php
+          if (empty($config['installedpackages']['rtsphelper']['config'][0]['enable'])): ?>
+          <header class="content-box-head container-fluid">
+            <h3><?= gettext('RTSP Helper is currently disabled.') ?></h3>
+          </header>
+<?php
+          else: ?>
+          <div class="table-responsive">
+            <table class="table table-striped">
+              <thead>
+                <tr>
+                  <td><?=gettext("Internal IP");?></td>
+                  <td><?=gettext("Int. Port");?></td>
+                </tr>
+              </thead>
+              <tbody>
+<?php
+              foreach ($rdr_entries as $rdr_entry):
+                  if (!preg_match("/on (.*) inet proto (.*) from (.*) to (.*) port = (.*) -> (.*)/", $rdr_entry, $matches)) {
+                      continue;
+                  }
+                  $rdr_ip = $matches[6];
+                  $rdr_iport = $matches[5];
+              ?>
+                <tr>
+                  <td><?=$rdr_ip;?></td>
+                  <td><?=$rdr_iport;?></td>
+                </tr>
+<?php
+              endforeach;?>
+              </tbody>
+              <tfoot>
+                  <tr>
+                    <td colspan="5">
+                      <form method="post">
+                        <button type="submit" name="clear" id="clear" class="btn btn-primary" value="Clear"><?=gettext("Clear");?></button>
+                        <?=gettext("all currently connected sessions");?>.
+                      </form>
+                    </td>
+                  </tr>
+              </tfoot>
+            </table>
+          </div>
+<?php
+          endif; ?>
+        </div>
+      </section>
+    </div>
+  </div>
+</section>
+<?php include("foot.inc"); ?>


### PR DESCRIPTION
Hello,

This is a simple plugin that I have made to allow some RTSP streams to work behind a NAT firewall.
The main reason is the TV service offered by m provider (French internet provider named Free), that provides RTSP streams to watch TV on the router LAN.

This stream won't work because the server ports used are refusing UDP packets, with an ICMP Port Unreachable return. This causes the firewall to cancel the NAT inbound port, and then blocks the video stream.

The plugin is there to intercept RTSP TCP connections, and watching for "client_port" option. It then creates inbound redirections of these ports, allowing the video to pass. This port remains opened as long as the TCP connection stays opened, and is checked against access rules (for both IP and ports). 

This plugin acts as a TCP proxy server for the TCP RTSP stream. It is fully configurable from the web UI.

I can provide PCAP files showing the "fixed" issue.

Thanks !