### PR TITLE
security/acme-client: release 1.24 (additions)

### DIFF
--- a/security/acme-client/Makefile
+++ b/security/acme-client/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		acme-client
-PLUGIN_VERSION=		1.23
+PLUGIN_VERSION=		1.24
 PLUGIN_COMMENT=		Let's Encrypt client
 PLUGIN_MAINTAINER=	opnsense@moov.de
 PLUGIN_DEPENDS=		acme.sh

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/Api/CertificatesController.php
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/Api/CertificatesController.php
@@ -62,6 +62,16 @@ class CertificatesController extends ApiMutableModelControllerBase
 
     public function delAction($uuid)
     {
+        # Remove the cert from list of certs known to acme.sh.
+        $mdlAcme = new AcmeClient();
+        if ($uuid != null) {
+            $node = $mdlAcme->getNodeByReference('certificates.certificate.' . $uuid);
+            if ($node != null) {
+                $cert_id = $node->id;
+                $backend = new Backend();
+                $response = $backend->configdRun("acmeclient remove-cert {$cert_id}");
+            }
+        }
         return $this->delBase('certificates.certificate', $uuid);
     }
 

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/Api/CertificatesController.php
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/Api/CertificatesController.php
@@ -110,6 +110,26 @@ class CertificatesController extends ApiMutableModelControllerBase
     }
 
     /**
+     * remove private key from certificate by uuid
+     * @param $uuid item unique id
+     * @return array status
+     */
+    public function removekeyAction($uuid)
+    {
+        $result = array("result"=>"failed");
+        $mdlAcme = new AcmeClient();
+        if ($uuid != null) {
+            $node = $mdlAcme->getNodeByReference('certificates.certificate.' . $uuid);
+            if ($node != null) {
+                $cert_id = $node->id;
+                $backend = new Backend();
+                $response = $backend->configdRun("acmeclient remove-key {$cert_id}");
+            }
+        }
+        return $result;
+    }
+
+    /**
      * revoke certificate by uuid
      * @param $uuid item unique id
      * @return array status

--- a/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/certificates.volt
+++ b/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/certificates.volt
@@ -47,6 +47,7 @@ POSSIBILITY OF SUCH DAMAGE.
             toggle:'/api/acmeclient/certificates/toggle/',
             sign:'/api/acmeclient/certificates/sign/',
             revoke:'/api/acmeclient/certificates/revoke/',
+            removekey:'/api/acmeclient/certificates/removekey/',
         };
 
         var gridopt = {
@@ -61,7 +62,8 @@ POSSIBILITY OF SUCH DAMAGE.
                         "<button type=\"button\" class=\"btn btn-xs btn-default command-copy\" data-row-id=\"" + row.uuid + "\"><span class=\"fa fa-clone\"></span></button>" +
                         "<button type=\"button\" class=\"btn btn-xs btn-default command-delete\" data-row-id=\"" + row.uuid + "\"><span class=\"fa fa-trash-o\"></span></button>" +
                         "<button type=\"button\" class=\"btn btn-xs btn-default command-sign\" data-row-id=\"" + row.uuid + "\"><span class=\"fa fa-repeat\"></span></button>" +
-                        "<button type=\"button\" class=\"btn btn-xs btn-default command-revoke\" data-row-id=\"" + row.uuid + "\"><span class=\"fa fa-power-off\"></span></button>";
+                        "<button type=\"button\" class=\"btn btn-xs btn-default command-revoke\" data-row-id=\"" + row.uuid + "\"><span class=\"fa fa-power-off\"></span></button>" +
+                        "<button type=\"button\" class=\"btn btn-xs btn-default command-removekey\" data-row-id=\"" + row.uuid + "\"><span class=\"fa fa-history\"></span></button>";
                 },
                 "rowtoggle": function (column, row) {
                     if (parseInt(row[column.id], 2) == 1) {
@@ -314,7 +316,7 @@ POSSIBILITY OF SUCH DAMAGE.
             });
 
             // sign cert
-            // TODO: this should block other sign/revoke actions
+            // TODO: this should block other acme.sh actions
             grid_certificates.find(".command-sign").on("click", function(e)
             {
                 if (gridParams['sign'] != undefined) {
@@ -336,7 +338,7 @@ POSSIBILITY OF SUCH DAMAGE.
             });
 
             // revoke cert
-            // TODO: this should block other sign/revoke actions
+            // TODO: this should block other acme.sh actions
             grid_certificates.find(".command-revoke").on("click", function(e)
             {
                 if (gridParams['revoke'] != undefined) {
@@ -355,6 +357,26 @@ POSSIBILITY OF SUCH DAMAGE.
                 }
             });
 
+            // remove private key
+            // TODO: this should block other acme.sh actions
+            grid_certificates.find(".command-removekey").on("click", function(e)
+            {
+                if (gridParams['removekey'] != undefined) {
+                    var uuid=$(this).data("row-id");
+                    stdDialogConfirm('{{ lang._('Confirmation Required') }}',
+                        '{{ lang._('Really remove the private key?%s%sThe certificate will be completely reset. This is useful when the private key has been compromised or when you have changed the key options and want to regenerate the private key.%sNote that you have to revalidate the certificate afterwards in order to create a new private key and a matching certificate.') | format('<br/>', '<br/>', '<br/>') }}',
+                        '{{ lang._('Yes') }}', '{{ lang._('Cancel') }}', function() {
+                        ajaxCall(url=gridParams['removekey'] + uuid,
+                            sendData={},callback=function(data,status){
+                                // reload grid after sign
+                                $("#"+gridId).bootgrid("reload");
+                            });
+                    }, 'danger');
+                } else {
+                    console.log("[grid] action removekey missing")
+                }
+            });
+
         });
 
         /***********************************************************************
@@ -363,7 +385,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
         /**
          * Sign or renew ALL certificates
-         * TODO: this should block other sign/revoke actions
+         * TODO: this should block other acme.sh actions
          */
         $("#signallcertsAct").click(function(){
             //$("#signallcertsAct_progress").addClass("fa fa-spinner fa-pulse");

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -77,22 +77,18 @@ if (isset($options["C"])) {
 // Run the specified action
 switch ($options["a"]) {
     case 'sign':
-        //$result = sign_or_renew_cert($options["c"]);
         $result = cert_action_validator($options["c"]);
         echo json_encode(array('status'=>$result));
         break;
     case 'renew':
-        //$result = sign_or_renew_cert($options["c"]);
         $result = cert_action_validator($options["c"]);
         echo json_encode(array('status'=>$result));
         break;
     case 'remove':
-        //$result = revoke_cert($options["c"]);
         $result = cert_action_validator($options["c"]);
         echo json_encode(array('status'=>$result));
         exit(1);
     case 'revoke':
-        //$result = revoke_cert($options["c"]);
         $result = cert_action_validator($options["c"]);
         echo json_encode(array('status'=>$result));
         exit(1);
@@ -962,8 +958,6 @@ function revoke_cert($certObj, $valObj, $acctObj)
       . "--accountconf " . $account_conf_file . " "
       . $ecc_param;
     $result = mwexec($acmecmd);
-
-    // TODO: maybe clear lastUpdate value?
 
     // Simply return acme clients exit code
     return($result);

--- a/security/acme-client/src/opnsense/service/conf/actions.d/actions_acmeclient.conf
+++ b/security/acme-client/src/opnsense/service/conf/actions.d/actions_acmeclient.conf
@@ -53,6 +53,12 @@ parameters:%s
 type:script
 message:revoking a certificate
 
+[remove-cert]
+command:/usr/local/opnsense/scripts/OPNsense/AcmeClient/certhelper.php -a remove -c
+parameters:%s
+type:script
+message:removing a certificate
+
 [sign-all-certs]
 command:/usr/sbin/daemon -f /usr/local/opnsense/scripts/OPNsense/AcmeClient/certhelper.php -a sign -A
 parameters:

--- a/security/acme-client/src/opnsense/service/conf/actions.d/actions_acmeclient.conf
+++ b/security/acme-client/src/opnsense/service/conf/actions.d/actions_acmeclient.conf
@@ -59,6 +59,12 @@ parameters:%s
 type:script
 message:removing a certificate
 
+[remove-key]
+command:/usr/local/opnsense/scripts/OPNsense/AcmeClient/certhelper.php -a removekey -c
+parameters:%s
+type:script
+message:removing a certificate private key
+
 [sign-all-certs]
 command:/usr/sbin/daemon -f /usr/local/opnsense/scripts/OPNsense/AcmeClient/certhelper.php -a sign -A
 parameters:


### PR DESCRIPTION
## New features
- run `acme.sh --remove` when a cert is removed from the GUI (#1380)
- add a new button to remove the private key (#990)

## Bugfixes
none

## Enhancements
none