### PR TITLE
dns/bind: Implement filter-aaaa

### DIFF
--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/general.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/general.xml
@@ -42,6 +42,26 @@
         <help>Set one or more hosts to send your DNS queries if the request is unknown.</help>
     </field>
     <field>
+        <id>general.filteraaaav4</id>
+        <label>Enable filter-aaaa on IPv4 Clients</label>
+        <type>checkbox</type>
+        <help>This will filter AAAA records on IPv4 Clients</help>
+    </field>
+    <field>
+        <id>general.filteraaaav6</id>
+        <label>Enable filter-aaaa on IPv6 Clients</label>
+        <type>checkbox</type>
+        <help>This will filter AAAA records on IPv6 Clients</help>
+    </field>
+    <field>
+        <id>general.filteraaaaacl</id>
+        <label>ACl for filter-aaaa</label>
+        <style>tokenize</style>
+        <type>select_multiple</type>
+        <allownew>true</allownew>
+        <help>Specifies a list of client addresses for which AAAA filtering is to be applied.</help>
+    </field>
+    <field>
         <id>general.logsize</id>
         <label>Logsize in MB</label>
         <type>text</type>

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/General.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/General.xml
@@ -36,6 +36,19 @@
             <Required>N</Required>
             <asList>Y</asList>
         </forwarders>
+        <filteraaaav4 type="BooleanField">
+            <default>0</default>
+            <Required>Y</Required>
+        </filteraaaav4>
+        <filteraaaav6 type="BooleanField">
+            <default>0</default>
+            <Required>Y</Required>
+        </filteraaaav6>
+        <filteraaaaacl type="NetworkField">
+            <FieldSeparator>,</FieldSeparator>
+            <Required>N</Required>
+            <asList>Y</asList>
+        </filteraaaaacl>
         <logsize type="IntegerField">
             <default>5</default>
             <Required>Y</Required>

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
@@ -143,3 +143,17 @@ logging {
         category lame-servers { null; };
 };
 {% endif %}
+
+{% if helpers.exists('OPNsense.bind.general.filteraaaav4') and OPNsense.bind.general.filteraaaav4 == '1' or helpers.exists('OPNsense.bind.general.filteraaaav6') and OPNsense.bind.general.filteraaaav6 == '1' %}
+plugin query "/usr/local/lib/filter-aaaa.so" {
+{% if helpers.exists('OPNsense.bind.general.filteraaaav4') and OPNsense.bind.general.filteraaaav4 == '1' %}
+                   filter-aaaa-on-v4 yes;
+{% endif %}
+{% if helpers.exists('OPNsense.bind.general.filteraaaav6') and OPNsense.bind.general.filteraaaav6 == '1' %}
+                   filter-aaaa-on-v6 yes;
+{% endif %}
+{% if helpers.exists('OPNsense.bind.general.filteraaaaacl') and OPNsense.bind.general.filteraaaaacl != '' %}
+        filter-aaaa    { {{ OPNsense.bind.general.filteraaaaacl.replace(',', '; ') }}; };
+{% endif %}
+           };
+{% endif %}


### PR DESCRIPTION
Applying the named config according to http://www.manpagez.com/man/8/filter-aaaa/ since we're using bind914 which already supports plugins