### PR TITLE
dns/unbound-plus: fix DoT validations

### DIFF
--- a/dns/unbound-plus/src/opnsense/mvc/app/models/OPNsense/Unboundplus/Miscellaneous.xml
+++ b/dns/unbound-plus/src/opnsense/mvc/app/models/OPNsense/Unboundplus/Miscellaneous.xml
@@ -1,14 +1,14 @@
 <model>
     <mount>//OPNsense/unboundplus/miscellaneous</mount>
     <description>Unbound Miscellaneous configuration</description>
-    <version>0.0.2</version>
+    <version>0.0.3</version>
     <items>
         <privatedomain type="CSVListField">
             <Required>N</Required>
         </privatedomain>
         <dotservers type="CSVListField">
             <Required>N</Required>
-            <mask>/^[a-fA-F0-9\.\@]{1,46}$/</mask>
+            <mask>/^[a-fA-F0-9\.\,\:\@]{1,512}$/</mask>
         </dotservers>
     </items>
 </model>

--- a/dns/unbound-plus/src/opnsense/mvc/app/models/OPNsense/Unboundplus/Miscellaneous.xml
+++ b/dns/unbound-plus/src/opnsense/mvc/app/models/OPNsense/Unboundplus/Miscellaneous.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/unboundplus/miscellaneous</mount>
     <description>Unbound Miscellaneous configuration</description>
-    <version>0.0.3</version>
+    <version>0.0.2</version>
     <items>
         <privatedomain type="CSVListField">
             <Required>N</Required>


### PR DESCRIPTION
CSVListField needs comma for validator, also 46 chars is only one v6 address without shortening.