### PR TITLE
net-mgmt/zabbix4-proxy: Allow for special settings to use the default Include directory

### DIFF
--- a/net-mgmt/zabbix4-proxy/src/opnsense/service/templates/OPNsense/Zabbixproxy/zabbix_proxy.conf
+++ b/net-mgmt/zabbix4-proxy/src/opnsense/service/templates/OPNsense/Zabbixproxy/zabbix_proxy.conf
@@ -70,5 +70,5 @@ TLSConnect=psk
 TLSPSKFile=/usr/local/etc/zabbix4/zabbix_proxy.psk
 TLSPSKIdentity={{ OPNsense.zabbixproxy.general.encryptionidentity }}
 {% endif %}
+Include /usr/local/etc/zabbix4/zabbix_proxy.conf.d/
 {% endif %}
-Include /usr/local/etc/zabbix4/zabbix_proxy.d/

--- a/net-mgmt/zabbix4-proxy/src/opnsense/service/templates/OPNsense/Zabbixproxy/zabbix_proxy.conf
+++ b/net-mgmt/zabbix4-proxy/src/opnsense/service/templates/OPNsense/Zabbixproxy/zabbix_proxy.conf
@@ -71,3 +71,4 @@ TLSPSKFile=/usr/local/etc/zabbix4/zabbix_proxy.psk
 TLSPSKIdentity={{ OPNsense.zabbixproxy.general.encryptionidentity }}
 {% endif %}
 {% endif %}
+Include /usr/local/etc/zabbix4/zabbix_proxy.d/


### PR DESCRIPTION
Hi,

I would like to add a few UserParameter(s) .

Can you enable the Include so I could just maintain those with a include file?

Thanks and Best regards
Rainer