### PR TITLE
net-mgmt/telegraf: Fix TLS connect (#1821)

### DIFF
--- a/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/output.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/output.xml
@@ -75,7 +75,7 @@
         <id>output.graphite_server</id>
         <label>Graphite Server</label>
         <type>text</type>
-        <help>Set the IP and port where metrics shoud be sent to.</help>
+        <help>Set the IP and port where metrics shoud be sent to. Format: IP:port.</help>
     </field>
     <field>
         <id>output.graphite_prefix</id>
@@ -91,9 +91,15 @@
     </field>
     <field>
         <id>output.graphite_verify</id>
-        <label>Graphite SSL Verification</label>
+        <label>Graphite SSL/TLS Verification</label>
         <type>checkbox</type>
         <help>This will enable verification of a secure connection to Graphite. Default is disabled for compatibility reasons.</help>
+    </field>
+    <field>
+        <id>output.graphite_ssl_disable</id>
+        <label>Disable Graphite SSL/TLS</label>
+        <type>checkbox</type>
+        <help>This will disable SSL/TLS connection to Graphite host. Default is encrypted connection.</help>
     </field>
     <field>
         <id>output.graphite_tagsupport</id>

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Output.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Output.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/telegraf/output</mount>
     <description>Telegraf outputs configuration</description>
-    <version>1.4.0</version>
+    <version>1.4.1</version>
     <items>
         <influx_enable type="BooleanField">
             <default>0</default>
@@ -40,6 +40,10 @@
         <graphite_template type="TextField">
             <Required>N</Required>
         </graphite_template>
+        <graphite_ssl_disable type="BooleanField">
+            <default>0</default>
+            <Required>N</Required>
+        </graphite_ssl_disable>
         <graphite_verify type="BooleanField">
             <default>0</default>
             <Required>N</Required>

--- a/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
+++ b/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
@@ -84,10 +84,12 @@
   template = "{{ OPNsense.telegraf.output.graphite_template }}"
 {%   endif %}
   timeout = 2
-{%   if helpers.exists('OPNsense.telegraf.output.graphite_verify') and OPNsense.telegraf.output.graphite_verify == '0' %}
+{%   if helpers.exists('OPNsense.telegraf.output.graphite_ssl_disable') and OPNsense.telegraf.output.graphite_ssl_disable != '1' %}
+{%     if helpers.exists('OPNsense.telegraf.output.graphite_verify') and OPNsense.telegraf.output.graphite_verify == '0' %}
   insecure_skip_verify = true
-{%   else %}
+{%     else %}
   insecure_skip_verify = false
+{%     endif %}
 {%   endif %}
 {%   if helpers.exists('OPNsense.telegraf.output.graphite_tagsupport') and OPNsense.telegraf.output.graphite_tagsupport == '1' %}
   graphite_tag_support = true


### PR DESCRIPTION
This PR fixes #1821 .

- Add new checkbox that enables TLS:
![graphite](https://user-images.githubusercontent.com/13877624/86002488-b0ff8400-ba10-11ea-96dd-22b0fe283838.png)

Only if that checkbox is set, verification is evaluated. 
As soon as  insecure_skip_verify = {true | false} is in the Telegraf config file, Telegraf will connect to Graphite using TLS.