### PR TITLE
net/frr: Disable eBGP policies

### DIFF
--- a/net/frr/Makefile
+++ b/net/frr/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		frr
-PLUGIN_VERSION=		1.14
+PLUGIN_VERSION=		1.15
 PLUGIN_COMMENT=		The FRRouting Protocol Suite
 PLUGIN_DEPENDS=		frr7 ruby
 PLUGIN_MAINTAINER=	franz.fabian.94@gmail.com

--- a/net/frr/pkg-descr
+++ b/net/frr/pkg-descr
@@ -11,6 +11,10 @@ switching and routing, Internet access routers, and Internet peering.
 Plugin Changelog
 ================
 
+1.15
+
+* Disable eBGP policies introduced with FRR 7.4
+
 1.14
 
 * fix null route issue in parsing

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -17,6 +17,7 @@ log syslog {{ OPNsense.quagga.general.sysloglevel }}
 !
 {% if helpers.exists('OPNsense.quagga.bgp.asnumber') and OPNsense.quagga.bgp.asnumber != '' %}
 router bgp {{ OPNsense.quagga.bgp.asnumber }}
+ no bgp ebgp-requires-policy
 {%   if helpers.exists('OPNsense.quagga.bgp.routerid') and OPNsense.quagga.bgp.routerid != '' %}
  bgp router-id {{ OPNsense.quagga.bgp.routerid }}
 {%   endif %}


### PR DESCRIPTION
Without eBGP filters no prefixes are exchanged without a policy.
To not break too many setups disable globally

https://github.com/FRRouting/frr/issues/6843
https://forum.opnsense.org/index.php?topic=18379.0