### PR TITLE
phpDynDNS.inc: Fix missing break statement in switch case for Linode

### DIFF
--- a/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
+++ b/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
@@ -97,8 +97,8 @@
  *  dynv6 v6            - Last Tested: 25 June 2019
  *  DigitalOcean        - Last Tested: 25 June 2019
  *  Azure DNS           - Last Tested: 16 October 2019
- *  Linode              - Last Tested: 12 November 2019
- *  Linode v6           - Last Tested: 12 November 2019
+ *  Linode              - Last Tested: 25 February 2020
+ *  Linode v6           - Last Tested: 25 February 2020
  * +====================================================+
  *
  * @author    E.Kristensen
@@ -990,6 +990,7 @@ class updatedns
                 } else {
                     log_error("Dynamic DNS($fqdn): No zone found for domain");
                 }
+                break;
             case 'azurev6':
             case 'azure':
                 $hostname = "{$this->_dnsHost}";


### PR DESCRIPTION
Commit ab0ccc3be92ff4b716296d0d683cc0e1c8975030 seems to have mistakenly removed the `break` statement for the `switch` case for Linode. This commit adds it back, which fixes dynamic DNS updates for Linode.