### PR TITLE
Make doc for password more explicit, group options logically 

### DIFF
--- a/net/shadowsocks/src/opnsense/mvc/app/controllers/OPNsense/Shadowsocks/forms/local.xml
+++ b/net/shadowsocks/src/opnsense/mvc/app/controllers/OPNsense/Shadowsocks/forms/local.xml
@@ -18,6 +18,12 @@
         <help>Port of the remote server.</help>
     </field>
     <field>
+        <id>local.password</id>
+        <label>Password</label>
+        <type>text</type>
+        <help>Password to authenticate against at the remote server.</help>
+    </field>
+    <field>
         <id>local.localaddress</id>
         <label>Local Address</label>
         <type>text</type>
@@ -28,12 +34,6 @@
         <label>Local Port</label>
         <type>text</type>
         <help>The local port of the daemon, default is fine.</help>
-    </field>
-    <field>
-        <id>local.password</id>
-        <label>Password</label>
-        <type>text</type>
-        <help>Password to authenticate against the server.</help>
     </field>
     <field>
         <id>local.cipher</id>

--- a/net/shadowsocks/src/opnsense/mvc/app/controllers/OPNsense/Shadowsocks/forms/local.xml
+++ b/net/shadowsocks/src/opnsense/mvc/app/controllers/OPNsense/Shadowsocks/forms/local.xml
@@ -21,7 +21,7 @@
         <id>local.password</id>
         <label>Password</label>
         <type>text</type>
-        <help>Password to authenticate against at the remote server.</help>
+        <help>Password to authenticate against the remote server.</help>
     </field>
     <field>
         <id>local.localaddress</id>


### PR DESCRIPTION
It may be obvious to some, but I think there's some value in making it more explicit that the password required here is for the *remote* `shadowsocks` server and not for a connection to the local proxy. Furthermore, I would suggest moving the password in the form closer to the remove server info, to group them a bit more logically.

I am aware that the `shadowsocks` local config JSON has the same order of the fields as the form currently does, but regrouping makes it clearer in my view what the password is for. And then you could argue somebody who doesn't know what the password is for is probably not "fit" to use `shadowsocks` in the first place anyway.  