### PR TITLE
www/nginx: fix ACME support

### DIFF
--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/http.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/http.conf
@@ -180,7 +180,11 @@ server {
 {% if server.enable_acme_support is defined and server.enable_acme_support == '1' %}
     location ^~ /.well-known/acme-challenge/ {
         default_type "text/plain";
-        root /var/etc/acme-client/challenges;
+{%   if helpers.exists('OPNsense.AcmeClient.settings.challengePort') and OPNsense.AcmeClient.settings.challengePort|default("") != "" %}
+        proxy_pass http://127.0.0.1:{{OPNsense.AcmeClient.settings.challengePort}};
+{%   else %}
+        proxy_pass http://127.0.0.1:43580;
+{%   endif %}
     }
 {% endif %}
 {% if server.disable_bot_protection is not defined or server.disable_bot_protection != '1' %}


### PR DESCRIPTION
@fabianfrz As stated in https://github.com/opnsense/plugins/pull/1292#issuecomment-487414386 I think the current approach is flawed:

https://github.com/opnsense/plugins/blob/930ebe8111cc33bbb9825fd8b213b4c4aa68c704/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/http.conf#L180-L184

nginx should proxy requests to ACME's own web service instead of accessing ACME's files directly. Furthermore the configurable port number of ACME's web service should be used:

https://github.com/opnsense/plugins/blob/930ebe8111cc33bbb9825fd8b213b4c4aa68c704/security/acme-client/src/opnsense/service/templates/OPNsense/AcmeClient/lighttpd-acme-challenge.conf#L65

This way we're one step closer to a better integration between our Let's Encrypt and nginx plugins. 