### PR TITLE
security/acme-client: Add Support for netcup DNS API

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -612,6 +612,26 @@
         <type>text</type>
     </field>
     <field>
+        <label>netcup DNS API</label>
+        <type>header</type>
+        <style>table_dns table_dns_netcup</style>
+    </field>
+    <field>
+        <id>validation.dns_netcup_cid</id>
+        <label>Customer number</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_netcup_key</id>
+        <label>API Key</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_netcup_pw</id>
+        <label>API Password</label>
+        <type>text</type>
+    </field>
+    <field>
         <label>NS1.com</label>
         <type>header</type>
         <style>table_dns table_dns_nsone</style>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -375,6 +375,7 @@
                         <dns_lua>LuaDNS.com API</dns_lua>
                         <dns_namecom>Name.com API</dns_namecom>
                         <dns_namesilo>Namesilo.com API</dns_namesilo>
+                        <dns_netcup>netcup DNS API</dns_netcup>
                         <dns_nsone>NS1.com API</dns_nsone>
                         <dns_nsupdate>nsupdate (RFC 2136)</dns_nsupdate>
                         <dns_ovh>OVH, kimsufi, soyoustart and runabove API</dns_ovh>
@@ -606,6 +607,15 @@
                 <dns_namesilo_key type="TextField">
                     <Required>N</Required>
                 </dns_namesilo_key>
+                <dns_netcup_cid type="TextField">
+                    <Required>N</Required>
+                </dns_netcup_cid>
+                <dns_netcup_key type="TextField">
+                    <Required>N</Required>
+                </dns_netcup_key>
+                <dns_netcup_pw type="TextField">
+                    <Required>N</Required>
+                </dns_netcup_pw>
                 <dns_nsone_key type="TextField">
                     <Required>N</Required>
                 </dns_nsone_key>

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -718,6 +718,13 @@ function run_acme_validation($certObj, $valObj, $acctObj)
                 // Namesilo applies changes to DNS records only every 15 minutes.
                 $acme_hook_options[] = "--dnssleep 960";
                 break;
+            case 'dns_netcup':
+                $proc_env['NC_CID'] = (string)$valObj->dns_netcup_cid;
+                $proc_env['NC_Apikey'] = (string)$valObj->dns_netcup_key;
+                $proc_env['NC_Apipw'] = (string)$valObj->dns_netcup_pw;
+                // netcup applies changes to DNS records only every 10 minutes.
+                $acme_hook_options[] = "--dnssleep 600";
+                break;
             case 'dns_nsone':
                 $proc_env['NS1_Key'] = (string)$valObj->dns_nsone_key;
                 break;


### PR DESCRIPTION
**Important:**
This will only work with the next release of acme.sh (2.8.2).
Besause the current implementation of the netcup dns api in acme.sh dosen´t work on BSD systems.

For more infos see https://github.com/Neilpang/acme.sh/issues/2279 and https://github.com/Neilpang/acme.sh/pull/2284