### PR TITLE
Nginx: Refactored "ngx_autoblock" to reduce cpu consumption

### DIFF
--- a/www/nginx/src/opnsense/scripts/nginx/ngx_autoblock.php
+++ b/www/nginx/src/opnsense/scripts/nginx/ngx_autoblock.php
@@ -42,6 +42,7 @@ function nginx_print_error($msg)
         array('status' => 'error', 'message' => $msg)
     );
 }
+
 function exec_hidden($command): void
 {
     $descriptorspec = array(
@@ -55,110 +56,243 @@ function exec_hidden($command): void
         proc_close($process);
     }
 }
-function add_to_blocklist($tablename, $ip)
+
+function modify_blocklist($tablename, array $allIps, $operation = "add"): void
 {
-    $escaped = escapeshellarg($ip);
-    exec_hidden("/sbin/pfctl -t ${tablename} -T add ${escaped}");
+    if (empty($allIps) || !in_array($operation, ["add", "delete"]))
+        return;
+
+    $tablename = escapeshellarg($tablename);
+    $operation = escapeshellarg($operation);
+
+    $longestIp = array_reduce($allIps, function ($length, $ip) {
+        return max($length, strlen(escapeshellarg($ip)));
+    }, 0);
+
+    $chunkSize = floor(4096 / ($longestIp + 1));
+    $chunkSize = min(128, max(4, $chunkSize));
+
+    foreach (array_chunk($allIps, $chunkSize) as $ips) {
+        $escapedIps = join(" ", array_map("escapeshellarg", $ips));
+
+        exec_hidden("/sbin/pfctl -t ${tablename} -T ${operation} ${escapedIps}");
+    }
 }
 
+function read_all_from_blocklist($tablename)
+{
+    $tablename = escapeshellarg($tablename);
+
+    $descriptorspec = [
+        1 => ['pipe', 'w'],
+        2 => ['file', "/dev/null", "w"],
+    ];
+
+    $process = proc_open("/sbin/pfctl -t ${tablename} -T show", $descriptorspec, $pipes);
+    if (is_resource($process)) {
+        $ips = [];
+        while ($ip = fgets($pipes[1], 96))
+            $ips[] = strtolower(trim($ip));
+
+        fclose($pipes[1]);
+        proc_close($process);
+
+        return $ips;
+    } else {
+        return false;
+    }
+}
+
+function get_files_lastmodified(array $files): array
+{
+    // Maps [file => filemtime]
+    // File times of special files:
+    // - Non existing => random mtime
+    // - No content => -1
+    $times = [];
+    foreach ($files as $file) {
+        $mtime = @filemtime($file) ?: rand();
+        $times[$file] = @filesize($file) === 0 ? -1 : $mtime;
+    }
+    return $times;
+}
 
 function reopen_logs()
 {
     exec_hidden('/usr/local/sbin/nginx -s reopen');
 }
 
-$permanent_ban_file = '/var/log/nginx/permanentban.access.log';
-$permanent_ban_file_work = $permanent_ban_file . '.work';
-$autoblock_alias_name = 'nginx_autoblock';
-define('CRON_RUN_TEN_MINUTES', 10);
-$is_ten_minutes = intval(date('i')) % CRON_RUN_TEN_MINUTES != 0;
+const STATE_FILE = '/tmp/ngx_autoblock.state.json';
+const CONFIG_FILE = '/conf/config.xml';
 
+const PERMANENT_BAN_FILE = '/var/log/nginx/permanentban.access.log';
+const PERMANENT_BAN_FILE_WORK = PERMANENT_BAN_FILE . '.work';
 
-if (!file_exists($permanent_ban_file)) {
+const TLS_HANDSHAKE_FILE = '/var/log/nginx/tls_handshake.log';
+const TLS_HANDSHAKE_FILE_WORK = TLS_HANDSHAKE_FILE . '.work';
+const TLS_HANDSHAKE_PROCESSING_TASK = '/usr/local/opnsense/scripts/nginx/tls_ua_fingerprint.php';
+
+const AUTOBLOCK_ALIAS_NAME = 'nginx_autoblock';
+
+const CRON_RUN_TEN_MINUTES = 10;
+$is_ten_minutes = intval(date('i')) % CRON_RUN_TEN_MINUTES == 0;
+
+// Abort if permanent ban file is missing
+if (!file_exists(PERMANENT_BAN_FILE)) {
     nginx_print_error('No Log exists - nothing to do');
     // let create it
     reopen_logs();
     exit(0);
 }
 
-// move the file, and inform nginx that we deleted the file
-rename($permanent_ban_file, $permanent_ban_file_work);
-if ($is_ten_minutes) {
-    rename('/var/log/nginx/tls_handshake.log', '/var/log/nginx/tls_handshake.log.work');
-}
-reopen_logs();
-if ($is_ten_minutes) {
-    mwexec_bg('/usr/local/opnsense/scripts/nginx/tls_ua_fingerprint.php');
-}
-
-$log_parser = new AccessLogParser($permanent_ban_file_work);
-
-$log_lines = $log_parser->get_result();
-
-$model = new Alias();
-
-$blacklist_element = null;
-foreach ($model->aliases->alias->iterateItems() as $alias) {
-    if ((string)$alias->name == $autoblock_alias_name) {
-        if ((string)$alias->type != 'external') {
-            nginx_print_error('alias is misconfigured - exiting');
-            exit(0);
-        } else {
-            $blacklist_element = $alias;
-            break;
-        }
-    }
-}
-
-// does not exist yet, create it
-if ($blacklist_element == null) {
-    $blacklist_element = $model->aliases->alias->Add();
-    $blacklist_element->name = $autoblock_alias_name;
-    $blacklist_element->type = "external";
-    $model->serializeToConfig();
-}
-
-$model = new Nginx();
-$alias_ips = [];
-foreach ($model->ban->iterateItems() as $entry) {
-    $alias_ips[] = (string)$entry->ip;
-}
-
-$new_ips = array_unique(
-    array_map(function ($row) {
-        if (stripos($row->remote_ip, '.') !== false) {
-            return $row->remote_ip;
-        }
-        // in case of IPv6, we have to use the network address instead
-        // danger of DoS because the attacker should have at least 2 ** 64 IPs
-        return Net_IPv6::getNetmask($row->remote_ip, 64) . '/64';
-    }, $log_lines)
-);
-
-$change_required = false;
-
-foreach (array_diff($new_ips, $alias_ips) as $new_ip) {
-    $entry = $model->ban->Add();
-    $entry->ip = $new_ip;
-    $entry->time = time();
-    $change_required = true;
-}
-
-if ($change_required) {
-    $val_result = $model->performValidation(false);
-    if (count($val_result) !== 0) {
-        print_r($val_result);
-        exit(1);
+// Move log files and inform Nginx that we deleted them
+function create_work_files($include_tls_handshake)
+{
+    rename(PERMANENT_BAN_FILE, PERMANENT_BAN_FILE_WORK);
+    if ($include_tls_handshake) {
+        rename(TLS_HANDSHAKE_FILE, TLS_HANDSHAKE_FILE_WORK);
     }
 
-    $model->serializeToConfig();
-    Config::getInstance()->save();
+    reopen_logs();
+
+    register_shutdown_function("cleanup_work_files");
 }
+
+function cleanup_work_files()
+{
+    @unlink(PERMANENT_BAN_FILE_WORK);
+}
+
+// Checking if our sources are modified and create work files as needed (do nothing if sources are unchanged)
+(function () use ($is_ten_minutes) {
+    $sources = get_files_lastmodified([CONFIG_FILE, PERMANENT_BAN_FILE]);
+
+    $state = @json_decode(@file_get_contents(STATE_FILE), true);
+    $changed = empty($state)
+        || !isset($state["sources"])
+        || $state["sources"] != $sources;
+
+    if ($changed || $is_ten_minutes) {
+        // Rename sources to ".work" and tell nginx to reopen logs.
+        create_work_files($is_ten_minutes);
+
+        // Store state
+        if (!is_array($state))
+            $state = [];
+        $state["sources"] = get_files_lastmodified(array_keys($sources));
+        @file_put_contents(STATE_FILE, json_encode($state));
+
+    } else {
+        // Sources are not modified, nothing to do when not in "$is_ten_minutes".
+        exit(0);
+    }
+})();
+
+// Triggering TLS-handshake processor every 10 minutes.
+if ($is_ten_minutes) {
+    mwexec_bg(TLS_HANDSHAKE_PROCESSING_TASK);
+}
+
+// Verifing autoblock fw-alias and adding it if missing
+(function () {
+    $model = new Alias();
+
+    $blacklist_element = null;
+    foreach ($model->aliases->alias->iterateItems() as $alias) {
+        if ((string)$alias->name == AUTOBLOCK_ALIAS_NAME) {
+            if ((string)$alias->type != 'external') {
+                nginx_print_error('alias is misconfigured - exiting');
+                exit(0);
+            } else {
+                $blacklist_element = $alias;
+                break;
+            }
+        }
+    }
+
+    // does not exist yet, create it
+    if ($blacklist_element == null) {
+        $blacklist_element = $model->aliases->alias->Add();
+        $blacklist_element->name = AUTOBLOCK_ALIAS_NAME;
+        $blacklist_element->type = "external";
+        $model->serializeToConfig();
+    }
+})();
+
+// Getting new banned IPs list
+$banned_ips = (function () {
+    // Reading stored banned IPs from config
+    $model = new Nginx();
+    $alias_ips = [];
+    foreach ($model->ban->iterateItems() as $entry) {
+        $alias_ips[] = (string)$entry->ip;
+    }
+
+    // Collecting all new IPs from ban file not yet in $alias_ips.
+    $new_ips = (function () use ($alias_ips) {
+        // Read IPs from the log file
+        $log_parser = new AccessLogParser(PERMANENT_BAN_FILE_WORK);
+        $log_lines = $log_parser->get_result();
+        $new_ips = array_unique(
+            array_map(function ($row) {
+                if (stripos($row->remote_ip, '.') !== false) {
+                    return $row->remote_ip;
+                }
+                // in case of IPv6, we have to use the network address instead
+                // danger of DoS because the attacker should have at least 2 ** 64 IPs
+                return Net_IPv6::getNetmask($row->remote_ip, 64) . '/64';
+            }, $log_lines)
+        );
+
+        // Return only IPs not yet in $alias_ips
+        return array_diff($new_ips, $alias_ips);
+    })();
+
+    // Transfering new IPs into $alias_ips and store them permanently.
+    $new_and_alias_ips = (function () use ($model, $new_ips, $alias_ips) {
+        $change_required = false;
+
+        foreach ($new_ips as $new_ip) {
+            $alias_ips[] = $new_ip;
+
+            $entry = $model->ban->Add();
+            $entry->ip = $new_ip;
+            $entry->time = time();
+            $change_required = true;
+        }
+
+        if ($change_required) {
+            $val_result = $model->performValidation(false);
+            if (count($val_result) !== 0) {
+                print_r($val_result);
+                exit(1);
+            }
+
+            $model->serializeToConfig();
+            Config::getInstance()->save();
+        }
+
+        return $alias_ips;
+    })();
+
+    // Returning banned IPs (= combination of (new_ips + alias_ips))
+    return $new_and_alias_ips;
+})();
+
 echo '{"status":"saved"}';
 
-// all ips are used because the others may not be set for some reason
-foreach ($model->ban->iterateItems() as $entry) {
-    add_to_blocklist($autoblock_alias_name, (string)$entry->ip);
-}
+// Updating PF table with banned IPs
+(function () use ($banned_ips) {
+    $ips_to_add = $banned_ips;
+    $ips_to_remove = [];
 
-@unlink($permanent_ban_file_work);
+    // Checking which IPs are in the table and apply changes
+    $ips_in_table = read_all_from_blocklist(AUTOBLOCK_ALIAS_NAME);
+    if (!empty($ips_in_table)) {
+        $ips_to_add = array_diff($banned_ips, $ips_in_table);
+        $ips_to_remove = array_diff($ips_in_table, $banned_ips);
+    }
+
+    modify_blocklist(AUTOBLOCK_ALIAS_NAME, $ips_to_add, "add");
+    modify_blocklist(AUTOBLOCK_ALIAS_NAME, $ips_to_remove, "delete");
+})();


### PR DESCRIPTION
This PR addresses a CPU consumption issues I have with "`ngx_autoblock.php`". The script dominates the top process list, it consumes more CPU than all other processes and it runs for almost 30 seconds (every minute).

### Environment:
* Latest Opnsense on Intel quad core.
* ~**955** banned IP addresses (collected over time in ~1 year)
* Average load 1.3 (prior) and 0.8 (after applying the changes)

### Performance:
**Original "`ngx_autoblock.php`" (24 seconds +- 3)**: 
```.sh
time /usr/local/opnsense/scripts/nginx/ngx_autoblock.php
7.557u 16.446s 0:24.03 99.8%	4390+1547k 0+0io 0pf+0w
```
**Updated "`ngx_autoblock.php`"**:

| Condition                      | Time results  |
| ---------------------  |:-------------:|
| Regular schedule with no changes | 0.690u 0.839s 0:01.55 |
| Every 10 minutes, no changes | 4.047u 5.147s 0:09.31 |
| Adding one IP from ban file to PF | 4.932u 6.848s 0:11.83 |
| Adding all IPs to PF | 3.861u 5.614s 0:09.84 |

The updated version is ~12 times faster for the regular schedule and still ~3 times faster for the full run "every 10 minutes".
**Note**: "*Adding one IP from ban file to PF*" is slower than "*Adding all IPs to PF*", since adding an IP from ban file updates the model.

### Hotspots
The profiler shows 2 hotspots:
* ~70% of the time is spent to execute "`pfctl ... -T add $singleIP`".
* ~30% of the time is spent for config loading & model parsing.

### Changes
* Monitoring sources for changes to see if an action is required.
  This saves time in both hotspots, model parsing and `pfctl` operations.
* Every 10 minutes the script runs regardless of the monitoring results to avoid missing changes e.g. done directly via `pfctl`.
*  `pfctl` is invoked with batches of multiple IPs. 
    This reduces the 70% hotspot to almost nothing.
* `pfctl` is used to read the contents of the table and incrementally sync the table to the desired state instead of always populating the full list of IPs.

### Fixes
- `$is_ten_minutes` triggered always except every 10 minutes. 
   Intended was likely to trigger every 10 minutes.
- IPs are not just added but also removed. Fixes possible race conditions between UI and script-invocation that may perfectly well happen due to the long runtime of the script.