### PR TITLE
FIX - Sensor not starting without server enabled

### DIFF
--- a/security/maltrail/src/opnsense/service/templates/OPNsense/Maltrail/maltrail.conf
+++ b/security/maltrail/src/opnsense/service/templates/OPNsense/Maltrail/maltrail.conf
@@ -13,6 +13,8 @@ UDP_ADDRESS {{ OPNsense.maltrail.server.loglistenaddress }}
 {%   if helpers.exists('OPNsense.maltrail.server.loglistenport') and OPNsense.maltrail.server.loglistenport != '' %}
 UDP_PORT {{ OPNsense.maltrail.server.loglistenport }}
 {%   endif %}
+{% else %}
+HTTP_PORT {{ OPNsense.maltrail.server.listenport }}
 {% endif %}
 
 {% if helpers.exists('OPNsense.maltrail.sensor.enabled') and OPNsense.maltrail.sensor.enabled == '1' %}


### PR DESCRIPTION
Sensor now starts even with local server disabled.