### PR TITLE
security/acme-client: Make "log level" GUI control always visible

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/settings.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/settings.xml
@@ -24,6 +24,12 @@
         <help><![CDATA[Enable automatic integration with the OPNsense HAProxy plugin. <b>Requires that the OPNsense HAProxy plugin is installed.</b> This will automatically add the required backend, server, action and ACL for you. You just need to select your HAProxy frontend when configuration the certificate or validation method. <div class="text-info"><b>NOTE:</b>This will only work for HTTP-01 validation and HAProxy frontends running in <i>http</i> mode; TCP frontends are not supported.</div>]]></help>
     </field>
     <field>
+        <id>acmeclient.settings.logLevel</id>
+        <label>Log Level</label>
+        <type>dropdown</type>
+        <help><![CDATA[Specifies the log level for acme.sh, default is "normal". All other log levels add information for debug purposes, but be aware that this will break the log formatting in the GUI.  Levels "debug 2" and "debug 3" log successively deeper log messages from the acme.sh including messages from DNS-01 DNSAPI scripts.]]></help>
+    </field>
+    <field>
         <id>acmeclient.settings.challengePort</id>
         <label>Local HTTP Port</label>
         <type>text</type>
@@ -35,13 +41,6 @@
         <label>Automation Timeout</label>
         <type>text</type>
         <help><![CDATA[The maximum time in seconds to wait for an automation to complete. When the timeout is reached the command is forcefully aborted. Defaults to 600 seconds.]]></help>
-        <advanced>true</advanced>
-    </field>
-    <field>
-        <id>acmeclient.settings.logLevel</id>
-        <label>Log Level</label>
-        <type>dropdown</type>
-        <help><![CDATA[Specifies the log level for acme.sh, default is "normal". All other log levels add information for debug purposes, but be aware that this will break the log formatting in the GUI.  Levels "debug 2" and "debug 3" log successively deeper log messages from the acme.sh including messages from DNS-01 DNSAPI scripts.]]></help>
         <advanced>true</advanced>
     </field>
 </form>


### PR DESCRIPTION
Log level is probably one of the most useful options for anyone using a plugin such as LE. I don't think any other function or plugin that offers a log level option, hides it from the user behind a "show/hide advanced" button.

This PR simply moves the control in the GUI to be always visible, without needing to be exposed by "show advanced".