### PR TITLE
security/acme-client: add support for dnsapi "Euserv.eu"

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -420,9 +420,9 @@
                 </dns_service>
                 <dns_sleep type="IntegerField">
                     <MinimumValue>1</MinimumValue>
-                    <MaximumValue>10000</MaximumValue>
+                    <MaximumValue>84600</MaximumValue>
                     <default>120</default>
-                    <ValidationMessage>Please specify a value between 1 and 10000.</ValidationMessage>
+                    <ValidationMessage>Please specify a value between 1 and 84600.</ValidationMessage>
                     <Required>Y</Required>
                 </dns_sleep>
                 <dns_ad_key type="TextField">

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -735,6 +735,7 @@ function run_acme_validation($certObj, $valObj, $acctObj)
             case 'dns_euserv':
                 $proc_env['EUSERV_Username'] = (string)$valObj->dns_euserv_user;
                 $proc_env['EUSERV_Password'] = (string)$valObj->dns_euserv_password;
+                $acme_hook_options[] = "--insecure";
                 break;
             case 'dns_freedns':
                 $proc_env['FREEDNS_User'] = (string)$valObj->dns_freedns_user;


### PR DESCRIPTION
Additional changes for https://github.com/opnsense/plugins/issues/1779

- added option "--insecure"
- increased maximum dns sleep time