### PR TITLE
Clarify purpose of ID httpserver.ca

### DIFF
--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/httpserver.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/httpserver.xml
@@ -94,7 +94,7 @@
   </field>
   <field>
     <id>httpserver.ca</id>
-    <label>CA Certificate</label>
+    <label>Client CA Certificate</label>
     <type>dropdown</type>
   </field>
   <field>


### PR DESCRIPTION
The existing description of "CA Certificate" is confusing, in that it implies the user should select the Certificate Authority responsible for generating their SSL pem (e.g. LetsEncrypt), whereas the parameter is solely used to specify the CA used for verifying Client Certificates. While this might be acceptable in self-signed scenarios where users have the appropriate keys to generate a client CA, it's unfortunately not the case for production SSL certs.