### PR TITLE
new plugin: google-cloud-sdk, refs #1318

### DIFF
--- a/net/google-cloud-sdk/Makefile
+++ b/net/google-cloud-sdk/Makefile
@@ -1,0 +1,7 @@
+PLUGIN_NAME=		google-cloud-sdk
+PLUGIN_VERSION=		1.0
+PLUGIN_COMMENT=		Google Cloud SDK
+PLUGIN_DEPENDS=		google-cloud-sdk
+PLUGIN_MAINTAINER=	opnsense@moov.de
+
+.include "../../Mk/plugins.mk"

--- a/net/google-cloud-sdk/pkg-descr
+++ b/net/google-cloud-sdk/pkg-descr
@@ -1,0 +1,2 @@
+This plugin installs the Google Cloud SDK. The SDK may be used on the CLI or in
+conjunction with the Let's Encrypt plugin.


### PR DESCRIPTION
This is a dummy plugin in order to install the Google Cloud SDK (and to check wether it's installed programmatically).

This is mostly required for our Let's Encrypt plugin to support Google Cloud DNS API (#1318).
I've decided to create a separate plugin instead of adding it as a dependency in os-acme-client, because the SDK is relatively huge and not useful for most users.