### PR TITLE
net-mgmt/net-snmp: allow to call opnsense-version via snmp

### DIFF
--- a/net-mgmt/net-snmp/Makefile
+++ b/net-mgmt/net-snmp/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		net-snmp
-PLUGIN_VERSION=		1.3
+PLUGIN_VERSION=		1.4
 PLUGIN_COMMENT=		Net-SNMP is a daemon for the SNMP protocol
 PLUGIN_DEPENDS=		net-snmp
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net-mgmt/net-snmp/pkg-descr
+++ b/net-mgmt/net-snmp/pkg-descr
@@ -6,3 +6,11 @@ Net-SNMP is a suite of applications used to implement
 SNMP v1, SNMP v2c and SNMP v3 using both IPv4 and IPv6.
 
 WWW: http://www.net-snmp.org
+
+
+Plugin Changelog
+----------------
+
+1.4
+
+* Allow to set the OPNsense version as SysDesc

--- a/net-mgmt/net-snmp/pkg-descr
+++ b/net-mgmt/net-snmp/pkg-descr
@@ -13,4 +13,4 @@ Plugin Changelog
 
 1.4
 
-* Allow to set the OPNsense version as SysDesc
+* Include installed version number in extended OID

--- a/net-mgmt/net-snmp/src/opnsense/mvc/app/controllers/OPNsense/Netsnmp/forms/general.xml
+++ b/net-mgmt/net-snmp/src/opnsense/mvc/app/controllers/OPNsense/Netsnmp/forms/general.xml
@@ -30,10 +30,10 @@
         <help>Make this device visible as Layer 3 enabled.</help>
     </field>
     <field>
-        <id>general.sysdesc</id>
-        <label>Manipulate SysDesc</label>
+        <id>general.versionoid</id>
+        <label>Display Verion in OID</label>
         <type>checkbox</type>
-        <help>If enabled the SysDesc value will output the installed OPNsense version.</help>
+        <help>This let you fetch the current installed version via NET-SNMP-EXTEND-MIB::nsExtendOutput1Line."version"</help>
     </field>
     <field>
         <id>general.listen</id>

--- a/net-mgmt/net-snmp/src/opnsense/mvc/app/controllers/OPNsense/Netsnmp/forms/general.xml
+++ b/net-mgmt/net-snmp/src/opnsense/mvc/app/controllers/OPNsense/Netsnmp/forms/general.xml
@@ -33,7 +33,7 @@
         <id>general.versionoid</id>
         <label>Display Verion in OID</label>
         <type>checkbox</type>
-        <help>This let you fetch the current installed version via NET-SNMP-EXTEND-MIB::nsExtendOutput1Line."version"</help>
+        <help>This let you fetch the current installed version via .1.3.6.1.4.1.8072.1.3.2.3.1.2.7.118.101.114.115.105.111.110</help>
     </field>
     <field>
         <id>general.listen</id>

--- a/net-mgmt/net-snmp/src/opnsense/mvc/app/controllers/OPNsense/Netsnmp/forms/general.xml
+++ b/net-mgmt/net-snmp/src/opnsense/mvc/app/controllers/OPNsense/Netsnmp/forms/general.xml
@@ -30,6 +30,12 @@
         <help>Make this device visible as Layer 3 enabled.</help>
     </field>
     <field>
+        <id>general.sysdesc</id>
+        <label>Manipulate SysDesc</label>
+        <type>checkbox</type>
+        <help>If enabled the SysDesc value will output the installed OPNsense version.</help>
+    </field>
+    <field>
         <id>general.listen</id>
         <label>Listen IPs</label>
         <style>tokenize</style>

--- a/net-mgmt/net-snmp/src/opnsense/mvc/app/models/OPNsense/Netsnmp/General.xml
+++ b/net-mgmt/net-snmp/src/opnsense/mvc/app/models/OPNsense/Netsnmp/General.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/netsnmp/general</mount>
     <description>Netsnmp configuration</description>
-    <version>1.0.1</version>
+    <version>1.0.3</version>
     <items>
         <enabled type="BooleanField">
             <default>0</default>
@@ -22,7 +22,14 @@
         <l3visibility type="BooleanField">
             <default>0</default>
             <Required>Y</Required>
-        </l3visibility>
+        </l3visibility>        
+        <sysdesc type="BooleanField">
+            <default>0</default>
+            <Required>Y</Required>
+        </sysdesc>
+        <opnsenseversion type="TextField">
+            <Required>N</Required>
+        </opnsenseversion>
         <listen type="NetworkField">
             <FieldSeparator>,</FieldSeparator>
             <Required>N</Required>

--- a/net-mgmt/net-snmp/src/opnsense/mvc/app/models/OPNsense/Netsnmp/General.xml
+++ b/net-mgmt/net-snmp/src/opnsense/mvc/app/models/OPNsense/Netsnmp/General.xml
@@ -23,13 +23,10 @@
             <default>0</default>
             <Required>Y</Required>
         </l3visibility>        
-        <sysdesc type="BooleanField">
+        <versionoid type="BooleanField">
             <default>0</default>
             <Required>Y</Required>
-        </sysdesc>
-        <opnsenseversion type="TextField">
-            <Required>N</Required>
-        </opnsenseversion>
+        </versionoid>
         <listen type="NetworkField">
             <FieldSeparator>,</FieldSeparator>
             <Required>N</Required>

--- a/net-mgmt/net-snmp/src/opnsense/service/conf/actions.d/actions_netsnmp.conf
+++ b/net-mgmt/net-snmp/src/opnsense/service/conf/actions.d/actions_netsnmp.conf
@@ -21,3 +21,9 @@ command:/usr/local/etc/rc.d/snmpd status;exit 0
 parameters:
 type:script_output
 message:request Net-SNMP status
+
+[version]
+command:/usr/local/sbin/opnsense-version
+parameters:
+type:script_output
+message:write OPNsense version to Net-SNMP

--- a/net-mgmt/net-snmp/src/opnsense/service/conf/actions.d/actions_netsnmp.conf
+++ b/net-mgmt/net-snmp/src/opnsense/service/conf/actions.d/actions_netsnmp.conf
@@ -21,9 +21,3 @@ command:/usr/local/etc/rc.d/snmpd status;exit 0
 parameters:
 type:script_output
 message:request Net-SNMP status
-
-[version]
-command:/usr/local/sbin/opnsense-version
-parameters:
-type:script_output
-message:write OPNsense version to Net-SNMP

--- a/net-mgmt/net-snmp/src/opnsense/service/templates/OPNsense/Netsnmp/snmpd.conf
+++ b/net-mgmt/net-snmp/src/opnsense/service/templates/OPNsense/Netsnmp/snmpd.conf
@@ -39,4 +39,8 @@ sysContact {{ OPNsense.netsnmp.general.syscontact }}
 sysServices 76
 {% endif %}
 
+{% if helpers.exists('OPNsense.netsnmp.general.versionoid') and OPNsense.netsnmp.general.versionoid == '1' %}
+extend    version   /usr/local/sbin/opnsense-version
+{% endif %}
+
 {% endif %}


### PR DESCRIPTION
Closes #1602 

Setting version in SysDesc is complicated as it needs a hook to update the config when updating opnsense itself. Better to just call the command and output in a separate OID