### PR TITLE
bind/dnscrypt-proxy: DNSBL ZeuS Tracker has been discontinued

### DIFF
--- a/dns/bind/Makefile
+++ b/dns/bind/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		bind
-PLUGIN_VERSION=		1.8
+PLUGIN_VERSION=		1.9
 PLUGIN_COMMENT=		BIND domain name service
 PLUGIN_DEPENDS=		bind914
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/dns/bind/pkg-descr
+++ b/dns/bind/pkg-descr
@@ -8,6 +8,10 @@ necessary for asking and answering name service questions.
 Plugin Changelog
 ================
 
+1.9
+
+* Removed discontinued DNSBL Zeus Tracker list
+
 1.8
 
 * Fix template generation when there is only one zone configured

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Dnsbl.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Dnsbl.xml
@@ -36,7 +36,6 @@
                 <wsu>WindowsSpyBlocker (update)</wsu>
                 <wse>WindowsSpyBlocker (extra)</wse>
                 <yy>YoYo List</yy>
-                <za>ZeusTracker Abuse.ch List</za>
             </OptionValues>
         </type>
         <whitelists type="CSVListField">

--- a/dns/bind/src/opnsense/scripts/OPNsense/Bind/dnsbl.sh
+++ b/dns/bind/src/opnsense/scripts/OPNsense/Bind/dnsbl.sh
@@ -217,13 +217,6 @@ simpletrack() {
 	rm ${WORKDIR}/simpletrack-raw
 }
 
-zeusabuse() {
-	# Zeus Tracker List from abuse.ch
-	${FETCH} https://zeustracker.abuse.ch/blocklist.php?download=domainblocklist -o ${WORKDIR}/zeusabuse-raw
-	sed "/\.$/d" ${WORKDIR}/zeusabuse-raw | sed "/^#/d" | sed "/\_/d" | sed "/^\s*$/d" | sed "/\.\./d" | sed "s/^\.//g" > ${WORKDIR}/zeusabuse
-	rm ${WORKDIR}/zeusabuse-raw
-}
-
 install() {
 	# Put all files in correct format
 	for FILE in $(find ${WORKDIR} -type f); do
@@ -321,9 +314,6 @@ for CAT in $(echo ${DNSBL} | tr ',' ' '); do
 		;;
 	yy)
 		yoyo
-		;;
-	za)
-		zeusabuse
 		;;
 	esac
 done

--- a/dns/dnscrypt-proxy/Makefile
+++ b/dns/dnscrypt-proxy/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		dnscrypt-proxy
-PLUGIN_VERSION=		1.5
+PLUGIN_VERSION=		1.6
 PLUGIN_COMMENT=		Flexible DNS proxy supporting DNSCrypt and DoH
 PLUGIN_DEPENDS=		dnscrypt-proxy2
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/dns/dnscrypt-proxy/pkg-descr
+++ b/dns/dnscrypt-proxy/pkg-descr
@@ -5,6 +5,10 @@ such as DNSCrypt v2 and DNS-over-HTTPS.
 Plugin Changelog
 ================
 
+1.6
+
+* Removed discontinued DNSBL Zeus Tracker list
+
 1.5
 
 * Add update and extra WindowsSpyBlocker list

--- a/dns/dnscrypt-proxy/src/opnsense/mvc/app/models/OPNsense/Dnscryptproxy/Dnsbl.xml
+++ b/dns/dnscrypt-proxy/src/opnsense/mvc/app/models/OPNsense/Dnscryptproxy/Dnsbl.xml
@@ -36,7 +36,6 @@
                 <wsu>WindowsSpyBlocker (update)</wsu>
                 <wse>WindowsSpyBlocker (extra)</wse>
                 <yy>YoYo List</yy>
-                <za>ZeusTracker Abuse.ch List</za>
             </OptionValues>
         </type>
     </items>

--- a/dns/dnscrypt-proxy/src/opnsense/scripts/OPNsense/Dnscryptproxy/dnsbl.sh
+++ b/dns/dnscrypt-proxy/src/opnsense/scripts/OPNsense/Dnscryptproxy/dnsbl.sh
@@ -217,13 +217,6 @@ simpletrack() {
 	rm ${WORKDIR}/simpletrack-raw
 }
 
-zeusabuse() {
-	# Zeus Tracker List from abuse.ch
-	${FETCH} https://zeustracker.abuse.ch/blocklist.php?download=domainblocklist -o ${WORKDIR}/zeusabuse-raw
-	sed "/\.$/d" ${WORKDIR}/zeusabuse-raw | sed "/^#/d" | sed "/\_/d" | sed "/^\s*$/d" | sed "/\.\./d" | sed "s/^\.//g" > ${WORKDIR}/zeusabuse
-	rm ${WORKDIR}/zeusabuse-raw
-}
-
 install() {
 	# Put all files in correct format
 	for FILE in $(find ${WORKDIR} -type f); do
@@ -321,9 +314,6 @@ for CAT in $(echo ${DNSBL} | tr ',' ' '); do
 		;;
 	yy)
 		yoyo
-		;;
-	za)
-		zeusabuse
 		;;
 	esac
 done


### PR DESCRIPTION
Per https://zeustracker.abuse.ch/ # ZeuS Tracker has been discontinued on Jul 8th, 2019, remove zeus tracker from dnsbl.