### PR TITLE
security/acme-client: implement cloudflare token

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -192,7 +192,19 @@
     <field>
         <id>validation.dns_cf_key</id>
         <label>CF Key</label>
+        <type>password</type>
+    </field>
+    <field>
+        <id>validation.dns_cf_account_id</id>
+        <label>CF Account ID</label>
         <type>text</type>
+        <help>Can be found in the URI after loggin into the Cloudflare dashboard.</help>
+    </field>
+    <field>
+        <id>validation.dns_cf_token</id>
+        <label>CF API Token</label>
+        <type>password</type>
+        <help>The token needs "Read" access to Zone.Zone and "Edit" to Zone.DNS across "All zones from an account".</help>
     </field>
     <field>
         <label>ClouDNS</label>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -461,6 +461,12 @@
                 <dns_cf_key type="TextField">
                     <Required>N</Required>
                 </dns_cf_key>
+                <dns_cf_token type="TextField">
+                    <Required>N</Required>
+                </dns_cf_token>
+                <dns_cf_account_id type="TextField">
+                    <Required>N</Required>
+                </dns_cf_account_id>
                 <dns_cloudns_auth_id type="TextField">
                     <Required>N</Required>
                 </dns_cloudns_auth_id>

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -654,6 +654,9 @@ function run_acme_validation($certObj, $valObj, $acctObj)
             case 'dns_cf':
                 $proc_env['CF_Key'] = (string)$valObj->dns_cf_key;
                 $proc_env['CF_Email'] = (string)$valObj->dns_cf_email;
+                // FIXME Only one auth method should be present in ENV
+                $proc_env['CF_Token'] = (string)$valObj->dns_cf_token;
+                $proc_env['CF_Account_ID'] = (string)$valObj->dns_cf_account_id;
                 break;
             case 'dns_cloudns':
                 $proc_env['CLOUDNS_AUTH_ID'] = (string)$valObj->dns_cloudns_auth_id;


### PR DESCRIPTION
solves  #1477 #1614

I've tested this with mutiple domains on a testing env and my home environment, both 19.7.7. Seems to be functional.

Please do an honest review though, I feel this is dodgy at best. Esp. the hack in security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php would need some attention.