### PR TITLE
acme-client: add support for Joker API DNS validation

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -552,6 +552,21 @@
         <help>Uncheck this box if you have a valid SSL certificate for your ISPConfig installation.</help>
     </field>
     <field>
+        <label>Joker</label>
+        <type>header</type>
+        <style>table_dns table_dns_joker</style>
+    </field>
+    <field>
+        <id>validation.dns_joker_username</id>
+        <label>Username</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_joker_password</id>
+        <label>Password</label>
+        <type>password</type>
+    </field>
+    <field>
         <label>KingHost</label>
         <type>header</type>
         <style>table_dns table_dns_kinghost</style>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -394,6 +394,7 @@
                         <dns_infoblox>Infoblox API</dns_infoblox>
                         <dns_inwx>INWX XMLRPC API</dns_inwx>
                         <dns_ispconfig>ISPConfig 3.1+ API</dns_ispconfig>
+                        <dns_joker>Joker API</dns_joker>
                         <dns_kinghost>KingHost DNS API</dns_kinghost>
                         <dns_knot>Knot (knsupdate) DNS API</dns_knot>
                         <dns_leaseweb>LeaseWeb API</dns_leaseweb>
@@ -604,6 +605,12 @@
                     <Required>N</Required>
                     <default>1</default>
                 </dns_ispconfig_insecure>
+                <dns_joker_username type="TextField">
+                    <Required>N</Required>
+                </dns_joker_username>
+                <dns_joker_password type="TextField">
+                    <Required>N</Required>
+                </dns_joker_password>
                 <dns_kinghost_username type="TextField">
                     <Required>N</Required>
                 </dns_kinghost_username>

--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/certhelper.php
@@ -829,6 +829,10 @@ function run_acme_validation($certObj, $valObj, $acctObj)
                 $proc_env['ISPC_Api'] = (string)$valObj->dns_ispconfig_api;
                 $proc_env['ISPC_Api_Insecure'] = (string)$valObj->dns_ispconfig_insecure;
                 break;
+            case 'dns_joker':
+                $proc_env['JOKER_USERNAME'] = (string)$valObj->dns_joker_username;
+                $proc_env['JOKER_PASSWORD'] = (string)$valObj->dns_joker_password;
+                break;
             case 'dns_kinghost':
                 $proc_env['KINGHOST_username'] = (string)$valObj->dns_kinghost_username;
                 $proc_env['KINGHOST_Password'] = (string)$valObj->dns_kinghost_password;


### PR DESCRIPTION
This PR adds support for the Joker API DNS validation via `dns_joker.sh`. Note that `dns_joker.sh` doesn't exist yet in the current `acme.sh` package version, 2.8.6. However, due to #1946 that script should soon be part of the `acme.sh` package.

I've verified that my modification works with a manually-installed `dns_joker.sh`.

I have read the contributing guidelines.