### PR TITLE
dns/bind: enable xmlrpc sync

### DIFF
--- a/dns/bind/src/etc/inc/plugins.inc.d/bind.inc
+++ b/dns/bind/src/etc/inc/plugins.inc.d/bind.inc
@@ -53,3 +53,12 @@ function bind_services()
 
     return $services;
 }
+
+function bind_xmlrpc_sync()
+{
+    $result = array();
+    $result['id'] = 'bind';
+    $result['section'] = 'OPNsense.bind';
+    $result['description'] = gettext('BIND domain name service');
+    return array($result);
+}


### PR DESCRIPTION
This patch allows to sync the BIND configuration to a secondary node in a OPNsense cluster.
I've tested it with slave zones only (but it should work with master zones too).