### PR TITLE
www/nginx: insert correct SNI name

### DIFF
--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/location.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/location.conf
@@ -178,9 +178,9 @@ location {{ location.matchtype }} {{ location.urlpattern }} {
     proxy_ssl_server_name on;
 {%     else %}
     proxy_ssl_server_name off;
+{%    endif %}
 {%         if upstream.tls_name_override is defined and upstream.tls_name_override != '' %}
     proxy_ssl_name {{ upstream.tls_name_override }};
-{%         endif %}
 {%     endif%}
 {%     if upstream.tls_protocol_versions is defined and upstream.tls_protocol_versions != '' %}
     proxy_ssl_protocols {{ upstream.tls_protocol_versions.replace(',', ' ') }};


### PR DESCRIPTION
Update location.conf to allow to use proxy_ssl_name directive with  proxy_ssl_server_name directive "on" (allow SNI and insert SNI server name)