### PR TITLE
security/acme-client: release 1.26

### DIFF
--- a/security/acme-client/Makefile
+++ b/security/acme-client/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		acme-client
-PLUGIN_VERSION=		1.25
+PLUGIN_VERSION=		1.26
 PLUGIN_COMMENT=		Let's Encrypt client
 PLUGIN_MAINTAINER=	opnsense@moov.de
 PLUGIN_DEPENDS=		acme.sh

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/Api/SettingsController.php
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/Api/SettingsController.php
@@ -390,4 +390,22 @@ class SettingsController extends ApiMutableModelControllerBase
 
         return $result;
     }
+
+    /**
+     * Check wether the BIND plugin is installed.
+     * @return array status action
+     */
+    public function getBindPluginStatusAction()
+    {
+        $result = array("result" => "0");
+
+        $mdlAcme = $this->getModel();
+
+        // Check if the required plugin is installed
+        if ((string)$mdlAcme->isPluginInstalled('bind') == "1") {
+            $result['result'] = "1";
+        }
+
+        return $result;
+    }
 }

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogCertificate.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogCertificate.xml
@@ -70,4 +70,32 @@
         <type>text</type>
         <help><![CDATA[Specifies the days to renew the cert. The max value is 60 days.]]></help>
     </field>
+    <field>
+        <id>certificate.aliasmode</id>
+        <label>DNS Alias Mode</label>
+        <type>dropdown</type>
+        <help><![CDATA[Configure DNS alias mode to validate the certificate.]]></help>
+    </field>
+    <field>
+        <label>DNS Alias Mode</label>
+        <type>header</type>
+        <style>aliasmode aliasmode_domain</style>
+    </field>
+    <field>
+        <id>certificate.domainalias</id>
+        <label>Domain Alias</label>
+        <type>text</type>
+        <help><![CDATA[When setting DNS alias mode to "Domain Alias", enter the domain name that should be used for certificate validation. Please refer to the <a href="https://github.com/Neilpang/acme.sh/wiki/DNS-alias-mode">acme.sh documentation</a> for further information.]]></help>
+    </field>
+    <field>
+        <label>DNS Alias Mode</label>
+        <type>header</type>
+        <style>aliasmode aliasmode_challenge</style>
+    </field>
+    <field>
+        <id>certificate.challengealias</id>
+        <label>Challenge Alias</label>
+        <type>text</type>
+        <help><![CDATA[When setting DNS alias mode to "Challenge Alias", enter the domain name that should be used for certificate validation. Please refer to the <a href="https://github.com/Neilpang/acme.sh/wiki/DNS-alias-mode">acme.sh documentation</a> for further information.]]></help>
+    </field>
 </form>

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogCertificate.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogCertificate.xml
@@ -1,5 +1,9 @@
 <form>
     <field>
+        <label>Certificate Options</label>
+        <type>header</type>
+    </field>
+    <field>
         <id>certificate.enabled</id>
         <label>Enabled</label>
         <type>checkbox</type>
@@ -27,6 +31,10 @@
         <hint>Enter FQDN here. Finish with TAB.</hint>
     </field>
     <field>
+        <label>Let's Encrypt Settings</label>
+        <type>header</type>
+    </field>
+    <field>
         <id>certificate.account</id>
         <label>LE Account</label>
         <type>dropdown</type>
@@ -37,6 +45,22 @@
         <label>Validation Method</label>
         <type>dropdown</type>
         <help><![CDATA[Set the Let's Encrypt validation method for this certificate.]]></help>
+    </field>
+    <field>
+        <id>certificate.autoRenewal</id>
+        <label>Auto Renewal</label>
+        <type>checkbox</type>
+        <help>Enable automatic renewal for this certificate to prevent expiration.</help>
+    </field>
+    <field>
+        <id>certificate.renewInterval</id>
+        <label>Renewal Interval</label>
+        <type>text</type>
+        <help><![CDATA[Specifies the days to renew the cert. The max value is 60 days.]]></help>
+    </field>
+    <field>
+        <label>Security Settings</label>
+        <type>header</type>
     </field>
     <field>
         <id>certificate.keyLength</id>
@@ -51,24 +75,16 @@
         <help>Generate and add OCSP Must Staple extension to the certificate.</help>
     </field>
     <field>
+        <label>Advanced Settings</label>
+        <type>header</type>
+    </field>
+    <field>
         <id>certificate.restartActions</id>
         <label>Automations</label>
         <type>select_multiple</type>
         <style>tokenize</style>
         <allownew>true</allownew>
         <help>Choose the automations that should be run after certificate creation and renewal. Basically every application requires a quick restart to reload the updated certificate. If you don't configure an automation, the in-memory certificate may expire and cause security warnings and other issues.</help>
-    </field>
-    <field>
-        <id>certificate.autoRenewal</id>
-        <label>Auto Renewal</label>
-        <type>checkbox</type>
-        <help>Enable automatic renewal for this certificate to prevent expiration.</help>
-    </field>
-    <field>
-        <id>certificate.renewInterval</id>
-        <label>Renewal Interval</label>
-        <type>text</type>
-        <help><![CDATA[Specifies the days to renew the cert. The max value is 60 days.]]></help>
     </field>
     <field>
         <id>certificate.aliasmode</id>

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -718,10 +718,6 @@
         <style>table_dns table_dns_opnsense</style>
     </field>
     <field>
-        <label>Please manually install and configure the bind plugin.</label>
-        <type>info</type>
-    </field>
-    <field>
         <id>validation.dns_opnsense_host</id>
         <label>OPNSense Server (FQDN)</label>
         <type>text</type>
@@ -730,7 +726,7 @@
         <id>validation.dns_opnsense_port</id>
         <label>OPNSense Server Port</label>
         <type>text</type>
-    </field>    
+    </field>
     <field>
         <id>validation.dns_opnsense_key</id>
         <label>User API key </label>
@@ -746,6 +742,15 @@
         <label>Disable TLS Verification</label>
         <type>checkbox</type>
         <help>Uncheck this box if you have a valid certificate for your OPNsense interface.</help>
+    </field>
+    <field>
+        <label>Action required</label>
+        <type>header</type>
+        <style>table_dns table_dns_opnsense bind_plugin_warning</style>
+    </field>
+    <field>
+        <label><![CDATA[Please manually install the plugin "os-bind" to enable support for it.]]></label>
+        <type>info</type>
     </field>
     <field>
         <label>OVH</label>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -243,6 +243,22 @@
                     <MaximumValue>60</MaximumValue>
                     <default>60</default>
                 </renewInterval>
+                <aliasmode type="OptionField">
+                    <Required>Y</Required>
+                    <default>none</default>
+                    <OptionValues>
+                        <none>Not using DNS alias mode</none>
+                        <automatic>Automatic Mode (uses DNS lookups)</automatic>
+                        <domain>Domain alias mode</domain>
+                        <challenge>Challenge alias mode</challenge>
+                    </OptionValues>
+                </aliasmode>
+                <domainalias type="TextField">
+                    <Required>N</Required>
+                </domainalias>
+                <challengealias type="TextField">
+                    <Required>N</Required>
+                </challengealias>
                 <!-- hidden field; ID of the certificate in Cert Manager -->
                 <certRefId type="TextField">
                     <Required>N</Required>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -381,7 +381,7 @@
                         <dns_netcup>netcup DNS API</dns_netcup>
                         <dns_nsone>NS1.com API</dns_nsone>
                         <dns_nsupdate>nsupdate (RFC 2136)</dns_nsupdate>
-                        <dns_opnsense>OPNsense Bind Plugin</dns_opnsense>
+                        <dns_opnsense>OPNsense BIND Plugin</dns_opnsense>
                         <dns_ovh>OVH, kimsufi, soyoustart and runabove API</dns_ovh>
                         <dns_pdns>PowerDNS.com API</dns_pdns>
                         <dns_selectel>selectel.com / selectel.ru domain API</dns_selectel>

--- a/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/certificates.volt
+++ b/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/certificates.volt
@@ -379,6 +379,16 @@ POSSIBILITY OF SUCH DAMAGE.
 
         });
 
+        // Hide options that are irrelevant in this context.
+        $('#DialogCertificate').on('shown.bs.modal', function (e) {
+            $("#certificate\\.aliasmode").change(function(){
+                $(".aliasmode").hide();
+                $(".aliasmode_"+$(this).val()).show();
+            });
+            $("#certificate\\.aliasmode").change();
+        })
+
+
         /***********************************************************************
          * Commands
          **********************************************************************/

--- a/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/validations.volt
+++ b/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/validations.volt
@@ -62,6 +62,12 @@ POSSIBILITY OF SUCH DAMAGE.
                         $(".gcloud_plugin_warning").hide();
                     }
                 });
+                // Show a warning if the BIND plugin is missing.
+                ajaxCall(url="/api/acmeclient/settings/getBindPluginStatus", sendData={}, callback=function(data,status) {
+                    if (data['result'] != 0) {
+                        $(".bind_plugin_warning").hide();
+                    }
+                });
             });
             $("#validation\\.http_service").change(function(){
                 var service_id = 'table_http_' + $(this).val();

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -892,10 +892,25 @@ function run_acme_validation($certObj, $valObj, $acctObj)
 
     // Prepare altNames
     $altnames = "";
+
+    //Find Alias for main domain
+    // https://github.com/Neilpang/acme.sh/wiki/DNS-alias-mode
+    $name = "_acme-challenge." . ltrim((string)$certObj->name, '*.');
+    if ($dst = dns_get_record($name, DNS_CNAME )) {
+        $altnames .= "--domain-alias " .$dst[0]['target'] . " ";
+    }
+
     if (!empty((string)$certObj->altNames)) {
         $_altnames = explode(",", (string)$certObj->altNames);
         foreach (explode(",", (string)$certObj->altNames) as $altname) {
             $altnames .= "--domain ${altname} ";
+            //Find Alias
+            // https://github.com/Neilpang/acme.sh/wiki/DNS-alias-mode
+            $name="_acme-challenge." . ltrim($altname, '*.');
+
+            if ($dst = dns_get_record($name, DNS_CNAME )) {
+                $altnames .= "--domain-alias " .$dst[0]['target'] . " ";
+            }
         }
     }
 

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -893,24 +893,49 @@ function run_acme_validation($certObj, $valObj, $acctObj)
     // Prepare altNames
     $altnames = "";
 
-    //Find Alias for main domain
+    // Main domain: Use DNS alias mode for domain validation?
     // https://github.com/Neilpang/acme.sh/wiki/DNS-alias-mode
-    $name = "_acme-challenge." . ltrim((string)$certObj->name, '*.');
-    if ($dst = dns_get_record($name, DNS_CNAME )) {
-        $altnames .= "--domain-alias " .$dst[0]['target'] . " ";
+    if ($val_method == 'dns01') {
+        switch ((string)$valObj->aliasmode) {
+            case 'automatic':
+                $name = "_acme-challenge." . ltrim((string)$certObj->name, '*.');
+                if ($dst = dns_get_record($name, DNS_CNAME )) {
+                    $altnames .= "--domain-alias " . $dst[0]['target'] . " ";
+                }
+                break;
+            case 'domain':
+                $altnames .= "--domain-alias " . (string)$certObj->domainalias . " ";
+                break;
+            case 'challenge':
+                $altnames .= "--challenge-alias " . (string)$certObj->challengealias . " ";
+                break;
+        }
     }
 
     if (!empty((string)$certObj->altNames)) {
         $_altnames = explode(",", (string)$certObj->altNames);
         foreach (explode(",", (string)$certObj->altNames) as $altname) {
             $altnames .= "--domain ${altname} ";
-            //Find Alias
-            // https://github.com/Neilpang/acme.sh/wiki/DNS-alias-mode
-            $name="_acme-challenge." . ltrim($altname, '*.');
 
-            if ($dst = dns_get_record($name, DNS_CNAME )) {
-                $altnames .= "--domain-alias " .$dst[0]['target'] . " ";
+            // altNames: Use DNS alias mode for domain validation?
+            // https://github.com/Neilpang/acme.sh/wiki/DNS-alias-mode
+            if ($val_method == 'dns01') {
+                switch ((string)$valObj->aliasmode) {
+                    case 'automatic':
+                        $name = "_acme-challenge." . ltrim($altname, '*.');
+                        if ($dst = dns_get_record($name, DNS_CNAME )) {
+                            $altnames .= "--domain-alias " . $dst[0]['target'] . " ";
+                        }
+                        break;
+                    case 'domain':
+                        $altnames .= "--domain-alias " . (string)$certObj->domainalias . " ";
+                        break;
+                    case 'challenge':
+                        $altnames .= "--challenge-alias " . (string)$certObj->challengealias . " ";
+                        break;
+                }
             }
+
         }
     }
 

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -829,6 +829,11 @@ function run_acme_validation($certObj, $valObj, $acctObj)
                 $proc_env['NSUPDATE_SERVER'] = (string)$valObj->dns_nsupdate_server;
                 break;
             case 'dns_opnsense':
+                # BIND plugin must be installed.
+                if ((string)$modelObj->isPluginInstalled('bind') != "1") {
+                    log_error("AcmeClient: BIND plugin is NOT installed. Please install os-bind.");
+                    return(1);
+                }
                 $proc_env['OPNs_Host'] = (string)$valObj->dns_opnsense_host;
                 $proc_env['OPNs_Port'] = (string)$valObj->dns_opnsense_port;
                 $proc_env['OPNs_Key'] = (string)$valObj->dns_opnsense_key;

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/dns_opnsense.sh
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/dns_opnsense.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-#OPNsense Bind API 
+#OPNsense Bind API
 #https://docs.opnsense.org/development/api.html
 #
 #OPNs_Host="opnsense.example.com"
@@ -61,21 +61,19 @@ set_record() {
     # Update
     if _opns_rest "POST" "/record/setRecord/${_uuid}" "$_record_string"; then
       _return_str="$response"
-
     else
       return 1
     fi
-      
+
   else
     #create
     if _opns_rest "POST" "/record/addRecord" "$_record_string"; then
       _return_str="$response"
-
     else
       return 1
     fi
-
   fi
+
   if echo "$_return_str" | _egrep_o  "\"result\":\"saved\"" >/dev/null
   then
     _opns_rest "POST" "/service/reconfigure" "{}"
@@ -85,7 +83,6 @@ set_record() {
     return 1
   fi
 
-   
   return 0
 }
 
@@ -117,14 +114,12 @@ rm_record() {
     else
         _err "Error delteting record $fulldomain"
         return 1
-    fi      
+    fi
   else
     _info "Record not found, nothing to remove"
-
   fi
 
   return 0
-
 }
 
 ####################  Private functions below ##################################
@@ -199,7 +194,6 @@ _build_record_string() {
 }
 
 _existingchallenge() {
-
   if _opns_rest "GET" "/record/searchRecord"; then
     _record_response="$response"
   else
@@ -218,8 +212,6 @@ _existingchallenge() {
 }
 
 _opns_check_auth() {
-
-
   OPNs_Host="${OPNs_Host:-$(_readaccountconf_mutable OPNs_Host)}"
   OPNs_Port="${OPNs_Port:-$(_readaccountconf_mutable OPNs_Port)}"
   OPNs_Key="${OPNs_Key:-$(_readaccountconf_mutable OPNs_Key)}" 
@@ -267,5 +259,4 @@ _opns_check_auth() {
     return 1
   fi
   return 0
-
 }

--- a/security/acme-client/src/opnsense/service/conf/actions.d/actions_acmeclient.conf
+++ b/security/acme-client/src/opnsense/service/conf/actions.d/actions_acmeclient.conf
@@ -42,7 +42,7 @@ message:testing acme_http_challenge configuration
 ##########################################
 
 [sign-cert]
-command:/usr/sbin/daemon -f /usr/local/opnsense/scripts/OPNsense/AcmeClient/certhelper.php -F -a sign -c
+command:/usr/local/opnsense/scripts/OPNsense/AcmeClient/setup.sh; /usr/sbin/daemon -f /usr/local/opnsense/scripts/OPNsense/AcmeClient/certhelper.php -F -a sign -c
 parameters:%s
 type:script
 message:signing or renewing a certificate
@@ -66,13 +66,13 @@ type:script
 message:removing a certificate private key
 
 [sign-all-certs]
-command:/usr/sbin/daemon -f /usr/local/opnsense/scripts/OPNsense/AcmeClient/certhelper.php -a sign -A
+command:/usr/local/opnsense/scripts/OPNsense/AcmeClient/setup.sh; /usr/sbin/daemon -f /usr/local/opnsense/scripts/OPNsense/AcmeClient/certhelper.php -a sign -A
 parameters:
 type:script
 message:signing or renewing a certificate
 
 [cron-auto-renew]
-command:/usr/sbin/daemon -f /usr/local/opnsense/scripts/OPNsense/AcmeClient/certhelper.php -a sign -A -C
+command:/usr/local/opnsense/scripts/OPNsense/AcmeClient/setup.sh; /usr/sbin/daemon -f /usr/local/opnsense/scripts/OPNsense/AcmeClient/certhelper.php -a sign -A -C
 parameters:
 type:script
 message:cronjob running to sign or renew certificates


### PR DESCRIPTION
## New features
- new automation: support cert upload via sftp (#1455)
- add support for OPNsense's BIND plugin (#1491)
- add support for DNS alias mode (#1492, #1301)

## Bugfixes
none

## Enhancements
- add headers for certificate options for the sake of clarity