### PR TITLE
SMART dashboard widget to display correct status

### DIFF
--- a/sysutils/smart/src/opnsense/scripts/OPNsense/Smart/detailed_list.sh
+++ b/sysutils/smart/src/opnsense/scripts/OPNsense/Smart/detailed_list.sh
@@ -29,7 +29,7 @@ result=""
 
 for dev in `ls /dev | grep '^\(ad\|da\|ada\)[0-9]\{1,2\}$'`; do
     ident=`/usr/sbin/diskinfo -v $dev | grep ident | awk '{print $1}'`;
-    state=`/usr/local/sbin/smartctl -H $dev | awk -F: '
+    state=`/usr/local/sbin/smartctl -H /dev/$dev | awk "-F: " '
 /^SMART overall-health self-assessment test result/ {print $2;exit}
 /^SMART Health Status/ {print $2;exit}'`;
 

--- a/sysutils/smart/src/opnsense/scripts/OPNsense/Smart/detailed_list.sh
+++ b/sysutils/smart/src/opnsense/scripts/OPNsense/Smart/detailed_list.sh
@@ -29,15 +29,13 @@ result=""
 
 for dev in `ls /dev | grep '^\(ad\|da\|ada\)[0-9]\{1,2\}$'`; do
     ident=`/usr/sbin/diskinfo -v $dev | grep ident | awk '{print $1}'`;
-    state=`/usr/local/sbin/smartctl -H /dev/$dev | awk "-F: " '
-/^SMART overall-health self-assessment test result/ {print $2;exit}
-/^SMART Health Status/ {print $2;exit}'`;
+    state=`/usr/local/sbin/smartctl -jH /dev/$dev`
 
     if [ -n "$result" ]; then
 	result="$result,";
     fi
 
-    result="$result{\"device\":\"$dev\",\"ident\":\"$ident\",\"state\":\"$state\"}";
+    result="$result{\"device\":\"$dev\",\"ident\":\"$ident\",\"state\":$state}";
 done
 
 echo "[$result]"

--- a/sysutils/smart/src/www/widgets/widgets/smart_status.widget.php
+++ b/sysutils/smart/src/www/widgets/widgets/smart_status.widget.php
@@ -46,20 +46,12 @@ $devs = json_decode (configd_run ("smart detailed list"));
 foreach ($devs as $dev) {
     $dev_state_translated = "";
 
-    switch ($dev->state) {
-    case "PASSED":
-    case "OK":
+    if ($dev->state->smart_status->passed) {
         $dev_state_translated = gettext('OK');
         $color = "success";
-        break;
-    case "":
+    } else {
         $dev_state_translated = gettext('Unknown');
         $color = "warning";
-        break;
-    default:
-        $dev_state_translated = $dev->state;
-        $color = "danger";
-        break;
     }
 ?>
         <tr>

--- a/sysutils/smart/src/www/widgets/widgets/smart_status.widget.php
+++ b/sysutils/smart/src/www/widgets/widgets/smart_status.widget.php
@@ -57,6 +57,7 @@ foreach ($devs as $dev) {
         $color = "warning";
         break;
     default:
+        $dev_state_translated = $dev->state;
         $color = "danger";
         break;
     }
@@ -64,7 +65,7 @@ foreach ($devs as $dev) {
         <tr>
             <td><?= $dev->device ?></td>
             <td style="text-align:center"><?= $dev->ident ?></td>
-            <td style="text-align:center"><span class="label label-<?= $color ?>">&nbsp;<?= $dev_state_translated ?>&nbsp;</span></td>
+            <td style="text-align:center"><span class="label label-<?= $color ?>">&nbsp;<?= html_safe($dev_state_translated) ?>&nbsp;</span></td>
         </tr>
 <?php
 }


### PR DESCRIPTION
Hi,

In my environment , SMART status in dashboard was not correctly displayed.

- OPNsense 19.7.1 (with no patch, and fixed with only patch of this pull request)
- Protectli Vault FW1
- Transcend mSATA 64GB SSD TS64GMSA370

In that I had two problems:

- `smartctl -H` accepts device file path like /dev/ada0, while `ls /dev | grep ad` shows just a basename like ada0.
- `smartctl -H` emits space after colon, while current program does not ignore in comparison.

and the one trivial addition:

- In case of error (`default:` in `switch`), a small red box shows up but has no message in it.

```
% sudo smartctl -H /dev/ada0
smartctl 7.0 2018-12-30 r4883 [FreeBSD 11.2-RELEASE-p11-HBSD amd64] (local build)
Copyright (C) 2002-18, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF READ SMART DATA SECTION ===
SMART overall-health self-assessment test result: PASSED

```

In my environment this change fixes, but I have checked no other environments. Could you check this?