### PR TITLE
net/haproxy: release 2.18

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		haproxy
-PLUGIN_VERSION=		2.17
+PLUGIN_VERSION=		2.18
 PLUGIN_COMMENT=		Reliable, high performance TCP/HTTP load balancer
 PLUGIN_DEPENDS=		haproxy18
 PLUGIN_MAINTAINER=	opnsense@moov.de

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -1304,7 +1304,7 @@ backend {{backend.name}}
 {%       if backend.tuning_httpreuse|default("") != "" and backend.mode == "http" %}
     http-reuse {{backend.tuning_httpreuse}}
 {%       endif %}
-{%       if helpers.exists('OPNsense.HAProxy.general.cache') and OPNsense.HAProxy.general.cache.enabled|default("") == "1" and if backend.tuning_caching|default("") == "1" and backend.mode == "http" %}
+{%       if helpers.exists('OPNsense.HAProxy.general.cache') and OPNsense.HAProxy.general.cache.enabled|default("") == "1" and backend.tuning_caching|default("") == "1" and backend.mode == "http" %}
     http-request cache-use opnsense-haproxy-cache
     http-response cache-store opnsense-haproxy-cache
 {%       endif %}


### PR DESCRIPTION
## New features
- add support for HAProxy cache (#1442)

## Bugfixes
none

## Enhancements
- change http-reuse default (align with HAProxy's default value, #1439)