### PR TITLE
net/haproxy: Update cache to support HAProxy 2.0 option

### DIFF
--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/main.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/main.xml
@@ -337,6 +337,12 @@
                 <type>text</type>
                 <help><![CDATA[Define the maximum expiration duration. Cache-Control response headers will be respected if they are less than this value. The default value is 60 seconds.]]></help>
             </field>
+            <field>
+                <id>haproxy.general.cache.maxObjectSize</id>
+                <label>Maximum Object Size (bytes)</label>
+                <type>text</type>
+                <help><![CDATA[Define the maximum size of the objects to be cached. Must not be greater than an half of the maximum size of the cache. If not set, it equals to a 256th of the cache size. All objects with sizes larger than this value will not be cached.]]></help>
+            </field>
         </subtab>
     </tab>
 </form>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -343,6 +343,12 @@
                     <Required>N</Required>
                     <ValidationMessage>Please specify a value between 1 and 3600.</ValidationMessage>
                 </maxAge>
+                <maxObjectSize type="IntegerField">
+                    <MinimumValue>1</MinimumValue>
+                    <MaximumValue>2146435072</MaximumValue>
+                    <Required>N</Required>
+                    <ValidationMessage>Please specify a value between 1 and 2146435072.</ValidationMessage>
+                </maxObjectSize>
             </cache>
         </general>
         <frontends>

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -884,6 +884,9 @@ cache opnsense-haproxy-cache
 {%   if OPNsense.HAProxy.general.cache.maxAge|default("") != "" %}
     max-age {{OPNsense.HAProxy.general.cache.maxAge}}
 {%   endif %}
+{%   if OPNsense.HAProxy.general.cache.maxObjectSize|default("") != "" %}
+    max-object-size {{OPNsense.HAProxy.general.cache.maxObjectSize}}
+{%   endif %}
 {%- endif -%}
 
 {# ############################### #}


### PR DESCRIPTION
This adds support for the "[max-object-size](http://cbonte.github.io/haproxy-dconv/2.0/configuration.html#10.2.1-max-object-size)" cache configuration option that was added in HAProxy 1.9/2.0.

As this option is not present in Haproxy < 1.9 this must not be merged until #1089 is closed.