### PR TITLE
dns/bind: small improvements for zone management

### DIFF
--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindDomain.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindDomain.xml
@@ -6,10 +6,21 @@
         <help>This will enable or disable the ACL.</help>
     </field>
     <field>
+        <id>domain.domainname</id>
+        <label>Domain Name</label>
+        <type>text</type>
+        <help>Set the name for this ACL.</help>
+    </field>
+    <field>
         <id>domain.type</id>
         <label>Type</label>
         <type>dropdown</type>
         <help>Set the type for this domain.</help>
+    </field>
+    <field>
+        <label>Slave Zone</label>
+        <type>header</type>
+        <style>zone_type zone_type_slave</style>
     </field>
     <field>
         <id>domain.masterip</id>
@@ -18,10 +29,9 @@
         <help>Set the IP address of master server when using slave mode.</help>
     </field>
     <field>
-        <id>domain.domainname</id>
-        <label>Domain Name</label>
-        <type>text</type>
-        <help>Set the name for this ACL.</help>
+        <label>Master Zone</label>
+        <type>header</type>
+        <style>zone_type zone_type_master</style>
     </field>
     <field>
         <id>domain.allowtransfer</id>

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindDomain.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindDomain.xml
@@ -55,19 +55,19 @@
         <id>domain.refresh</id>
         <label>Refresh Time</label>
         <type>text</type>
-        <help>Set the time in seconds after which secondary name servers should refresh the zone information.</help>
+        <help>Set the time in seconds after which name servers should refresh the zone information.</help>
     </field>
     <field>
         <id>domain.retry</id>
         <label>Retry Time</label>
         <type>text</type>
-        <help>Set the time in seconds after which secondary name servers should retry requests if the master does not respond.</help>
+        <help>Set the time in seconds after which name servers should retry requests if the master does not respond.</help>
     </field>
     <field>
         <id>domain.expire</id>
         <label>Expire Time</label>
         <type>text</type>
-        <help>Set the time in seconds after which secondary name servers should stop answering requests if the master does not respond.</help>
+        <help>Set the time in seconds after which name servers should stop answering requests if the master does not respond.</help>
     </field>
     <field>
         <id>domain.negative</id>

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindDomain.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindDomain.xml
@@ -3,19 +3,19 @@
         <id>domain.enabled</id>
         <label>Enabled</label>
         <type>checkbox</type>
-        <help>This will enable or disable the ACL.</help>
+        <help>This will enable or disable this zone.</help>
     </field>
     <field>
         <id>domain.domainname</id>
         <label>Zone Name</label>
         <type>text</type>
-        <help>Set the name for this ACL.</help>
+        <help>Set the name for this zone. Both forward and reverse zones may be specified, i.e. example.com or 0.168.192.in-addr.arpa.</help>
     </field>
     <field>
         <id>domain.type</id>
         <label>Type</label>
         <type>dropdown</type>
-        <help>Set the type for this domain.</help>
+        <help>Set the type for this zone.</help>
     </field>
     <field>
         <label>Slave Zone</label>
@@ -37,54 +37,54 @@
         <id>domain.allowtransfer</id>
         <label>Allow Transfer</label>
         <type>dropdown</type>
-        <help>Define an ACL where you allow which server can retrieve your zone.</help>
+        <help>Define an ACL where you allow which server can retrieve this zone.</help>
     </field>
     <field>
         <id>domain.allowquery</id>
         <label>Allow Query</label>
         <type>dropdown</type>
-        <help>Define an ACL where you allow which client are allowed to query this domain.</help>
+        <help>Define an ACL where you allow which client are allowed to query this zone.</help>
     </field>
     <field>
         <id>domain.ttl</id>
         <label>TTL</label>
         <type>text</type>
-        <help>Set the general TTL for this domain.</help>
+        <help>Set the general Time To Live for this zone.</help>
     </field>
     <field>
         <id>domain.refresh</id>
         <label>Refresh Time</label>
         <type>text</type>
-        <help>Set the time in seconds.</help>
+        <help>Set the time in seconds after which secondary name servers should refresh the zone information.</help>
     </field>
     <field>
         <id>domain.retry</id>
         <label>Retry Time</label>
         <type>text</type>
-        <help>Set the time in seconds.</help>
+        <help>Set the time in seconds after which secondary name servers should retry requests if the master does not respond.</help>
     </field>
     <field>
         <id>domain.expire</id>
         <label>Expire Time</label>
         <type>text</type>
-        <help>Set the time in seconds.</help>
+        <help>Set the time in seconds after which secondary name servers should stop answering requests if the master does not respond.</help>
     </field>
     <field>
         <id>domain.negative</id>
         <label>Negative TTL</label>
         <type>text</type>
-        <help>Set the time in seconds.</help>
+        <help>Set the time in seconds after which an entry for a non-existent record should expire from cache.</help>
     </field>
     <field>
         <id>domain.mailadmin</id>
         <label>Mail Admin</label>
         <type>text</type>
-        <help>Set the mail address of domain admin. Please replace @ with a dot.</help>
+        <help>Set the mail address of zone admin. Please replace @ with a dot.</help>
     </field>
     <field>
         <id>domain.dnsserver</id>
         <label>DNS Server</label>
         <type>text</type>
-        <help>Set the DNS Server hosting this file. This should be the FQDN of your Firewall.</help>
+        <help>Set the DNS server hosting this file. This should usually be the FQDN of your firewall where the BIND plugin is installed.</help>
     </field>
 </form>

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindDomain.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindDomain.xml
@@ -7,7 +7,7 @@
     </field>
     <field>
         <id>domain.domainname</id>
-        <label>Domain Name</label>
+        <label>Zone Name</label>
         <type>text</type>
         <help>Set the name for this ACL.</help>
     </field>

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindDomain.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindDomain.xml
@@ -79,7 +79,7 @@
         <id>domain.mailadmin</id>
         <label>Mail Admin</label>
         <type>text</type>
-        <help>Set the mail address of zone admin. Please replace @ with a dot.</help>
+        <help>Set the mail address of zone admin. A @-sign will automatically be replaced with a dot in the zone data.</help>
     </field>
     <field>
         <id>domain.dnsserver</id>

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindRecord.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindRecord.xml
@@ -3,30 +3,30 @@
         <id>record.enabled</id>
         <label>Enabled</label>
         <type>checkbox</type>
-        <help>This will enable or disable the ACL.</help>
+        <help>This will enable or disable this record.</help>
     </field>
     <field>
         <id>record.domain</id>
-        <label>Domain</label>
+        <label>Zone</label>
         <type>dropdown</type>
-        <help>Set the type for this record.</help>
+        <help>Select the zone for this record.</help>
     </field>
     <field>
         <id>record.name</id>
         <label>Name</label>
         <type>text</type>
-        <help>Set the name for this ACL.</help>
+        <help>Set the name for this record.</help>
     </field>
     <field>
         <id>record.type</id>
         <label>Type</label>
         <type>dropdown</type>
-        <help>Set the time in seconds.</help>
+        <help>Set the type for this record.</help>
     </field>
     <field>
         <id>record.value</id>
         <label>Value</label>
         <type>text</type>
-        <help>Set the time in seconds.</help>
+        <help>Set the value for this record.</help>
     </field>
 </form>

--- a/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/general.volt
+++ b/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/general.volt
@@ -113,6 +113,9 @@ POSSIBILITY OF SUCH DAMAGE.
             </tfoot>
         </table>
         <hr/>
+        <div class="col-md-12">
+            <h2>{{ lang._('Records') }}</h2>
+        </div>
         <div id="record-area">
             <table id="grid-records" class="table table-responsive" data-editDialog="dialogEditBindRecord">
                 <thead>

--- a/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/general.volt
+++ b/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/general.volt
@@ -91,7 +91,7 @@ POSSIBILITY OF SUCH DAMAGE.
                 <tr>
                     <th data-column-id="enabled" data-type="string" data-formatter="rowtoggle">{{ lang._('Enabled') }}</th>
                     <th data-column-id="type" data-type="string" data-visible="true">{{ lang._('Type') }}</th>
-                    <th data-column-id="domainname" data-type="string" data-visible="true">{{ lang._('Domain') }}</th>
+                    <th data-column-id="domainname" data-type="string" data-visible="true">{{ lang._('Zone') }}</th>
                     <th data-column-id="ttl" data-type="string" data-visible="true">{{ lang._('TTL') }}</th>
                     <th data-column-id="refresh" data-type="string" data-visible="true">{{ lang._('Refresh') }}</th>
                     <th data-column-id="retry" data-type="string" data-visible="true">{{ lang._('Retry') }}</th>
@@ -118,7 +118,7 @@ POSSIBILITY OF SUCH DAMAGE.
                 <thead>
                 <tr>
                     <th data-column-id="enabled" data-type="string" data-formatter="rowtoggle">{{ lang._('Enabled') }}</th>
-                    <th data-column-id="domain" data-type="string" data-visible="true">{{ lang._('Domain') }}</th>
+                    <th data-column-id="domain" data-type="string" data-visible="true">{{ lang._('Zone') }}</th>
                     <th data-column-id="name" data-type="string" data-visible="true">{{ lang._('Name') }}</th>
                     <th data-column-id="type" data-type="string" data-visible="true">{{ lang._('Type') }}</th>
                     <th data-column-id="value" data-type="string" data-visible="true">{{ lang._('Value') }}</th>
@@ -148,7 +148,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 {{ partial("layout_partials/base_dialog",['fields':formDialogEditBindAcl,'id':'dialogEditBindAcl','label':lang._('Edit ACL')])}}
 {{ partial("layout_partials/base_dialog",['fields':formDialogEditBindDomain,'id':'dialogEditBindDomain','label':lang._('Edit Zone')])}}
-{{ partial("layout_partials/base_dialog",['fields':formDialogEditBindRecord,'id':'dialogEditBindRecord','label':lang._('Edit Records')])}}
+{{ partial("layout_partials/base_dialog",['fields':formDialogEditBindRecord,'id':'dialogEditBindRecord','label':lang._('Edit Record')])}}
 
 <script>
 $( document ).ready(function() {

--- a/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/general.volt
+++ b/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/general.volt
@@ -262,5 +262,15 @@ $( document ).ready(function() {
             $("#saveAct_domain_progress").removeClass("fa fa-spinner fa-pulse");
         });
     });
+
+    // Hide options that are irrelevant in this context.
+    $('#dialogEditBindDomain').on('shown.bs.modal', function (e) {
+        $("#domain\\.type").change(function(){
+            $(".zone_type").hide();
+            $(".zone_type_"+$(this).val()).show();
+        });
+        $("#domain\\.type").change();
+    })
+
 });
 </script>

--- a/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/general.volt
+++ b/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/general.volt
@@ -32,7 +32,7 @@ POSSIBILITY OF SUCH DAMAGE.
     <li class="active"><a data-toggle="tab" href="#general">{{ lang._('General') }}</a></li>
     <li><a data-toggle="tab" href="#dnsbl">{{ lang._('DNSBL') }}</a></li>
     <li><a data-toggle="tab" href="#acls">{{ lang._('ACLs') }}</a></li>
-    <li><a data-toggle="tab" href="#domains">{{ lang._('Domains') }}</a></li>
+    <li><a data-toggle="tab" href="#domains">{{ lang._('Zones') }}</a></li>
 </ul>
 
 <div class="tab-content content-box tab-content">
@@ -147,7 +147,7 @@ POSSIBILITY OF SUCH DAMAGE.
 </div>
 
 {{ partial("layout_partials/base_dialog",['fields':formDialogEditBindAcl,'id':'dialogEditBindAcl','label':lang._('Edit ACL')])}}
-{{ partial("layout_partials/base_dialog",['fields':formDialogEditBindDomain,'id':'dialogEditBindDomain','label':lang._('Edit Domains')])}}
+{{ partial("layout_partials/base_dialog",['fields':formDialogEditBindDomain,'id':'dialogEditBindDomain','label':lang._('Edit Zone')])}}
 {{ partial("layout_partials/base_dialog",['fields':formDialogEditBindRecord,'id':'dialogEditBindRecord','label':lang._('Edit Records')])}}
 
 <script>

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/domain.db
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/domain.db
@@ -4,7 +4,7 @@
 {%       if TARGET_FILTERS['OPNsense.bind.domain.domains.domain.' ~ loop.index0] %}
 {%         if domaindb.enabled == '1' and domaindb.type == 'master' %}
 $TTL {{ domaindb.ttl }}
-@       IN      SOA    {{ domaindb.dnsserver }}. {{ domaindb.mailadmin|replace('@', '') }}. ( {{ domaindb.serial|trim }} {{ domaindb.refresh }} {{ domaindb.retry }} {{ domaindb.expire }} {{ domaindb.negative }} )
+@       IN      SOA    {{ domaindb.dnsserver }}. {{ domaindb.mailadmin|replace('@', '.') }}. ( {{ domaindb.serial|trim }} {{ domaindb.refresh }} {{ domaindb.retry }} {{ domaindb.expire }} {{ domaindb.negative }} )
 {%           for record in helpers.sortDictList(OPNsense.bind.record.records.record, 'name', 'type' ) %}
 {%             if record.domain == domaindb['@uuid'] %}
 {{ record.name }}                {{ record.type }} {{ record.value }}

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/domain.db
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/domain.db
@@ -4,7 +4,7 @@
 {%       if TARGET_FILTERS['OPNsense.bind.domain.domains.domain.' ~ loop.index0] %}
 {%         if domaindb.enabled == '1' and domaindb.type == 'master' %}
 $TTL {{ domaindb.ttl }}
-@       IN      SOA    {{ domaindb.dnsserver }}. {{ domaindb.mailadmin }}. ( {{ domaindb.serial|trim }} {{ domaindb.refresh }} {{ domaindb.retry }} {{ domaindb.expire }} {{ domaindb.negative }} )
+@       IN      SOA    {{ domaindb.dnsserver }}. {{ domaindb.mailadmin|replace('@', '') }}. ( {{ domaindb.serial|trim }} {{ domaindb.refresh }} {{ domaindb.retry }} {{ domaindb.expire }} {{ domaindb.negative }} )
 {%           for record in helpers.sortDictList(OPNsense.bind.record.records.record, 'name', 'type' ) %}
 {%             if record.domain == domaindb['@uuid'] %}
 {{ record.name }}                {{ record.type }} {{ record.value }}


### PR DESCRIPTION
Hi @mimugmail,

I'll be using your plugin to manage mostly _slave_ zones. I've noticed that some small tweaks improved my experience. Let me know what you think.

The most "controversal" change might be that I ask you to rename "domain" to "zone", because it more precisely describes what can be managed here – both forward and reverse zones. But "domain" usually refers only to forward zones. :)

However, here is the full list of changes:

* Rename "domain" to "zone", because both forward and reverse zones can be used
* Hide options that are only valid for either master or slave zones
* Move field "name" to the top (it's the logical order IMHO, but also required to hide options)
* Improve some help messages (fix typos, add examples and more detailed explanations)
* Automatically replace "@" with a "." in zone contact e-mail address
* Add a header for "records" in "zones" tab (seeing two lists one the same page was pretty confusing and my first thought was "This is a bug!")
