### PR TITLE
security/acme-client: release 1.25

### DIFF
--- a/security/acme-client/Makefile
+++ b/security/acme-client/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		acme-client
-PLUGIN_VERSION=		1.24
+PLUGIN_VERSION=		1.25
 PLUGIN_COMMENT=		Let's Encrypt client
 PLUGIN_MAINTAINER=	opnsense@moov.de
 PLUGIN_DEPENDS=		acme.sh

--- a/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/certificates.volt
+++ b/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/certificates.volt
@@ -60,10 +60,10 @@ POSSIBILITY OF SUCH DAMAGE.
                 "commands": function (column, row) {
                     return "<button type=\"button\" class=\"btn btn-xs btn-default command-edit\" data-row-id=\"" + row.uuid + "\"><span class=\"fa fa-pencil\"></span></button> " +
                         "<button type=\"button\" class=\"btn btn-xs btn-default command-copy\" data-row-id=\"" + row.uuid + "\"><span class=\"fa fa-clone\"></span></button>" +
-                        "<button type=\"button\" class=\"btn btn-xs btn-default command-delete\" data-row-id=\"" + row.uuid + "\"><span class=\"fa fa-trash-o\"></span></button>" +
                         "<button type=\"button\" class=\"btn btn-xs btn-default command-sign\" data-row-id=\"" + row.uuid + "\"><span class=\"fa fa-repeat\"></span></button>" +
                         "<button type=\"button\" class=\"btn btn-xs btn-default command-revoke\" data-row-id=\"" + row.uuid + "\"><span class=\"fa fa-power-off\"></span></button>" +
-                        "<button type=\"button\" class=\"btn btn-xs btn-default command-removekey\" data-row-id=\"" + row.uuid + "\"><span class=\"fa fa-history\"></span></button>";
+                        "<button type=\"button\" class=\"btn btn-xs btn-default command-removekey\" data-row-id=\"" + row.uuid + "\"><span class=\"fa fa-history\"></span></button>" +
+                        "<button type=\"button\" class=\"btn btn-xs btn-default command-delete\" data-row-id=\"" + row.uuid + "\"><span class=\"fa fa-trash-o\"></span></button>";
                 },
                 "rowtoggle": function (column, row) {
                     if (parseInt(row[column.id], 2) == 1) {

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/upload_highwinds.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/upload_highwinds.php
@@ -50,7 +50,7 @@ function find_certificate($acme_cert_id)
             if ($cert_id == $acme_cert_id) {
                 if ($certObj->enabled == 0) {
                     log_error("AcmeClient: certificate ${cert_name} is disabled, ignoring upload request");
-                    return None;
+                    return 'None';
                 }
                 if (isset($certObj->certRefId)) {
                     $data = array();
@@ -63,7 +63,7 @@ function find_certificate($acme_cert_id)
                 }
             }
         }
-        return None;
+        return 'None';
     }
 }
 
@@ -88,7 +88,7 @@ function export_certificate($cert_refid)
         }
     }
     log_error("AcmeClient: cert with refid ${cert_refid} not found in trust storage");
-    return None;
+    return 'None';
 }
 
 function upload_certificate($cert_name, $cert_refid, $acme_cert_id, $acme_automation_id)
@@ -101,25 +101,25 @@ function upload_certificate($cert_name, $cert_refid, $acme_cert_id, $acme_automa
             if ($autom_id == $acme_automation_id) {
                 if ($automObj->enabled == 0) {
                     log_error("AcmeClient: ignoring disabled upload job for cert ${cert_name}");
-                    return None;
+                    return 'None';
                 }
                 if (isset($automObj->highwinds_account_hash) && isset($automObj->highwinds_access_token)) {
                     $hw_account_hash = (string)$automObj->highwinds_account_hash;
                     $hw_access_token = (string)$automObj->highwinds_access_token;
                     $cert_data = export_certificate($cert_refid);
-                    if ($cert_data !== None) {
+                    if ($cert_data !== 'None') {
                         $hw_result = hw_upload_certificate($hw_account_hash, $hw_access_token, $cert_name, $cert_data);
-                        if ($hw_result !== None) {
+                        if ($hw_result !== 'None') {
                             return true;
                         }
                     }
                 } else {
                     log_error("AcmeClient: upload job for cert ${cert_name} is incomplete, missing Highwinds configuration");
-                    return None;
+                    return 'None';
                 }
             }
         }
-        return None;
+        return 'None';
     }
 }
 
@@ -148,7 +148,7 @@ function hw_list_certificates($account_hash, $access_token)
     $http_code = $info['http_code'];
     if ($http_code != 200 || $err) {
         log_error("AcmeClient: failed to access Highwinds API, HTTP Code: ${http_code}, error ${err}");
-        return None;
+        return 'None';
     }
     return json_decode($response);
 }
@@ -156,14 +156,14 @@ function hw_list_certificates($account_hash, $access_token)
 function hw_get_certificate($account_hash, $access_token, $cert_name)
 {
     $certificates = hw_list_certificates($account_hash, $access_token);
-    if ($certificates !== None) {
+    if ($certificates !== 'None') {
         foreach ($certificates->list as $cert) {
             if ($cert->commonName == $cert_name) {
                 return $cert;
             }
         }
     }
-    return None;
+    return 'None';
 }
 
 function hw_upload_certificate($account_hash, $access_token, $cert_name, $cert_data)
@@ -172,7 +172,7 @@ function hw_upload_certificate($account_hash, $access_token, $cert_name, $cert_d
     // Check current status of certificate at Highwinds
     $hw_cert = hw_get_certificate($account_hash, $access_token, $cert_name);
     $hw_url = 'certificates';
-    if ($hw_cert == None) {
+    if ($hw_cert == 'None') {
         log_error("AcmeClient: cert for ${cert_name} not found in Highwinds API, starting upload...");
     } else {
         log_error("AcmeClient: cert for ${cert_name} found in Highwinds API");
@@ -186,7 +186,7 @@ function hw_upload_certificate($account_hash, $access_token, $cert_name, $cert_d
         // Compare local and remote certificates
         if ($cert_sn == $hw_cert_sn) {
             log_error("AcmeClient: cert ${cert_name} has same serial in Highwinds API, not updating (${cert_sn})");
-            return None;
+            return 'None';
         }
         $hw_url = "${hw_url}/${hw_cert_id}";
     }
@@ -219,7 +219,7 @@ function hw_upload_certificate($account_hash, $access_token, $cert_name, $cert_d
     $http_code = $info['http_code'];
     if ($http_code != 200 || $err) {
         log_error("AcmeClient: Failed to upload cert ${cert_name} to Highwinds API, HTTP Code: ${http_code}, error ${err}");
-        return None;
+        return 'None';
     }
     return json_decode($response);
 }
@@ -235,13 +235,13 @@ $acme_automation_id = $options["a"];
 
 // Search certificate in configuration
 $cert_data = find_certificate($acme_cert_id);
-if ($cert_data == None) {
+if ($cert_data == 'None') {
     log_error("AcmeClient: ignoring cert ID ${acme_cert_id}");
     exit(1);
 } else {
     // Upload certificate (if required)
     $upload_result = upload_certificate($cert_data['name'], $cert_data['refid'], $acme_cert_id, $acme_automation_id);
-    if ($upload_result === None) {
+    if ($upload_result === 'None') {
         log_error("AcmeClient: cert ID ${acme_cert_id} was neither uploaded nor updated");
     } else {
         log_error("AcmeClient: cert ID ${acme_cert_id} was uploaded or updated");


### PR DESCRIPTION
## New features
- add support for netcup DNS API (#1350)

## Bugfixes
- updating an existing cert in Highwinds API failed with a 404 error (wrong HTTP method)

## Enhancements
- fix "Use of undefined constant" PHP errors
- treat certificate serial number as string not as integer
- move "remove certificate" button to the end of the button list