### PR TITLE
net/haproxy: automatically add inspect-delay

### DIFF
--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -45,6 +45,8 @@
 {%     set acls_seen = [] %}
 {%     set global_action_options = [] %}
 {%     set global_use_options = [] %}
+{#     # check if we need to inspect SNI #}
+{%     set sni = namespace(found=false) %}
 {%     for action in linkedData.split(",") %}
 {%       set action_data = helpers.getUUID(action) %}
 {#       # collect ACLs for this action #}
@@ -247,6 +249,7 @@
 {%               endif %}
 {%             elif acl_data.expression == 'ssl_sni' %}
 {%               if acl_data.ssl_sni|default("") != "" %}
+{%                 set sni.found = true %}
 {%                 do acl_options.append('req.ssl_sni -i ' ~ acl_data.ssl_sni) %}
 {%               else %}
 {%                 set acl_enabled = '0' %}
@@ -254,6 +257,7 @@
 {%               endif %}
 {%             elif acl_data.expression == 'ssl_sni_sub' %}
 {%               if acl_data.ssl_sni_sub|default("") != "" %}
+{%                 set sni.found = true %}
 {%                 do acl_options.append('req.ssl_sni -m sub -i ' ~ acl_data.ssl_sni_sub) %}
 {%               else %}
 {%                 set acl_enabled = '0' %}
@@ -261,6 +265,7 @@
 {%               endif %}
 {%             elif acl_data.expression == 'ssl_sni_beg' %}
 {%               if acl_data.ssl_sni_beg|default("") != "" %}
+{%                 set sni.found = true %}
 {%                 do acl_options.append('req.ssl_sni -m beg -i ' ~ acl_data.ssl_sni_beg) %}
 {%               else %}
 {%                 set acl_enabled = '0' %}
@@ -268,6 +273,7 @@
 {%               endif %}
 {%             elif acl_data.expression == 'ssl_sni_end' %}
 {%               if acl_data.ssl_sni_end|default("") != "" %}
+{%                 set sni.found = true %}
 {%                 do acl_options.append('req.ssl_sni -m end -i ' ~ acl_data.ssl_sni_end) %}
 {%               else %}
 {%                 set acl_enabled = '0' %}
@@ -275,6 +281,7 @@
 {%               endif %}
 {%             elif acl_data.expression == 'ssl_sni_reg' %}
 {%               if acl_data.ssl_sni_reg|default("") != "" %}
+{%                 set sni.found = true %}
 {%                 do acl_options.append('req.ssl_sni -m reg -i ' ~ acl_data.ssl_sni_reg) %}
 {%               else %}
 {%                 set acl_enabled = '0' %}
@@ -566,6 +573,12 @@
     # ACL ERROR COUNT: {{acl_errors}}
 {%       endif %}
 {%     endfor %}
+
+{%     if sni.found == true %}
+    # Required for SNI ACLs
+    tcp-request inspect-delay 5s
+    tcp-request content accept if { req_ssl_hello_type 1 }
+{%     endif %}
 
 {%     if global_action_options|length > 0 %}
     {{global_action_options|join('\n' + '    ')}}


### PR DESCRIPTION
If you use ACLs which need to inspect the Server Name TLS extension (SNI) you are required to add the directives (see the [Docs](http://cbonte.github.io/haproxy-dconv/2.1/configuration.html#7.3.5-req_ssl_sni)):
```
tcp-request inspect-delay 5s
tcp-request content accept if { req_ssl_hello_type 1 }
```

Currently these directives can be placed in the `Option pass-through` but then there is a waring that they are placed at the wrong position:
```
[WARNING] 161/133608 (42137) : parsing [/usr/local/etc/haproxy.conf:113] : a 'tcp-request' rule placed after a 'use_backend' rule will still be processed before.
Configuration file is valid
```

With this PR the directives are automatically placed before the `use_backend` directives but only if SNI ACLs exist. This could also be done via an extra configuration option, but I decided to do this automatically as there is no change required the model/gui/etc.
