### PR TITLE
Added fix for updating apex domains (mydomain.com) with gratisdns

### DIFF
--- a/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
+++ b/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
@@ -820,7 +820,12 @@ class updatedns
             case 'gratisdns':
                 $server = "https://admin.gratisdns.com/ddns.php";
                 curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
-                list($hostname, $domain) = explode(".", $this->_dnsHost, 2);
+                if(substr_count($this->_dnsHost, ".") < 2) {
+                   $domain = $this->_dnsHost;
+                   $hostname = $this->_dnsHost;
+                } else {
+                   list($hostname, $domain) = explode(".", $this->_dnsHost, 2);
+                }
                 curl_setopt($ch, CURLOPT_URL, $server . '?u=' . urlencode($this->_dnsUser) . '&p=' . $this->_dnsPass . '&h=' . $this->_dnsHost . '&d=' . $domain . '&i=' . $this->_dnsIP);
                 break;
             case 'ovh-dynhost':


### PR DESCRIPTION
When updating an apex domain (like mydomain.com) it fails as the domain sent to gratisdns becomes just com. Both hostname and domain should in this case be mydomain.com. The current logic is based on updating a subname like www.mydomain.com in which case the domain part becomes correctly mydomain.com.