### PR TITLE
[www/nginx] Add `url` and `urltable` to trusted-proxy-alias dropdown

### DIFF
--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
@@ -646,7 +646,7 @@
             <items>aliases.alias</items>
             <display>name</display>
             <filters>
-              <type>/^(host|network)$/</type>
+              <type>/^(host|network|url|urltable)$/</type>
             </filters>
           </template>
         </Model>


### PR DESCRIPTION
Quick fix adding the url and urltable alias types to the dropdown selecting trusted-proxy firewall aliasses in NGINX.

As discussed here:
https://forum.opnsense.org/index.php?topic=14617.msg71645#msg71645

Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>