### PR TITLE
net/haproxy: Change http-reuse default

### DIFF
--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -968,10 +968,10 @@
                 </tuning_noport>
                 <tuning_httpreuse type="OptionField">
                     <Required>N</Required>
-                    <default>never</default>
+                    <default>safe</default>
                     <OptionValues>
-                        <never>Never [default]</never>
-                        <safe>Safe</safe>
+                        <never>Never</never>
+                        <safe>Safe [default]</safe>
                         <aggressive>Aggressive</aggressive>
                         <always>Always</always>
                     </OptionValues>


### PR DESCRIPTION
This change updates the default for "http-reuse" to match the recommendation to use "safe" from the HAProxy documentation since HAProxy 1.6, despite the default actually being "never" since the option was introduced.

It also matches the new default in the current HAProxy 2.0 release so things are ready for when it comes to OPNsense.