### PR TITLE
security/acme-client: release 1.27

### DIFF
--- a/security/acme-client/Makefile
+++ b/security/acme-client/Makefile
@@ -2,6 +2,6 @@ PLUGIN_NAME=		acme-client
 PLUGIN_VERSION=		1.27
 PLUGIN_COMMENT=		Let's Encrypt client
 PLUGIN_MAINTAINER=	opnsense@moov.de
-PLUGIN_DEPENDS=		acme.sh bind-tools
+PLUGIN_DEPENDS=		acme.sh bind-tools py-dns-lexicon${PLUGIN_PYTHON}
 
 .include "../../Mk/plugins.mk"

--- a/security/acme-client/Makefile
+++ b/security/acme-client/Makefile
@@ -2,6 +2,6 @@ PLUGIN_NAME=		acme-client
 PLUGIN_VERSION=		1.27
 PLUGIN_COMMENT=		Let's Encrypt client
 PLUGIN_MAINTAINER=	opnsense@moov.de
-PLUGIN_DEPENDS=		acme.sh py-dns-lexicon${PLUGIN_PYTHON}
+PLUGIN_DEPENDS=		acme.sh py${PLUGIN_PYTHON}-dns-lexicon
 
 .include "../../Mk/plugins.mk"

--- a/security/acme-client/Makefile
+++ b/security/acme-client/Makefile
@@ -2,6 +2,6 @@ PLUGIN_NAME=		acme-client
 PLUGIN_VERSION=		1.27
 PLUGIN_COMMENT=		Let's Encrypt client
 PLUGIN_MAINTAINER=	opnsense@moov.de
-PLUGIN_DEPENDS=		acme.sh
+PLUGIN_DEPENDS=		acme.sh bind-tools
 
 .include "../../Mk/plugins.mk"

--- a/security/acme-client/Makefile
+++ b/security/acme-client/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		acme-client
-PLUGIN_VERSION=		1.26
+PLUGIN_VERSION=		1.27
 PLUGIN_COMMENT=		Let's Encrypt client
 PLUGIN_MAINTAINER=	opnsense@moov.de
 PLUGIN_DEPENDS=		acme.sh

--- a/security/acme-client/Makefile
+++ b/security/acme-client/Makefile
@@ -2,6 +2,6 @@ PLUGIN_NAME=		acme-client
 PLUGIN_VERSION=		1.27
 PLUGIN_COMMENT=		Let's Encrypt client
 PLUGIN_MAINTAINER=	opnsense@moov.de
-PLUGIN_DEPENDS=		acme.sh bind-tools py-dns-lexicon${PLUGIN_PYTHON}
+PLUGIN_DEPENDS=		acme.sh py-dns-lexicon${PLUGIN_PYTHON}
 
 .include "../../Mk/plugins.mk"

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -591,6 +591,26 @@
         <type>text</type>
     </field>
     <field>
+        <label>Loopia</label>
+        <type>header</type>
+        <style>table_dns table_dns_loopia</style>
+    </field>
+    <field>
+        <id>validation.dns_loopia_api</id>
+        <label>API Endpoint</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_loopia_user</id>
+        <label>User</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_loopia_password</id>
+        <label>Password</label>
+        <type>text</type>
+    </field>
+    <field>
         <label>LuaDNS</label>
         <type>header</type>
         <style>table_dns table_dns_lua</style>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/AcmeClient</mount>
-    <version>1.5.0</version>
+    <version>1.6.0</version>
     <description>A secure Let's Encrypt plugin</description>
     <items>
         <settings>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -390,6 +390,7 @@
                         <dns_knot>Knot (knsupdate) DNS API</dns_knot>
                         <dns_lexicon>lexicon DNS API</dns_lexicon>
                         <dns_linode>Linode API</dns_linode>
+                        <dns_loopia>Loopia API</dns_loopia>
                         <dns_lua>LuaDNS.com API</dns_lua>
                         <dns_namecom>Name.com API</dns_namecom>
                         <dns_namecheap>Namecheap API</dns_namecheap>
@@ -612,6 +613,16 @@
                 <dns_linode_key type="TextField">
                   <Required>N</Required>
                 </dns_linode_key>
+                <dns_loopia_api type="TextField">
+                  <Required>N</Required>
+                  <default>https://api.loopia.se/RPCSERV</default>
+                </dns_loopia_api>
+                <dns_loopia_user type="TextField">
+                  <Required>N</Required>
+                </dns_loopia_user>
+                <dns_loopia_password type="TextField">
+                  <Required>N</Required>
+                </dns_loopia_password>
                 <dns_lua_email type="TextField">
                     <Required>N</Required>
                 </dns_lua_email>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/Migrations/M1_6_0.php
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/Migrations/M1_6_0.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ *    Copyright (C) 2019 Frank Wall
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+namespace OPNsense\AcmeClient\Migrations;
+
+use OPNsense\Base\BaseModelMigration;
+
+class M1_6_0 extends BaseModelMigration
+{
+    public function run($model)
+    {
+        // Get LE environment
+        $env = (string)$model->settings->environment;
+        $dir = '/var/etc/acme-client/accounts/';
+
+        // Search accounts
+        foreach ($model->getNodeByReference('accounts.account')->iterateItems() as $account) {
+            $account_id = (string)$account->id;
+            $account_dir = "${dir}${account_id}";
+            $new_account_dir = "${dir}${account_id}_${env}";
+
+            // Check if account directory exists
+            // Accounts that haven't been used yet don't need to be migrated.
+            if (is_dir($account_dir)) {
+
+                // Check if account configuration can be found.
+                $account_file = "${account_dir}/account.conf";
+                if (is_file($account_file)) {
+
+                    // Parse config file and modify path information
+                    $account_conf = parse_ini_file($account_file);
+                    foreach ($account_conf as $key => $value) {
+                        switch ($key) {
+                            case 'ACCOUNT_KEY_PATH':
+                                $account_conf[$key] = "${new_account_dir}/account.key";
+                                break;
+                            case 'ACCOUNT_JSON_PATH':
+                                $account_conf[$key] = "${new_account_dir}/account.json";
+                                break;
+                            case 'CA_CONF':
+                                $account_conf[$key] = "${new_account_dir}/ca.conf";
+                                break;
+                        }
+                    }
+
+                    // Convert array back to ini file format
+                    $new_account_conf = array();
+                    foreach($account_conf as $key => $value)
+                    {
+                        $new_account_conf[] = "${key}='${value}'";
+                    }
+
+                    // Write changes back to file
+                    file_put_contents($account_file, implode("\r\n", $new_account_conf));
+                    chmod($account_file, 0600);
+
+                    // Finally, rename account directory
+                    rename($account_dir, $new_account_dir);
+                }
+            }
+        }
+    }
+}

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/Migrations/M1_6_0.php
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/Migrations/M1_6_0.php
@@ -77,7 +77,7 @@ class M1_6_0 extends BaseModelMigration
                     }
 
                     // Write changes back to file
-                    file_put_contents($account_file, implode("\r\n", $new_account_conf));
+                    file_put_contents($account_file, implode("\r\n", $new_account_conf) . "\n");
                     chmod($account_file, 0600);
 
                     // Finally, rename account directory

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/Migrations/M1_6_0.php
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/Migrations/M1_6_0.php
@@ -42,7 +42,7 @@ class M1_6_0 extends BaseModelMigration
         // Search accounts
         foreach ($model->getNodeByReference('accounts.account')->iterateItems() as $account) {
             $account_id = (string)$account->id;
-            $account_dir = "${dir}${account_id}";
+            $account_dir = $dir . $account_id;
             $new_account_dir = "${dir}${account_id}_${env}";
 
             // Check if account directory exists

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -784,6 +784,11 @@ function run_acme_validation($certObj, $valObj, $acctObj)
                 // Linode can take up to 15 to update DNS records
                 $acme_hook_options[] = "--dnssleep 960";
                 break;
+            case 'dns_loopia':
+                $proc_env['LOOPIA_Api'] = (string)$valObj->dns_loopia_api;
+                $proc_env['LOOPIA_User'] = (string)$valObj->dns_loopia_user;
+                $proc_env['LOOPIA_Password'] = (string)$valObj->dns_loopia_password;
+                break;
             case 'dns_lua':
                 $proc_env['LUA_Key'] = (string)$valObj->dns_lua_key;
                 $proc_env['LUA_Email'] = (string)$valObj->dns_lua_email;

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -344,7 +344,8 @@ function run_acme_account_registration($acctObj, $certObj, $modelObj)
     $acme_args = eval_optional_acme_args();
 
     // Collect account information
-    $account_conf_dir = "/var/etc/acme-client/accounts/" . $acctObj->id;
+    $acme_env = (string)$modelObj->settings->environment;
+    $account_conf_dir = "/var/etc/acme-client/accounts/" . $acctObj->id . "_${acme_env}";
     $account_conf_file = $account_conf_dir . "/account.conf";
     $account_key_file = $account_conf_dir . "/account.key";
     $account_json_file = $account_conf_dir . "/account.json";
@@ -462,7 +463,8 @@ function run_acme_validation($certObj, $valObj, $acctObj)
     $modelObj = new OPNsense\AcmeClient\AcmeClient();
 
     // Collect account information
-    $account_conf_dir = "/var/etc/acme-client/accounts/" . $acctObj->id;
+    $acme_env = (string)$modelObj->settings->environment;
+    $account_conf_dir = "/var/etc/acme-client/accounts/" . $acctObj->id . "_${acme_env}";
     $account_conf_file = $account_conf_dir . "/account.conf";
 
     // Generate certificate filenames
@@ -1023,7 +1025,8 @@ function revoke_cert($certObj, $valObj, $acctObj)
     $acme_args = eval_optional_acme_args();
 
     // Collect account information
-    $account_conf_dir = "/var/etc/acme-client/accounts/" . $acctObj->id;
+    $acme_env = (string)$modelObj->settings->environment;
+    $account_conf_dir = "/var/etc/acme-client/accounts/" . $acctObj->id . "_${acme_env}";
     $account_conf_file = $account_conf_dir . "/account.conf";
 
     // Generate certificate filenames


### PR DESCRIPTION
## New features
- add support for Loopia DNS API (#1529)
- automations can now restart Captive Portal or IPsec service after cert renewal (#1534)
- add support for 60+ DNS APIs through [Lexicon](https://github.com/AnalogJ/lexicon) (#1524)

## Bugfixes
- don't break accounts when switching between stg/prod Let's Encrypt environments (#1528)

## Enhancements
- add py-dns-lexicon as plugin dependency to support it in DNS-01 out-of-the-box
- support acme.sh debug log level 2 and 3 (#1546)