### PR TITLE
net-mgmt/telegraf: Add log parser to display logs correctly 

### DIFF
--- a/net-mgmt/telegraf/Makefile
+++ b/net-mgmt/telegraf/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		telegraf
-PLUGIN_VERSION=		1.7.6
+PLUGIN_VERSION=		1.7.7
 PLUGIN_COMMENT=		Agent for collecting metrics and data
 PLUGIN_DEPENDS=		telegraf
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net-mgmt/telegraf/pkg-descr
+++ b/net-mgmt/telegraf/pkg-descr
@@ -11,6 +11,9 @@ Kafka, MQTT, NSQ, and many others.
 Plugin Changelog
 ================
 
+1.7.7
+* Fix log not properly parsed
+
 1.7.6
 
 * Add 'Debug' and 'Quiet' setting

--- a/net-mgmt/telegraf/src/opnsense/scripts/systemhealth/logformats/telegraf.py
+++ b/net-mgmt/telegraf/src/opnsense/scripts/systemhealth/logformats/telegraf.py
@@ -1,0 +1,49 @@
+"""
+    Copyright (c) 2020 Ad Schellevis <ad@opnsense.org>
+    Copyright (c) 2020 devNan0 <nan0@nan0.dev>
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+"""
+import re
+import datetime
+from . import BaseLogFormat
+telegraf_timeformat = r'^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z).*'
+
+
+class TelegrafLogFormat(BaseLogFormat):
+    def __init__(self, filename):
+        super(TelegrafLogFormat, self).__init__(filename)
+        self._priority = 100
+
+    def match(self, line):
+        return self._filename.find('telegraf') > -1 and re.match(telegraf_timeformat, line) is not  None
+
+    @staticmethod
+    def timestamp(line):
+        tmp = re.match(telegraf_timeformat, line)
+        grp = tmp.group(1)
+        return datetime.datetime.strptime(grp, "%Y-%m-%dT%H:%M:%SZ").isoformat()
+
+    @staticmethod
+    def line(line):
+        return line[20:].strip()


### PR DESCRIPTION
Add log parser for upcoming feature in core.
This changes can already be merged and will take effect as soon as the core will be updated.

**Before**
![1582003733](https://user-images.githubusercontent.com/49376203/74707836-3c733800-521b-11ea-9c6d-4358fbe58824.png)

**After**
![1582003674](https://user-images.githubusercontent.com/49376203/74707868-485efa00-521b-11ea-9eb6-b5fcce418e8c.png)

**Additional context**
#1702 and opnsense/core#3941

**Special thanks to @AdSchellevis for making this possible**