### PR TITLE
Add support for aggregation and Graphite Separate Instances to Collectd plugin, add 2 plugins to collectd

### DIFF
--- a/net-mgmt/collectd/src/opnsense/mvc/app/controllers/OPNsense/Collectd/forms/general.xml
+++ b/net-mgmt/collectd/src/opnsense/mvc/app/controllers/OPNsense/Collectd/forms/general.xml
@@ -114,6 +114,12 @@
         <help>The CPU plugin collects the amount of time spent by the CPU in various states, most notably executing user code, executing system code, waiting for IO-operations and being idle.</help>
     </field>
     <field>
+        <id>general.p_cpu_percent</id>
+        <label>Report cpu usage in percent</label>
+        <type>checkbox</type>
+        <help>When set, report CPU usage in percent instead of units of kernel time.</help>
+    </field>
+    <field>
         <id>general.p_cpu_aggregates</id>
         <label>Enable cpu aggregates</label>
         <type>checkbox</type>

--- a/net-mgmt/collectd/src/opnsense/mvc/app/controllers/OPNsense/Collectd/forms/general.xml
+++ b/net-mgmt/collectd/src/opnsense/mvc/app/controllers/OPNsense/Collectd/forms/general.xml
@@ -96,6 +96,12 @@
         <help>String to set after the hostname. For compatibility reason default is collectd, but you can also simply remove it.</help>
     </field>
     <field>
+        <id>general.p_graphite_separate_instances</id>
+        <label>Graphite separate instances</label>
+        <type>checkbox</type>
+        <help>Enabling sends the plugin instance and type instance to Graphite as separate path components: host.cpu.0.cpu.idle. Disabling sends the plugin and plugin instance as one path component and type and type instance as another component: host.cpu-0.cpu-idle.</help>
+    </field>
+    <field>
         <id>general.p_contextswitch_enable</id>
         <label>Enable contextswitch plugin</label>
         <type>checkbox</type>

--- a/net-mgmt/collectd/src/opnsense/mvc/app/controllers/OPNsense/Collectd/forms/general.xml
+++ b/net-mgmt/collectd/src/opnsense/mvc/app/controllers/OPNsense/Collectd/forms/general.xml
@@ -126,10 +126,10 @@
         <help>Send aggregate values for CPU metrics in addition to values for individual cores.</help>
     </field>
     <field>
-        <id>general.p_cputemp_enable</id>
-        <label>Enable cputemp plugin</label>
+        <id>general.p_disk_enable</id>
+        <label>Enable disk plugin</label>
         <type>checkbox</type>
-        <help>The CPUtemp plugin collects the CPU temperature over time.</help>
+        <help>The Disk plugin collects disk I/O information, i.e. read and write operations per second.</help>
     </field>
     <field>
         <id>general.p_df_enable</id>

--- a/net-mgmt/collectd/src/opnsense/mvc/app/controllers/OPNsense/Collectd/forms/general.xml
+++ b/net-mgmt/collectd/src/opnsense/mvc/app/controllers/OPNsense/Collectd/forms/general.xml
@@ -114,6 +114,12 @@
         <help>The CPU plugin collects the amount of time spent by the CPU in various states, most notably executing user code, executing system code, waiting for IO-operations and being idle.</help>
     </field>
     <field>
+        <id>general.p_cpu_aggregates</id>
+        <label>Enable cpu aggregates</label>
+        <type>checkbox</type>
+        <help>Send aggregate values for CPU metrics in addition to values for individual cores.</help>
+    </field>
+    <field>
         <id>general.p_df_enable</id>
         <label>Enable df plugin</label>
         <type>checkbox</type>

--- a/net-mgmt/collectd/src/opnsense/mvc/app/controllers/OPNsense/Collectd/forms/general.xml
+++ b/net-mgmt/collectd/src/opnsense/mvc/app/controllers/OPNsense/Collectd/forms/general.xml
@@ -153,7 +153,13 @@
         <id>general.p_memory_enable</id>
         <label>Enable memory plugin</label>
         <type>checkbox</type>
-        <help>The Memory plugin collects physical memory utilization (Used, buffered, cached and free).</help>
+        <help>The Memory plugin collects physical memory utilization (used, buffered, cached and free).</help>
+    </field>
+    <field>
+        <id>general.p_swap_enable</id>
+        <label>Enable swap plugin</label>
+        <type>checkbox</type>
+        <help>The Swap plugin collects swap space utilization (used and free).</help>
     </field>
     <field>
         <id>general.p_processes_enable</id>

--- a/net-mgmt/collectd/src/opnsense/mvc/app/controllers/OPNsense/Collectd/forms/general.xml
+++ b/net-mgmt/collectd/src/opnsense/mvc/app/controllers/OPNsense/Collectd/forms/general.xml
@@ -126,6 +126,12 @@
         <help>Send aggregate values for CPU metrics in addition to values for individual cores.</help>
     </field>
     <field>
+        <id>general.p_cputemp_enable</id>
+        <label>Enable cputemp plugin</label>
+        <type>checkbox</type>
+        <help>The CPUtemp plugin collects the CPU temperature over time.</help>
+    </field>
+    <field>
         <id>general.p_df_enable</id>
         <label>Enable df plugin</label>
         <type>checkbox</type>

--- a/net-mgmt/collectd/src/opnsense/mvc/app/controllers/OPNsense/Collectd/forms/general.xml
+++ b/net-mgmt/collectd/src/opnsense/mvc/app/controllers/OPNsense/Collectd/forms/general.xml
@@ -85,13 +85,13 @@
     </field>
     <field>
         <id>general.p_graphite_prefix</id>
-        <label>Graphite Prefix</label>
+        <label>Graphite prefix</label>
         <type>text</type>
         <help>Prefix to set before the hostname. If it ends with a dot it creates an own directory.</help>
     </field>
     <field>
         <id>general.p_graphite_postfix</id>
-        <label>Graphite Postfix</label>
+        <label>Graphite postfix</label>
         <type>text</type>
         <help>String to set after the hostname. For compatibility reason default is collectd, but you can also simply remove it.</help>
     </field>

--- a/net-mgmt/collectd/src/opnsense/mvc/app/models/OPNsense/Collectd/General.xml
+++ b/net-mgmt/collectd/src/opnsense/mvc/app/models/OPNsense/Collectd/General.xml
@@ -77,6 +77,10 @@
             <default>collectd</default>
             <Required>N</Required>
         </p_graphite_postfix>
+        <p_graphite_separate_instances type="BooleanField">
+            <default>0</default>
+            <Required>N</Required>
+        </p_graphite_separate_instances>
         <p_contextswitch_enable type="BooleanField">
             <default>1</default>
             <Required>N</Required>

--- a/net-mgmt/collectd/src/opnsense/mvc/app/models/OPNsense/Collectd/General.xml
+++ b/net-mgmt/collectd/src/opnsense/mvc/app/models/OPNsense/Collectd/General.xml
@@ -38,18 +38,18 @@
         </p_network_port>
         <p_network_username type="TextField">
             <default></default>
-	    <Required>N</Required>
-	    <mask>/^([0-9a-zA-Z._\-]){1,128}$/u</mask>
-	</p_network_username>
-        <p_network_password type="TextField">
-            <default></default>
-	    <Required>N</Required>
-	    <mask>/^([0-9a-zA-Z._\-\!\$\%\/\(\)\+\#\=]){1,128}$/u</mask>
-	</p_network_password>
-        <p_network_encryption type="BooleanField">
-            <default>0</default>
-	    <Required>N</Required>
-	</p_network_encryption>
+            <Required>N</Required>
+            <mask>/^([0-9a-zA-Z._\-]){1,128}$/u</mask>
+        </p_network_username>
+            <p_network_password type="TextField">
+                <default></default>
+            <Required>N</Required>
+            <mask>/^([0-9a-zA-Z._\-\!\$\%\/\(\)\+\#\=]){1,128}$/u</mask>
+        </p_network_password>
+            <p_network_encryption type="BooleanField">
+                <default>0</default>
+            <Required>N</Required>
+        </p_network_encryption>
         <p_graphite_enable type="BooleanField">
             <default>0</default>
             <Required>N</Required>

--- a/net-mgmt/collectd/src/opnsense/mvc/app/models/OPNsense/Collectd/General.xml
+++ b/net-mgmt/collectd/src/opnsense/mvc/app/models/OPNsense/Collectd/General.xml
@@ -97,10 +97,10 @@
             <default>1</default>
             <Required>N</Required>
         </p_cpu_aggregates>
-        <p_cputemp_enable type="BooleanField">
+        <p_disk_enable type="BooleanField">
             <default>1</default>
             <Required>N</Required>
-        </p_cputemp_enable>
+        </p_disk_enable>
         <p_df_enable type="BooleanField">
             <default>1</default>
             <Required>N</Required>

--- a/net-mgmt/collectd/src/opnsense/mvc/app/models/OPNsense/Collectd/General.xml
+++ b/net-mgmt/collectd/src/opnsense/mvc/app/models/OPNsense/Collectd/General.xml
@@ -89,6 +89,10 @@
             <default>1</default>
             <Required>N</Required>
         </p_cpu_enable>
+        <p_cpu_percent type="BooleanField">
+            <default>1</default>
+            <Required>N</Required>
+        </p_cpu_percent>
         <p_cpu_aggregates type="BooleanField">
             <default>1</default>
             <Required>N</Required>

--- a/net-mgmt/collectd/src/opnsense/mvc/app/models/OPNsense/Collectd/General.xml
+++ b/net-mgmt/collectd/src/opnsense/mvc/app/models/OPNsense/Collectd/General.xml
@@ -97,6 +97,10 @@
             <default>1</default>
             <Required>N</Required>
         </p_cpu_aggregates>
+        <p_cputemp_enable type="BooleanField">
+            <default>1</default>
+            <Required>N</Required>
+        </p_cputemp_enable>
         <p_df_enable type="BooleanField">
             <default>1</default>
             <Required>N</Required>

--- a/net-mgmt/collectd/src/opnsense/mvc/app/models/OPNsense/Collectd/General.xml
+++ b/net-mgmt/collectd/src/opnsense/mvc/app/models/OPNsense/Collectd/General.xml
@@ -89,6 +89,10 @@
             <default>1</default>
             <Required>N</Required>
         </p_cpu_enable>
+        <p_cpu_aggregates type="BooleanField">
+            <default>1</default>
+            <Required>N</Required>
+        </p_cpu_aggregates>
         <p_df_enable type="BooleanField">
             <default>1</default>
             <Required>N</Required>

--- a/net-mgmt/collectd/src/opnsense/mvc/app/models/OPNsense/Collectd/General.xml
+++ b/net-mgmt/collectd/src/opnsense/mvc/app/models/OPNsense/Collectd/General.xml
@@ -117,6 +117,10 @@
             <default>1</default>
             <Required>N</Required>
         </p_memory_enable>
+        <p_swap_enable type="BooleanField">
+            <default>1</default>
+            <Required>N</Required>
+        </p_swap_enable>
         <p_processes_enable type="BooleanField">
             <default>1</default>
             <Required>N</Required>

--- a/net-mgmt/collectd/src/opnsense/service/templates/OPNsense/Collectd/collectd.conf
+++ b/net-mgmt/collectd/src/opnsense/service/templates/OPNsense/Collectd/collectd.conf
@@ -102,10 +102,14 @@ LoadPlugin write_graphite
 {%     if helpers.exists('OPNsense.collectd.general.p_graphite_postfix') and OPNsense.collectd.general.p_graphite_postfix != '' %}
     Postfix "{{ OPNsense.collectd.general.p_graphite_postfix }}"
 {%     endif %}
+{%     if helpers.exists('OPNsense.collectd.general.p_graphite_separate_instances') and OPNsense.collectd.general.p_graphite_separate_instances == '1' %}
+    SeparateInstances true
+{%     else %}
+    SeparateInstances false
+{%     endif %}
     StoreRates true
     AlwaysAppendDS false
     EscapeCharacter "_"
-    SeparateInstances false
     PreserveSeparator false
     DropDuplicateFields false
   </Node>

--- a/net-mgmt/collectd/src/opnsense/service/templates/OPNsense/Collectd/collectd.conf
+++ b/net-mgmt/collectd/src/opnsense/service/templates/OPNsense/Collectd/collectd.conf
@@ -115,6 +115,7 @@ LoadPlugin write_graphite
   </Node>
 </Plugin>
 {%   endif %}
+
 {%   if helpers.exists('OPNsense.collectd.general.p_cpu_aggregates') and OPNsense.collectd.general.p_cpu_aggregates == '1' %}
 <Plugin "aggregation">
 	<Aggregation>

--- a/net-mgmt/collectd/src/opnsense/service/templates/OPNsense/Collectd/collectd.conf
+++ b/net-mgmt/collectd/src/opnsense/service/templates/OPNsense/Collectd/collectd.conf
@@ -26,6 +26,9 @@ LoadPlugin contextswitch
 {% if helpers.exists('OPNsense.collectd.general.p_cpu_enable') and OPNsense.collectd.general.p_cpu_enable == '1' %}
 LoadPlugin cpu
 {% endif %}
+{% if helpers.exists('OPNsense.collectd.general.p_cpu_aggregates') and OPNsense.collectd.general.p_cpu_aggregates == '1' %}
+LoadPlugin aggregation
+{% endif %}
 {% if helpers.exists('OPNsense.collectd.general.p_df_enable') and OPNsense.collectd.general.p_df_enable == '1' %}
 LoadPlugin df
 {% endif %}
@@ -113,6 +116,22 @@ LoadPlugin write_graphite
     PreserveSeparator false
     DropDuplicateFields false
   </Node>
+</Plugin>
+{%   endif %}
+{%   if helpers.exists('OPNsense.collectd.general.p_cpu_aggregates') and OPNsense.collectd.general.p_cpu_aggregates == '1' %}
+<Plugin "aggregation">
+	<Aggregation>
+		Plugin "cpu"
+		Type "percent"
+		GroupBy "Host"
+		GroupBy "TypeInstance"
+		CalculateNum false
+		CalculateSum true
+		CalculateAverage true
+		CalculateMinimum false
+		CalculateMaximum false
+		CalculateStddev false
+	</Aggregation>
 </Plugin>
 {%   endif %}
 {% endif %}

--- a/net-mgmt/collectd/src/opnsense/service/templates/OPNsense/Collectd/collectd.conf
+++ b/net-mgmt/collectd/src/opnsense/service/templates/OPNsense/Collectd/collectd.conf
@@ -13,7 +13,7 @@ Interval    {{ OPNsense.collectd.general.interval }}
 
 LoadPlugin syslog
 <Plugin syslog>
-    LogLevel err
+  LogLevel err
 </Plugin>
 
 {% if helpers.exists('OPNsense.collectd.general.p_contextswitch_enable') and OPNsense.collectd.general.p_contextswitch_enable == '1' %}
@@ -64,19 +64,19 @@ LoadPlugin write_graphite
 {%   if helpers.exists('OPNsense.collectd.general.p_network_host') and OPNsense.collectd.general.p_network_host != '' %}
 {%     if helpers.exists('OPNsense.collectd.general.p_network_port') and OPNsense.collectd.general.p_network_port != '' %}
 <Plugin network>
-        <Server "{{ OPNsense.collectd.general.p_network_host }}" "{{ OPNsense.collectd.general.p_network_port }}">
+  <Server "{{ OPNsense.collectd.general.p_network_host }}" "{{ OPNsense.collectd.general.p_network_port }}">
 {%       if helpers.exists('OPNsense.collectd.general.p_network_username') and OPNsense.collectd.general.p_network_username != '' %}
-                Username "{{ OPNsense.collectd.general.p_network_username }}"
+    Username "{{ OPNsense.collectd.general.p_network_username }}"
 {%       endif %}
 {%       if helpers.exists('OPNsense.collectd.general.p_network_password') and OPNsense.collectd.general.p_network_password != '' %}
-                Password "{{ OPNsense.collectd.general.p_network_password }}"
+    Password "{{ OPNsense.collectd.general.p_network_password }}"
 {%       endif %}
 {%       if helpers.exists('OPNsense.collectd.general.p_network_username') and OPNsense.collectd.general.p_network_username != '' %}
 {%         if helpers.exists('OPNsense.collectd.general.p_network_encryption') and OPNsense.collectd.general.p_network_encryption == '1' %}
-                SecurityLevel Encrypt
+    SecurityLevel Encrypt
 {%         endif %}
 {%       endif %}
-        </Server>
+  </Server>
 </Plugin>
 {%     endif %}
 {%   endif %}
@@ -117,26 +117,26 @@ LoadPlugin write_graphite
 
 <Plugin cpu>
 {%   if helpers.exists('OPNsense.collectd.general.p_cpu_percent') and OPNsense.collectd.general.p_cpu_percent == '1' %}
-	ValuesPercentage true
+  ValuesPercentage true
 {%     else %}
-	ValuesPercentage false
+  ValuesPercentage false
 {%   endif %}
 </Plugin>
 
 {%   if helpers.exists('OPNsense.collectd.general.p_cpu_aggregates') and OPNsense.collectd.general.p_cpu_aggregates == '1' %}
 <Plugin "aggregation">
-    <Aggregation>
-        Plugin "cpu"
-        Type "percent"
-        GroupBy "Host"
-        GroupBy "TypeInstance"
-        CalculateNum false
-        CalculateSum true
-        CalculateAverage true
-        CalculateMinimum false
-        CalculateMaximum false
-        CalculateStddev false
-    </Aggregation>
+  <Aggregation>
+    Plugin "cpu"
+    Type "percent"
+    GroupBy "Host"
+    GroupBy "TypeInstance"
+    CalculateNum false
+    CalculateSum true
+    CalculateAverage true
+    CalculateMinimum false
+    CalculateMaximum false
+    CalculateStddev false
+  </Aggregation>
 </Plugin>
 {%   endif %}
 {% endif %}

--- a/net-mgmt/collectd/src/opnsense/service/templates/OPNsense/Collectd/collectd.conf
+++ b/net-mgmt/collectd/src/opnsense/service/templates/OPNsense/Collectd/collectd.conf
@@ -120,16 +120,17 @@ LoadPlugin write_graphite
   </Node>
 </Plugin>
 {%   endif %}
+{% endif %}
 
 <Plugin cpu>
-{%   if helpers.exists('OPNsense.collectd.general.p_cpu_percent') and OPNsense.collectd.general.p_cpu_percent == '1' %}
+{% if helpers.exists('OPNsense.collectd.general.p_cpu_percent') and OPNsense.collectd.general.p_cpu_percent == '1' %}
   ValuesPercentage true
-{%     else %}
+{% else %}
   ValuesPercentage false
-{%   endif %}
+{% endif %}
 </Plugin>
 
-{%   if helpers.exists('OPNsense.collectd.general.p_cpu_aggregates') and OPNsense.collectd.general.p_cpu_aggregates == '1' %}
+{% if helpers.exists('OPNsense.collectd.general.p_cpu_aggregates') and OPNsense.collectd.general.p_cpu_aggregates == '1' %}
 <Plugin "aggregation">
   <Aggregation>
     Plugin "cpu"
@@ -144,6 +145,5 @@ LoadPlugin write_graphite
     CalculateStddev false
   </Aggregation>
 </Plugin>
-{%   endif %}
 {% endif %}
 {% endif %}

--- a/net-mgmt/collectd/src/opnsense/service/templates/OPNsense/Collectd/collectd.conf
+++ b/net-mgmt/collectd/src/opnsense/service/templates/OPNsense/Collectd/collectd.conf
@@ -22,11 +22,11 @@ LoadPlugin contextswitch
 {% if helpers.exists('OPNsense.collectd.general.p_cpu_enable') and OPNsense.collectd.general.p_cpu_enable == '1' %}
 LoadPlugin cpu
 {% endif %}
-{% if helpers.exists('OPNsense.collectd.general.p_cputemp_enable') and OPNsense.collectd.general.p_cputemp_enable == '1' %}
-LoadPlugin cputemp
-{% endif %}
 {% if helpers.exists('OPNsense.collectd.general.p_cpu_aggregates') and OPNsense.collectd.general.p_cpu_aggregates == '1' %}
 LoadPlugin aggregation
+{% endif %}
+{% if helpers.exists('OPNsense.collectd.general.p_disk_enable') and OPNsense.collectd.general.p_disk_enable == '1' %}
+LoadPlugin disk
 {% endif %}
 {% if helpers.exists('OPNsense.collectd.general.p_df_enable') and OPNsense.collectd.general.p_df_enable == '1' %}
 LoadPlugin df

--- a/net-mgmt/collectd/src/opnsense/service/templates/OPNsense/Collectd/collectd.conf
+++ b/net-mgmt/collectd/src/opnsense/service/templates/OPNsense/Collectd/collectd.conf
@@ -12,9 +12,6 @@ FQDNLookup    true
 Interval    {{ OPNsense.collectd.general.interval }}
 {% endif %}
 
-
-
-
 LoadPlugin syslog
 <Plugin syslog>
        LogLevel err

--- a/net-mgmt/collectd/src/opnsense/service/templates/OPNsense/Collectd/collectd.conf
+++ b/net-mgmt/collectd/src/opnsense/service/templates/OPNsense/Collectd/collectd.conf
@@ -116,6 +116,14 @@ LoadPlugin write_graphite
 </Plugin>
 {%   endif %}
 
+<Plugin cpu>
+{%   if helpers.exists('OPNsense.collectd.general.p_cpu_percent') and OPNsense.collectd.general.p_cpu_percent == '1' %}
+	ValuesPercentage true
+{%     else %}
+	ValuesPercentage false
+{%   endif %}
+</Plugin>
+
 {%   if helpers.exists('OPNsense.collectd.general.p_cpu_aggregates') and OPNsense.collectd.general.p_cpu_aggregates == '1' %}
 <Plugin "aggregation">
 	<Aggregation>

--- a/net-mgmt/collectd/src/opnsense/service/templates/OPNsense/Collectd/collectd.conf
+++ b/net-mgmt/collectd/src/opnsense/service/templates/OPNsense/Collectd/collectd.conf
@@ -22,6 +22,9 @@ LoadPlugin contextswitch
 {% if helpers.exists('OPNsense.collectd.general.p_cpu_enable') and OPNsense.collectd.general.p_cpu_enable == '1' %}
 LoadPlugin cpu
 {% endif %}
+{% if helpers.exists('OPNsense.collectd.general.p_cputemp_enable') and OPNsense.collectd.general.p_cputemp_enable == '1' %}
+LoadPlugin cputemp
+{% endif %}
 {% if helpers.exists('OPNsense.collectd.general.p_cpu_aggregates') and OPNsense.collectd.general.p_cpu_aggregates == '1' %}
 LoadPlugin aggregation
 {% endif %}

--- a/net-mgmt/collectd/src/opnsense/service/templates/OPNsense/Collectd/collectd.conf
+++ b/net-mgmt/collectd/src/opnsense/service/templates/OPNsense/Collectd/collectd.conf
@@ -40,6 +40,9 @@ LoadPlugin load
 {% if helpers.exists('OPNsense.collectd.general.p_memory_enable') and OPNsense.collectd.general.p_memory_enable == '1' %}
 LoadPlugin memory
 {% endif %}
+{% if helpers.exists('OPNsense.collectd.general.p_swap_enable') and OPNsense.collectd.general.p_swap_enable == '1' %}
+LoadPlugin swap
+{% endif %}
 {% if helpers.exists('OPNsense.collectd.general.p_network_enable') and OPNsense.collectd.general.p_network_enable == '1' %}
 LoadPlugin network
 {% endif %}

--- a/net-mgmt/collectd/src/opnsense/service/templates/OPNsense/Collectd/collectd.conf
+++ b/net-mgmt/collectd/src/opnsense/service/templates/OPNsense/Collectd/collectd.conf
@@ -1,5 +1,4 @@
 {% if helpers.exists('OPNsense.collectd.general.enabled') and OPNsense.collectd.general.enabled == '1' %}
-
 {% if helpers.exists('OPNsense.collectd.general.hostname') and OPNsense.collectd.general.hostname != '' %}
 Hostname    "{{ OPNsense.collectd.general.hostname }}"
 {% else %}
@@ -14,7 +13,7 @@ Interval    {{ OPNsense.collectd.general.interval }}
 
 LoadPlugin syslog
 <Plugin syslog>
-       LogLevel err
+    LogLevel err
 </Plugin>
 
 {% if helpers.exists('OPNsense.collectd.general.p_contextswitch_enable') and OPNsense.collectd.general.p_contextswitch_enable == '1' %}
@@ -126,20 +125,19 @@ LoadPlugin write_graphite
 
 {%   if helpers.exists('OPNsense.collectd.general.p_cpu_aggregates') and OPNsense.collectd.general.p_cpu_aggregates == '1' %}
 <Plugin "aggregation">
-	<Aggregation>
-		Plugin "cpu"
-		Type "percent"
-		GroupBy "Host"
-		GroupBy "TypeInstance"
-		CalculateNum false
-		CalculateSum true
-		CalculateAverage true
-		CalculateMinimum false
-		CalculateMaximum false
-		CalculateStddev false
-	</Aggregation>
+    <Aggregation>
+        Plugin "cpu"
+        Type "percent"
+        GroupBy "Host"
+        GroupBy "TypeInstance"
+        CalculateNum false
+        CalculateSum true
+        CalculateAverage true
+        CalculateMinimum false
+        CalculateMaximum false
+        CalculateStddev false
+    </Aggregation>
 </Plugin>
 {%   endif %}
 {% endif %}
-
 {% endif %}


### PR DESCRIPTION
https://github.com/opnsense/plugins/issues/1758

Implemented the aggregate values for CPU and the "separate instances" feature.
Added "disk" (disk i/o) and "swap" plugins.

I need to research why the "cputemp" plugin is not available in the package version used by OPNsense.