### PR TITLE
mail/postfix: Add support for configuring sender_canonical_maps

### DIFF
--- a/mail/postfix/Makefile
+++ b/mail/postfix/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		postfix
-PLUGIN_VERSION=		1.9
+PLUGIN_VERSION=		1.10
 PLUGIN_COMMENT=		SMTP mail relay
 PLUGIN_DEPENDS=		postfix-sasl
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/mail/postfix/pkg-descr
+++ b/mail/postfix/pkg-descr
@@ -6,6 +6,10 @@ is completely different.
 Plugin Changelog
 ================
 
+1.10
+
+* Add support for configuring sender_canonical_maps 
+
 1.9
 
 * Allow HA config sync via XMLRPC

--- a/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/Api/SendercanonicalController.php
+++ b/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/Api/SendercanonicalController.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * Copyright (C) 2018 Michael Muenz <m.muenz@gmail.com>
+ * Copyright (C) 2019 Felix Matouschek <felix@matouschek.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Postfix\Api;
+
+use \OPNsense\Base\ApiMutableModelControllerBase;
+
+class SendercanonicalController extends ApiMutableModelControllerBase
+{
+    protected static $internalModelName = 'sendercanonical';
+    protected static $internalModelClass = '\OPNsense\Postfix\Sendercanonical';
+
+    public function searchSendercanonicalAction()
+    {
+        return $this->searchBase('sendercanonicals.sendercanonical', array("enabled", "from", "to"));
+    }
+
+    public function getSendercanonicalAction($uuid = null)
+    {
+        return $this->getBase('sendercanonical', 'sendercanonicals.sendercanonical', $uuid);
+    }
+
+    public function addSendercanonicalAction()
+    {
+        return $this->addBase('sendercanonical', 'sendercanonicals.sendercanonical');
+    }
+
+    public function delSendercanonicalAction($uuid)
+    {
+        return $this->delBase('sendercanonicals.sendercanonical', $uuid);
+    }
+
+    public function setSendercanonicalAction($uuid)
+    {
+        return $this->setBase('sendercanonical', 'sendercanonicals.sendercanonical', $uuid);
+    }
+
+    public function toggleSendercanonicalAction($uuid)
+    {
+        return $this->toggleBase('sendercanonicals.sendercanonical', $uuid);
+    }
+}

--- a/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/SendercanonicalController.php
+++ b/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/SendercanonicalController.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Copyright (C) 2018 Michael Muenz <m.muenz@gmail.com>
+ * Copyright (C) 2019 Felix Matouschek <felix@matouschek.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Postfix;
+
+class SendercanonicalController extends \OPNsense\Base\IndexController
+{
+    public function indexAction()
+    {
+        $this->view->formDialogEditPostfixSendercanonical = $this->getForm("dialogEditPostfixSendercanonical");
+        $this->view->pick('OPNsense/Postfix/sendercanonical');
+    }
+}

--- a/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/dialogEditPostfixSendercanonical.xml
+++ b/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/dialogEditPostfixSendercanonical.xml
@@ -1,0 +1,22 @@
+<form>
+    <field>
+        <id>sendercanonical.enabled</id>
+        <label>Enabled</label>
+        <type>checkbox</type>
+        <help>This will enable or disable the sender canonical rewriting setting.</help>
+    </field>
+    <field>
+        <id>sendercanonical.from</id>
+        <label>Rewrite From</label>
+        <type>text</type>
+        <help>Set a pattern to match line user@example.com or @example.com</help>
+    </field>
+    <field>
+        <id>sendercanonical.to</id>
+        <label>Rewrite To</label>
+        <style>tokenize</style>
+        <type>select_multiple</type>
+        <allownew>true</allownew>
+        <help>Set here how to rewrite the Rewrite From pattern.</help>
+    </field>
+</form>

--- a/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Menu/Menu.xml
+++ b/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Menu/Menu.xml
@@ -7,6 +7,7 @@
       <Recipientbcc VisibleName="Recipient BCC" url="/ui/postfix/recipientbcc/index" order="35"/>
       <Senders url="/ui/postfix/sender/index" order="40"/>
       <Senderbcc VisibleName="Sender BCC" url="/ui/postfix/senderbcc/index" order="45"/>
+      <Sendercanonical VisibleName="Sender Canonical Rewriting" url="/ui/postfix/sendercanonical/index" order="48"/>
       <Address VisibleName="Address Rewriting" url="/ui/postfix/address/index" order="50"/>
       <LogFile VisibleName="Log File" order="50" url="/diag_logs_postfix.php"/>
     </Postfix>

--- a/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Sendercanonical.php
+++ b/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Sendercanonical.php
@@ -1,0 +1,31 @@
+<?php
+namespace OPNsense\Postfix;
+
+use OPNsense\Base\BaseModel;
+
+/*
+    Copyright (C) 2018 Michael Muenz <m.muenz@gmail.com>
+    Copyright (C) 2019 Felix Matouschek <felix@matouschek.org>
+    All rights reserved.
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+
+class Sendercanonical extends BaseModel
+{
+}

--- a/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Sendercanonical.xml
+++ b/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Sendercanonical.xml
@@ -1,0 +1,21 @@
+<model>
+    <mount>//OPNsense/postfix/sendercanonical</mount>
+    <description>Postfix sender_canonical rewrite configuration</description>
+    <version>1.0.0</version>
+    <items>
+        <sendercanonicals>
+            <sendercanonical type="ArrayField">
+                <enabled type="BooleanField">
+                    <default>1</default>
+                    <Required>Y</Required>
+                </enabled>
+                <from type="TextField">
+                    <Required>Y</Required>
+                </from>
+                <to type="CSVListField">
+                    <Required>Y</Required>
+                </to>
+            </sendercanonical>
+        </sendercanonicals>
+    </items>
+</model>

--- a/mail/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/sendercanonical.volt
+++ b/mail/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/sendercanonical.volt
@@ -1,0 +1,87 @@
+{#
+
+OPNsense® is Copyright © 2014 – 2017 by Deciso B.V.
+Copyright (C) 2018 Michael Muenz <m.muenz@gmail.com>
+Copyright (C) 2019 Felix Matouschek <felix@matouschek.org>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1.  Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2.  Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+#}
+
+<script>
+
+    $( document ).ready(function() {
+        /*************************************************************************************************************
+         * link grid actions
+         *************************************************************************************************************/
+
+        $("#grid-sendercanonicals").UIBootgrid(
+            {   'search':'/api/postfix/sendercanonical/searchSendercanonical',
+                'get':'/api/postfix/sendercanonical/getSendercanonical/',
+                'set':'/api/postfix/sendercanonical/setSendercanonical/',
+                'add':'/api/postfix/sendercanonical/addSendercanonical/',
+                'del':'/api/postfix/sendercanonical/delSendercanonical/',
+                'toggle':'/api/postfix/sendercanonical/toggleSendercanonical/'
+            }
+        );
+
+    {% include 'OPNsense/Postfix/apply.volt' %}
+
+    });
+
+</script>
+
+<div class="tab-content content-box tab-content">
+    <div id="sendercanonicals" class="tab-pane fade in active">
+        <!-- tab page "sendercanonicals" -->
+        <table id="grid-sendercanonicals" class="table table-responsive" data-editDialog="dialogEditPostfixSendercanonical">
+            <thead>
+            <tr>
+                <th data-column-id="enabled" data-type="string" data-formatter="rowtoggle">{{ lang._('Enabled') }}</th>
+                <th data-column-id="from" data-type="string" data-visible="true">{{ lang._('Rewrite From') }}</th>
+                <th data-column-id="to" data-type="string" data-visible="true">{{ lang._('Rewrite To') }}</th>
+                <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
+                <th data-column-id="commands" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
+            </tr>
+            </thead>
+            <tbody>
+            </tbody>
+            <tfoot>
+            <tr>
+                <td></td>
+                <td>
+                    <button data-action="add" type="button" class="btn btn-xs btn-default"><span class="fa fa-plus"></span></button>
+                    <button data-action="deleteSelected" type="button" class="btn btn-xs btn-default"><span class="fa fa-trash-o"></span></button>
+                </td>
+            </tr>
+            </tfoot>
+        </table>
+        <div class="col-md-12">
+            <hr/>
+            <button class="btn btn-primary" id="reconfigureAct" type="button"><b>{{ lang._('Apply') }}</b> <i id="reconfigureAct_progress" class=""></i></button>
+            <br/><br/>
+        </div>
+    </div>
+</div>
+
+{{ partial("layout_partials/base_dialog",['fields':formDialogEditPostfixSendercanonical,'id':'dialogEditPostfixSendercanonical','label':lang._('Edit sender_canonical rewriting')])}}

--- a/mail/postfix/src/opnsense/scripts/OPNsense/Postfix/setup.sh
+++ b/mail/postfix/src/opnsense/scripts/OPNsense/Postfix/setup.sh
@@ -34,6 +34,7 @@ postmap /usr/local/etc/postfix/sender_access
 postmap /usr/local/etc/postfix/senderbcc
 postmap /usr/local/etc/postfix/recipientbcc
 postmap /usr/local/etc/postfix/smtp_auth
+postmap /usr/local/etc/postfix/sendercanonical
 
 # Check for aliases
 if [ -f /usr/local/etc/postfix/aliases ]; then

--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/+TARGETS
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/+TARGETS
@@ -8,3 +8,4 @@ sender_access:/usr/local/etc/postfix/sender_access
 senderbcc:/usr/local/etc/postfix/senderbcc
 recipientbcc:/usr/local/etc/postfix/recipientbcc
 smtp_auth:/usr/local/etc/postfix/smtp_auth
+sendercanonical:/usr/local/etc/postfix/sendercanonical

--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
@@ -34,6 +34,7 @@ transport_maps = hash:/usr/local/etc/postfix/transport
 virtual_alias_maps = hash:/usr/local/etc/postfix/virtual
 sender_bcc_maps = hash:/usr/local/etc/postfix/senderbcc
 recipient_bcc_maps = hash:/usr/local/etc/postfix/recipientbcc
+sender_canonical_maps = regexp:/usr/local/etc/postfix/sendercanonical
 ##########################
 # END SYSTEM DEFAULTS
 ##########################

--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/sendercanonical
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/sendercanonical
@@ -1,0 +1,9 @@
+{% if helpers.exists('OPNsense.postfix.general.enabled') and OPNsense.postfix.general.enabled == '1' %}
+{%   if helpers.exists('OPNsense.postfix.sendercanonical.sendercanonicals.sendercanonical') %}
+{%     for sendercanonical in helpers.toList('OPNsense.postfix.sendercanonical.sendercanonicals.sendercanonical') %}
+{%       if sendercanonical.enabled == '1' %}
+{{ sendercanonical.from }} {{ sendercanonical.to }}
+{%       endif %}
+{%     endfor %}
+{%   endif %}
+{% endif %}


### PR DESCRIPTION
This PR adds support for configuring postfix sender_canonical_maps with regexp expressions. This is needed when relaying mail over an external SMTP server that only allows sending with specific sender addresses. (e.g. only the address that was also used for authenticating with the external relay). This PR is based on the Address/virtual configuration in the postfix plugin and works mostly the same.