### PR TITLE
FRR/ospf: demote/promote carp when no neighbors are found

### DIFF
--- a/net/frr/src/etc/rc.carp_service_status.d/carp_frr_ospf
+++ b/net/frr/src/etc/rc.carp_service_status.d/carp_frr_ospf
@@ -1,0 +1,25 @@
+#!/bin/sh
+if [ -f /etc/rc.conf.d/frr ]; then
+    . /etc/rc.conf.d/frr
+fi
+
+if [ "$frr_enable" == "YES" ] && (`echo "$frr_daemons" | /usr/bin/grep -F -q -w "ospfd"`) &&
+        (`echo "$frr_carp_demote" | /usr/bin/grep -F -q -w "ospfd"`)  ; then
+    # OSPF enabled
+    OSPF_NEIGHBOR=`echo "show ip ospf neighbor" | /usr/local/bin/vtysh 2>&1` IFS=
+    if [ "$?" -eq 0 ]; then
+        # running, check if we can find any neighbors
+        IFS=
+        neighbors_count=`echo $OSPF_NEIGHBOR |  grep "Full/" | wc -l`
+        unset IFS
+        if [ "$neighbors_count" -eq 0 ]; then
+            # no neighbors in state Full/* found
+            exit 2
+        else
+            exit 0
+        fi
+    else
+        # not running
+        exit 1
+    fi
+fi

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/ospf.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/ospf.xml
@@ -11,7 +11,7 @@
       <type>checkbox</type>
       <help>
             Register CARP status monitor, when no neighbors are found, consider this node less attractive.
-            This feature needs syslog enabled using a minimum of "Informational" logging to catch status events.
+            This feature needs syslog enabled using "Debugging" logging to catch all relevant status events.
             This option is not compatible with "Enable CARP Failover".
       </help>
     </field>

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/ospf.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/ospf.xml
@@ -6,6 +6,16 @@
         <help>This will activate the OSPF service if routing protocols are enabled in "General".</help>
     </field>
     <field>
+      <id>ospf.carp_demote</id>
+      <label>CARP demote</label>
+      <type>checkbox</type>
+      <help>
+            Register CARP status monitor, when no neighbors are found, consider this node less attractive.
+            This feature needs syslog enabled using a minimum of "Informational" logging to catch status events.
+            This option is not compatible with "Enable CARP Failover".
+      </help>
+    </field>
+    <field>
         <id>ospf.routerid</id>
         <label>Router ID</label>
         <type>text</type>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF.xml
@@ -7,6 +7,10 @@
             <default>0</default>
             <Required>Y</Required>
         </enabled>
+        <carp_demote type="BooleanField">
+            <default>0</default>
+            <Required>Y</Required>
+        </carp_demote>
         <routerid type="TextField">
             <default></default>
             <Required>N</Required>

--- a/net/frr/src/opnsense/scripts/quagga/event_loop.sh
+++ b/net/frr/src/opnsense/scripts/quagga/event_loop.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+while read line ; do
+    /usr/local/sbin/configctl interface update carp service_status
+done

--- a/net/frr/src/opnsense/scripts/quagga/event_loop.sh
+++ b/net/frr/src/opnsense/scripts/quagga/event_loop.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-while read line ; do
-    /usr/local/sbin/configctl interface update carp service_status
-done

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/+TARGETS
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/+TARGETS
@@ -5,4 +5,4 @@ ripd.conf:/usr/local/etc/frr/ripd.conf
 frr:/etc/rc.conf.d/frr
 zebra.conf:/usr/local/etc/frr/zebra.conf
 vtysh.conf:/usr/local/etc/frr/vtysh.conf
-syslog-ng-frr-events.conf:/usr/local/syslog-ng.conf.d/frr-events.conf
+syslog-ng-frr-events.conf:/usr/local/etc/syslog-ng.conf.d/frr-events.conf

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/+TARGETS
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/+TARGETS
@@ -5,3 +5,4 @@ ripd.conf:/usr/local/etc/frr/ripd.conf
 frr:/etc/rc.conf.d/frr
 zebra.conf:/usr/local/etc/frr/zebra.conf
 vtysh.conf:/usr/local/etc/frr/vtysh.conf
+syslog-ng-frr-events.conf:/usr/local/syslog-ng.conf.d/frr-events.conf

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/frr
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/frr
@@ -11,8 +11,7 @@ if helpers.exists('OPNsense.quagga.bgp.enabled') and OPNsense.quagga.bgp.enabled
 if helpers.exists('OPNsense.quagga.ospf6.enabled') and OPNsense.quagga.ospf6.enabled == '1' %} ospf6d{% endif %}{%
 if helpers.exists('OPNsense.quagga.ripng.enabled') and OPNsense.quagga.ripng.enabled == '1' %} ripngd{% endif %}{%
 if helpers.exists('OPNsense.quagga.isis.enabled') and OPNsense.quagga.isis.enabled == '1' %} isisd{% endif %}"
-frr_carp_demote="{%
-if not helpers.empty('OPNsense.quagga.ospf.carp_demote') %} ospfd{% endif %}"
+frr_carp_demote="{% if not helpers.empty('OPNsense.quagga.ospf.carp_demote') %} ospfd{% endif %}"
 {% else %}
 frr_enable="NO"
 {% endif %}

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/frr
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/frr
@@ -11,6 +11,8 @@ if helpers.exists('OPNsense.quagga.bgp.enabled') and OPNsense.quagga.bgp.enabled
 if helpers.exists('OPNsense.quagga.ospf6.enabled') and OPNsense.quagga.ospf6.enabled == '1' %} ospf6d{% endif %}{%
 if helpers.exists('OPNsense.quagga.ripng.enabled') and OPNsense.quagga.ripng.enabled == '1' %} ripngd{% endif %}{%
 if helpers.exists('OPNsense.quagga.isis.enabled') and OPNsense.quagga.isis.enabled == '1' %} isisd{% endif %}"
+frr_carp_demote="{%
+if not helpers.empty('OPNsense.quagga.ospf.carp_demote') %} ospfd{% endif %}"
 {% else %}
 frr_enable="NO"
 {% endif %}

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/syslog-ng-frr-events.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/syslog-ng-frr-events.conf
@@ -1,0 +1,19 @@
+{% if not helpers.empty('OPNsense.quagga.general.enabled')
+  and not helpers.empty('OPNsense.quagga.ospf.enabled')
+  and not helpers.empty('OPNsense.quagga.ospf.carp_demote') %}
+destination d_frr_event {
+    program("/usr/local/opnsense/scripts/quagga/event_loop.sh");
+};
+
+filter f_frr_ospf {
+    program("ospfd") and level("info") and (
+         message(".*Neighbor.*Negotiation.*")
+    );
+};
+
+log {
+    source(s_all);
+    filter(f_frr_ospf);
+    destination(d_frr_event);
+};
+{% endif %}

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/syslog-ng-frr-events.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/syslog-ng-frr-events.conf
@@ -2,7 +2,7 @@
   and not helpers.empty('OPNsense.quagga.ospf.enabled')
   and not helpers.empty('OPNsense.quagga.ospf.carp_demote') %}
 destination d_frr_event {
-    program("/usr/local/opnsense/scripts/quagga/event_loop.sh");
+    program("/usr/local/sbin/configctl -e -t 0.5 interface update carp service_status");
 };
 
 filter f_frr_ospf {

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/syslog-ng-frr-events.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/syslog-ng-frr-events.conf
@@ -6,8 +6,12 @@ destination d_frr_event {
 };
 
 filter f_frr_ospf {
-    program("ospfd") and level("info") and (
-         message(".*Neighbor.*Negotiation.*")
+    program("ospfd") and (
+        (
+                level("info") or level("notice")
+        ) or (
+                level("debug") and message(".*EXT .*ospf_ext_link_ism_change.*")
+        )
     );
 };
 


### PR DESCRIPTION
Currently when a carp node promotes back to MASTER while booting, it's quite likely that no neighbors are found yet and thus the machine wouldn't know where to route the traffic.

Inspired by OpenBSD's handling of carp demotion in ospfd (https://man.openbsd.org/ospfd.conf.5), this should lead to a similar result. Event handling is not complete yet, but the concept seems to be working.

- The basic idea is actually quite simple, create an ospf status monitor script to utilize our new carp hooks (https://docs.opnsense.org/development/backend/carp.html), which monitors if ospfd has neighbors.
- Use Syslog-NG's functionality to filter messages and use those as events, so we can trigger "configctl interface update carp service_status" when our state changes.

Ideally on the (new) backup mode the metrics would be set higher (as does OpenBSD), from the OpenBSD man page:

> .....With the depend on option, redistributed routes will have a metric of 65535 if the specified interface is down or in state backup. This is especially useful on a carp cluster to ensure all traffic goes to the carp master.

We haven't worked that piece of the puzzle out yet, although this part by itself should already be usable.