### PR TITLE
net/frr: show bgp status for IPv4 and IPv6 in diagnostics

### DIFF
--- a/net/frr/src/opnsense/scripts/quagga/diag-bgp.sh
+++ b/net/frr/src/opnsense/scripts/quagga/diag-bgp.sh
@@ -5,7 +5,7 @@ case "$1" in
     vtysh -d bgpd -c "show ip bgp"
     ;;
   summary)
-    vtysh -d bgpd -c "show ip bgp summary"
+    vtysh -d bgpd -c "show bgp summary"
     ;;
   neighbor)
     vtysh -d bgpd -c "show ip bgp neighbors $2"


### PR DESCRIPTION
By omitting the parameter 'ip' vtysh shows IPv4 as well as IPv6 sessions.