### PR TITLE
acme-client: add support for 1984Hosting API

### DIFF
--- a/security/acme-client/Makefile
+++ b/security/acme-client/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		acme-client
-PLUGIN_VERSION=		1.34
+PLUGIN_VERSION=		1.35
 PLUGIN_COMMENT=		Let's Encrypt client
 PLUGIN_MAINTAINER=	opnsense@moov.de
 PLUGIN_DEPENDS=		acme.sh py${PLUGIN_PYTHON}-dns-lexicon

--- a/security/acme-client/pkg-descr
+++ b/security/acme-client/pkg-descr
@@ -1,5 +1,5 @@
 This plugin contains a full ACME protocol implementation based on the
-acme.sh project.  Acording to the authors, it's probably "the easiest
+acme.sh project. According to the authors, it's probably "the easiest
 and smallest and smartest shell script" to automatically issue and renew
 the free certificates from Let's Encrypt.
 

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -1121,4 +1121,19 @@
         <label>API Token</label>
         <type>password</type>
     </field>
+    <field>
+        <label>1984Hosting API</label>
+        <type>header</type>
+        <style>table_dns table_dns_1984hosting</style>
+    </field>
+    <field>
+        <id>validation.dns_1984hosting_user</id>
+        <label>API User</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_1984hosting_password</id>
+        <label>API Password</label>
+        <type>password</type>
+    </field>
 </form>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/AcmeClient</mount>
-    <version>1.6.1</version>
+    <version>1.6.2</version>
     <description>A secure Let's Encrypt plugin</description>
     <items>
         <settings>
@@ -357,6 +357,7 @@
                     <Required>Y</Required>
                     <default>dns_nsupdate</default>
                     <OptionValues>
+                        <dns_1984hosting>1984Hosting API</dns_1984hosting>
                         <dns_acmedns>ACME DNS API</dns_acmedns>
                         <dns_acmeproxy>Acmeproxy API</dns_acmeproxy>
                         <dns_ad>Alwaysdata.com API</dns_ad>
@@ -893,6 +894,12 @@
                 <dns_hetzner_token type="TextField">
                     <Required>N</Required>
                 </dns_hetzner_token>
+                <dns_1984hosting_user type="TextField">
+                    <Required>N</Required>
+                </dns_1984hosting_user>
+                <dns_1984hosting_password type="TextField">
+                    <Required>N</Required>
+                </dns_1984hosting_password>
             </validation>
         </validations>
         <actions>

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -647,6 +647,10 @@ function run_acme_validation($certObj, $valObj, $acctObj)
         // Setup DNS hook:
         // Set required env variables, write secrets to files, etc.
         switch ((string)$valObj->dns_service) {
+            case 'dns_1984hosting':
+                $proc_env['One984HOSTING_Username'] = (string)$valObj->dns_1984hosting_user;
+                $proc_env['One984HOSTING_Password'] = (string)$valObj->dns_1984hosting_password;
+                break;
             case 'dns_acmedns':
                 $proc_env['ACMEDNS_USERNAME'] = (string)$valObj->dns_acmedns_user;
                 $proc_env['ACMEDNS_PASSWORD'] = (string)$valObj->dns_acmedns_password;


### PR DESCRIPTION
This PR adds support for `dns_1984Hosting` API.