### PR TITLE
DynDNS: Check IP Services - Plugin

### DIFF
--- a/dns/checkip/Makefile
+++ b/dns/checkip/Makefile
@@ -1,0 +1,7 @@
+PLUGIN_NAME=		checkip
+PLUGIN_VERSION=		1.0
+PLUGIN_REVISION=	0
+PLUGIN_COMMENT=		Use alternate services to get current IP address for DynDNS and RFC2136.
+PLUGIN_MAINTAINER=	NOYB at github
+
+.include "../../Mk/plugins.mk"

--- a/dns/checkip/pkg-descr
+++ b/dns/checkip/pkg-descr
@@ -1,0 +1,9 @@
+Manage and test the check IP services used by Dynamic DNS and
+RFC2136 entries that have the "Use public IP" option enabled, 
+to obtain the current IP address.
+
+Features:
+  * Interface specific configurable check IP services.  The service with matching interface and IP version, or the one that is enabled as the default, will be used by Dynamic DNS and RFC2136 services to check IP addresses.
+  * Verify SSL peer option
+  * Service Authentication
+  * Service backend test facility

--- a/dns/checkip/src/etc/inc/plugins.inc.d/checkip.inc
+++ b/dns/checkip/src/etc/inc/plugins.inc.d/checkip.inc
@@ -1,0 +1,233 @@
+<?php
+
+/*
+ * Copyright (C) 2020 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+function checkip_enabled()
+{
+    // The class exists?
+    if (class_exists('OPNsense\DynDNS\CheckIP')) {
+        return true;
+    }
+
+    return false;
+}
+
+function checkip_services()
+{
+    $mdlCheckIPService = new OPNsense\DynDNS\CheckIP();
+
+    // Reveal the enabled default service name.
+    foreach (checkip_services_array() as $service => $node) {
+        if ($node['default']) {
+            $defaultsrvcname = $node['name'];
+            $defaultsrvcname .= ($service == 'FDS') ? ' (FDS)' : '';
+            break;
+        }
+    }
+
+    $defaultsrvcname = ($defaultsrvcname) ?: sprintf('<span style="color:red; background-color:yellow">%s</span>', gettext('no default service set'));
+
+    // Enabled and at least one service exists or the factory default service is enabled.
+    $srvc_exists = (
+        checkip_enabled() &&
+        (
+         is_array($mdlCheckIPService->service) ||
+         $mdlCheckIPService->factory_default_service->default
+        )
+    ) ? true : false;
+
+    $services[] = array(
+        'description' => sprintf(gettext('Check IP Services (%s)'), $defaultsrvcname),
+        'nocheck' => $srvc_exists,
+        'name' => 'checkip',
+    );
+
+    return $services;
+}
+
+function checkip_services_array()
+{
+    $mdlCheckIPService = new OPNsense\DynDNS\CheckIP();
+
+    // Get the check IP services.
+    $checkipservices = $mdlCheckIPService->service->getNodes();
+
+    // If this was initiated from either the DynDNS or RFC2136 plugin UI there may have been a write_config() call.
+    // Reload config and try again.
+    if (
+        empty($checkipservices)  ||
+        !is_array($checkipservices)
+       ) {
+        OPNsense\Core\Config::getInstance()->forceReload();
+        $mdlCheckIPService = new OPNsense\DynDNS\CheckIP();
+        $checkipservices = $mdlCheckIPService->service->getNodes();
+    }
+
+    // Include the factory default check IP service.
+    $checkipservices['FDS'] = $mdlCheckIPService->factory_default_service->getNodes();
+
+    return $checkipservices;
+}
+
+function checkip_service_use($checkipservices, $servicename = '', $int = 'wan', $ipver = 4)
+{
+    // Use the service specified by name.
+    // Else use the first service found with a matching interface and IP version assignment.
+    // Else use the enabled default service.
+    $family = ($ipver == 4 ? 'all' : ($ipver == 6 ? 'inet6' : 'all'));
+    foreach ($checkipservices as $i => $checkipservice) {
+
+        // Look for a check IP service interface that matches up with the "real" interface.
+        foreach (array_keys($checkipservice['interfaces']) as $checkip_service_interface) {
+            if (
+                $checkipservice['interfaces'][$checkip_service_interface]['selected'] &&
+                (
+                 $int == get_real_interface($checkip_service_interface, $family) ||
+                 $int == $checkip_service_interface    // For RFC2136 plugin; not using the "real" interface.
+                )
+               ) {
+                break;
+            }
+            $checkip_service_interface = '';
+        }
+
+        if ($checkipservice['name'] == $servicename) {
+            return $checkipservice;
+        }
+
+        if (
+            empty($servicename) &&
+            $checkipservice['interfaces'][$checkip_service_interface]['selected'] &&
+            $checkipservice['ipver']['ipver'.$ipver]['selected']
+           ) {
+            return $checkipservice;
+        }
+
+        if ($checkipservice['default']) {
+            $default_checkipservice = $checkipservice;
+        }
+    }
+
+    return $default_checkipservice;
+}
+
+function checkip_service($servicename = '', $int = 'wan', $ipver = 4)
+{
+    if (!checkip_enabled()) {
+        $status = gettext('Check IP services not available.');
+    } elseif (
+        !is_array($checkipservices = checkip_services_array()) ||
+        empty($checkipservices)
+       ) {
+        $status = gettext('No Check IP services defined.');
+    } elseif (
+        !is_array($checkipservice = checkip_service_use($checkipservices, $servicename, $int, $ipver)) ||
+        empty($checkipservice)
+       ) {
+        $status = sprintf(gettext('Check IP service %s not found and no default service is enabled.'), $servicename);
+    }
+
+    if ($status) {
+        log_error('CheckIP Plugin: Service Name: ' . $servicename . ', Interface: ' . $int . ', IP Version: ' . $ipver . ', Status: ' . $status);
+        return $status;
+    }
+
+    // Get the service parameters.
+       $hosttocheck = $checkipservice['url'];
+     $verifysslpeer = $checkipservice['verifysslpeer'];
+     $capture_regex = $checkipservice['capture_regex'];
+          $username = $checkipservice['username'];
+          $password = $checkipservice['password'];
+
+    foreach ($checkipservice['authtype'] as $authtype => $property) {
+        if ($property['selected']) {
+            break;
+        }
+        $authtype = '';
+    }
+
+    // Set and return the service parameters.
+    $curl_options[CURLOPT_URL] = $hosttocheck;
+    $curl_options[CURLOPT_HTTPAUTH] = CURLAUTH_NONE;
+    $curl_options[CURLOPT_SSL_VERIFYPEER] = (bool) $verifysslpeer;
+
+    // Set auth type and enforce secure connection when sending authentication credentials.
+    if (
+        !empty($username) ||
+        !empty($password)
+    ) {
+        switch ($authtype) {
+            case 'basic':
+                $curl_options[CURLOPT_HTTPAUTH] = CURLAUTH_BASIC;
+                break;
+            case 'digest':
+                $curl_options[CURLOPT_HTTPAUTH] = CURLAUTH_DIGEST;
+                break;
+            case 'gssnegotiate':
+                $curl_options[CURLOPT_HTTPAUTH] = CURLAUTH_GSSNEGOTIATE;
+                break;
+            case 'ntlm':
+                $curl_options[CURLOPT_HTTPAUTH] = CURLAUTH_NTLM;
+                break;
+        }
+        $curl_options[CURLOPT_SSL_VERIFYPEER] = true;
+        $curl_options[CURLOPT_USERPWD] = "{$username}:{$password}";
+    }
+
+    return array('curl_options' => $curl_options, 'capture_regex' => $capture_regex);
+}
+
+function checkip_service_test($servicename = '', $interface = 'wan', $ipver = 4)
+{
+    global $config;
+
+    $servicename = ($servicename == 'auto_select') ? '' : $servicename;
+
+    $family = ($ipver == 4 ? 'all' : ($ipver == 6 ? 'inet6' : 'all'));
+    $real_if = get_real_interface($interface, $family);
+
+    $if_descr = $config['interfaces'][$interface]['descr'];
+
+    $result = array(
+      'ServiceName' => ($servicename ?: gettext('selected by interface and IP version, or the enabled default service')), 
+        'Interface' => $if_descr . ' (' . $interface . ', ' . $real_if . ')', 
+        'IPVersion' => $ipver, 
+        'IPAddress' => checkip_service_get_dyndns_ip($real_if, $ipver, $servicename)
+    );
+
+    return $result;
+}
+
+function checkip_service_get_dyndns_ip($int, $ipver = 4, $servicename = '')
+{
+    $checkip = checkip_service($servicename, $int, $ipver);
+    if (!is_array($checkip['curl_options'])) {
+        return $checkip;
+    }
+
+    return get_dyndns_ip($int, $ipver, $checkip);
+}

--- a/dns/checkip/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/Api/CheckipServiceController.php
+++ b/dns/checkip/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/Api/CheckipServiceController.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ *    Copyright (C) 2015 Deciso B.V.
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+namespace OPNsense\DynDNS\Api;
+
+use OPNsense\Base\ApiControllerBase;
+use OPNsense\Core\Backend;
+
+/**
+ * Class ServiceController
+ * @package OPNsense\CheckIP
+ */
+class CheckIPServiceController extends ApiControllerBase
+{
+    /**
+     * test CheckIP service
+     */
+    public function testAction()
+    {
+        if ($this->request->isPost()) {
+            $this->sessionClose();
+
+            // Retrieve data from the form post.
+            $servicename = $this->request->getPost("servicename");
+            $interface = $this->request->getPost("interface");
+            $ipver = $this->request->getPost("ipver");
+
+            $backend = new Backend();
+
+            $result['function'] = "service test";
+            $result['result'] = json_decode(trim($backend->configdpRun('dynamicdns checkip test', array($servicename, $interface, $ipver))));
+            return $result;
+        } else {
+            return array('status' => 'failed');
+        }
+    }
+}

--- a/dns/checkip/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/Api/CheckipSettingsController.php
+++ b/dns/checkip/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/Api/CheckipSettingsController.php
@@ -1,0 +1,247 @@
+<?php
+
+/**
+ *    Copyright (C) 2015 Deciso B.V.
+ *    Copyright (C) 2017-2018 EURO-LOG AG
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+namespace OPNsense\DynDNS\Api;
+
+use OPNsense\Base\ApiMutableModelControllerBase;
+use OPNsense\Core\Config;
+use OPNsense\DynDNS\CheckIP;
+use OPNsense\Base\UIModelGrid;
+
+/**
+ * Class SettingsController
+ * @package OPNsense\CheckIP
+ */
+class CheckIPSettingsController extends ApiMutableModelControllerBase
+{
+    static protected $internalModelName = 'CheckIP';
+    static protected $internalModelClass = '\OPNsense\DynDNS\CheckIP';
+
+    /**
+     * list with valid model node types
+     */
+    private $nodeTypes = array('service');
+
+    /**
+     * query CheckIP settings
+     * @param $nodeType string
+     * @param $uuid string
+     * @return result array
+     */
+    public function getAction($nodeType = null, $uuid = null)
+    {
+        $result = array("result" => "failed");
+        if ($this->request->isGet() && $nodeType != null) {
+            $this->validateNodeType($nodeType);
+            $mdlCheckIPService = new CheckIP();
+            if ($uuid != null) {
+                $node = $mdlCheckIPService->getNodeByReference($nodeType . '.' . $uuid);
+            } else {
+                $node = $mdlCheckIPService->$nodeType->Add();
+            }
+            if ($node != null) {
+                $result['checkip'] = array($nodeType => $node->getNodes());
+                $result['result'] = 'ok';
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * set CheckIP properties
+     * @param $nodeType string
+     * @param $uuid string
+     * @return status array
+     */
+    public function setAction($nodeType = null, $uuid = null)
+    {
+        $result = array("result" => "failed", "validations" => array());
+        if ($this->request->isPost() && $this->request->hasPost("checkip") && $nodeType != null) {
+            $this->validateNodeType($nodeType);
+            $mdlCheckIPService = new CheckIP();
+            if ($uuid != null) {
+                $node = $mdlCheckIPService->getNodeByReference($nodeType . '.' . $uuid);
+            } else {
+                $node = $mdlCheckIPService->$nodeType->Add();
+            }
+            if ($node != null) {
+                $checkIPInfo = $this->request->getPost("checkip");
+
+                $node->setNodes($checkIPInfo[$nodeType]);
+
+                // perform validation
+                $valMsgs = $mdlCheckIPService->performValidation();
+                foreach ($valMsgs as $field => $msg) {
+                    $fieldnm = str_replace($node->__reference, "checkip." . $nodeType, $msg->getField());
+                    $result["validations"][$fieldnm] = $msg->getMessage();
+                }
+                if (empty($result["validations"])) {
+                    unset($result["validations"]);
+                    $result['result'] = 'ok';
+
+                    // If enabling this node, disable all others.  Only one service is to be enabled as the default.
+                    if ($node->default->__toString() == "1") {
+                        $this->disableAll($mdlCheckIPService, $nodeType);  // first disable all
+                        $node->default = "1";
+                    }
+
+                    $mdlCheckIPService->serializeToConfig();
+                    Config::getInstance()->save();
+                }
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * delete CheckIP settings
+     * @param $nodeType string
+     * @param $uuid string
+     * @return status array
+     */
+    public function delAction($nodeType = null, $uuid = null)
+    {
+        return $this->delBase($nodeType, $uuid);
+    }
+
+    /**
+     * toggle CheckIP items (enable/disable)
+     * @param $nodeType string
+     * @param $uuid string
+     * @return result array
+     */
+    public function toggleAction($nodeType = null, $uuid = null)
+    {
+        $result = array("result" => "failed");
+        if ($this->request->isPost() && $nodeType != null) {
+            $mdlCheckIPService = new CheckIP();
+            if ($uuid != null) {
+
+                if ($uuid == 'FDS') {
+                    $node = $mdlCheckIPService->factory_default_service;
+                } else {
+                    $node = $mdlCheckIPService->getNodeByReference($nodeType . '.' . $uuid);
+                }
+
+                if ($node != null) {    // toggle the service
+                    $default = $node->default->__toString();
+                    $this->disableAll($mdlCheckIPService, $nodeType);  // first disable all
+                    if (!$default) {    // toggle to default i.e. enabled state
+                        $node->default = "1";
+                    }
+                } else {
+                    $result['result'] = "not found";
+                }
+
+                if ($result['result'] != 'not found') {
+                    $mdlCheckIPService->serializeToConfig();
+                    Config::getInstance()->save();
+                    $result["result"] = "ok";
+                }
+
+            } else {
+                $result['result'] = "uuid not given";
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * search CheckIP settings
+     * @param $nodeType string
+     * @return result array
+     */
+    public function searchAction($nodeType = null)
+    {
+        $this->sessionClose();
+        if ($this->request->isPost() && $nodeType != null) {
+            $this->validateNodeType($nodeType);
+            $mdlCheckIPService = new CheckIP();
+
+            $grid = new UIModelGrid($mdlCheckIPService->$nodeType);
+            $fields = array("default", "name", "url", "capture_regex", "username", "password", "verifysslpeer", "description");
+            $grid = $grid->fetchBindRequest($this->request, $fields);
+
+            // Include the factory default check IP service.
+            $fds = $mdlCheckIPService->factory_default_service->getNodes();
+            $grid['rows'][] = ['uuid' => 'FDS'] + array_intersect_key($fds, array_flip($fields));
+
+            return $grid;
+        }
+    }
+
+    /**
+     * is_default (is at least one CheckIP service enabled as the default; FDS inclusive)
+     * @return result array
+     */
+    public function is_defaultAction($nodeType = null)
+    {
+        $is_default = false;
+        if ($nodeType != null) {
+            $mdlCheckIPService = new CheckIP();
+
+            $nodes = $mdlCheckIPService->$nodeType->getNodes();
+            foreach ($nodes as $nodeUuid => $node) {
+                $node = $mdlCheckIPService->getNodeByReference($nodeType . '.' . $nodeUuid);
+                $is_default = $node->default->__toString() == "1" ? true : $is_default;
+            }
+            $is_default = ($mdlCheckIPService->factory_default_service->default->__toString() == "1") ? true : $is_default;
+        }
+        return array('result' => $is_default);
+    }
+
+    /**
+     * validate nodeType
+     * @param $nodeType string
+     * @throws \Exception
+     */
+    private function validateNodeType($nodeType = null)
+    {
+        if (array_search($nodeType, $this->nodeTypes) === false) {
+            throw new \Exception('unknown nodeType: ' . $nodeType);
+        }
+    }
+
+    /**
+     * disable all CheckIP service items; FDS inclusive
+     * @param $nodeType string
+     * @param &$mdlCheckIPService reference
+     */
+    private function disableAll(&$mdlCheckIPService, $nodeType)
+    {
+        $nodes = $mdlCheckIPService->$nodeType->getNodes();
+        foreach ($nodes as $nodeUuid => $node) {
+            $node = $mdlCheckIPService->getNodeByReference($nodeType . '.' . $nodeUuid);
+            $node->default = "0";
+        }
+        $mdlCheckIPService->factory_default_service->default = "0";
+    }
+}

--- a/dns/checkip/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/Api/CheckipTestController.php
+++ b/dns/checkip/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/Api/CheckipTestController.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ *    Copyright (C) 2015 Deciso B.V.
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+namespace OPNsense\DynDNS\Api;
+
+use OPNsense\Base\ApiControllerBase;
+use OPNsense\DynDNS\CheckIP;
+use OPNsense\Core\Config;
+
+/**
+ * Class TestController Handles test settings related API actions for the Check IP module
+ * @package OPNsense\CheckIP
+ */
+class CheckIPTestController extends ApiControllerBase
+{
+    /**
+     * retrieve CheckIP test settings
+     * @param $nodeType string
+     * @return test settings array
+     */
+    public function getAction($nodeType = null)
+    {
+        $result = array("result" => "failed");
+        if ($this->request->isGet() && $nodeType == 'service') {
+
+            $mdlCheckIPService = new CheckIP();
+
+            // Get the factory default test settings.
+            $so = $mdlCheckIPService->factory_default_test->getNodes();
+
+            // Get the check IP services.
+            $nodes = $mdlCheckIPService->$nodeType->getNodes();
+
+            // Include the factory default check IP service.
+            $nodes['FDS'] = $mdlCheckIPService->factory_default_service->getNodes();
+
+            // Populate the service options.
+            if (is_array($nodes)) {
+                foreach ($nodes as $nodeUuid => $node) {
+                    $servicename = $node['name'];
+                    $selected = ($node['default'] == "1") ? 1 : 0;
+
+                    $suffix1 = ($nodeUuid == "FDS") ? " (" . gettext("FDS") . ")" : "";
+                    $suffix2 = ($node['default'] == "1") ? " (" . gettext("default") . ")" : "";
+
+                    $so[$nodeType][$servicename]['value'] = $servicename . $suffix1 . $suffix2;
+                    $so[$nodeType][$servicename]['selected'] = $selected;
+                }
+            }
+
+            $result['checkip']['test'] = $so;
+            $result['result'] = 'ok';
+        }
+        return $result;
+    }
+}

--- a/dns/checkip/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/CheckipController.php
+++ b/dns/checkip/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/CheckipController.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ *    Copyright (C) 2015 Deciso B.V.
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+namespace OPNsense\DynDNS;
+
+/**
+ * Class IndexController
+ * @package OPNsense\CheckIP
+ */
+class CheckIPController extends \OPNsense\Base\IndexController
+{
+    public function indexAction()
+    {
+        // pick the template to serve to our users.
+        $this->view->pick('OPNsense/DynDNS/checkip');
+        // fetch form data "service" in
+        $this->view->serviceForm = $this->getForm("checkip_service");
+        // fetch form data "test" in
+        $this->view->testForm = $this->getForm("checkip_test");
+    }
+}

--- a/dns/checkip/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/checkip_service.xml
+++ b/dns/checkip/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/checkip_service.xml
@@ -1,0 +1,74 @@
+<form>
+    <field>
+        <id>checkip.service.default</id>
+        <label>Default</label>
+        <type>checkbox</type>
+        <help>Sets this check IP service to be used as the default.</help>
+        <hint>Enable this service</hint>
+    </field>
+    <field>
+        <id>checkip.service.name</id>
+        <label>Name</label>
+        <type>text</type>
+        <help>The service name may only consist of the characters "a-z, A-Z, 0-9 and _". And may not be "DynDNS" (the factory default service).</help>
+        <hint>Enter a valid name</hint>
+    </field>
+    <field>
+        <id>checkip.service.url</id>
+        <label>URL</label>
+        <type>text</type>
+        <help>The service URL to use.</help>
+    </field>
+    <field>
+        <id>checkip.service.verifysslpeer</id>
+        <label>Verify SSL peer</label>
+        <type>checkbox</type>
+        <help>Verify that the certificate received from the server is valid and trusted by one of the installed certificate authorities (CA cert). Automatically enforced when sending authentication credentials.</help>
+    </field>
+    <field>
+        <id>checkip.service.capture_regex</id>
+        <label>Address capture regular expression</label>
+        <type>text</type>
+        <help>The regular expression to capture the returned IP address.<![CDATA[<br />Examples:<br />&emsp;&lt;body&gt;Current IP Address: (.*)&lt;/body&gt;<br />&emsp;^(.*)$]]></help>
+    </field>
+    <field>
+        <id>checkip.service.interfaces</id>
+        <label>Interfaces</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <help>The network interfaces to use this service on.</help>
+        <hint>Type or select interface.</hint>
+    </field>
+    <field>
+        <id>checkip.service.ipver</id>
+        <label>IP version</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <help>The IP versions to use this service with.</help>
+        <hint>Type or select IP version.</hint>
+    </field>
+    <field>
+        <id>checkip.service.username</id>
+        <label>Username</label>
+        <type>text</type>
+        <help>The username to authenticate with the service.</help>
+    </field>
+    <field>
+        <id>checkip.service.password</id>
+        <label>Password</label>
+        <type>password</type>
+        <help>The password to authenticate with the service.</help>
+    </field>
+    <field>
+        <id>checkip.service.authtype</id>
+        <label>Authentication type</label>
+        <type>dropdown</type>
+        <help>The authentication type to use for sending login credentials to the service.</help>
+    </field>
+    <field>
+        <id>checkip.service.description</id>
+        <label>Description</label>
+        <type>text</type>
+        <help>A description for administrative reference (not parsed).</help>
+    </field>
+</form>

--- a/dns/checkip/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/checkip_test.xml
+++ b/dns/checkip/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/checkip_test.xml
@@ -1,0 +1,23 @@
+<form>
+    <field>
+        <id>checkip.test.service</id>
+        <label>Service</label>
+        <type>dropdown</type>
+        <help><![CDATA[The Check IP service to test.<br>Or automatically select based on interface and IP version, or the enabled default service.]]></help>
+        <hint>Select check IP service.</hint>
+    </field>
+    <field>
+        <id>checkip.test.interface</id>
+        <label>Interface</label>
+        <type>dropdown</type>
+        <help>The network interface to use for the test.</help>
+        <hint>Select network interface.</hint>
+    </field>
+    <field>
+        <id>checkip.test.ipver</id>
+        <label>IP Version</label>
+        <type>dropdown</type>
+        <help>The Internet Protocol version to use for the test.</help>
+        <hint>Select IP version.</hint>
+    </field>
+</form>

--- a/dns/checkip/src/opnsense/mvc/app/models/OPNsense/DynDNS/ACL/ACL.xml
+++ b/dns/checkip/src/opnsense/mvc/app/models/OPNsense/DynDNS/ACL/ACL.xml
@@ -1,0 +1,10 @@
+<acl>
+   <page-services-checkip>
+      <name>WebCfg - Services: Check IP</name>
+      <description>Allow access to the 'Services: Check IP' page.</description>
+      <patterns>
+         <pattern>ui/DynDNS/CheckIP*</pattern>
+         <pattern>api/DynDNS/CheckIP*</pattern>
+      </patterns>
+   </page-services-checkip>
+</acl>

--- a/dns/checkip/src/opnsense/mvc/app/models/OPNsense/DynDNS/CheckIP.php
+++ b/dns/checkip/src/opnsense/mvc/app/models/OPNsense/DynDNS/CheckIP.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ *    Copyright (C) 2015 Deciso B.V.
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+namespace OPNsense\DynDNS;
+
+use OPNsense\Base\BaseModel;
+
+class CheckIP extends BaseModel
+{
+}

--- a/dns/checkip/src/opnsense/mvc/app/models/OPNsense/DynDNS/CheckIP.xml
+++ b/dns/checkip/src/opnsense/mvc/app/models/OPNsense/DynDNS/CheckIP.xml
@@ -1,0 +1,203 @@
+<model>
+   <mount>//OPNsense/DynDNS/CheckIP</mount>
+   <version>1.0.0</version>
+   <description>Check IP settings</description>
+   <items>
+      <factory_default_service>
+         <default type="BooleanField">
+            <Required>Y</Required>
+            <default>1</default>
+         </default>
+         <name type="TextField">
+            <Required>Y</Required>
+            <default>DynDNS</default>
+         </name>
+         <url type="TextField">
+            <Required>Y</Required>
+            <default>http://checkip.dyndns.org</default>
+         </url>
+         <verifysslpeer type="BooleanField">
+            <Required>Y</Required>
+            <default>0</default>
+         </verifysslpeer>
+         <capture_regex type="TextField">
+            <Required>Y</Required>
+            <default><![CDATA[<body>Current IP Address: (.*)</body>]]></default>
+         </capture_regex>
+         <interfaces type="InterfaceField">
+            <Required>N</Required>
+            <default></default>
+            <multiple>Y</multiple>
+            <filters>
+               <enable>/^(?!0).*$/</enable>
+            </filters>
+         </interfaces>
+         <ipver type="OptionField">
+            <Required>N</Required>
+            <default></default>
+            <multiple>Y</multiple>
+            <OptionValues>
+               <ipver4>4</ipver4>
+               <ipver6>6</ipver6>
+            </OptionValues>
+         </ipver>
+         <username type="TextField">
+            <Required>N</Required>
+            <default></default>
+         </username>
+         <password type="TextField">
+            <Required>N</Required>
+            <default></default>
+         </password>
+         <authtype type="OptionField">
+            <Required>N</Required>
+            <default></default>
+            <OptionValues>
+               <basic>Basic</basic>
+               <digest>Digest</digest>
+               <gssnegotiate>GSS Negotiate</gssnegotiate>
+               <ntlm>NTLM</ntlm>
+            </OptionValues>
+         </authtype>
+         <description type="TextField">
+            <Required>N</Required>
+            <default>Factory Default Service</default>
+         </description>
+      </factory_default_service>
+      <service type="ArrayField">
+         <default type="BooleanField">
+            <Required>Y</Required>
+            <default>0</default>
+         </default>
+         <name type="TextField">
+            <Required>Y</Required>
+            <default></default>
+            <mask>/(?!^DynDNS$)^([a-zA-Z0-9_]){0,255}$/u</mask>
+            <ValidationMessage>A valid service name is mandatory.</ValidationMessage>
+            <Constraints>
+               <check001>
+                  <ValidationMessage>Service name must be unique.</ValidationMessage>
+                  <type>UniqueConstraint</type>
+               </check001>
+            </Constraints>
+         </name>
+         <url type="TextField">
+            <Required>Y</Required>
+            <default></default>
+            <ValidationMessage>A correctly formated URL is mandatory.</ValidationMessage>
+         </url>
+         <verifysslpeer type="BooleanField">
+            <Required>Y</Required>
+            <default>1</default>
+            <Constraints>
+               <check001>
+                  <ValidationMessage>Username/Password requires verify SSL peer.</ValidationMessage>
+                  <type>DependConstraint</type>
+                  <addFields>
+                     <field1>username</field1>
+                     <field2>password</field2>
+                  </addFields>
+               </check001>
+            </Constraints>
+         </verifysslpeer>
+         <capture_regex type="TextField">
+            <Required>Y</Required>
+            <default><![CDATA[<body>Current IP Address: (.*)</body>]]></default>
+            <ValidationMessage>An address capture regular expression is mandatory.</ValidationMessage>
+         </capture_regex>
+         <interfaces type="InterfaceField">
+            <Required>N</Required>
+            <default>wan</default>
+            <multiple>Y</multiple>
+            <filters>
+               <enable>/^(?!0).*$/</enable>
+            </filters>
+         </interfaces>
+         <ipver type="OptionField">
+            <Required>N</Required>
+            <default></default>
+            <multiple>Y</multiple>
+            <OptionValues>
+               <ipver4>4</ipver4>
+               <ipver6>6</ipver6>
+            </OptionValues>
+         </ipver>
+         <username type="TextField">
+            <Required>N</Required>
+            <default></default>
+            <Constraints>
+               <check001>
+                  <reference>verifysslpeer.check001</reference>
+               </check001>
+               <check002>
+                  <reference>authtype.check001</reference>
+               </check002>
+            </Constraints>
+         </username>
+         <password type="TextField">
+            <Required>N</Required>
+            <default></default>
+            <Constraints>
+               <check001>
+                  <reference>verifysslpeer.check001</reference>
+               </check001>
+               <check002>
+                  <reference>authtype.check001</reference>
+               </check002>
+            </Constraints>
+         </password>
+         <authtype type="OptionField">
+            <Required>N</Required>
+            <default></default>
+            <OptionValues>
+               <basic>Basic</basic>
+               <digest>Digest</digest>
+               <gssnegotiate>GSS Negotiate</gssnegotiate>
+               <ntlm>NTLM</ntlm>
+            </OptionValues>
+            <Constraints>
+               <check001>
+                  <ValidationMessage>Username/Password requires authentication type.</ValidationMessage>
+                  <type>DependConstraint</type>
+                  <addFields>
+                     <field1>username</field1>
+                     <field2>password</field2>
+                  </addFields>
+               </check001>
+            </Constraints>
+         </authtype>
+         <description type="TextField">
+            <Required>N</Required>
+            <default></default>
+            <mask>/^.{1,255}$/u</mask>
+            <ValidationMessage>Description too long.  Upto 255 characters.</ValidationMessage>
+         </description>
+      </service>
+      <factory_default_test>
+         <service type="OptionField">
+            <Required>Y</Required>
+            <default>auto_select</default>
+            <OptionValues>
+               <auto_select>Auto Select Service</auto_select>
+            </OptionValues>
+         </service>
+         <interface type="InterfaceField">
+            <Required>Y</Required>
+            <default>wan</default>
+            <AddParentDevices>Y</AddParentDevices>
+            <filters>
+               <enable>/^(?!0).*$/</enable>
+               <type>/(?s)^((?!group).)*$/</type>
+            </filters>
+         </interface>
+         <ipver type="OptionField">
+            <Required>Y</Required>
+            <default>ipver4</default>
+            <OptionValues>
+               <ipver4>4</ipver4>
+               <ipver6>6</ipver6>
+            </OptionValues>
+         </ipver>
+      </factory_default_test>
+   </items>
+</model>

--- a/dns/checkip/src/opnsense/mvc/app/models/OPNsense/DynDNS/Menu/Menu.xml
+++ b/dns/checkip/src/opnsense/mvc/app/models/OPNsense/DynDNS/Menu/Menu.xml
@@ -1,0 +1,5 @@
+<menu>
+   <Services>
+      <CheckIP VisibleName="Check IP" url="/ui/dyndns/checkip" cssClass="fa fa-tags fa-fw"/>
+   </Services>
+</menu>

--- a/dns/checkip/src/opnsense/mvc/app/views/OPNsense/DynDNS/checkip.volt
+++ b/dns/checkip/src/opnsense/mvc/app/views/OPNsense/DynDNS/checkip.volt
@@ -1,0 +1,209 @@
+{#
+
+OPNsense® is Copyright © 2014 – 2015 by Deciso B.V.
+Copyright © 2017-2018 by EURO-LOG AG
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1.  Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2.  Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+#}
+
+<script>
+
+$( document ).ready(function() {
+
+  /**
+   * service settings
+   **/
+
+  $("#grid-services").UIBootgrid({
+    'search':'/api/dyndns/checkip_settings/search/service/',
+    'get':'/api/dyndns/checkip_settings/get/service/',
+    'set':'/api/dyndns/checkip_settings/set/service/',
+    'add':'/api/dyndns/checkip_settings/set/service/',
+    'del':'/api/dyndns/checkip_settings/del/service/',
+    'toggle':'/api/dyndns/checkip_settings/toggle/service/'
+  });
+
+  // Determine if at least one service is enabled as the default.  Allow, but warn if not.
+  function is_service_default() {
+    ajaxCall(url="/api/dyndns/checkip_settings/is_default/service/", sendData={}, callback=function(data,status) {
+      if (status == 'success' && data['result']) {
+         $("#responseMsg").css({'background-color': '', 'color': ''});
+         $("#responseMsg").addClass('hidden');
+         $("#responseMsg").html('');
+      } else {
+         $("#responseMsg").html("<b>{{ lang._('WARNING') }}: </b>{{ lang._('There is no default check IP service enabled!') }}");
+         $("#responseMsg").css({'background-color': 'yellow', 'color': 'red'});
+         $("#responseMsg").removeClass('hidden');
+      }
+    });
+  }
+
+  // Apply changes to the DOM
+  function dom_update() {
+    // suppress FDS selection checkbox and command buttons, and keep unselected
+    $('table#grid-services tbody tr[data-row-id="FDS"]').each(function() {
+      $(this).find('td.select-cell input.select-box').addClass('hidden');
+      $(this).find('td button').filter('.command-edit,.command-copy,.command-delete').addClass('hidden');
+      $(this).find('td.select-cell input.select-box').prop('checked', false);
+      $(this).attr('aria-selected', false);
+      $(this).removeClass('active');
+    });
+  }
+
+  // DOM observer
+  var targetNode = document.querySelector('table#grid-services tbody');
+  var config = { childList: true };
+  var callback = function() {
+    dom_update();
+    is_service_default();
+  };
+  var observer = new MutationObserver(callback);
+  observer.observe(targetNode, config);
+
+  $('div#services').removeClass('hidden');
+
+
+  /**
+   * service test
+   */
+
+  $('[data-toggle][href="#test"]').click(function(){
+    $('#full_help_button').addClass('hidden');
+    var data_get_map = {'frm_TestSettings':"/api/dyndns/checkip_test/get/service/"};
+    mapDataToFormUI(data_get_map).done(function(data){
+      // place actions to run after load, for example update form styles.
+        formatTokenizersUI();
+        $('.selectpicker').selectpicker('refresh');
+    });
+  });
+
+  $('#btn_test').off('click').click(function(){
+    $('#btn_test_progress').addClass("fa fa-spinner fa-pulse");
+
+    var formData = {
+      'servicename' : $('#checkip\\.test\\.service').val(),
+      'interface' : $('#checkip\\.test\\.interface').val(),
+      'ipver' : $('#checkip\\.test\\.ipver').val(),
+    };
+
+    ajaxCall(url="/api/dyndns/checkip_service/test", sendData=formData, callback=function(data,status) {
+      $('#btn_test_progress').removeClass("fa fa-spinner fa-pulse");
+      $('#btn_test').blur();
+
+      var col1_span = '<span style="display:inline-block; width:6em; text-align:right; margin-right:1em"><b>';
+      var col1_naps = '</b></span>';
+
+      var responseMsg = '' +
+        col1_span + "{{ lang._(   'Service') }}:" + col1_naps + data['result']['ServiceName'] + '<br/>' +
+        col1_span + "{{ lang._( 'Interface') }}:" + col1_naps + data['result']['Interface']   + '<br/>' +
+        col1_span + "{{ lang._('IP Version') }}:" + col1_naps + data['result']['IPVersion']   + '<br/>' +
+        col1_span + "{{ lang._('IP Address') }}:" + col1_naps + data['result']['IPAddress']   + '<br/>' +
+        '';
+
+      $("#responseMsg").html(responseMsg);
+      $("#responseMsg").css({'background-color': '', 'color': ''});
+      $("#responseMsg").removeClass("hidden");
+    });
+  });
+
+});
+
+</script>
+
+<div class="alert alert-info hidden" role="alert" id="responseMsg"></div>
+
+<ul class="nav nav-tabs" role="tablist" id="maintabs">
+  <li class="active"><a data-toggle="tab" href="#services">{{ lang._('Service Settings') }}</a></li>
+  <li><a data-toggle="tab" href="#test">{{ lang._('Service Test') }}</a></li>
+</ul>
+
+<div class="tab-content content-box">
+
+  <div id="services" class="tab-pane fade in active hidden">
+
+    <table id="grid-services" class="table table-condensed table-hover table-striped table-responsive" data-editDialog="DialogEditService">
+      <thead>
+        <tr>
+          <th data-column-id="default" data-width="6em" data-type="string" data-formatter="rowtoggle" data-css-class="text-center" data-header-css-class="text-center">{{ lang._('Default') }}</th>
+          <th data-column-id="name" data-width="6em" data-type="string" data-formatter="hyperlink">{{ lang._('Name') }}</th>
+          <th data-column-id="url" data-width="24em" data-type="string" data-formatter="hyperlink" data-visible="false" data-sortable="false">{{ lang._('URL') }}</th>
+          <th data-column-id="verifysslpeer" data-width="9em" data-type="string" data-formatter="boolean-show-true" data-css-class="text-center" data-header-css-class="text-center">{{ lang._('Verify SSL Peer') }}</th>
+          <th data-column-id="description" data-width="15em" data-type="string">{{ lang._('Description') }}</th>
+          <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
+          <th data-column-id="commands" data-width="8em" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+      </tbody>
+      <tfoot>
+      <tr>
+        <td colspan="6"></td>
+          <td>
+            <button data-action="add" type="button" class="btn btn-xs btn-default"><span class="fa fa-plus"></span></button>
+            <button data-action="deleteSelected" type="button" class="btn btn-xs btn-default"><span class="fa fa-trash-o"></span></button>
+          </td>
+        </tr>
+      </tfoot>
+    </table>
+
+    <table class="table">
+      <tr>
+        <td><a id="help_for_services" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a></td>
+        <td>
+          <div class="hidden" data-for="help_for_services">
+              <p><?= htmlspecialchars(gettext('These services will be used to check IP addresses for Dynamic DNS services, and RFC 2136 entries that have the "Use public IP" option enabled.')) ?></p>
+              <p><?= htmlspecialchars(gettext('If a check IP service with a matching interface and IP version assignment is not found. The one enabled here as the default will be used.')) ?></p>
+              <p><?= htmlspecialchars(gettext('The server must return the client IP address as a string in the format of the "address capture regular expression" option that is specified in the service configuration.')) ?></p>
+              <hr/>
+                 <?= htmlspecialchars(gettext('Examples of address capture regular expression')) ?><br/>
+                 <?= htmlspecialchars(gettext('HTML containing address:')) ?>
+            <pre><?= htmlspecialchars('<body>Current IP Address: (.*)</body>') ?></pre>
+                 <?= htmlspecialchars(gettext('Text only address:')) ?>
+            <pre><?= htmlspecialchars('^(.*)$') ?></pre>
+              <hr/>
+                 <?= htmlspecialchars(gettext('Examples of server PHP')) ?><br/>
+                 <?= htmlspecialchars(gettext('HTML:')) ?>
+            <pre><?= htmlspecialchars('<html><head><title>Current IP Check</title></head><body>Current IP Address: <?=$_SERVER[\'REMOTE_ADDR\']?></body></html>') ?></pre>
+                 <?= htmlspecialchars(gettext('Text:')) ?>
+            <pre><?= htmlspecialchars('<?=$_SERVER[\'REMOTE_ADDR\']?>') ?></pre>
+          </div>
+        </td>
+      </tr>
+    </table>
+
+  </div>
+
+  <div id="test" class="tab-pane fade in">
+    {{ partial("layout_partials/base_form",['fields':testForm,'id':'frm_TestSettings'])}}
+
+    <div class="col-md-12">
+      <hr/>
+        <button style='margin-bottom: 1em;' class="btn btn-primary" id="btn_test" type="button"><b>{{ lang._('Test Service') }}</b><i id="btn_test_progress" class=""></i></button>
+    </div>
+  </div>
+
+</div>
+
+{# include dialogs #}
+{{ partial("layout_partials/base_dialog",['fields':serviceForm,'id':'DialogEditService','label':'Edit Service'])}}

--- a/dns/checkip/src/opnsense/scripts/OPNsense/DynDNS/checkip_test.php
+++ b/dns/checkip/src/opnsense/scripts/OPNsense/DynDNS/checkip_test.php
@@ -1,0 +1,41 @@
+#!/usr/local/bin/php
+<?php
+
+/**
+ *    Copyright (C) 2018 Deciso B.V.
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+require_once("config.inc");
+require_once("interfaces.inc");
+require_once("util.inc");
+require_once("plugins.inc.d/checkip.inc");
+
+$servicename = (isset($argv[1])) ? trim($argv[1], " \n")    : '';
+  $interface = (isset($argv[2])) ? trim($argv[2], " \n")    : 'wan';
+      $ipver = (isset($argv[3])) ? trim($argv[3], "ipver \n") : 4;
+
+echo json_encode(checkip_service_test($servicename, $interface, $ipver));

--- a/dns/checkip/src/opnsense/service/conf/actions.d/actions_dynamicdns.conf
+++ b/dns/checkip/src/opnsense/service/conf/actions.d/actions_dynamicdns.conf
@@ -1,0 +1,6 @@
+[checkip.test]
+command:/usr/local/opnsense/scripts/OPNsense/DynDNS/checkip_test.php
+description:Check IP Test
+parameters:%s %s %s
+type:script_output
+message:testing check ip service

--- a/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns.inc
+++ b/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns.inc
@@ -234,3 +234,13 @@ function dyndns_failover_interface($interface, $family = 'all')
     /* fall through to get real interface the hard way */
     return get_real_interface($interface, $family);
 }
+
+function dyndns_get_dyndns_ip($int, $ipver = 4, $servicename = '')
+{
+    if (stream_resolve_include_path('plugins.inc.d/checkip.inc')) {
+        require_once('plugins.inc.d/checkip.inc');
+        return checkip_service_get_dyndns_ip($int, $ipver, $servicename);
+    }
+
+    return get_dyndns_ip($int, $ipver);
+}

--- a/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
+++ b/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
@@ -1676,7 +1676,7 @@ class updatedns
 
     function _checkIP()
     {
-        $ip_address = get_dyndns_ip($this->_if, $this->_useIPv6 ? 6 : 4);
+        $ip_address = dyndns_get_dyndns_ip($this->_if, $this->_useIPv6 ? 6 : 4);
         if (!is_ipaddr($ip_address)) {
             if ($this->_dnsVerboseLog) {
                 log_error("Dynamic DNS ({$this->_dnsHost}): IP address could not be extracted");

--- a/dns/dyndns/src/www/services_dyndns.php
+++ b/dns/dyndns/src/www/services_dyndns.php
@@ -146,14 +146,14 @@ $main_buttons = array(
                       $filename = dyndns_cache_file($dyndns, 4);
                       $fdata = '';
                       if (file_exists($filename) && !empty($dyndns['enable'])) {
-                          $ipaddr = get_dyndns_ip(dyndns_failover_interface($dyndns['interface'], 'all'), 4);
+                          $ipaddr = dyndns_get_dyndns_ip(dyndns_failover_interface($dyndns['interface'], 'all'), 4);
                           $fdata = @file_get_contents($filename);
                       }
 
                       $filename_v6 = dyndns_cache_file($dyndns, 6);
                       $fdata6 = '';
                       if (file_exists($filename_v6) && !empty($dyndns['enable'])) {
-                          $ipv6addr = get_dyndns_ip(dyndns_failover_interface($dyndns['interface'], 'inet6'), 6);
+                          $ipv6addr = dyndns_get_dyndns_ip(dyndns_failover_interface($dyndns['interface'], 'inet6'), 6);
                           $fdata6 = @file_get_contents($filename_v6);
                       }
 

--- a/dns/dyndns/src/www/widgets/widgets/dyn_dns_status.widget.php
+++ b/dns/dyndns/src/www/widgets/widgets/dyn_dns_status.widget.php
@@ -48,14 +48,14 @@ if (!empty($_REQUEST['getdyndnsstatus'])) {
         $filename = dyndns_cache_file($dyndns, 4);
         $fdata = '';
         if (!empty($dyndns['enable']) && file_exists($filename)) {
-            $ipaddr = get_dyndns_ip(dyndns_failover_interface($dyndns['interface'], 'all'), 4);
+            $ipaddr = dyndns_get_dyndns_ip(dyndns_failover_interface($dyndns['interface'], 'all'), 4);
             $fdata = @file_get_contents($filename);
         }
 
         $filename_v6 = dyndns_cache_file($dyndns, 6);
         $fdata6 = '';
         if (!empty($dyndns['enable']) && file_exists($filename_v6)) {
-            $ipv6addr = get_dyndns_ip(dyndns_failover_interface($dyndns['interface'], 'inet6'), 6);
+            $ipv6addr = dyndns_get_dyndns_ip(dyndns_failover_interface($dyndns['interface'], 'inet6'), 6);
             $fdata6 = @file_get_contents($filename_v6);
         }
 

--- a/dns/rfc2136/src/etc/inc/plugins.inc.d/rfc2136.inc
+++ b/dns/rfc2136/src/etc/inc/plugins.inc.d/rfc2136.inc
@@ -173,7 +173,7 @@ EOD;
                 list($cachedipv4, $cacheTimev4) = array('', '');
             }
             if (isset($dnsupdate['usepublicip'])) {
-                $wanip = get_dyndns_ip($dnsupdate['interface'], 4);
+                $wanip = rfc2136_get_dyndns_ip($dnsupdate['interface'], 4);
             } else {
                 $wanip = get_interface_ip($dnsupdate['interface']);
             }
@@ -200,7 +200,7 @@ EOD;
                 list($cachedipv6, $cacheTimev6) = array('', '');
             }
             if (isset($dnsupdate['usepublicip'])) {
-                $wanipv6 = get_dyndns_ip($dnsupdate['interface'], 6);
+                $wanipv6 = rfc2136_get_dyndns_ip($dnsupdate['interface'], 6);
             } else {
                 $wanipv6 = get_interface_ipv6($dnsupdate['interface']);
             }
@@ -238,4 +238,14 @@ EOD;
     if ($verbose) {
         echo "done.\n";
     }
+}
+
+function rfc2136_get_dyndns_ip($int, $ipver = 4, $servicename = '')
+{
+    if (stream_resolve_include_path('plugins.inc.d/checkip.inc')) {
+        require_once('plugins.inc.d/checkip.inc');
+        return checkip_service_get_dyndns_ip($int, $ipver, $servicename);
+    }
+
+    return get_dyndns_ip($int, $ipver);
 }

--- a/dns/rfc2136/src/www/services_rfc2136.php
+++ b/dns/rfc2136/src/www/services_rfc2136.php
@@ -146,7 +146,7 @@ $main_buttons = array(
                         if (file_exists($filename) && !empty($rfc2136['enable']) && (empty($rfc2136['recordtype']) || $rfc2136['recordtype'] == 'A')) {
                             echo "IPv4: ";
                             if (isset($rfc2136['usepublicip'])) {
-                                $ipaddr = get_dyndns_ip($rfc2136['interface'], 4);
+                                $ipaddr = rfc2136_get_dyndns_ip($rfc2136['interface'], 4);
                             } else {
                                 $ipaddr = get_interface_ip($rfc2136['interface']);
                             }
@@ -167,7 +167,7 @@ $main_buttons = array(
                         if (file_exists($filename6) && !empty($rfc2136['enable']) && (empty($rfc2136['recordtype']) || $rfc2136['recordtype'] == 'AAAA')) {
                             echo "IPv6: ";
                             if (isset($rfc2136['usepublicip'])) {
-                                $ipaddr = get_dyndns_ip($rfc2136['interface'], 6);
+                                $ipaddr = rfc2136_get_dyndns_ip($rfc2136['interface'], 6);
                             } else {
                                 $ipaddr = get_interface_ipv6($rfc2136['interface']);
                             }

--- a/dns/rfc2136/src/www/widgets/widgets/rfc2136.widget.php
+++ b/dns/rfc2136/src/www/widgets/widgets/rfc2136.widget.php
@@ -49,14 +49,14 @@ if (!empty($_REQUEST['getrfc2136status'])) {
         $filename = rfc2136_cache_file($rfc2136, 4);
         $fdata = '';
         if (!empty($rfc2136['enable']) && (empty($rfc2136['recordtype']) || $rfc2136['recordtype'] == 'A') && file_exists($filename)) {
-            $ipaddr = get_dyndns_ip($rfc2136['interface'], 4);
+            $ipaddr = rfc2136_get_dyndns_ip($rfc2136['interface'], 4);
             $fdata = @file_get_contents($filename);
         }
 
         $filename_v6 = rfc2136_cache_file($rfc2136, 6);
         $fdata6 = '';
         if (!empty($rfc2136['enable']) && (empty($rfc2136['recordtype']) || $rfc2136['recordtype'] == 'AAAA') && file_exists($filename_v6)) {
-            $ipv6addr = get_dyndns_ip($rfc2136['interface'], 6);
+            $ipv6addr = rfc2136_get_dyndns_ip($rfc2136['interface'], 6);
             $fdata6 = @file_get_contents($filename_v6);
         }
 


### PR DESCRIPTION
Allow other, public and private, check IP services to be used.

Features:
  * Interface specific configurable check IP services.  The service with matching interface and IP version, or the one that is enabled as the default, will be used by Dynamic DNS and RFC2136 services to check IP addresses.
  * Verify SSL peer option
  * Service authentication support
  * Service backend test facility

Needs Check IP Services - plugin support (opnsense/core#3971)
Needs BootgridUI Formatters (opnsense/core#3971)

**Screen Shots:**

![1) Service Settings](https://user-images.githubusercontent.com/1977521/80299100-9a099080-8746-11ea-9193-905776154b47.jpg)

![2) Service Test](https://user-images.githubusercontent.com/1977521/80299314-4730d880-8748-11ea-9533-a8059592767e.jpg)

![3) Edit Service](https://user-images.githubusercontent.com/1977521/80299366-a262cb00-8748-11ea-892a-8888a0918295.jpg)
