### PR TITLE
Cicada correct fixed backround colour by override on ipsec_vpn.php

### DIFF
--- a/misc/theme-cicada/src/opnsense/www/themes/cicada/assets/stylesheets/main.scss
+++ b/misc/theme-cicada/src/opnsense/www/themes/cicada/assets/stylesheets/main.scss
@@ -10732,3 +10732,6 @@ label.btn.au-target {
 .metric-table tbody > tr:last-child > td, .list-table tbody > tr:last-child > td {
   border-bottom: 1px solid #555 !important;
 }
+.phase1_tr td {
+  background-color: #262626 !important;
+}

--- a/misc/theme-cicada/src/opnsense/www/themes/cicada/build/css/main.css
+++ b/misc/theme-cicada/src/opnsense/www/themes/cicada/build/css/main.css
@@ -6587,3 +6587,7 @@ label.btn.au-target {
 .metric-table tbody > tr:last-child > td, .list-table tbody > tr:last-child > td {
   border-bottom: 1px solid #555 !important;
 }
+
+.phase1_tr td {
+  background-color: #262626 !important;
+}


### PR DESCRIPTION
ipsec_vpn.php uses a fixed colour, this is overriden by an !important flag in this fix.  On behalf of René.