### PR TITLE
DynDNS Custom Updater: Un-restrict Verify Peer & IPv4 Resolve

### DIFF
--- a/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
+++ b/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
@@ -733,15 +733,15 @@ class updatedns
                 break;
             case 'custom':
             case 'custom-v6':
+                if ($this->_curlIpresolveV4) {
+                    curl_setopt($ch, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
+                }
+                if ($this->_curlSslVerifypeer) {
+                    curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+                } else {
+                    curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+                }
                 if ($this->_dnsUser != '') {
-                    if ($this->_curlIpresolveV4) {
-                        curl_setopt($ch, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
-                    }
-                    if ($this->_curlSslVerifypeer) {
-                        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
-                    } else {
-                        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-                    }
                     curl_setopt($ch, CURLOPT_USERPWD, "{$this->_dnsUser}:{$this->_dnsPass}");
                 }
                 $server = str_replace("%IP%", $this->_dnsIP, $this->_dnsUpdateURL);


### PR DESCRIPTION
Verify peer and IP resolve have value aside from authentication.  For cases where authentication is not used it can still be desirable to confirm identity and prevent MITM.