### PR TITLE
security/tinc: Fix switch mode

### DIFF
--- a/security/tinc/src/opnsense/mvc/app/models/OPNsense/Tinc/Tinc.xml
+++ b/security/tinc/src/opnsense/mvc/app/models/OPNsense/Tinc/Tinc.xml
@@ -43,7 +43,7 @@
                     <FieldSeparator>,</FieldSeparator>
                     <Constraints>
                         <check001>
-                            <ValidationMessage>This field must be set in router mode.</ValidationMessage>
+                            <ValidationMessage>Subnet field must be set in router mode.</ValidationMessage>
                             <type>SetIfConstraint</type>
                             <field>mode</field>
                             <check>router</check>
@@ -77,6 +77,11 @@
                       <router>router</router>
                       <switch>switch</switch>
                   </OptionValues>
+                  <Constraints>
+                      <check001>
+                          <reference>subnet.check001</reference>
+                      </check001>
+                  </Constraints>
                 </mode>
                 <PMTUDiscovery type="BooleanField">
                     <default>1</default>

--- a/security/tinc/src/opnsense/mvc/app/models/OPNsense/Tinc/Tinc.xml
+++ b/security/tinc/src/opnsense/mvc/app/models/OPNsense/Tinc/Tinc.xml
@@ -37,10 +37,18 @@
                     <WildcardEnabled>N</WildcardEnabled>
                 </intaddress>
                 <subnet type="NetworkField">
-                    <Required>Y</Required>
+                    <Required>N</Required>
                     <WildcardEnabled>N</WildcardEnabled>
                     <NetMaskRequired>Y</NetMaskRequired>
                     <FieldSeparator>,</FieldSeparator>
+                    <Constraints>
+                        <check001>
+                            <ValidationMessage>This field must be set in router mode.</ValidationMessage>
+                            <type>SetIfConstraint</type>
+                            <field>mode</field>
+                            <check>router</check>
+                        </check001>
+                    </Constraints>
                 </subnet>
                 <pingtimeout type="IntegerField">
                     <Required>Y</Required>
@@ -123,7 +131,7 @@
                     <mask>/^([0-9a-zA-Z\.,_\-:]){0,1024}$/u</mask>
                 </extaddress>
                 <subnet type="NetworkField">
-                    <Required>Y</Required>
+                    <Required>N</Required>
                     <WildcardEnabled>N</WildcardEnabled>
                     <NetMaskRequired>Y</NetMaskRequired>
                     <FieldSeparator>,</FieldSeparator>

--- a/security/tinc/src/opnsense/scripts/OPNsense/Tinc/lib/objects.py
+++ b/security/tinc/src/opnsense/scripts/OPNsense/Tinc/lib/objects.py
@@ -123,7 +123,6 @@ class Host(NetwConfObject):
     def __init__(self):
         super(Host, self).__init__()
         self._connectTo = "0"
-        self._payload['subnet'] = None
         self._payload['pubkey'] = None
         self._payload['cipher'] = None
 
@@ -139,9 +138,10 @@ class Host(NetwConfObject):
     def config_text(self):
         result = list()
         result.append('Address=%(address)s %(port)s'%self._payload)
-        networks = self._payload['subnet'].split(',')
-        for network in networks:
-            result.append('Subnet=%s' % network)
+        if 'subnet' in self._payload:
+            networks = self._payload['subnet'].split(',')
+            for network in networks:
+                result.append('Subnet=%s' % network)
         result.append('Cipher=%(cipher)s'%self._payload)
         result.append('Digest=sha256')
         result.append(self._payload['pubkey'])

--- a/security/tinc/src/opnsense/scripts/OPNsense/Tinc/tincd.py
+++ b/security/tinc/src/opnsense/scripts/OPNsense/Tinc/tincd.py
@@ -110,11 +110,11 @@ def deploy(config_filename):
 if len(sys.argv) > 1:
     if sys.argv[1] == 'stop':
         for instance in glob.glob('/usr/local/etc/tinc/*'):
-            proc_cat = subprocess.Popen(['cat', '%s/tinc.conf' % instance], stdout=subprocess.PIPE)
-            proc_grep = subprocess.Popen(['grep', 'Device='], stdin=proc_cat.stdout, stdout=subprocess.PIPE)
-            interface_name = proc_grep.communicate()[0].decode('utf-8').rstrip('\n').split('/')[-1]
             subprocess.run(['/usr/local/sbin/tincd','-n',instance.split('/')[-1], '-k'])
-            subprocess.run(['/sbin/ifconfig',interface_name,'destroy'])
+            if os.path.exists('%s/tinc.conf' % instance):
+                interface_name  = open('%s/tinc.conf' % instance).read().split('Device=')[-1].split()[0].split('/')[-1]
+                if interface_name.startswith('tinc'):
+                    subprocess.run(['/sbin/ifconfig',interface_name,'destroy'])
     elif sys.argv[1] == 'start':
         for netwrk in deploy('/usr/local/etc/tinc_deploy.xml'):
             subprocess.run(['/usr/local/sbin/tincd','-n',netwrk.get_network(), '-R', '-d', netwrk.get_debuglevel()])

--- a/security/tinc/src/opnsense/scripts/OPNsense/Tinc/tincd.py
+++ b/security/tinc/src/opnsense/scripts/OPNsense/Tinc/tincd.py
@@ -110,7 +110,11 @@ def deploy(config_filename):
 if len(sys.argv) > 1:
     if sys.argv[1] == 'stop':
         for instance in glob.glob('/usr/local/etc/tinc/*'):
+            proc_cat = subprocess.Popen(['cat', '%s/tinc.conf' % instance], stdout=subprocess.PIPE)
+            proc_grep = subprocess.Popen(['grep', 'Device='], stdin=proc_cat.stdout, stdout=subprocess.PIPE)
+            interface_name = proc_grep.communicate()[0].decode('utf-8').rstrip('\n').split('/')[-1]
             subprocess.run(['/usr/local/sbin/tincd','-n',instance.split('/')[-1], '-k'])
+            subprocess.run(['/sbin/ifconfig',interface_name,'destroy'])
     elif sys.argv[1] == 'start':
         for netwrk in deploy('/usr/local/etc/tinc_deploy.xml'):
             subprocess.run(['/usr/local/sbin/tincd','-n',netwrk.get_network(), '-R', '-d', netwrk.get_debuglevel()])

--- a/security/tinc/src/opnsense/scripts/OPNsense/Tinc/tincd.py
+++ b/security/tinc/src/opnsense/scripts/OPNsense/Tinc/tincd.py
@@ -86,11 +86,14 @@ def deploy(config_filename):
 
         # write tinc-up file
         interface_address = network.get_local_address()
-        interface_family = "inet6" if ipaddress.ip_network(interface_address, False).version == 6 else "inet"
+        interface_network = ipaddress.ip_network(interface_address, False)
+        interface_family = "inet6" if interface_network.version == 6 else "inet"
+        interface_configd = "newipv6" if interface_network.version == 6 else "newip"
 
         if_up = list()
         if_up.append("#!/bin/sh")
-        if_up.append("ifconfig %s %s %s " % (interface_name, interface_family, pipes.quote(interface_address)))
+        if_up.append("ifconfig %s %s %s" % (interface_name, interface_family, pipes.quote(interface_address)))
+        if_up.append("configctl interface %s %s" % (interface_configd, interface_name))
         write_file("%s/tinc-up" % network.get_basepath(), '\n'.join(if_up) + "\n", 0o700)
 
         # configure and rename new tun device, place all in group "tinc" symlink associated tun device


### PR DESCRIPTION
**Background**

What I would like to achieve is a dual-stack ethernet bridge using Tinc (layer 2 VPN). Since it is completely possible using Tinc on Linux, it should be achievable in OPNsense.

**Current situation summary**
- [x] Router mode, IPv4 addresses only (possible before #1707)
- [x] Router mode, IPv6 addresses only (possible after #1707)
- [x] Switch mode, IPv4 addresses only (possible after this PR, commits 1 and 2)
- [x] Switch mode, IPv6 addresses only (possible after this PR, commits 1 and 2)
- [x] Any mode, dual-stack (see [#3972](https://github.com/opnsense/core/issues/3972), possible after this PR, commits 3 and 4)

**About this PR**

If I change Tinc mode from router (L3VPN) to switch (L2VPN), it wont start properly because irrelevant `subnet` variables are included in host configuration files. Before this commit I cannot leave them empty in OPNsense WebGUI. Commenting out these variables and restarting Tinc daemon from console fixes the problem.

Following [the official manual](https://www.tinc-vpn.org/documentation/tinc.pdf), `subnet` configuration variable seems to be used by Tinc for routing purposes in router mode. Although this field can also be a single MAC address which might be suitable for switch mode purposes, OPNsense does not currently support such an option.

This PR includes the following changes:
- Remove required flag from subnet fields
- Add a required constraint to network subnet field for router mode
- Relax validation and drafting mechanism for Tinc configration (only include subnet if not empty)

What could be further improved (but I have failed to implement):
- WebGUI: Support MAC value in subnet fields
- WebGUI: Hide/show subnet field when changing mode
- WebGUI: Make subnet field required in other hosts configuration when they are assigned to a router-mode network (a multi-level constraint, seems to be impossible in current architecture)