### PR TITLE
net/vnstat: make plugin compatible to new v2 version

### DIFF
--- a/net/vnstat/Makefile
+++ b/net/vnstat/Makefile
@@ -1,6 +1,5 @@
 PLUGIN_NAME=		vnstat
-PLUGIN_VERSION=		1.1
-PLUGIN_REVISION=        1
+PLUGIN_VERSION=		1.2
 PLUGIN_COMMENT=		vnStat is a console-based network traffic monitor
 PLUGIN_DEPENDS=		vnstat
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net/vnstat/pkg-descr
+++ b/net/vnstat/pkg-descr
@@ -9,6 +9,10 @@ ensures light use of system resources.
 Plugin Changelog
 ================
 
+1.2
+
+* Remove Weekly statistics, unsupported since vnStat v2
+
 1.1
 
 * Add button to remove database

--- a/net/vnstat/pkg-descr
+++ b/net/vnstat/pkg-descr
@@ -12,6 +12,7 @@ Plugin Changelog
 1.2
 
 * Remove Weekly statistics, unsupported since vnStat v2
+* Reset of DB is required due to SQLite migration
 
 1.1
 

--- a/net/vnstat/src/opnsense/mvc/app/controllers/OPNsense/Vnstat/Api/ServiceController.php
+++ b/net/vnstat/src/opnsense/mvc/app/controllers/OPNsense/Vnstat/Api/ServiceController.php
@@ -68,17 +68,6 @@ class ServiceController extends ApiMutableServiceControllerBase
     }
 
     /**
-     * list weekly statistics
-     * @return array
-     */
-    public function weeklyAction()
-    {
-        $backend = new Backend();
-        $response = $backend->configdRun("vnstat weekly");
-        return array("response" => $response);
-    }
-
-    /**
      * list monthly statistics
      * @return array
      */

--- a/net/vnstat/src/opnsense/mvc/app/views/OPNsense/Vnstat/general.volt
+++ b/net/vnstat/src/opnsense/mvc/app/views/OPNsense/Vnstat/general.volt
@@ -30,7 +30,6 @@
     <li class="active"><a data-toggle="tab" href="#general">{{ lang._('General') }}</a></li>
     <li><a data-toggle="tab" href="#hourly">{{ lang._('Hourly Statistics') }}</a></li>
     <li><a data-toggle="tab" href="#daily">{{ lang._('Daily Statistics') }}</a></li>
-    <li><a data-toggle="tab" href="#weekly">{{ lang._('Weekly Statistics') }}</a></li>
     <li><a data-toggle="tab" href="#monthly">{{ lang._('Monthly Statistics') }}</a></li>
 </ul>
 
@@ -51,9 +50,6 @@
     <div id="daily" class="tab-pane fade in">
       <pre id="listdaily"></pre>
     </div>
-    <div id="weekly" class="tab-pane fade in">
-      <pre id="listweekly"></pre>
-    </div>
     <div id="monthly" class="tab-pane fade in">
       <pre id="listmonthly"></pre>
     </div>
@@ -70,11 +66,6 @@ function update_hourly() {
 function update_daily() {
     ajaxCall(url="/api/vnstat/service/daily", sendData={}, callback=function(data,status) {
         $("#listdaily").text(data['response']);
-    });
-}
-function update_weekly() {
-    ajaxCall(url="/api/vnstat/service/weekly", sendData={}, callback=function(data,status) {
-        $("#listweekly").text(data['response']);
     });
 }
 function update_monthly() {
@@ -95,7 +86,6 @@ $( document ).ready(function() {
     // Call function update_neighbor with a auto-refresh of 3 seconds
     setInterval(update_hourly, 3000);
     setInterval(update_daily, 3000);
-    setInterval(update_weekly, 3000);
     setInterval(update_monthly, 3000);
 
     $("#saveAct").click(function(){

--- a/net/vnstat/src/opnsense/service/conf/actions.d/actions_vnstat.conf
+++ b/net/vnstat/src/opnsense/service/conf/actions.d/actions_vnstat.conf
@@ -34,12 +34,6 @@ parameters:
 type:script_output
 message:request Vnstat daily status
 
-[weekly]
-command:/usr/local/bin/vnstat -w
-parameters:
-type:script_output
-message:request Vnstat weekly status
-
 [monthly]
 command:/usr/local/bin/vnstat -m
 parameters:


### PR DESCRIPTION
Removed weekly, added a note for wiping DB in plugin changelog