### PR TITLE
wake_on_lan widget: find macs case-insensitive

### DIFF
--- a/net/wol/src/www/widgets/widgets/wake_on_lan.widget.php
+++ b/net/wol/src/www/widgets/widgets/wake_on_lan.widget.php
@@ -45,7 +45,7 @@ $wol = new Wol();
   <tbody>
 <?php
     foreach ($wol->wolentry->iterateItems() as $wolent):
-      $is_active = exec("/usr/sbin/arp -an |/usr/bin/grep {$wolent->mac}| /usr/bin/wc -l|/usr/bin/awk '{print $1;}'");?>
+      $is_active = exec("/usr/sbin/arp -an |/usr/bin/grep -i {$wolent->mac}| /usr/bin/wc -l|/usr/bin/awk '{print $1;}'");?>
     <tr>
         <td><?= !empty((string)$wolent->descr) ? $wolent->descr : gettext('Unnamed entry') ?><br/><?= $wolent->mac ?></td>
         <td><?=htmlspecialchars(convert_friendly_interface_to_friendly_descr((string)$wolent->interface));?></td>


### PR DESCRIPTION
Find mac addresses case-insensitive. When mac addresses are added, they are saved like the users enters them. If the user used upper-case letters, this results in showing the host offline in the dashboard, although it´s online. Other fix would be to make all mac inputs lowercase while saving.