### PR TITLE
mail/postfix: quick fix syslog

### DIFF
--- a/mail/postfix/src/etc/inc/plugins.inc.d/postfix.inc
+++ b/mail/postfix/src/etc/inc/plugins.inc.d/postfix.inc
@@ -52,10 +52,7 @@ function postfix_syslog()
 {
     $syslogconf = array();
 
-    $syslogconf['postfix'] = array(
-        'facility' => array('postfix'),
-        'remote' => 'postfix',
-    );
+    $syslogconf['postfix'] = array('facility' => array('postfix'));
 
     return $syslogconf;
 }

--- a/mail/postfix/src/etc/inc/plugins.inc.d/postfix.inc
+++ b/mail/postfix/src/etc/inc/plugins.inc.d/postfix.inc
@@ -52,9 +52,9 @@ function postfix_syslog()
 {
     $syslogconf = array();
 
-    $syslogconf['mail'] = array(
+    $syslogconf['postfix'] = array(
         'facility' => array('postfix'),
-        'remote' => 'mail',
+        'remote' => 'postfix',
     );
 
     return $syslogconf;


### PR DESCRIPTION
Missed this one, mentioned by @AdSchellevis 

Changing remote => mail to postfix *may* break syslog filter for graylog or ELK, but I think for a major this is ok-ish