### PR TITLE
Update quagga.rb

### DIFF
--- a/net/frr/src/opnsense/scripts/quagga/quagga.rb
+++ b/net/frr/src/opnsense/scripts/quagga/quagga.rb
@@ -113,7 +113,7 @@ class General
     end
 
     # you don't have to understand this regex ;)
-    entry_regex = /(\S+?)\s+?(\S+?)(?: \[(\d+)\/(\d+)\])? (?:(?:via (\S+?)|is ([^,]+?)|), ([^,\n]+)|(unreachable \(blackhole\)))(?:, (\S+))?/
+    entry_regex = /(\S+?|\S\s\S)\s+(\S+\d)?\s(?:\[(\d+)\/(\d+)\])?(?:.+\s(\d+\S+\d+|(c\w+d|u\w+e|b\w+e)))(?:,\s(\D+[^,]))?(?:.+\s((\d\S+\d)))/
     entries = []
     while (line = lines.shift&.strip)
       if line.length > 10

--- a/net/frr/src/opnsense/scripts/quagga/quagga.rb
+++ b/net/frr/src/opnsense/scripts/quagga/quagga.rb
@@ -113,7 +113,7 @@ class General
     end
 
     # you don't have to understand this regex ;)
-    entry_regex = /(\S+?|\S\s\S)\s+(\S+\d)?\s(?:\[(\d+)\/(\d+)\])?(?:.+\s(\d+\S+\d+|(c\w+d|u\w+e|b\w+e)))(?:,\s(\D+[^,]))?(?:.+\s((\d\S+\d)))/
+    entry_regex = /(\S+|\S\s\S)\s+(\S+\d|[:.0-9a-f]+\S+)?\s(?:\[(\d+)\/(\d+)\])?(?:.+\s([:.0-9a-f]+\S+\b|(c\w+d|u\w+e|b\w+e)))(?:,\s(\D+[^,]))?(?:.+\s((\d\S+\d)))/
     entries = []
     while (line = lines.shift&.strip)
       if line.length > 10


### PR DESCRIPTION
Given the routing table output similar to the one shown below the regex fails and produces a blank page in Routing->Diagnostics->General->IPv4 Page. The updated regex should allow more flexibility in parsing variations in the "show ip/ipv6 route" output.

K>* 0.0.0.0/0 [0/0] via 172.20.16.1, 19:10:08
K * 10.3.12.0/24 [0/0] via 10.3.102.1, 19:10:08
C>* 10.3.12.0/24 [0/1] is directly connected, ovpnc1, 19:10:08
O>* 10.11.12.0/24 [110/20] via 172.20.1.1, ix1, weight 1, 19:09:18
O>* 10.2.30.0/24 [110/20] via 172.20.1.1, ix1, weight 1, 19:09:17
O>* 10.2.40.0/24 [110/20] via 172.20.1.1, ix1, weight 1, 19:09:17
C>* 10.29.0.0/24 [0/1] is directly connected, wg1, 19:10:08
O>* 10.1.1.0/30 [110/20] via 10.1.1.10, wg0 onlink, weight 1, 19:09:53
[  *                          via 10.1.1.10, wg2 onlink, weight 1, 19:09:53] <-Remove brackets
O>* 10.1.1.4/30 [110/20] via 10.1.1.10, wg0 onlink, weight 1, 19:09:53
O   10.1.1.8/30 [110/20] via 10.1.1.10, wg0 onlink, weight 1, 19:09:53
C>* 10.1.1.8/30 [0/1] is directly connected, wg0, 19:10:08
O   10.1.1.12/30 [110/20] via 10.1.1.14, wg2 onlink, weight 1, 19:10:01
C>* 10.1.1.12/30 [0/1] is directly connected, wg2, 19:10:08
O>* 10.1.1.16/30 [110/20] via 10.1.1.14, wg2 onlink, weight 1, 19:10:01
O>* 10.1.21.0/24 [110/20] via 10.1.1.10, wg0 onlink, weight 1, 19:09:53
O>* 10.1.22.0/24 [110/20] via 10.1.1.14, wg2 onlink, weight 1, 19:10:01
C>* 10.6.3.1/32 [0/1] is directly connected, lo2, 19:10:08
O>* 10.6.3.2/32 [110/20] via 10.1.1.14, wg2 onlink, weight 1, 19:10:01
O>* 10.6.3.3/32 [110/20] via 10.1.1.10, wg0 onlink, weight 1, 19:09:53
O>* 10.6.3.254/32 [110/20] via 172.20.1.253, ix1, weight 1, 19:09:18
O>* 172.20.0.0/24 [110/20] via 172.20.1.253, ix1, weight 1, 19:09:18
O>* 172.20.1.0/24 [110/20] via 172.20.1.253, ix1, weight 1, 19:09:18
O>* 172.20.2.0/24 [110/20] via 172.20.1.253, ix1, weight 1, 19:09:18
O>* 172.20.4.0/24 [110/20] via 172.20.1.253, ix1, weight 1, 19:09:18
C>* 172.20.9.0/24 [0/1] is directly connected, ix2, 19:10:08
O>* 172.20.10.0/24 [110/20] via 172.20.1.253, ix1, weight 1, 19:09:18
C>* 172.20.1.0/24 [0/1] is directly connected, ix0, 19:10:08
O   172.20.1.0/24 [110/10] is directly connected, ix1, weight 1, 19:10:08
C>* 172.20.1.0/24 [0/1] is directly connected, ix1, 19:10:08
O>* 172.20.15.0/24 [110/20] via 172.20.1.253, ix1, weight 1, 19:09:18
O>* 172.21.0.0/24 [110/20] via 10.1.1.10, wg0 onlink, weight 1, 15:45:02
S   172.21.0.0/24 [254/0] unreachable (ICMP unreachable), weight 1, 19:10:08