### PR TITLE
security/acme-client: release 1.24

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/Api/SettingsController.php
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/Api/SettingsController.php
@@ -372,4 +372,22 @@ class SettingsController extends ApiMutableModelControllerBase
 
         return $result;
     }
+
+    /**
+     * Check wether the Google Cloud plugin is installed.
+     * @return array status action
+     */
+    public function getGcloudPluginStatusAction()
+    {
+        $result = array("result" => "0");
+
+        $mdlAcme = $this->getModel();
+
+        // Check if the required plugin is installed
+        if ((string)$mdlAcme->isPluginInstalled('google-cloud-sdk') == "1") {
+            $result['result'] = "1";
+        }
+
+        return $result;
+    }
 }

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -597,6 +597,27 @@
         <type>text</type>
     </field>
     <field>
+        <label>Namecheap</label>
+        <type>header</type>
+        <style>table_dns table_dns_namecheap</style>
+    </field>
+    <field>
+        <id>validation.dns_namecheap_user</id>
+        <label>User</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_namecheap_api</id>
+        <label>API Key</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_namecheap_sourceip</id>
+        <label>Source IP</label>
+        <type>text</type>
+        <advanced>true</advanced>
+    </field>
+    <field>
         <label>Name.com</label>
         <type>header</type>
         <style>table_dns table_dns_namecom</style>

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -282,7 +282,17 @@
         <help>Note that this is the account token not the user token.</help>
     </field>
     <field>
-        <label>Domain-Offensive</label>
+        <label>Domain-Offensive LetsEncrypt</label>
+        <type>header</type>
+        <style>table_dns table_dns_doapi</style>
+    </field>
+    <field>
+        <id>validation.dns_doapi_token</id>
+        <label>API Token</label>
+        <type>text</type>
+    </field>
+    <field>
+        <label>Domain-Offensive Resellerinterface</label>
         <type>header</type>
         <style>table_dns table_dns_do</style>
     </field>

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -402,6 +402,30 @@
         <type>text</type>
     </field>
     <field>
+        <label>Google Cloud DNS</label>
+        <type>header</type>
+        <style>table_dns table_dns_gcloud</style>
+    </field>
+    <field>
+        <label><![CDATA[NOTE: First you must create a <a target="_blank" href="https://cloud.google.com/iam/docs/creating-managing-service-account-keys">service account key</a> using the GCP Console and enable the <a target="_blank" href="https://console.developers.google.com/apis/api/cloudresourcemanager.googleapis.com/overview">Cloud Resource Manager API</a>. Afterwards paste the full JSON key in the textbox below.]]></label>
+        <type>info</type>
+    </field>
+    <field>
+        <id>validation.dns_gcloud_key</id>
+        <label>JSON Key</label>
+        <type>textbox</type>
+        <help>Provide a service account key in JSON format for your Google Cloud account.</help>
+    </field>
+    <field>
+        <label>Action required</label>
+        <type>header</type>
+        <style>table_dns table_dns_gcloud gcloud_plugin_warning</style>
+    </field>
+    <field>
+        <label><![CDATA[Please manually install the plugin "os-google-cloud-sdk" to enable support for Google Cloud DNS.]]></label>
+        <type>info</type>
+    </field>
+    <field>
         <label>GoDaddy</label>
         <type>header</type>
         <style>table_dns table_dns_gd</style>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -363,6 +363,7 @@
                         <dns_freedns>FreeDNS API</dns_freedns>
                         <dns_gandi_livedns>Gandi LiveDNS API</dns_gandi_livedns>
                         <dns_gd>GoDaddy.com API</dns_gd>
+                        <dns_gcloud>Google Cloud DNS API</dns_gcloud>
                         <dns_gdnsdk>GratisDNS.dk</dns_gdnsdk>
                         <dns_hostingde>hosting.de API</dns_hostingde>
                         <dns_he>Hurricane Electric</dns_he>
@@ -518,6 +519,9 @@
                 <dns_gandi_livedns_key type="TextField">
                     <Required>N</Required>
                 </dns_gandi_livedns_key>
+                <dns_gcloud_key type="TextField">
+                    <Required>N</Required>
+                </dns_gcloud_key>
                 <dns_gd_key type="TextField">
                     <Required>N</Required>
                 </dns_gd_key>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -342,7 +342,7 @@
                         <dns_acmedns>ACME DNS API</dns_acmedns>
                         <dns_ad>Alwaysdata.com API</dns_ad>
                         <dns_ali>aliyun.com API</dns_ali>
-                        <dns_autodns>autoDNS (InternetX) API</dns_autodns>
+                        <dns_autodns>AutoDNS (InterNetX) API</dns_autodns>
                         <dns_aws>AWS Route 53</dns_aws>
                         <dns_azure>Azure DNS API</dns_azure>
                         <dns_cf>CloudFlare.com API</dns_cf>
@@ -354,7 +354,8 @@
                         <dns_dnsimple>DNSimple API</dns_dnsimple>
                         <dns_me>DNSMadeEasy.com API</dns_me>
                         <dns_dp>DNSPod.cn API</dns_dp>
-                        <dns_do>Domain-Offensive/Resellerinterface/Domainrobot API</dns_do>
+                        <dns_doapi>Domain-Offensive LetsEncrypt API</dns_doapi>
+                        <dns_do>Domain-Offensive Resellerinterface/Domainrobot API</dns_do>
                         <dns_dreamhost>DreamHost DNS API</dns_dreamhost>
                         <dns_duckdns>DuckDNS API</dns_duckdns>
                         <dns_dyn>Dyn Managed DNS API</dns_dyn>
@@ -471,6 +472,9 @@
                 <dns_dnsimple_token type="TextField">
                   <Required>N</Required>
                 </dns_dnsimple_token>
+                <dns_doapi_token type="TextField">
+                  <Required>N</Required>
+                </dns_doapi_token>
                 <dns_do_pid type="TextField">
                   <Required>N</Required>
                 </dns_do_pid>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -375,6 +375,7 @@
                         <dns_linode>Linode API</dns_linode>
                         <dns_lua>LuaDNS.com API</dns_lua>
                         <dns_namecom>Name.com API</dns_namecom>
+                        <dns_namecheap>Namecheap API</dns_namecheap>
                         <dns_namesilo>Namesilo.com API</dns_namesilo>
                         <dns_nsone>NS1.com API</dns_nsone>
                         <dns_nsupdate>nsupdate (RFC 2136)</dns_nsupdate>
@@ -601,6 +602,15 @@
                 <dns_me_secret type="TextField">
                     <Required>N</Required>
                 </dns_me_secret>
+                <dns_namecheap_user type="TextField">
+                    <Required>N</Required>
+                </dns_namecheap_user>
+                <dns_namecheap_api type="TextField">
+                    <Required>N</Required>
+                </dns_namecheap_api>
+                <dns_namecheap_sourceip type="TextField">
+                    <Required>N</Required>
+                </dns_namecheap_sourceip>
                 <dns_namecom_user type="TextField">
                     <Required>N</Required>
                 </dns_namecom_user>

--- a/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/validations.volt
+++ b/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/validations.volt
@@ -56,6 +56,12 @@ POSSIBILITY OF SUCH DAMAGE.
                 if ($("#validation\\.method").val() == 'dns01') {
                     $("."+service_id).show();
                 }
+                // Show a warning if the Google Cloud SDK plugin is missing.
+                ajaxCall(url="/api/acmeclient/settings/getGcloudPluginStatus", sendData={}, callback=function(data,status) {
+                    if (data['result'] != 0) {
+                        $(".gcloud_plugin_warning").hide();
+                    }
+                });
             });
             $("#validation\\.http_service").change(function(){
                 var service_id = 'table_http_' + $(this).val();
@@ -72,6 +78,7 @@ POSSIBILITY OF SUCH DAMAGE.
                 $("#validation\\.http_service").change();
             });
             $("#validation\\.method").change();
+
         })
     });
 

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -626,6 +626,9 @@ function run_acme_validation($certObj, $valObj, $acctObj)
                 $proc_env['DO_PID'] = (string)$valObj->dns_do_pid;
                 $proc_env['DO_PW'] = (string)$valObj->dns_do_password;
                 break;
+            case 'dns_doapi':
+                $proc_env['DO_LETOKEN'] = (string)$valObj->dns_doapi_token;
+                break;
             case 'dns_dp':
                 $proc_env['DP_Id'] = (string)$valObj->dns_dp_id;
                 $proc_env['DP_Key'] = (string)$valObj->dns_dp_key;

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -712,6 +712,16 @@ function run_acme_validation($certObj, $valObj, $acctObj)
                 $proc_env['ME_Key'] = (string)$valObj->dns_me_key;
                 $proc_env['ME_Secret'] = (string)$valObj->dns_me_secret;
                 break;
+            case 'dns_namecheap':
+                $proc_env['NAMECHEAP_USERNAME'] = (string)$valObj->dns_namecheap_user;
+                $proc_env['NAMECHEAP_API_KEY'] = (string)$valObj->dns_namecheap_api;
+                if (!empty((string)$valObj->dns_namecheap_sourceip)) {
+                    $proc_env['NAMECHEAP_SOURCEIP'] = (string)$valObj->dns_namecheap_sourceip;
+                } else {
+                    // Use a public service to get our source IP for Namecheap API
+                    $proc_env['NAMECHEAP_SOURCEIP'] = 'https://ifconfig.co/ip';
+                }
+                break;
             case 'dns_namecom':
                 $proc_env['Namecom_Username'] = (string)$valObj->dns_namecom_user;
                 $proc_env['Namecom_Token'] = (string)$valObj->dns_namecom_token;


### PR DESCRIPTION
## New features
- add support for Domain-Offensive LetsEncrypt API dns_doapi (#1294)
- add support for Namecheap API (dns_namecheap)
- add support for Google Cloud DNS API dns_gcloud (#549)

## Bugfixes
- certificate status not correctly updated ( #1307)

## Enhancements
- add log message when certificate status is updated (refs #1307)