### PR TITLE
Added dyndns support for the german provider all-inkl.com

### DIFF
--- a/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns.inc
+++ b/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns.inc
@@ -97,6 +97,8 @@ function dyndns_list()
 
     return array(
         '3322' => '3322',
+        'all-inkl' => 'All-Inkl.com',
+        'all-inkl-v6' => 'All-Inkl.com (v6)',
         'azure' => 'Azure DNS',
         'azurev6' => 'Azure DNS (v6)',
         'citynetwork' => 'City Network',

--- a/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns.inc
+++ b/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns.inc
@@ -98,7 +98,6 @@ function dyndns_list()
     return array(
         '3322' => '3322',
         'all-inkl' => 'All-Inkl.com',
-        'all-inkl-v6' => 'All-Inkl.com (v6)',
         'azure' => 'Azure DNS',
         'azurev6' => 'Azure DNS (v6)',
         'citynetwork' => 'City Network',

--- a/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
+++ b/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
@@ -43,6 +43,7 @@
  *    - Azure DNS (azure.microsoft.com)
  *    - Linode (linode.com)
  *    - Linode IPv6 (linode.com)
+*    -  All-Inkl.com (all-inkl.com)
  * +----------------------------------------------------+
  *  Requirements:
  *    - PHP version 4.0.2 or higher with the CURL Library and the PCRE Library
@@ -99,6 +100,7 @@
  *  Azure DNS           - Last Tested: 16 October 2019
  *  Linode              - Last Tested: 25 February 2020
  *  Linode v6           - Last Tested: 25 February 2020
+ *  All-Inkl.com        - Last Tested: 18 May 2020
  * +====================================================+
  *
  * @author    E.Kristensen
@@ -264,6 +266,7 @@ class updatedns
 
         switch ($dnsService) {
             case 'azurev6':
+            case 'all-inkl-v6':
             case 'cloudflare-v6':
             case 'custom-v6':
             case 'dynv6-v6':
@@ -314,6 +317,8 @@ class updatedns
         } else {
             switch ($this->_dnsService) {
                 case '3322':
+                case 'all-inkl':	
+                case 'all-inkl-v6':	
                 case 'azure':
                 case 'azurev6':
                 case 'citynetwork':
@@ -1059,6 +1064,13 @@ class updatedns
                 curl_setopt($ch, CURLOPT_HEADER, 1);
                 curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT');
                 break;
+            case 'all-inkl':
+            case 'all-inkl-v6':
+                $url = 'https://dyndns.kasserver.com/?myip=' . $this->_dnsIP;
+                curl_setopt($ch, CURLOPT_USERPWD, $this->_dnsUser . ':'.$this->_dnsPass);
+                curl_setopt($ch, CURLOPT_URL, $url );
+                break; 
+
             default:
                 break;
         }
@@ -1504,6 +1516,24 @@ class updatedns
                     $this->_debug($data);
                 }
                 break;
+            case 'all-inkl':
+            case 'all-inkl-v6':
+                $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+                if (preg_match('/good\s'.$this->_dnsIP.'/i', $data)) {
+                    $status =  "IP Address Changed Successfully! {$this->_dnsIP}";
+                    $successful_update = true;
+                } else if (preg_match('/good/i', $data)) {
+                    $status = "Result did not match.";
+                } else if ($http_code == 401) {
+                    $status = "Invalid username or password";
+                } else {
+                    $status = "Unknown Response";
+                    // log_error($status_intro . gettext("PAYLOAD:") . " " . $header . $data);
+                    log_error("Dynamic DNS: HTTP Status: {$http_code}  PAYLOAD: {$data}");
+                    $this->_debug($data);
+                   
+            }
+            break; 
             default:
                 break;
         }

--- a/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
+++ b/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
@@ -266,7 +266,6 @@ class updatedns
 
         switch ($dnsService) {
             case 'azurev6':
-            case 'all-inkl-v6':
             case 'cloudflare-v6':
             case 'custom-v6':
             case 'dynv6-v6':
@@ -318,7 +317,6 @@ class updatedns
             switch ($this->_dnsService) {
                 case '3322':
                 case 'all-inkl':	
-                case 'all-inkl-v6':	
                 case 'azure':
                 case 'azurev6':
                 case 'citynetwork':
@@ -1065,7 +1063,6 @@ class updatedns
                 curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT');
                 break;
             case 'all-inkl':
-            case 'all-inkl-v6':
                 $url = 'https://dyndns.kasserver.com/?myip=' . $this->_dnsIP;
                 curl_setopt($ch, CURLOPT_USERPWD, $this->_dnsUser . ':'.$this->_dnsPass);
                 curl_setopt($ch, CURLOPT_URL, $url );
@@ -1517,7 +1514,6 @@ class updatedns
                 }
                 break;
             case 'all-inkl':
-            case 'all-inkl-v6':
                 $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
                 if (preg_match('/good\s'.$this->_dnsIP.'/i', $data)) {
                     $status =  "IP Address Changed Successfully! {$this->_dnsIP}";


### PR DESCRIPTION
added dyndns support for all-inkl.com ipv4
tried also to add ipv6 (see first commit) but somehow curl did not work, though the constructed url worked when i copy&pasted it into the browser.