### PR TITLE
security/maltrail: add missing dependency

### DIFF
--- a/security/maltrail/Makefile
+++ b/security/maltrail/Makefile
@@ -1,7 +1,8 @@
 PLUGIN_NAME=		maltrail
 PLUGIN_VERSION=		1.0
+PLUGIN_REVISION=        1
 PLUGIN_COMMENT=		Malicious traffic detection system
-PLUGIN_DEPENDS=		maltrail
+PLUGIN_DEPENDS=		maltrail py27-sqlite3
 PLUGIN_MAINTAINER=	m.muenz@gmail.com
 
 .include "../../Mk/plugins.mk"


### PR DESCRIPTION
add missing dependency since python3 upgrade