### PR TITLE
unboundplus: Use 'forward-tls-upstream' config key

### DIFF
--- a/dns/unbound-plus/src/opnsense/service/templates/OPNsense/Unboundplus/dot.conf
+++ b/dns/unbound-plus/src/opnsense/service/templates/OPNsense/Unboundplus/dot.conf
@@ -3,7 +3,7 @@ server:
   tls-cert-bundle: /etc/ssl/cert.pem
 forward-zone:
   name: "."
-  forward-ssl-upstream: yes
+  forward-tls-upstream: yes
 {%   for dot in OPNsense.unboundplus.miscellaneous.dotservers.split(',') %}
   forward-addr: {{ dot }}
 {%   endfor %}


### PR DESCRIPTION
While 'forward-ssl-upstream' is indeed an alias/alternative syntax for the '*tls*' option, therefore it's more a cosmetic thing - specially because it's called DNS over TLS. Just to be consistent with terms used.

I've paid a look into the configuration file due to some UI validation issues, since then it's annoying me unfortunately - therefore the PR... :)