### PR TITLE
net-mgmt/telegraf: Add ntpq input

### DIFF
--- a/net-mgmt/telegraf/Makefile
+++ b/net-mgmt/telegraf/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		telegraf
-PLUGIN_VERSION=		1.8.1
+PLUGIN_VERSION=		1.8.2
 PLUGIN_COMMENT=		Agent for collecting metrics and data
 PLUGIN_DEPENDS=		telegraf
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net-mgmt/telegraf/pkg-descr
+++ b/net-mgmt/telegraf/pkg-descr
@@ -11,6 +11,10 @@ Kafka, MQTT, NSQ, and many others.
 Plugin Changelog
 ================
 
+1.8.2
+
+* Add 'ntpq' input
+
 1.8.1
 
 * Fix 'flush interval' templating by @Jontron123

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/input.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/input.xml
@@ -123,10 +123,4 @@
         <type>checkbox</type>
         <help>Can increase metric gather times.</help>
     </field>
-    <field>
-        <id>input.custom</id>
-        <label>Custom inputs</label>
-        <type>textbox</type>
-        <help>You can add custom inputs here.</help>
-    </field>
 </form>

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/input.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/input.xml
@@ -119,7 +119,7 @@
     </field>
     <field>
         <id>input.ntpq_dns_lookup</id>
-        <label>NTPQ DNS lookup</label>
+        <label>NTPQ DNS Lookup</label>
         <type>checkbox</type>
         <help>Can increase metric gather times.</help>
     </field>

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/input.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/input.xml
@@ -111,4 +111,16 @@
         <type>checkbox</type>
         <help>Enable the collection of ZFS statistics.</help>
     </field>
+    <field>
+        <id>input.ntpq</id>
+        <label>NTPQ</label>
+        <type>checkbox</type>
+        <help>Enable the collection of NTP query metrics.</help>
+    </field>
+    <field>
+        <id>input.ntpq_dns_lookup</id>
+        <label>NTPQ DNS lookup</label>
+        <type>checkbox</type>
+        <help>Can increase metric gather times.</help>
+    </field>
 </form>

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/input.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/input.xml
@@ -123,4 +123,10 @@
         <type>checkbox</type>
         <help>Can increase metric gather times.</help>
     </field>
+    <field>
+        <id>input.custom</id>
+        <label>Custom inputs</label>
+        <type>textbox</type>
+        <help>You can add custom inputs here.</help>
+    </field>
 </form>

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Input.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Input.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/telegraf/input</mount>
     <description>Telegraf inputs configuration</description>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <items>
         <cpu type="BooleanField">
             <default>1</default>
@@ -74,5 +74,13 @@
             <default>0</default>
             <Required>N</Required>
         </zfs>
+        <ntpq type="BooleanField">
+            <default>0</default>
+            <Required>N</Required>
+        </ntpq>
+        <ntpq_dns_lookup type="BooleanField">
+            <default>0</default>
+            <Required>N</Required>
+        </ntpq_dns_lookup>
     </items>
 </model>

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Input.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Input.xml
@@ -82,9 +82,5 @@
             <default>0</default>
             <Required>N</Required>
         </ntpq_dns_lookup>
-        <custom type="TextField">
-            <default></default>
-            <Required>N</Required>
-        </custom>
     </items>
 </model>

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Input.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Input.xml
@@ -82,5 +82,9 @@
             <default>0</default>
             <Required>N</Required>
         </ntpq_dns_lookup>
+        <custom type="TextField">
+            <default></default>
+            <Required>N</Required>
+        </custom>
     </items>
 </model>

--- a/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
+++ b/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
@@ -224,4 +224,13 @@
   poolMetrics = true
 {% endif %}
 
+{% if helpers.exists('OPNsense.telegraf.input.ntpq') and OPNsense.telegraf.input.ntpq == '1' %}
+[[inputs.ntpq]]
+{%   if helpers.exists('OPNsense.telegraf.input.ntpq_dns_lookup') and OPNsense.telegraf.input.ntpq_dns_lookup == '1' %}
+  dns_lookup = true
+{%   else %}
+  dns_lookup = false
+{%   endif %}
+{% endif %}
+
 {% endif %}

--- a/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
+++ b/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
@@ -233,4 +233,8 @@
 {%   endif %}
 {% endif %}
 
+{% if helpers.exists('OPNsense.telegraf.input.custom') %}
+{{ OPNsense.telegraf.input.custom }}
+{% endif %}
+
 {% endif %}

--- a/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
+++ b/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
@@ -233,8 +233,4 @@
 {%   endif %}
 {% endif %}
 
-{% if helpers.exists('OPNsense.telegraf.input.custom') %}
-{{ OPNsense.telegraf.input.custom }}
-{% endif %}
-
 {% endif %}


### PR DESCRIPTION
Add ntpq input

![1596929167](https://user-images.githubusercontent.com/49376203/89721567-68f45980-d9df-11ea-93c0-1b9576531405.png)

**Unbound:**
I would also like to add unbound input. See: https://github.com/influxdata/telegraf/tree/master/plugins/inputs/unbound
Unfortunately the telegraf user don't has all required permissions for that.

```
:~ # sudo -u telegraf unbound-control -c /var/unbound/unbound.conf stats_noreset
/var/unbound/unbound.conf:121: error: cannot open include file '/var/unbound/etc/*.conf': Permission denied
read /var/unbound/unbound.conf failed: 1 errors in configuration file
[1596929270] unbound-control[24137:0] fatal error: could not read config file
```
Is it possible to change the permissions of the folder `/var/unbound/etc` so telegraf can load the config file?