### PR TITLE
Updating the snort rules snapshot version from 2990 to 2983

### DIFF
--- a/security/intrusion-detection-content-snort-vrt/src/opnsense/scripts/suricata/metadata/rules/snort-vrt.xml
+++ b/security/intrusion-detection-content-snort-vrt/src/opnsense/scripts/suricata/metadata/rules/snort-vrt.xml
@@ -123,6 +123,6 @@
 	</files>
 	<properties>
 		<property name="snort_vrt.oinkcode" default=""/>
-		<property name="snort_vrt.rulesfile" default="snortrules-snapshot-29111.tar.gz"/>
+		<property name="snort_vrt.rulesfile" default="snortrules-snapshot-2983.tar.gz"/>
 	</properties>
 </ruleset>

--- a/security/intrusion-detection-content-snort-vrt/src/opnsense/scripts/suricata/metadata/rules/snort-vrt.xml
+++ b/security/intrusion-detection-content-snort-vrt/src/opnsense/scripts/suricata/metadata/rules/snort-vrt.xml
@@ -123,6 +123,6 @@
 	</files>
 	<properties>
 		<property name="snort_vrt.oinkcode" default=""/>
-		<property name="snort_vrt.rulesfile" default="snortrules-snapshot-2990.tar.gz"/>
+		<property name="snort_vrt.rulesfile" default="snortrules-snapshot-3000.tar.gz"/>
 	</properties>
 </ruleset>

--- a/security/intrusion-detection-content-snort-vrt/src/opnsense/scripts/suricata/metadata/rules/snort-vrt.xml
+++ b/security/intrusion-detection-content-snort-vrt/src/opnsense/scripts/suricata/metadata/rules/snort-vrt.xml
@@ -123,6 +123,6 @@
 	</files>
 	<properties>
 		<property name="snort_vrt.oinkcode" default=""/>
-		<property name="snort_vrt.rulesfile" default="snortrules-snapshot-3000.tar.gz"/>
+		<property name="snort_vrt.rulesfile" default="snortrules-snapshot-29111.tar.gz"/>
 	</properties>
 </ruleset>


### PR DESCRIPTION
The 2990 snapshot is no longer available for downloading, from the website, as it returns HTTP 422 error code.

In: https://www.snort.org/downloads#rules & https://www.snort.org/eol