### PR TITLE
net/wol: add validation message + support for uppercase hex

### DIFF
--- a/net/wol/src/opnsense/mvc/app/models/OPNsense/Wol/Wol.xml
+++ b/net/wol/src/opnsense/mvc/app/models/OPNsense/Wol/Wol.xml
@@ -15,8 +15,9 @@
         <mac type="TextField">
             <Required>Y</Required>
             <multiple>N</multiple>
-            <mask>/^((?:[a-f0-9]{2}:){5}(?:[a-f0-9]{2}))$/</mask>
+            <mask>/^((?:[a-fA-F0-9]{2}:){5}(?:[a-fA-F0-9]{2}))$/</mask>
             <default>00:00:00:00:00:00</default>
+            <ValidationMessage>Should be 6 groups of 2 hex characters (a-fA-F0-9) separated by ':'</ValidationMessage>
         </mac>
         <descr type="TextField">
             <Required>N</Required>


### PR DESCRIPTION
Took me a while to figure out why the mac address of my computer
wasn't accepted. The added validation message will make it more
clear what's expected.

I have verified that wol will generate identical 'magic' packets
regardless if it is given a mac address with lower, upper or mixed case.