### PR TITLE
security/acme-client: Add support for --debug 2/ 3

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/settings.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/settings.xml
@@ -41,7 +41,7 @@
         <id>acmeclient.settings.logLevel</id>
         <label>Log Level</label>
         <type>dropdown</type>
-        <help><![CDATA[Specifies the log level for acme.sh, default is "normal". All other log levels add information for debug purposes, but be aware that this will break the log formatting in the GUI.]]></help>
+        <help><![CDATA[Specifies the log level for acme.sh, default is "normal". All other log levels add information for debug purposes, but be aware that this will break the log formatting in the GUI.  Levels "debug 2" and "debug 3" log successively deeper log messages from the acme.sh including messages from DNS-01 DNSAPI scripts.]]></help>
         <advanced>true</advanced>
     </field>
 </form>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -105,6 +105,8 @@
                     <normal>normal</normal>
                     <extended>extended</extended>
                     <debug>debug</debug>
+                    <debug2>debug 2</debug2>
+                    <debug3>debug 3</debug3>
                 </OptionValues>
             </logLevel>
         </settings>

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -328,8 +328,18 @@ function eval_optional_acme_args()
     $acme_args[] = isset($options["S"]) ? "--staging" : null; // for debug purpose
 
     // Set log level
-    $acme_args[] = $configObj->OPNsense->AcmeClient->settings->logLevel == "normal" ? "--log-level 1" : "--log-level 2";
-    $acme_args[] = $configObj->OPNsense->AcmeClient->settings->logLevel == "debug" ? "--debug" : null;
+    switch($configObj->OPNsense->AcmeClient->settings->logLevel) {
+        case "extended":
+            $acme_args[] = "--log-level 2";
+        case "debug":
+            $acme_args[] = "--debug";
+        case "debug2":
+            $acme_args[] = "--debug 2";
+        case "debug3":
+            $acme_args[] = "--debug 3";
+        default:
+            $acme_args[] = "--log-level 1";
+    }
 
     // Remove empty and duplicate elements from array
     return(array_unique(array_filter($acme_args)));


### PR DESCRIPTION
@fraenki 

Separate PR as suggested for _--debug 2_ and _--debug 3_ support. 

acme.sh is capable of deeper levels of debug messages. This is especially important when the DNS-01 acme challenge doesn't work as expected. The messages include debug messages about the exported env vars, http method calls, etc. that would not be printed at the debug (_--debug_) level. 

This probably is not the best way to do this. Would be happy to take on suggestions to have debug level selection in Settings when _debug_ is selected from _Log Level_. Unfortunately, the volt scripting/ config is currently beyond me.

acme.sh debug levels are implemented as the private functions *_debug*, *_debug2*, and *_debug3*. There are currently no deeper debug levels. A quick verification with [the source code](https://github.com/Neilpang/acme.sh/blob/master/acme.sh#L301) shows the only additional levels are 2 and 3. Not that this won't change.

If you're happy with this, cool - if not please let me know. BTW this is working on my local OPNsense server.