### PR TITLE
Fix issue #1759 - dnsbl.py

### DIFF
--- a/dns/unbound-plus/src/opnsense/scripts/OPNsense/Unboundplus/dnsbl.py
+++ b/dns/unbound-plus/src/opnsense/scripts/OPNsense/Unboundplus/dnsbl.py
@@ -86,11 +86,12 @@ def process_url(url):
     print(f"Processing BL items from: {url}")
 
     try:
-        http = urllib3.PoolManager()
-        r = http.request('GET', url)
+        http = urllib3.PoolManager(timeout=5.0)
+        r = http.request('GET', url, retries=2)
 
-        for line in str(r.data).split('\\n'):
-            parse_line(line)
+        if r.status == 200:
+            for line in str(r.data).split('\\n'):
+                parse_line(line)
     except Exception as e:
         print(str(e))
 
@@ -135,7 +136,8 @@ def load_whitelist():
     print("Loading whitelist")
     global re_whitelist
     wl = load_list('/var/unbound/etc/whitelist.inc', ',')
-    wl.add('.*localhost$')
+    wl.add(r'.*localhost$')
+    wl.add(r'^(?![a-zA-Z\d]).*') # Exclude domains NOT starting with alphanumeric char
     print(f"Loaded {len(wl)} whitelist items")
 
     try:


### PR DESCRIPTION
Fix for https://github.com/opnsense/plugins/issues/1759

* Restrict download timeout to 5 seconds and 2 retries. Parse only if HTTP response status is 200 OK.
* "Whitelist" (exclude) domains which aren't starting with alphanumeric char causing Unbound not to start.