### PR TITLE
security/acme-client: Add Acmeproxy DNS provider dialog

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -1009,6 +1009,26 @@
         <help>Specify the custom ACME DNS Update URL, i.e. https://auth.acme-dns.io/update (optional)</help>
     </field>
     <field>
+        <label>acmeproxy</label>
+        <type>header</type>
+        <style>table_dns table_dns_acmeproxy</style>
+    </field>
+    <field>
+        <id>validation.dns_acmeproxy_endpoint</id>
+        <label>Endpoint</label>
+        <type>text</type>
+        <help>Specify the acmeproxy endpoint URL, i.e. https://acmeproxy.examp
+    </field>                                                                      <field>
+        <id>validation.dns_acmeproxy_username</id>
+        <label>User</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_acmeproxy_password</id>
+        <label>Password</label>
+        <type>password</type>
+    </field>
+    <field>
         <label>Variomedia</label>
         <type>header</type>
         <style>table_dns table_dns_variomedia</style>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -358,6 +358,7 @@
                     <default>dns_nsupdate</default>
                     <OptionValues>
                         <dns_acmedns>ACME DNS API</dns_acmedns>
+                        <dns_acmeproxy>Acmeproxy API</dns_acmeproxy>
                         <dns_ad>Alwaysdata.com API</dns_ad>
                         <dns_ali>aliyun.com API</dns_ali>
                         <dns_autodns>AutoDNS (InterNetX) API</dns_autodns>
@@ -847,7 +848,16 @@
                 <dns_acmedns_updateurl type="TextField">
                     <Required>N</Required>
                 </dns_acmedns_updateurl>
-                <dns_variomedia_key type="TextField">
+                <dns_acmeproxy_endpoint type="TextField">
+                    <Required>N</Required>
+                </dns_acmeproxy_endpoint>
+                <dns_acmeproxy_username type="TextField">
+                    <Required>N</Required>
+                </dns_acmeproxy_username>
+                <dns_acmeproxy_password type="TextField">
+                    <Required>N</Required>
+                </dns_acmeproxy_password>
+		<dns_variomedia_key type="TextField">
                     <Required>N</Required>
                 </dns_variomedia_key>
                 <dns_schlundtech_user type="TextField">

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -857,7 +857,7 @@
                 <dns_acmeproxy_password type="TextField">
                     <Required>N</Required>
                 </dns_acmeproxy_password>
-		<dns_variomedia_key type="TextField">
+                <dns_variomedia_key type="TextField">
                     <Required>N</Required>
                 </dns_variomedia_key>
                 <dns_schlundtech_user type="TextField">

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -658,7 +658,7 @@ function run_acme_validation($certObj, $valObj, $acctObj)
                 $proc_env['ACMEPROXY_USERNAME'] = (string)$valObj->dns_acmeproxy_username;
                 $proc_env['ACMEPROXY_PASSWORD'] = (string)$valObj->dns_acmeproxy_password;
                 break;
-	    case 'dns_ad':
+            case 'dns_ad':
                 $proc_env['AD_API_KEY'] = (string)$valObj->dns_ad_key;
                 break;
             case 'dns_ali':

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -653,7 +653,12 @@ function run_acme_validation($certObj, $valObj, $acctObj)
                 $proc_env['ACMEDNS_SUBDOMAIN'] = (string)$valObj->dns_acmedns_subdomain;
                 $proc_env['ACMEDNS_UPDATE_URL'] = (string)$valObj->dns_acmedns_updateurl;
                 break;
-            case 'dns_ad':
+            case 'dns_acmeproxy':
+                $proc_env['ACMEPROXY_ENDPOINT'] = (string)$valObj->dns_acmeproxy_endpoint;
+                $proc_env['ACMEPROXY_USERNAME'] = (string)$valObj->dns_acmeproxy_username;
+                $proc_env['ACMEPROXY_PASSWORD'] = (string)$valObj->dns_acmeproxy_password;
+                break;
+	    case 'dns_ad':
                 $proc_env['AD_API_KEY'] = (string)$valObj->dns_ad_key;
                 break;
             case 'dns_ali':


### PR DESCRIPTION
acme.sh contains support for the Acmeproxy provider (https://github.com/acmesh-official/acme.sh/pull/2250), but OPNsense didn't yet support the dialogs which are added with this PR. 