### PR TITLE
Fixed expected mime-type

### DIFF
--- a/www/nginx/src/opnsense/scripts/nginx/csp_report.php
+++ b/www/nginx/src/opnsense/scripts/nginx/csp_report.php
@@ -29,7 +29,7 @@
 $log_file = '/var/log/nginx/csp_violations.log';
 
 // make sure we don't have any formatting issues here
-if (stristr($_SERVER['CONTENT_TYPE'], 'json') === false) {
+if (stristr($_SERVER['CONTENT_TYPE'], 'csp-report') === false) {
     http_response_code(400);
     echo "This endpoint expects JSON data. Please send data using a json mime time (for example application/json)";
     exit(0);


### PR DESCRIPTION
Chrome and Firefox report CSP as application/csp-report and not application/json. This lead to HTTP 400 BAD REQUEST.
No csp logs were created. With this fix, the form is csp report is processed and written to logs.