### PR TITLE
[security/acme-client] Add core-networks API option

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -1086,4 +1086,19 @@
         <label>API Key</label>
         <type>password</type>
     </field>
+    <field>
+        <label>Core-Networks API</label>
+        <type>header</type>
+        <style>table_dns table_dns_cn</style>
+    </field>
+    <field>
+        <id>validation.dns_cn_user</id>
+        <label>API User</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_cn_password</id>
+        <label>API Password</label>
+        <type>password</type>
+    </field>
 </form>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -366,6 +366,7 @@
                         <dns_azure>Azure DNS API</dns_azure>
                         <dns_cf>CloudFlare.com API</dns_cf>
                         <dns_cloudns>ClouDNS API</dns_cloudns>
+                        <dns_cn>Core-Networks API</dns_cn>
                         <dns_cx>CloudXNS.com API</dns_cx>
                         <dns_cyon>cyon.ch API</dns_cyon>
                         <dns_da>DirectAdmin API</dns_da>
@@ -878,6 +879,12 @@
                 <dns_leaseweb_key type="TextField">
                     <Required>N</Required>
                 </dns_leaseweb_key>
+                <dns_cn_user type="TextField">
+                    <Required>N</Required>
+                </dns_cn_user>
+                <dns_cn_password type="TextField">
+                    <Required>N</Required>
+                </dns_cn_password>
             </validation>
         </validations>
         <actions>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -366,8 +366,8 @@
                         <dns_azure>Azure DNS API</dns_azure>
                         <dns_cf>CloudFlare.com API</dns_cf>
                         <dns_cloudns>ClouDNS API</dns_cloudns>
-                        <dns_cn>Core-Networks API</dns_cn>
                         <dns_cx>CloudXNS.com API</dns_cx>
+                        <dns_cn>Core-Networks API</dns_cn>
                         <dns_cyon>cyon.ch API</dns_cyon>
                         <dns_da>DirectAdmin API</dns_da>
                         <dns_dgon>DigitalOcean API</dns_dgon>

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -693,6 +693,10 @@ function run_acme_validation($certObj, $valObj, $acctObj)
                 $proc_env['CLOUDNS_SUB_AUTH_ID'] = (string)$valObj->dns_cloudns_sub_auth_id;
                 $proc_env['CLOUDNS_AUTH_PASSWORD'] = (string)$valObj->dns_cloudns_auth_password;
                 break;
+            case 'dns_cn':
+                $proc_env['CN_User'] = (string)$valObj->dns_cn_user;
+                $proc_env['CN_Password'] = (string)$valObj->dns_cn_password;
+                break;
             case 'dns_cx':
                 $proc_env['CX_Key'] = (string)$valObj->dns_cx_key;
                 $proc_env['CX_Secret'] = (string)$valObj->dns_cx_secret;


### PR DESCRIPTION
Added core-networks API config options, to fix #1872 

NEEDS TESTING
Pleas advice, how I can test this on my opnsense. I sadly do not have a test environment, hence would need to do that on my live environment. As this is my first PR here, would appreciate some advice on how to do that securely.