### PR TITLE
Telegraf: fix flush_interval option

### DIFF
--- a/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
+++ b/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
@@ -28,6 +28,9 @@
 {% if helpers.exists('OPNsense.telegraf.general.collection_jitter') and OPNsense.telegraf.general.collection_jitter != '' %}
   collection_jitter = "{{ OPNsense.telegraf.general.collection_jitter }}s"
 {% endif %}
+{% if helpers.exists('OPNsense.telegraf.general.flush_interval') and OPNsense.telegraf.general.flush_interval != '' %}
+  flush_interval = "{{ OPNsense.telegraf.general.flush_interval }}s"
+{% endif %}
 {% if helpers.exists('OPNsense.telegraf.general.flush_jitter') and OPNsense.telegraf.general.flush_jitter != '' %}
   flush_jitter = "{{ OPNsense.telegraf.general.flush_jitter }}s"
 {% endif %}


### PR DESCRIPTION
The Telegraf flush_interval option is not working correctly. The option was not being added to the telegraf.conf file. Add the missing flush_interval option to the template to fix this problem.