### PR TITLE
Invert routing interface selection

### DIFF
--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditOSPF6Interface.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditOSPF6Interface.xml
@@ -17,8 +17,8 @@
     <help>Area in wildcard mask style like 0.0.0.0 and no decimal 0</help>
   </field>
   <field>
-    <id>interface.passive</id>
-    <label>Passive Interface</label>
+    <id>interface.active</id>
+    <label>Active Interface</label>
     <type>checkbox</type>
   </field>
   <field>

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/ospf.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/ospf.xml
@@ -23,8 +23,8 @@
         <help>If you have a CARP setup, you may want to configure a router id in case of a conflict.</help>
     </field>
     <field>
-        <id>ospf.passiveinterfaces</id>
-        <label>Passive Interfaces</label>
+        <id>ospf.activeinterfaces</id>
+        <label>Active Interfaces</label>
         <type>select_multiple</type>
         <help><![CDATA[Select the interfaces, where no OSPF packets should be sent to.]]></help>
         <hint>Type or select interface.</hint>

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/rip.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/rip.xml
@@ -12,8 +12,8 @@
         <help>Choose your RIP version (1 or 2). 1 is classful, 2 supports CIDR.</help>
     </field>
     <field>
-        <id>rip.passiveinterfaces</id>
-        <label>Passive Interfaces</label>
+        <id>rip.activeinterfaces</id>
+        <label>Active Interfaces</label>
         <type>select_multiple</type>
         <help><![CDATA[Select the interfaces, where no RIP packets should be sent to.]]></help>
         <hint>Type or select interface.</hint>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF.xml
@@ -30,7 +30,7 @@
             <MaximumValue>16777214</MaximumValue>
             <ValidationMessage>Must be a number between 0 and 16777214.</ValidationMessage>
         </originatemetric>
-        <passiveinterfaces type="InterfaceField">
+        <activeinterfaces type="InterfaceField">
                 <Required>N</Required>
                 <multiple>Y</multiple>
                 <default></default>
@@ -38,7 +38,7 @@
                 <filters>
                     <enable>/^(?!0).*$/</enable>
                 </filters>
-        </passiveinterfaces>
+        </activeinterfaces>
         <redistribute type="OptionField">
                 <Required>N</Required>
                 <multiple>Y</multiple>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF6.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF6.xml
@@ -42,10 +42,10 @@
                                 <Required>Y</Required>
                                 <mask>/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/</mask>
                         </area>
-                        <passive type="BooleanField">
+                        <active type="BooleanField">
                                 <default>0</default>
                                 <Required>Y</Required>
-                        </passive>
+                        </active>
                         <cost type="IntegerField">
                                 <default></default>
                                 <MinimumValue>0</MinimumValue>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/RIP.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/RIP.xml
@@ -18,7 +18,7 @@
             <Required>Y</Required>
             <mask>/^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\/\d{1,2},)*(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\/\d{1,2})$/</mask>
         </networks>
-        <passiveinterfaces type="InterfaceField">
+        <activeinterfaces type="InterfaceField">
                 <Required>N</Required>
                 <multiple>Y</multiple>
                 <default></default>
@@ -26,7 +26,7 @@
                 <filters>
                     <enable>/^(?!0).*$/</enable>
                 </filters>
-        </passiveinterfaces>
+        </activeinterfaces>
         <redistribute type="OptionField">
                 <Required>N</Required>
                 <multiple>Y</multiple>

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospf6d.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospf6d.conf
@@ -25,7 +25,7 @@ interface {{ physical_interface(interface.interfacename) }}
 {% if interface.networktype  %}
   ipv6 ospf6 network {{ interface.networktype }}
 {% endif %}
-{% if interface.passive == '1' %}
+{% if interface.active == '0' %}
   ipv6 ospf6 passive
 {% endif %}
 {{       cline("cost",interface.cost)

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
@@ -49,9 +49,10 @@ router ospf
 {% if helpers.exists('OPNsense.quagga.ospf.redistributemap') and OPNsense.quagga.ospf.redistributemap != '' %}{% set line = line + " route-map " + helpers.getUUID(OPNsense.quagga.ospf.redistributemap).name %}{% endif %}
  redistribute {{ line }}
 {% endfor %}{% endif %}
-{% if helpers.exists('OPNsense.quagga.ospf.passiveinterfaces') and OPNsense.quagga.ospf.passiveinterfaces != '' %}
-{% for line in OPNsense.quagga.ospf.passiveinterfaces.split(',') %}
- passive-interface {{ physical_interface(line) }}
+{% if helpers.exists('OPNsense.quagga.ospf.activeinterfaces') and OPNsense.quagga.ospf.activeinterfaces != '' %}
+ passive-interface default
+{% for line in OPNsense.quagga.ospf.activeinterfaces.split(',') %}
+ no passive-interface {{ physical_interface(line) }}
 {% endfor %}{% endif %}
 {% if helpers.exists('OPNsense.quagga.ospf.networks.network') %}
 {%   for network in helpers.toList('OPNsense.quagga.ospf.networks.network') %}

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ripd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ripd.conf
@@ -24,9 +24,10 @@ router rip
  network {{ network }}
 {%   endfor %}
 {%  endif %}
-{% if helpers.exists('OPNsense.quagga.rip.passiveinterfaces') and OPNsense.quagga.rip.passiveinterfaces != '' %}
-{% for line in OPNsense.quagga.rip.passiveinterfaces.split(',') %}
- passive-interface {{ physical_interface(line) }}
+{% if helpers.exists('OPNsense.quagga.rip.activeinterfaces') and OPNsense.quagga.rip.activeinterfaces != '' %}
+ passive-interface default
+{% for line in OPNsense.quagga.rip.activeinterfaces.split(',') %}
+ no passive-interface {{ physical_interface(line) }}
 {% endfor %}{% endif %}
 {% if helpers.exists('OPNsense.quagga.rip.defaultmetric') and OPNsense.quagga.rip.defaultmetric != '' %}
  default-metric {{ OPNsense.quagga.rip.defaultmetric }}


### PR DESCRIPTION
Change passive interface selection to default to passive and instead only select active interfaces, interface selection can be tedious when you have many interfaces (in our case a lot of VLANs).  This also fixes new interfaces being added defaulting to an active routing interface, which requires you to select each new interface as passive.
