### PR TITLE
security/acme-client: Add NSUPDATE_ZONE support to nsupdate DNS-01 Service

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -772,7 +772,6 @@
         <label>Server (FQDN)</label>
         <type>text</type>
     </field>
-        <field>
         <id>validation.dns_nsupdate_zone</id>
         <label>Zone</label>
         <type>text</type>

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -772,6 +772,12 @@
         <label>Server (FQDN)</label>
         <type>text</type>
     </field>
+        <field>
+        <id>validation.dns_nsupdate_zone</id>
+        <label>Zone</label>
+        <type>text</type>
+        <help>Set hosted zone (e.g. example.com) as some DNS Providers require, such as dyn.com's 'Standard DNS' service.</help>
+    </field>
     <field>
         <id>validation.dns_nsupdate_key</id>
         <label>Secret Key</label>

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -772,6 +772,7 @@
         <label>Server (FQDN)</label>
         <type>text</type>
     </field>
+    <field>
         <id>validation.dns_nsupdate_zone</id>
         <label>Zone</label>
         <type>text</type>

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -776,7 +776,7 @@
         <id>validation.dns_nsupdate_zone</id>
         <label>Zone</label>
         <type>text</type>
-        <help>Set hosted zone (e.g. example.com) as some DNS Providers require, such as dyn.com's 'Standard DNS' service.</help>
+        <help>Set hosted zone (e.g. example.com) as some DNS Providers require, like dyn.com's 'Standard DNS'.</help>
     </field>
     <field>
         <id>validation.dns_nsupdate_key</id>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -751,6 +751,9 @@
                 <dns_nsupdate_server type="TextField">
                     <Required>N</Required>
                 </dns_nsupdate_server>
+                <dns_nsupdate_zone type="TextField">
+                    <Required>N</Required>
+                </dns_nsupdate_zone>
                 <!-- TODO: maybe we should base64encode this field? -->
                 <dns_nsupdate_key type="TextField">
                     <Required>N</Required>

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -893,6 +893,7 @@ function run_acme_validation($certObj, $valObj, $acctObj)
                 file_put_contents($secret_key_filename, $secret_key_data);
                 $proc_env['NSUPDATE_KEY'] = $secret_key_filename;
                 $proc_env['NSUPDATE_SERVER'] = (string)$valObj->dns_nsupdate_server;
+                $proc_env['NSUPDATE_ZONE'] = (string)$valObj->dns_nsupdate_zone;
                 break;
             case 'dns_opnsense':
                 # BIND plugin must be installed.


### PR DESCRIPTION
This change is to update nsupdate (RFC 2136) DNS Service for the Let's Encrypt module to support a Zone declaration.  As described in PR#1963 for acme.sh:

> Some DNS servers for which dns_nsupdate.sh is applicable (such as dyn.com's 'Standard DNS' TSIG update mechanism), require that the zone be set during the nsupdate transaction.  Therefore we add a new environment variable NSUPDATE_ZONE which is used to set the zone for the DNS TSIG transaction.

Currently OPNSense is a year and a half behind what acme.sh supports for the nsupdate DNSAPI. See the [acme.sh pull request](https://github.com/acmesh-official/acme.sh/pull/1963) for more detailed information.