### PR TITLE
NUT plugin: Specify usernames for admin and monitor users in help text

### DIFF
--- a/sysutils/nut/src/opnsense/mvc/app/controllers/OPNsense/Nut/forms/settings.xml
+++ b/sysutils/nut/src/opnsense/mvc/app/controllers/OPNsense/Nut/forms/settings.xml
@@ -33,13 +33,13 @@
                 <id>nut.account.admin_password</id>
                 <label>Admin Password</label>
                 <type>text</type>
-                <help>Set the admin password.</help>
+                <help>Set the password for admin user "admin".</help>
             </field>
             <field>
                 <id>nut.account.mon_password</id>
                 <label>Monitor Password</label>
                 <type>text</type>
-                <help>Set the monitor password.</help>
+                <help>Set the password for monitoring user "monuser".</help>
             </field>
         </subtab>
     </tab>


### PR DESCRIPTION
The monitoring user created by the NUT plugin is named "monuser". While this can be found in the NUT documentation, it's not evident from the plugin's help text or UI. 

With this small change, the user gets a hint for the correct username. To be consistent, the change also spells out the username for the "admin" user. There might be other approaches but this seemed the most sensible one to have the information available when needed.