### PR TITLE
security/maltrail: switch python version

### DIFF
--- a/security/maltrail/Makefile
+++ b/security/maltrail/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		maltrail
-PLUGIN_VERSION=		1.3
+PLUGIN_VERSION=		1.4
 PLUGIN_COMMENT=		Malicious traffic detection system
 PLUGIN_DEPENDS=		maltrail
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/security/maltrail/pkg-descr
+++ b/security/maltrail/pkg-descr
@@ -11,6 +11,10 @@ WWW: https://github.com/stamparm/maltrail
 Changelog
 ---------
 
+1.4
+
+* Switch Python to version 3
+
 1.3
 
 * Fix a typo in model labeling preventing to use remote server logging

--- a/security/maltrail/src/etc/rc.d/opnsense-maltrailsensor
+++ b/security/maltrail/src/etc/rc.d/opnsense-maltrailsensor
@@ -14,7 +14,7 @@ name=maltrailsensor
 rcvar=maltrailsensor_enable
 pidfile=/var/run/${name}.pid
 command=/usr/sbin/daemon
-command_args="-f -P /var/run/maltrailsensor.pid python3.7 /usr/local/share/maltrail/sensor.py"
+command_args="-f -P /var/run/maltrailsensor.pid python3 /usr/local/share/maltrail/sensor.py"
 
 load_rc_config opnsense-maltrailsensor
 

--- a/security/maltrail/src/etc/rc.d/opnsense-maltrailsensor
+++ b/security/maltrail/src/etc/rc.d/opnsense-maltrailsensor
@@ -14,7 +14,7 @@ name=maltrailsensor
 rcvar=maltrailsensor_enable
 pidfile=/var/run/${name}.pid
 command=/usr/sbin/daemon
-command_args="-f -P /var/run/maltrailsensor.pid python2.7 /usr/local/share/maltrail/sensor.py"
+command_args="-f -P /var/run/maltrailsensor.pid python3.7 /usr/local/share/maltrail/sensor.py"
 
 load_rc_config opnsense-maltrailsensor
 

--- a/security/maltrail/src/etc/rc.d/opnsense-maltrailserver
+++ b/security/maltrail/src/etc/rc.d/opnsense-maltrailserver
@@ -14,7 +14,7 @@ name=maltrailserver
 rcvar=maltrailserver_enable
 pidfile=/var/run/${name}.pid
 command=/usr/sbin/daemon
-command_args="-f -P /var/run/maltrailserver.pid python2.7 /usr/local/share/maltrail/server.py"
+command_args="-f -P /var/run/maltrailserver.pid python3.7 /usr/local/share/maltrail/server.py"
 
 load_rc_config opnsense-maltrailserver
 

--- a/security/maltrail/src/etc/rc.d/opnsense-maltrailserver
+++ b/security/maltrail/src/etc/rc.d/opnsense-maltrailserver
@@ -14,7 +14,7 @@ name=maltrailserver
 rcvar=maltrailserver_enable
 pidfile=/var/run/${name}.pid
 command=/usr/sbin/daemon
-command_args="-f -P /var/run/maltrailserver.pid python3.7 /usr/local/share/maltrail/server.py"
+command_args="-f -P /var/run/maltrailserver.pid python3 /usr/local/share/maltrail/server.py"
 
 load_rc_config opnsense-maltrailserver
 


### PR DESCRIPTION
Needed for maltrail 0.17