### PR TITLE
security/acme-client: Added "fullchain" name-template to model & dialog

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogAction.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogAction.xml
@@ -134,6 +134,15 @@
         <advanced>true</advanced>
     </field>
     <field>
+        <id>action.sftp_filename_fullchain</id>
+        <label>Naming "fullchain.pem"</label>
+        <type>text</type>
+        <help>Name template for the public certificate fullchain file (cert + ca).
+            Placeholders "{{name}}" and "%s" are replaced by the name of the certificate being uploaded.
+            Leave blank to use default "{{name}}/fullchain.pem".</help>
+        <advanced>true</advanced>
+    </field>
+    <field>
         <label>Required Parameters</label>
         <type>header</type>
         <style>method_table method_table_configd</style>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -959,6 +959,12 @@
                     <ValidationMessage>Should be a string between 1 and 255 characters.
                                        Characters are limited to [a-z], [0-9] and [{}@./-_%] and the string must neither begin nor end with '/'.</ValidationMessage>
                 </sftp_filename_ca>
+                <sftp_filename_fullchain type="TextField">
+                    <Required>N</Required>
+                    <mask>/^(?![\/\\])[\w\d_\-@.\/{}%]{1,255}(?&lt;![\/\\])$/ui</mask>
+                    <ValidationMessage>Should be a string between 1 and 255 characters.
+                                       Characters are limited to [a-z], [0-9] and [{}@./-_%] and the string must neither begin nor end with '/'.</ValidationMessage>
+                </sftp_filename_fullchain>
                 <configd type="ConfigdActionsField">
                     <filters>
                         <description>/^(?!.*(Let\'s\ Encrypt|acme|[fF]irmware))([\S\s]{1,255})/</description>

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/upload_sftp.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/upload_sftp.php
@@ -120,7 +120,6 @@ const UPLOAD_NAME_TEMPLATES = [
     "key" => ["default" => "{{name}}/key.pem", "option" => "key-name"],
     "ca" => ["default" => "{{name}}/ca.pem", "option" => "ca-name"],
     "fullchain" => ["default" => "{{name}}/fullchain.pem", "option" => "fullchain-name"],
-
 ];
 
 // Exit codes


### PR DESCRIPTION
This is a small complementary change to [PR-1753](https://github.com/opnsense/plugins/pull/1753). It adds the ability to customise upload name & location of "fullchain.pem", similar to "cert", "key" and "ca" files.