### PR TITLE
mail/postfix: add milter protocol selection

### DIFF
--- a/mail/postfix/Makefile
+++ b/mail/postfix/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		postfix
-PLUGIN_VERSION=		1.12
+PLUGIN_VERSION=		1.13
 PLUGIN_COMMENT=		SMTP mail relay
 PLUGIN_DEPENDS=		postfix-sasl
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/mail/postfix/pkg-descr
+++ b/mail/postfix/pkg-descr
@@ -6,6 +6,11 @@ is completely different.
 Plugin Changelog
 ================
 
+
+1.13
+
+* Allow setting IP version for connecting to rspamd
+
 1.12
 
 * Fix sort order to put sender acces in front of recipient access

--- a/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/antispam.xml
+++ b/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/antispam.xml
@@ -5,4 +5,10 @@
         <type>checkbox</type>
         <help>This will allow Postfix to connect to rspamd via milter protocol.</help>
     </field>
+    <field>
+        <id>antispam.milter_rspamd</id>
+        <label>Milter IP Version</label>
+        <type>dropdown</type>
+        <help>Select the IP version for connecting to rspamd.</help>
+    </field>
 </form>

--- a/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Antispam.xml
+++ b/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Antispam.xml
@@ -8,7 +8,7 @@
             <Required>Y</Required>
         </enable_rspamd>
         <milter_rspamd type="OptionField">
-            <default>Option1</default>
+            <default>6</default>
             <Required>Y</Required>
             <OptionValues>
                 <Option1 value="6">IPv6</Option1>

--- a/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Antispam.xml
+++ b/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Antispam.xml
@@ -7,5 +7,13 @@
             <default>0</default>
             <Required>Y</Required>
         </enable_rspamd>
+        <milter_rspamd type="OptionField">
+            <default>Option1</default>
+            <Required>Y</Required>
+            <OptionValues>
+                <Option1 value="6">IPv6</Option1>
+                <Option2 value="4">IPv4</Option2>
+            </OptionValues>
+        </milter_rspamd>
     </items>
 </model>

--- a/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Antispam.xml
+++ b/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Antispam.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/postfix/antispam</mount>
     <description>Postfix Antispam configuration</description>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <items>
         <enable_rspamd type="BooleanField">
             <default>0</default>

--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
@@ -117,7 +117,7 @@ smtp_sasl_security_options =
 {% if helpers.exists('OPNsense.postfix.antispam.enable_rspamd') and OPNsense.postfix.antispam.enable_rspamd == '1' %}
 smtpd_milters = inet:localhost:11332
 non_smtpd_milters = inet:localhost:11332
-milter_protocol = 6
+milter_protocol = {{ OPNsense.postfix.antispam.milter_rspamd }}
 milter_mail_macros =  i {mail_addr} {client_addr} {client_name} {auth_authen}
 milter_default_action = accept
 {% endif %}


### PR DESCRIPTION
Closes #1591 

Currently WIP as I get an model upgrad error.
Anyone have an idea what's wrong?

```
Installed packages to be REMOVED:
        os-postfix-devel-1.13

Number of packages to be removed: 1
[1/1] Deinstalling os-postfix-devel-1.13...
[1/1] Deleting files for os-postfix-devel-1.13: 100%
Reloading plugin configuration
Installing os-postfix-devel-1.13...
Extracting os-postfix-devel-1.13: 100%
Stopping configd...done
Starting configd.
*** OPNsense\Postfix\Antispam Migration failed, check log for details
Keep version OPNsense\Postfix\Domain (1.0.1)
Keep version OPNsense\Postfix\General (1.2.4)
Keep version OPNsense\Postfix\Recipient (1.0.0)
Keep version OPNsense\Postfix\Recipientbcc (1.0.0)
Keep version OPNsense\Postfix\Sender (1.0.0)
Keep version OPNsense\Postfix\Senderbcc (1.0.0)
Keep version OPNsense\Postfix\Sendercanonical (1.0.0)
Keep version OPNsense\Postfix\Address (1.0.0)
Reloading plugin configuration
Configuring system logging...done.
Reloading template OPNsense/Postfix: OK

```


```
Dec  1 10:55:15 OPNsense config[29430]: [OPNsense\Postfix\Antispam:milter_rspamd] option not in list
Dec  1 10:55:15 OPNsense config[29430]: Model OPNsense\Postfix\Antispam can't be saved, skip ( Phalcon\Validation\Exception: [OPNsense\Postfix\Antispam:milter_rspamd] option not in list  in /usr/local/opnsense/mvc/app/models/OPNsense/Base/BaseModel.php:540 Stack trace: #0 /usr/local/opnsense/mvc/app/models/OPNsense/Base/BaseModel.php(648): OPNsense\Base\BaseModel->serializeToConfig() #1 /usr/local/opnsense/mvc/script/run_migrations.php(56): OPNsense\Base\BaseModel->runMigrations() #2 {main} )

```