### PR TITLE
Adding graceful configuration update and reload for Wireguard

### DIFF
--- a/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/Api/ServiceController.php
+++ b/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/Api/ServiceController.php
@@ -66,4 +66,22 @@ class ServiceController extends ApiMutableServiceControllerBase
         $response = $backend->configdRun("wireguard showhandshake");
         return array("response" => $response);
     }
+
+    /**
+     * Gracefully reload Wireguard with latest configuration
+     * @return array
+     */
+    public function reconfigureAction()
+    {
+        if ($this->request->isPost()) {
+            $this->sessionClose();
+
+            $backend = new Backend();
+            $backend->configdRun('template reload OPNsense/Wireguard');
+            $backend->configdRun("wireguard reload");
+            return array("status" => "ok");
+        } else {
+            return array("status" => "failed");
+        }
+    }
 }

--- a/net/wireguard/src/opnsense/service/conf/actions.d/actions_wireguard.conf
+++ b/net/wireguard/src/opnsense/service/conf/actions.d/actions_wireguard.conf
@@ -22,6 +22,15 @@ parameters:
 type:script
 message:restarting Wireguard
 
+[reload]
+command:
+    /usr/local/opnsense/scripts/OPNsense/Wireguard/setup.sh;
+    /usr/local/etc/rc.d/wireguard reload;
+    /usr/local/etc/rc.routing_configure
+parameters:
+type:script
+message:reloading Wireguard
+
 [genkey]
 command:/usr/local/opnsense/scripts/OPNsense/Wireguard/genkey.sh
 parameters: %s


### PR DESCRIPTION
This is a collaboration with @astuckey123 to address this issue:

https://github.com/opnsense/plugins/issues/1951

This implements a reconfigureAction that does a wireguard reload, rather that falling back to the default reconfigureAction which does a full restart. Doing it this way will not disconnect peers that aren't affected by configuration changes. 