### PR TITLE
Fixing smart widget

### DIFF
--- a/sysutils/smart/src/www/widgets/widgets/smart_status.widget.php
+++ b/sysutils/smart/src/www/widgets/widgets/smart_status.widget.php
@@ -32,6 +32,10 @@ require_once('guiconfig.inc');
 require_once('widgets/include/smart_status.inc');
 
 $devs = json_decode(configd_run('smart detailed list'));
+if (empty($devs)) {
+  echo 'Unable to retrieve status';
+  return;
+}
 
 ?>
 


### PR DESCRIPTION
Fix for:
`Warning: Invalid argument supplied for foreach() in /usr/local/www/widgets/widgets/smart_status.widget.php on line 48`

For some reason, `configd_run('smart detailed list')` is returning `NULL`, this will at least handle that case.