### PR TITLE
security/acme-client: Enable new DNS-01 method "pleskxml" in GUI

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -881,6 +881,27 @@
         <type>text</type>
     </field>
     <field>
+        <label>Plesk XML API</label>
+        <type>header</type>
+        <style>table_dns table_dns_pleskxml</style>
+    </field>
+    <field>
+        <id>validation.dns_pleskxml_user</id>
+        <label>User</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_pleskxml_pass</id>
+        <label>Password</label>
+        <type>password</type>
+    </field>
+    <field>
+        <id>validation.dns_pleskxml_uri</id>
+        <label>Plesk API URI</label>
+        <type>text</type>
+        <help>Plesk XML URIs often look similar to: https://my-plesk-site.com:8443/enterprise/control/agent.php</help>
+    </field>
+    <field>
         <label>Zilore</label>
         <type>header</type>
         <style>table_dns table_dns_zilore</style>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -403,6 +403,7 @@
                         <dns_opnsense>OPNsense BIND Plugin</dns_opnsense>
                         <dns_ovh>OVH, kimsufi, soyoustart and runabove API</dns_ovh>
                         <dns_pdns>PowerDNS.com API</dns_pdns>
+                        <dns_pleskxml>Plesk XML API</dns_pleskxml>
                         <dns_selectel>selectel.com / selectel.ru domain API</dns_selectel>
                         <dns_servercow>Servercow API v1</dns_servercow>
                         <dns_unoeuro>UnoEuro API</dns_unoeuro>
@@ -763,6 +764,15 @@
                 <dns_ovh_endpoint type="TextField">
                     <Required>N</Required>
                 </dns_ovh_endpoint>
+                <dns_pleskxml_user type="TextField">
+                    <Required>N</Required>
+                </dns_pleskxml_user>
+                <dns_pleskxml_pass type="TextField">
+                    <Required>N</Required>
+                </dns_pleskxml_pass>
+                <dns_pleskxml_uri type="TextField">
+                    <Required>N</Required>
+                </dns_pleskxml_uri>
                 <dns_pdns_url type="TextField">
                     <Required>N</Required>
                 </dns_pdns_url>

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -867,6 +867,11 @@ function run_acme_validation($certObj, $valObj, $acctObj)
                 $proc_env['PDNS_ServerId'] = (string)$valObj->dns_pdns_serverid;
                 $proc_env['PDNS_Token'] = (string)$valObj->dns_pdns_token;
                 break;
+            case 'dns_pleskxml':
+                $proc_env['pleskxml_user'] = (string)$valObj->dns_pleskxml_user;
+                $proc_env['pleskxml_pass'] = (string)$valObj->dns_pleskxml_pass;
+                $proc_env['pleskxml_uri'] = (string)$valObj->dns_pleskxml_uri;
+                break;
             case 'dns_selectel':
                 $proc_env['SL_Key'] = (string)$valObj->dns_sl_key;
                 break;


### PR DESCRIPTION
See related upstream commit: ([Neilpang's acme.sh PR # 2562](https://github.com/Neilpang/acme.sh/pull/2562)), adding a DNS-01 method using the Plesk XML API to `acme.sh`. Now merged into acme.sh "dev" branch.

This PR contains the code to allow use of that DNS-01 method via the OPNSense GUI.

**The DNS-01 method has been accepted, but this PR should continue to be left "on hold" until upstream DNS-01 patch appears in a release**