### PR TITLE
[BUGFIX] freeradius does not interpolate strings with single quotes, …

### DIFF
--- a/net/freeradius/Makefile
+++ b/net/freeradius/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		freeradius
-PLUGIN_VERSION=		1.9.2
+PLUGIN_VERSION=		1.9.3
 PLUGIN_COMMENT=		RADIUS Authentication, Authorization and Accounting Server
 PLUGIN_DEPENDS=		freeradius3
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-ldap
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-ldap
@@ -70,7 +70,7 @@ ldap {
         user {
                 base_dn = "${..base_dn}"
 {%     if helpers.exists('OPNsense.freeradius.ldap.user_filter') and OPNsense.freeradius.ldap.user_filter != '' %}
-                filter = '{{ OPNsense.freeradius.ldap.user_filter }}'
+                filter = "{{ OPNsense.freeradius.ldap.user_filter }}"
 {%     endif %}
                 sasl {
                 }
@@ -78,7 +78,7 @@ ldap {
         group {
                 base_dn = "${..base_dn}"
 {%     if helpers.exists('OPNsense.freeradius.ldap.group_filter') and OPNsense.freeradius.ldap.group_filter != '' %}
-                filter = '{{ OPNsense.freeradius.ldap.group_filter }}'
+                filter = "{{ OPNsense.freeradius.ldap.group_filter }}"
 {%     endif %}
                 membership_attribute = 'memberOf'
         }


### PR DESCRIPTION
Fix description:

In the OPNsense GUI you can set the user and group filters that freeradius uses on querying ldap. Since freeradius allows to use variables like %User-Name to tell radius the current user name e.g. the whole filter string MUST be placed inside double quotes. Otherwise freeradius will not interpolate variables inside that string (had a hard time figuring out that this was the reason ldap authentication was not working on OPNsense)

Until this fix is released, ldap in conjunction with freeradius is currently broken in OPNsense.

I did not review every code inside that plugin, but I recommend to have a look if there are other places where variables are possibly used and are not inside double quotes.