### PR TITLE
www/nginx: #1374 - Fixes matching values in URLs using naxsi rules.

### DIFF
--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
@@ -522,6 +522,9 @@
       <args type="BooleanField">
         <Required>Y</Required>
       </args>
+      <url type="BooleanField">
+        <Required>Y</Required>
+      </url>
       <headers type="BooleanField">
         <Required>Y</Required>
       </headers>

--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/naxsirule.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/naxsirule.conf
@@ -7,6 +7,9 @@
 {%   if mz_helper_rule.args == '1' %}
 {%     do mz_matches.append('ARGS')  %}
 {%   endif %}
+{%   if mz_helper_rule.url == '1' %}
+{%     do mz_matches.append('URL')  %}
+{%   endif %}
 {%   if mz_helper_rule.headers == '1' %}
 {%     do mz_matches.append('HEADERS')  %}
 {%   endif %}


### PR DESCRIPTION
This PR fixes #1374, locally verified with my own rules. 
Since the form already allowed to specify the "URL" zone, this PR is a bugfix only.