### PR TITLE
smartctl needs the full device path

### DIFF
--- a/sysutils/smart/src/opnsense/scripts/OPNsense/Smart/detailed_list.sh
+++ b/sysutils/smart/src/opnsense/scripts/OPNsense/Smart/detailed_list.sh
@@ -29,7 +29,7 @@ result=""
 
 for dev in `ls /dev | grep '^\(ad\|da\|ada\)[0-9]\{1,2\}$'`; do
     ident=`/usr/sbin/diskinfo -v $dev | grep ident | awk '{print $1}'`;
-    state=`/usr/local/sbin/smartctl -H $dev | awk -F: '
+    state=`/usr/local/sbin/smartctl -H /dev/$dev | awk -F: '
 /^SMART overall-health self-assessment test result/ {print $2;exit}
 /^SMART Health Status/ {print $2;exit}'`;
 


### PR DESCRIPTION
In contrast to the diskinfo command, smartctl needs the full device path, not just geom.