### PR TITLE
net/haproxy: release 2.22

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		haproxy
-PLUGIN_VERSION=		2.21
+PLUGIN_VERSION=		2.22
 PLUGIN_COMMENT=		Reliable, high performance TCP/HTTP load balancer
 PLUGIN_DEPENDS=		haproxy
 PLUGIN_MAINTAINER=	opnsense@moov.de

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -1388,7 +1388,7 @@
                         <src_http_req_cnt>Source IP: number of HTTP requests</src_http_req_cnt>
                         <src_http_req_rate>Source IP: rate of HTTP requests</src_http_req_rate>
                         <!-- <src_inc_gpc0>Source IP: increment the first General Purpose Counter</src_inc_gpc0> -->
-                        <src_sess_cnt>Source IP: cumulative number of connections</src_sess_cnt>
+                        <src_sess_cnt>Source IP: cumulative number of sessions</src_sess_cnt>
                         <src_sess_rate>Source IP: session rate</src_sess_rate>
                         <nbsrv>Minimum number of usable servers in backend</nbsrv>
                         <traffic_is_http>Traffic is HTTP</traffic_is_http>

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -1383,6 +1383,22 @@ backend {{backend.name}}
 {#             # server ssl communication #}
 {%             if server_data.ssl|default("") == '1' %}
 {%               do server_options.append('ssl') %}
+{#               # HTTP/2 #}
+{%               if backend.http2Enabled|default("") == '1' and backend.ba_advertised_protocols|default("") != "" %}
+{#                 # convert protocols to HAProxy-compatible format #}
+{%                 set alpn_options = backend.ba_advertised_protocols|replace('http10', 'http/1.0')|replace('http11', 'http/1.1') %}
+{%                 do server_options.append('alpn ' ~ alpn_options) %}
+{%               endif %}
+{#             # HTTP/2 without TLS #}
+{%             elif backend.http2Enabled|default("") == '1' and backend.http2Enabled_nontls|default("") == '1' %}
+{%               do server_options.append('proto h2') %}
+{%             endif %}
+{#             # ssl verification can be enabled for two reasons: #}
+{#             # 1. in server settings: to verify *all* communication to this server #}
+{#             # 2. in health checks: to verify *only* health check communication to this server #}
+{#             # When 1. is enabled, health checks are automatically secured. #}
+{#             # Use-case for 2: when using TCP for server communication, but HTTPS for health checks. #}
+{%             if server_data.ssl|default("") == '1' or (healthcheck_enabled == '1' and healthcheck_data.force_ssl|default('') == '1') %}
 {#               # get status of ssl verification #}
 {%               set ssl_verify_enabled = '0' %}
 {%               if helpers.exists('OPNsense.HAProxy.general.tuning.sslServerVerify') and OPNsense.HAProxy.general.tuning.sslServerVerify|default("") != 'ignore' %}
@@ -1410,15 +1426,6 @@ backend {{backend.name}}
 {%               else %}
 {%                 do server_options.append('verify none') %}
 {%               endif %}
-{#               # HTTP/2 #}
-{%               if backend.http2Enabled|default("") == '1' and backend.ba_advertised_protocols|default("") != "" %}
-{#                 # convert protocols to HAProxy-compatible format #}
-{%                 set alpn_options = backend.ba_advertised_protocols|replace('http10', 'http/1.0')|replace('http11', 'http/1.1') %}
-{%                 do server_options.append('alpn ' ~ alpn_options) %}
-{%               endif %}
-{#             # HTTP/2 without TLS #}
-{%             elif backend.http2Enabled|default("") == '1' and backend.http2Enabled_nontls|default("") == '1' %}
-{%               do server_options.append('proto h2') %}
 {%             endif %}
 {#             # source address #}
 {%             if backend.source|default("") != "" %}

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -1087,7 +1087,7 @@ frontend {{frontend.name}}
     http-request replace-header Cookie '^(.*?; )?({{backend_data.persistence_cookiename}}=)"([^;"]*)"(;.*)?$' \1\2\3\4
 {%         endif %}
 {%       endif %}
-{%       if frontend.forwardFor == '1' %}
+{%       if frontend.forwardFor == '1' and frontend.mode == 'http' %}
     option forwardfor
 {%       endif %}
     # tuning options

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -1119,7 +1119,7 @@ frontend {{frontend.name}}
 {%       endif %}
 {%       if frontend.logging_detailedLog=='1' %}
 {#         # automatically select the best-suited log type #}
-{%         if frontend.mode == 'tcp' %}
+{%         if frontend.mode == 'tcp' or frontend.mode == 'ssl' %}
     option tcplog
 {%         else %}
     option httplog

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -1414,6 +1414,9 @@ backend {{backend.name}}
 {#                 # check for SSL CA #}
 {%                 if server_data.sslCA|default("") != "" %}
 {%                   do server_options.append('ca-file /tmp/haproxy/ssl/' ~ server_data.id ~ '.calist') %}
+{%                 else %}
+{#                   # fallback to system CA Root Certificates #}
+{%                   do server_options.append('ca-file /etc/ssl/cert.pem') %}
 {%                 endif %}
 {#                 # check for SSL CRL #}
 {%                 if server_data.sslCRL|default("") != "" %}


### PR DESCRIPTION
**WARNING: The changes to the SSL verification settings may break existing configurations. Please test this change (or review the resulting haproxy.conf) before using it in production!**

## New features
- enable SSL verification for a server when "Force SSL" is enabled in the associated health check (#1761)
- use the systems local Root CA Certificates for SSL verification when no CA was selected (#1761)

## Bugfixes
- fix label of `src_sess_cnt` (#1780)
- fix invalid use of `option httplog` (resolves a warning in config test)
- fix invalid use of `option forwardfor` (resolves a warning in config test)

## Enhancements
none