### PR TITLE
net/haproxy: keep HAProxy 1.8.x

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -2,7 +2,7 @@ PLUGIN_NAME=		haproxy
 PLUGIN_VERSION=		2.15
 PLUGIN_REVISION=	1
 PLUGIN_COMMENT=		Reliable, high performance TCP/HTTP load balancer
-PLUGIN_DEPENDS=		haproxy
+PLUGIN_DEPENDS=		haproxy18
 PLUGIN_MAINTAINER=	opnsense@moov.de
 
 .include "../../Mk/plugins.mk"


### PR DESCRIPTION
The FreeBSD port net/haproxy was recently switched to the 1.9 release series of HAProxy. As stated in https://github.com/opnsense/plugins/issues/1089 I'd rather stay on 1.8.x until 2.0 was released and stabilized.

HAProxy 1.8 moved to a new port:
https://www.freshports.org/net/haproxy18

refs https://github.com/opnsense/tools/pull/141