### PR TITLE
net/frr: [ospf] Enable Area on a per Interface basis instead of just on router for VTI IPSec

### DIFF
--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditOSPFInterface.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditOSPFInterface.xml
@@ -27,6 +27,12 @@
     <type>text</type>
   </field>
   <field>
+    <id>interface.area</id>
+    <label>Area</label>
+    <type>text</type>
+    <help>Area in wildcard mask style like 0.0.0.0 and no decimal 0</help>
+  </field>
+  <field>
     <id>interface.cost</id>
     <label>Cost</label>
     <type>text</type>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF.xml
@@ -149,6 +149,11 @@
                                 <Required>Y</Required>
                                 <ValidationMessage>The authentication key ID must be between 1 and 255.</ValidationMessage>
                         </authkey_id>
+                        <area type="TextField">
+                                <default></default>
+                                <Required>N</Required>
+                                <mask>/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/</mask>
+                        </area>
                         <cost type="IntegerField">
                                 <default></default>
                                 <MinimumValue>0</MinimumValue>

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
@@ -29,7 +29,8 @@ interface {{ physical_interface(interface.interfacename) }}
 }}{% if interface.authtype and interface.authtype == 'message-digest'
 %}{{       cline("message-digest-key " + interface.authkey_id + " md5",interface.authkey)
 }}{% endif
-%}{{       cline("cost",interface.cost)
+%}{{       cline("area",interface.area)
+}}{{       cline("cost",interface.cost)
 }}{{       cline("dead-interval",interface.deadinterval)
 }}{{       cline("hello-interval",interface.hellointerval)
 }}{{       cline("priority",interface.priority)


### PR DESCRIPTION
**Problem:**
Currently, it is not possible to have OSPF talk over IPSec VTI interface (and most likely other interfaces but my use case does not cover this).

**Proposed Solution:**
Enable "area" to be defined on a per interface basis.  The expected change is `ip ospf area {{ areaDefinedByUser }}` under each interface in the following file `/usr/local/etc/frr/ospfd.conf`

**Notes:**
Interestingly enough, "area" seem to exist in the Diagnostics view as found in `net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/diagnosticsospf.volt`.  I do not believe I might have accidentally overlooked the GUI as `interface.area` wasn't set in the model.

I also put "area" on top of "cost" in `ospfd.conf` which made the diff look like I deleted a line.  I wanted to keep the order consistent with `dialogEditOSPFInterface.xml` and `OSPF.xml` model.