### PR TITLE
net/frr: Issue #1509. Fixing issue with net/frr BGP diagnostics summary tab

### DIFF
--- a/net/frr/src/opnsense/scripts/quagga/quagga.rb
+++ b/net/frr/src/opnsense/scripts/quagga/quagga.rb
@@ -394,35 +394,46 @@ class BGP
     output = output.split("\n")
     bgp = {}
 
-    x,y = output.shift.scan(/.*?version is (\d+).*?ID is ([0-9\.]+).*/).first
-    bgp['table_version'] = x
-    bgp['local_router_id'] = y
-
-    # find out, what the status abbreviations mean
-    status_codes = {}
-    line = output.shift
-    line.split(":").last.strip.split(",").each do |x|
-      k,v = x.strip.split(" ")
-      status_codes[k] = v
-    end
-    while line.end_with? ","
-      line = output.shift
-      line.strip.split(",").each do |x|
-        k,v = x.strip.split(" ")
-        status_codes[k] = v
+    # Process the header/definitions
+    while line = output.shift&.rstrip
+      case line
+      when /^BGP table version/
+        x,y = line.scan(/.*?version is (\d+).*?ID is ([0-9\.]+).*/).first
+        bgp['table_version'] = x
+        bgp['local_router_id'] = y
+      when /^Status codes/
+        # find out, what the status abbreviations mean
+        status_codes = {}
+        line.split(":").last.strip.split(",").each do |x|
+          k,v = x.strip.split(" ")
+          status_codes[k] = v
+        end
+        while line.end_with? ","
+          line = output.shift
+          line.strip.split(",").each do |x|
+            k,v = x.strip.split(" ")
+            status_codes[k] = v
+          end
+        end
+      when /^Origin codes/
+        # same like before but for the origin codes
+        origin_codes = {}
+        line.split(":").last.strip.split(",").each do |x|
+          k,v = x.strip.split(" - ")
+          origin_codes[k] = v
+        end
+      when /^Nexthop codes/
+        # Just eat this line, nothing to do with it
+      when ""
+        # Found the end of the header, reached the table
+        break
+      else
+        # eat all other (unexpected) lines
+        puts line if $QUAGGA_DEBUG
       end
     end
 
-    # same like before but for the origin codes
-    origin_codes = {}
-    output.shift.split(":").last.strip.split(",").each do |x|
-      k,v = x.strip.split(" - ")
-      origin_codes[k] = v
-    end
-
-    # drop empty line
-    output.shift
-    # read entries
+    # Process the tabular data
     bgp['output'] = []
     qta = QuaggaTableReader.new(["Network", "Next Hop", "Metric", "LocPrf", "Weight", "Path"])
     qta.read_headline(output.shift,true)


### PR DESCRIPTION
… by frr adding a new line of output to the vtysh command. I reworked the code for processing the 'header' to decrease the likelihood of this happening with future additions in the header. The new code looks for header lines it is interested in, and skips all others until it gets a blank line, at which time it assumes the tabular data is to follow