### PR TITLE
security/acme-client: Adding more providers from dns-lexicon

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -599,8 +599,67 @@
                     <Required>N</Required>
                     <default>cloudflare</default>
                     <OptionValues>
-                        <cloudflare>Cloudflare API</cloudflare>
+                        <aliyun>Aliyun.com API</aliyun>
+                        <aurora>AuroraDNS API</aurora>
+                        <auto>Auto API</auto>
+                        <azure>Azure DNS API</azure>
+                        <cloudflare>CloudFlare API</cloudflare>
+                        <cloudns>ClouDNS API</cloudns>
+                        <cloudxns>CloudXNS API</cloudxns>
+                        <conoha>ConoHa API</conoha>
+                        <constellix>Constellix API</constellix>
+                        <digitalocean>DigitalOcean API</digitalocean>
+                        <dinahosting>Dinahosting API</dinahosting>
+                        <directadmin>DirectAdmin API</directadmin>
+                        <dnsimple>DNSimple API</dnsimple>
+                        <dnsmadeeasy>DnsMadeEasy API</dnsmadeeasy>
+                        <dnspark>DNSPark API</dnspark>
+                        <dnspod>DNSPod API</dnspod>
+                        <dreamhost>Dreamhost API</dreamhost>
+                        <easydns>EasyDNS API</easydns>
+                        <easyname>Easyname API</easyname>
+                        <exoscale>ExoScale API</exoscale>
+                        <gandi>Gandi API</gandi>
+                        <gehirn>Gehirn API</gehirn>
+                        <glesys>Glesys API</glesys>
+                        <godaddy>GoDaddy API</godaddy>
+                        <googleclouddns>Google Cloud DNS API</googleclouddns>
+                        <gratisdns>GratisDNS API</gratisdns>
+                        <henet>Hurricane Electric DNS API</henet>
+                        <hetzner>Hetzner API</hetzner>
+                        <hover>Hover API</hover>
+                        <infoblox>Infoblox API</infoblox>
+                        <internetbs>Internet.bs API</internetbs>
+                        <inwx>INWX API</inwx>
+                        <linode>Linode API</linode>
+                        <linode4>Linode v4 API</linode4>
+                        <localzone>Localzone API</localzone>
+                        <luadns>LuaDNS API</luadns>
+                        <memset>Memset API</memset>
+                        <namecheap>Namecheap API</namecheap>
                         <namesilo>Namesilo API</namesilo>
+                        <netcup>Netcup API</netcup>
+                        <nfsn>NFSN API</nfsn>
+                        <nsone>NS1 API</nsone>
+                        <onapp>OnApp API</onapp>
+                        <online>Online API</online>
+                        <ovh>OVH API</ovh>
+                        <plesk>Plesk API</plesk>
+                        <pointhq>PointHQ API</pointhq>
+                        <powerdns>PowerDNS API</powerdns>
+                        <rackspace>Rackspace API</rackspace>
+                        <rage4>Rage4 API</rage4>
+                        <route53>Route 53 API</route53>
+                        <safedns>SafeDNS API</safedns>
+                        <sakuracloud>SakuraCloud API</sakuracloud>
+                        <softlayer>Softlayer API</softlayer>
+                        <subreg>Subreg API</subreg>
+                        <transip>Transip API</transip>
+                        <vultr>Vultr API</vultr>
+                        <yandex>Yandex API</yandex>
+                        <zeit>Zeit API</zeit>
+                        <zilore>Zilore API</zilore>
+                        <zonomi>Zonomi API</zonomi>
                     </OptionValues>
                 </dns_lexicon_provider>
                 <dns_lexicon_user type="TextField">

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -771,8 +771,8 @@ function run_acme_validation($certObj, $valObj, $acctObj)
                 break;
             case 'dns_lexicon':
                 $proc_env['PROVIDER'] = (string)$valObj->dns_lexicon_provider;
-                $proc_env['LEXICON_CLOUDFLARE_USERNAME'] = (string)$valObj->dns_lexicon_user;
-                $proc_env['LEXICON_CLOUDFLARE_TOKEN'] = (string)$valObj->dns_lexicon_token;
+                $proc_env['LEXICON_' . strtoupper($proc_env['PROVIDER']) . '_USERNAME'] = (string)$valObj->dns_lexicon_user;
+                $proc_env['LEXICON_' . strtoupper($proc_env['PROVIDER']) . '_TOKEN'] = (string)$valObj->dns_lexicon_token;
                 $proc_env['LEXICON_NAMESILO_TOKEN'] = (string)$valObj->dns_lexicon_token;
                 if ((string)$valObj->dns_lexicon_provider == 'namesilo') {
                     // Namesilo applies changes to DNS records only every 15 minutes.

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -773,7 +773,6 @@ function run_acme_validation($certObj, $valObj, $acctObj)
                 $proc_env['PROVIDER'] = (string)$valObj->dns_lexicon_provider;
                 $proc_env['LEXICON_' . strtoupper($proc_env['PROVIDER']) . '_USERNAME'] = (string)$valObj->dns_lexicon_user;
                 $proc_env['LEXICON_' . strtoupper($proc_env['PROVIDER']) . '_TOKEN'] = (string)$valObj->dns_lexicon_token;
-                $proc_env['LEXICON_NAMESILO_TOKEN'] = (string)$valObj->dns_lexicon_token;
                 if ((string)$valObj->dns_lexicon_provider == 'namesilo') {
                     // Namesilo applies changes to DNS records only every 15 minutes.
                     $acme_hook_options[] = "--dnssleep 960";


### PR DESCRIPTION
I wanted to have support for Rage4 and added it to the XML configuration file.
It works perfectly fine.

Instead of just adding the single provider I want to use, I am adding all providers from dns-lexicon v3.3.3, based on output from `lexicon -h`.