### PR TITLE
security/acme-client: release 1.29

### DIFF
--- a/security/acme-client/Makefile
+++ b/security/acme-client/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		acme-client
-PLUGIN_VERSION=		1.28
+PLUGIN_VERSION=		1.29
 PLUGIN_COMMENT=		Let's Encrypt client
 PLUGIN_MAINTAINER=	opnsense@moov.de
 PLUGIN_DEPENDS=		acme.sh py${PLUGIN_PYTHON}-dns-lexicon

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -185,26 +185,35 @@
         <style>table_dns table_dns_cf</style>
     </field>
     <field>
+        <label>Global API Key</label>
+        <type>header</type>
+    </field>
+    <field>
         <id>validation.dns_cf_email</id>
-        <label>CF E-Mail</label>
+        <label>E-Mail</label>
         <type>text</type>
+        <help>Use your CF account with full privileges. This is less secure, a API token should be used instead (see below).</help>
     </field>
     <field>
         <id>validation.dns_cf_key</id>
-        <label>CF Key</label>
+        <label>Key</label>
         <type>password</type>
+    </field>
+    <field>
+        <label>Restricted API Token</label>
+        <type>header</type>
     </field>
     <field>
         <id>validation.dns_cf_account_id</id>
         <label>CF Account ID</label>
         <type>text</type>
-        <help>Can be found in the URI after loggin into the Cloudflare dashboard.</help>
+        <help>Can be found in the URI after logging into the Cloudflare dashboard.</help>
     </field>
     <field>
         <id>validation.dns_cf_token</id>
         <label>CF API Token</label>
         <type>password</type>
-        <help>The token needs "Read" access to Zone.Zone and "Edit" to Zone.DNS across "All zones from an account".</help>
+        <help>The token needs "Read" access to Zone.Zone and "Edit" access to Zone.DNS across all zones from an account.</help>
     </field>
     <field>
         <label>ClouDNS</label>

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -187,6 +187,7 @@
     <field>
         <label>Global API Key</label>
         <type>header</type>
+        <style>table_dns table_dns_cf</style>
     </field>
     <field>
         <id>validation.dns_cf_email</id>
@@ -202,6 +203,7 @@
     <field>
         <label>Restricted API Token</label>
         <type>header</type>
+        <style>table_dns table_dns_cf</style>
     </field>
     <field>
         <id>validation.dns_cf_account_id</id>

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -940,7 +940,7 @@
         <label>ACME DNS</label>
         <type>header</type>
         <style>table_dns table_dns_acmedns</style>
-	</field>
+    </field>
     <field>
         <id>validation.dns_acmedns_user</id>
         <label>User</label>
@@ -961,5 +961,16 @@
         <label>Update URL</label>
         <type>text</type>
         <help>Specify the custom ACME DNS Update URL, i.e. https://auth.acme-dns.io/update (optional)</help>
+    </field>
+    <field>
+        <label>Variomedia</label>
+        <type>header</type>
+        <style>table_dns table_dns_variomedia</style>
+    </field>
+    <field>
+        <id>validation.dns_variomedia_key</id>
+        <label>API Key</label>
+        <type>password</type>
+        <help>You need to obtain your API key from variomedia's customer support.</help>
     </field>
 </form>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -406,6 +406,7 @@
                         <dns_selectel>selectel.com / selectel.ru domain API</dns_selectel>
                         <dns_servercow>Servercow API v1</dns_servercow>
                         <dns_unoeuro>UnoEuro API</dns_unoeuro>
+                        <dns_variomedia>Variomedia.de API</dns_variomedia>
                         <dns_vscale>Vscale API</dns_vscale>
                         <dns_yandex>Yandex PDD API</dns_yandex>
                         <dns_zilore>Zilore DNS API</dns_zilore>
@@ -823,6 +824,9 @@
                 <dns_acmedns_updateurl type="TextField">
                    <Required>N</Required>
                 </dns_acmedns_updateurl>
+                <dns_variomedia_key type="TextField">
+                   <Required>N</Required>
+                </dns_variomedia_key>
             </validation>
         </validations>
         <actions>

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -629,6 +629,12 @@ function run_acme_validation($certObj, $valObj, $acctObj)
         // Setup DNS hook:
         // Set required env variables, write secrets to files, etc.
         switch ((string)$valObj->dns_service) {
+            case 'dns_acmedns':
+                $proc_env['ACMEDNS_USERNAME'] = (string)$valObj->dns_acmedns_user;
+                $proc_env['ACMEDNS_PASSWORD'] = (string)$valObj->dns_acmedns_password;
+                $proc_env['ACMEDNS_SUBDOMAIN'] = (string)$valObj->dns_acmedns_subdomain;
+                $proc_env['ACMEDNS_UPDATE_URL'] = (string)$valObj->dns_acmedns_updateurl;
+                break;
             case 'dns_ad':
                 $proc_env['AD_API_KEY'] = (string)$valObj->dns_ad_key;
                 break;
@@ -754,6 +760,10 @@ function run_acme_validation($certObj, $valObj, $acctObj)
             case 'dns_gd':
                 $proc_env['GD_Key'] = (string)$valObj->dns_gd_key;
                 $proc_env['GD_Secret'] = (string)$valObj->dns_gd_secret;
+                break;
+            case 'dns_gdnsdk':
+                $proc_env['GDNSDK_Username'] = (string)$valObj->dns_gdnsdk_user;
+                $proc_env['GDNSDK_Password'] = (string)$valObj->dns_gdnsdk_password;
                 break;
             case 'dns_hostingde':
                 $proc_env['HOSTINGDE_ENDPOINT'] = (string)$valObj->dns_hostingde_server;
@@ -896,16 +906,6 @@ function run_acme_validation($certObj, $valObj, $acctObj)
                 break;
             case 'dns_zonomi':
                 $proc_env['ZM_Key'] = (string)$valObj->dns_zm_key;
-                break;
-            case 'dns_gdnsdk':
-                $proc_env['GDNSDK_Username'] = (string)$valObj->dns_gdnsdk_user;
-                $proc_env['GDNSDK_Password'] = (string)$valObj->dns_gdnsdk_password;
-                break;
-            case 'dns_acmedns':
-                $proc_env['ACMEDNS_USERNAME'] = (string)$valObj->dns_acmedns_user;
-                $proc_env['ACMEDNS_PASSWORD'] = (string)$valObj->dns_acmedns_password;
-                $proc_env['ACMEDNS_SUBDOMAIN'] = (string)$valObj->dns_acmedns_subdomain;
-                $proc_env['ACMEDNS_UPDATE_URL'] = (string)$valObj->dns_acmedns_updateurl;
                 break;
             default:
                 log_error("AcmeClient: invalid DNS-01 service specified: " . (string)$valObj->dns_service);

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -881,6 +881,9 @@ function run_acme_validation($certObj, $valObj, $acctObj)
                 $proc_env['UNO_Key'] = (string)$valObj->dns_uno_key;
                 $proc_env['UNO_User'] = (string)$valObj->dns_uno_user;
                 break;
+            case 'dns_variomedia':
+                $proc_env['VARIOMEDIA_API_TOKEN'] = (string)$valObj->dns_variomedia_key;
+                break;
             case 'dns_vscale':
                 $proc_env['VSCALE_API_KEY'] = (string)$valObj->dns_vscale_key;
                 break;

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -652,9 +652,10 @@ function run_acme_validation($certObj, $valObj, $acctObj)
                 $proc_env['AZUREDNS_CLIENTSECRET'] = (string)$valObj->dns_azuredns_clientsecret;
                 break;
             case 'dns_cf':
+                // Global API key (insecure)
                 $proc_env['CF_Key'] = (string)$valObj->dns_cf_key;
                 $proc_env['CF_Email'] = (string)$valObj->dns_cf_email;
-                // FIXME Only one auth method should be present in ENV
+                // Restricted API token (recommended)
                 $proc_env['CF_Token'] = (string)$valObj->dns_cf_token;
                 $proc_env['CF_Account_ID'] = (string)$valObj->dns_cf_account_id;
                 break;

--- a/security/acme-client/src/opnsense/service/templates/OPNsense/AcmeClient/lighttpd-acme-challenge.conf
+++ b/security/acme-client/src/opnsense/service/templates/OPNsense/AcmeClient/lighttpd-acme-challenge.conf
@@ -64,6 +64,11 @@ server.bind = "127.0.0.1"
 server.port = {{OPNsense.AcmeClient.settings.challengePort}}
 $SERVER["socket"]  == "127.0.0.1:{{OPNsense.AcmeClient.settings.challengePort}}" { }
 
+{% if helpers.exists('system.ipv6allow') and system.ipv6allow|default("0") == "1" %}
+# IPv6
+$SERVER["socket"]  == "[::1]:{{OPNsense.AcmeClient.settings.challengePort}}" { }
+{% endif %}
+
 # to help the rc.scripts
 server.pid-file = "/var/run/lighttpd-acme-challenge.pid"
 


### PR DESCRIPTION
## New features
- add support for CloudFlare token (#1625)
- add support for MailinaBox DNS API (#1531)
- add support for Plesk XML API (#1567)
- add support for Variomedia DNS API

## Bugfixes
- fix IPv6 support for "automatic port forward" validation method (#1590)

## Enhancements
- validate IPv4 and IPv6 addresses before using them for "automatic port forward"
- enable IPv6 support on local ACME webservice (when `system.ipv6allow` is enabled)