### PR TITLE
net/haproxy: Initial support for HAProxy cache

### DIFF
--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogBackend.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogBackend.xml
@@ -308,6 +308,13 @@
         <advanced>true</advanced>
     </field>
     <field>
+        <id>backend.tuning_caching</id>
+        <label>Enable Caching</label>
+        <type>checkbox</type>
+        <help><![CDATA[Enable caching of responses from this backend. The HAProxy cache must be enabled under Settings before this will have any effect.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
         <label>Rules</label>
         <type>header</type>
     </field>

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/main.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/main.xml
@@ -318,5 +318,25 @@
                 <advanced>true</advanced>
             </field>
         </subtab>
+        <subtab id="haproxy-general-cache" description="Cache">
+            <field>
+                <id>haproxy.general.cache.enabled</id>
+                <label>Cache enabled</label>
+                <type>checkbox</type>
+                <help><![CDATA[Enable HAProxy's cache which was designed to perform cache on small objects (favicon, css...). This is a minimalist low-maintenance cache which runs in RAM.]]></help>
+            </field>
+            <field>
+                <id>haproxy.general.cache.totalMaxSize</id>
+                <label>Maximum Size of Cache (MB)</label>
+                <type>text</type>
+                <help><![CDATA[Define the size in RAM of the cache in megabytes. This size is split in blocks of 1kB which are used by the cache entries. Its maximum value is 4095.]]></help>
+            </field>
+            <field>
+                <id>haproxy.general.cache.maxAge</id>
+                <label>Maximum Object Age (sec)</label>
+                <type>text</type>
+                <help><![CDATA[Define the maximum expiration duration. Cache-Control response headers will be respected if they are less than this value. The default value is 60 seconds.]]></help>
+            </field>
+        </subtab>
     </tab>
 </form>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -324,6 +324,26 @@
                     <Required>N</Required>
                 </customOptions>
             </stats>
+            <cache>
+                <enabled type="BooleanField">
+                    <default>0</default>
+                    <Required>N</Required>
+                </enabled>
+                <totalMaxSize type="IntegerField">
+                    <MinimumValue>1</MinimumValue>
+                    <MaximumValue>4095</MaximumValue>
+                    <default>4</default>
+                    <Required>Y</Required>
+                    <ValidationMessage>Please specify a value between 1 and 4095.</ValidationMessage>
+                </totalMaxSize>
+                <maxAge type="IntegerField">
+                    <MinimumValue>1</MinimumValue>
+                    <MaximumValue>3600</MaximumValue>
+                    <default>60</default>
+                    <Required>N</Required>
+                    <ValidationMessage>Please specify a value between 1 and 3600.</ValidationMessage>
+                </maxAge>
+            </cache>
         </general>
         <frontends>
             <frontend type="ArrayField">
@@ -976,6 +996,10 @@
                         <always>Always</always>
                     </OptionValues>
                 </tuning_httpreuse>
+                <tuning_caching type="BooleanField">
+                    <default>0</default>
+                    <Required>N</Required>
+                </tuning_caching>
                 <linkedActions type="ModelRelationField">
                     <Model>
                         <template>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/Menu/Menu.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/Menu/Menu.xml
@@ -8,6 +8,7 @@
               <DefaultParameters VisibleName="Default Parameters" url="/ui/haproxy#subtab_haproxy-general-defaults"/>
               <LoggingConfiguration VisibleName="Logging Configuration" url="/ui/haproxy#subtab_haproxy-general-logging"/>
               <StatisticsConfiguration VisibleName="Statistics Configuration" url="/ui/haproxy#subtab_haproxy-general-statistics"/>
+              <CacheConfiguration VisibleName="Cache Configuration" url="/ui/haproxy#subtab_haproxy-general-cache"/>
               <Frontends VisibleName="Frontends" url="/ui/haproxy#frontends"/>
               <Backends VisibleName="Backends" url="/ui/haproxy#backends"/>
               <Servers VisibleName="Servers" url="/ui/haproxy#servers"/>

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -873,6 +873,20 @@ global
 {%- endif -%}
 
 {# ############################### #}
+{#             CACHE               #}
+{# ############################### #}
+
+{%- if helpers.exists('OPNsense.HAProxy.general.cache') and OPNsense.HAProxy.general.cache.enabled|default("") == "1" %}
+cache opnsense-haproxy-cache
+{%   if OPNsense.HAProxy.general.cache.totalMaxSize|default("") != "" %}
+    total-max-size {{OPNsense.HAProxy.general.cache.totalMaxSize}}
+{%   endif %}
+{%   if OPNsense.HAProxy.general.cache.maxAge|default("") != "" %}
+    max-age {{OPNsense.HAProxy.general.cache.maxAge}}
+{%   endif %}
+{%- endif -%}
+
+{# ############################### #}
 {#             DEFAULTS            #}
 {# ############################### #}
 
@@ -1289,6 +1303,10 @@ backend {{backend.name}}
 {%       endif %}
 {%       if backend.tuning_httpreuse|default("") != "" and backend.mode == "http" %}
     http-reuse {{backend.tuning_httpreuse}}
+{%       endif %}
+{%       if helpers.exists('OPNsense.HAProxy.general.cache') and OPNsense.HAProxy.general.cache.enabled|default("") == "1" and if backend.tuning_caching|default("") == "1" and backend.mode == "http" %}
+    http-request cache-use opnsense-haproxy-cache
+    http-response cache-store opnsense-haproxy-cache
 {%       endif %}
 {%       if backend.tuning_defaultserver|default("") != "" %}
     default-server {{backend.tuning_defaultserver}}


### PR DESCRIPTION
This adds support for a single HTTP cache in HAProxy.

This currently supports the configuration options that HAProxy 1.8 allows for the cache ("total-max-size" and "max-age") but not the "max-object-size" option supported by HAProxy 2.0.

Only a single cache can be defined and this initial version does not allow caching to be based on an ACL.

Configuration is a two step process by firstly enabling and configuring the cache and then enabling caching in a backend pool.

Enabling caching in a backend pool without first enabling the cache under Settings will have no effect on the config.