### PR TITLE
www/nginx - newsyslog: added tls_handshake.log rotation

### DIFF
--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/newsyslog.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/newsyslog.conf
@@ -2,4 +2,5 @@
 {% if helpers.exists('OPNsense.Nginx') %}
 /var/log/nginx/*access.log   www:www     640     14       *      @T00     GZB      /var/run/nginx.pid       30
 /var/log/nginx/*error.log   www:www     640     14       *      @T00     GZB      /var/run/nginx.pid       30
+/var/log/nginx/tls_handshake.log   www:www     640     14       *      @T00     GZB      /var/run/nginx.pid       30
 {% endif %}


### PR DESCRIPTION
Fix problem with tls_handshake.log lacking rotation.