### PR TITLE
net-mgmt/telegraf: Add ping6 input

### DIFF
--- a/net-mgmt/telegraf/Makefile
+++ b/net-mgmt/telegraf/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		telegraf
-PLUGIN_VERSION=		1.8.2
+PLUGIN_VERSION=		1.8.3
 PLUGIN_COMMENT=		Agent for collecting metrics and data
 PLUGIN_DEPENDS=		telegraf
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/input.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/input.xml
@@ -87,17 +87,31 @@
     </field>
     <field>
         <id>input.ping</id>
-        <label>Ping</label>
+        <label>Ping (IPv4)</label>
         <type>checkbox</type>
-        <help>Ping Hosts and measure the metrics.</help>
+        <help>Ping Hosts using IPv4 and measure the metrics.</help>
     </field>
     <field>
         <id>input.ping_hosts</id>
-        <label>Ping Hosts</label>
+        <label>Ping Hosts (IPv4)</label>
         <type>select_multiple</type>
         <style>tokenize</style>
         <allownew>true</allownew>
-        <help>Set the Hosts to ping in a CSV list.</help>
+        <help>Set the Hosts to ping using IPv4 in a CSV list.</help>
+    </field>
+    <field>
+        <id>input.ping6</id>
+        <label>Ping (IPv6)</label>
+        <type>checkbox</type>
+        <help>Ping Hosts using IPv6 and measure the metrics.</help>
+    </field>
+    <field>
+        <id>input.ping6_hosts</id>
+        <label>Ping Hosts (IPv6)</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <allownew>true</allownew>
+        <help>Set the Hosts to ping using IPv6 in a CSV list.</help>
     </field>
     <field>
         <id>input.haproxy</id>

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Input.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Input.xml
@@ -66,6 +66,13 @@
         <ping_hosts type="CSVListField">
             <Required>N</Required>
         </ping_hosts>
+        <ping6 type="BooleanField">
+            <default>0</default>
+            <Required>N</Required>
+        </ping6>
+        <ping6_hosts type="CSVListField">
+            <Required>N</Required>
+        </ping6_hosts>
         <haproxy type="BooleanField">
             <default>0</default>
             <Required>N</Required>

--- a/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
+++ b/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
@@ -209,8 +209,18 @@
 
 {% if helpers.exists('OPNsense.telegraf.input.ping') and OPNsense.telegraf.input.ping == '1' %}
 [[inputs.ping]]
+  method = "exec"
 {%   if helpers.exists('OPNsense.telegraf.input.ping_hosts') and OPNsense.telegraf.input.ping_hosts != '' %}
   urls = [{{ "'" + ("','".join(OPNsense.telegraf.input.ping_hosts.split(','))) + "'" }}]
+{%   endif %}
+{% endif %}
+
+{% if helpers.exists('OPNsense.telegraf.input.ping6') and OPNsense.telegraf.input.ping6 == '1' %}
+[[inputs.ping]]
+  method = "exec"
+  binary = "ping6"
+{%   if helpers.exists('OPNsense.telegraf.input.ping6_hosts') and OPNsense.telegraf.input.ping6_hosts != '' %}
+  urls = [{{ "'" + ("','".join(OPNsense.telegraf.input.ping6_hosts.split(','))) + "'" }}]
 {%   endif %}
 {% endif %}
 


### PR DESCRIPTION
## Background
Many months ago I discovered that Telegraf's ping input plugin doesn't work for IPv6 on OPNsense (and FreeBSD in general).
I fixed the general FreeBSD problems in [this pull request](https://github.com/influxdata/telegraf/pull/7861) for Telegraf, which is included since release 1.15.3.
OPNsense also needs some changes to make use of the fixed Telegraf.

## Changes
Added another checkbox to enable a second instance of the ping input for IPv6, and a list box where one can specify the IPv6 hosts, to the GUI.
This second instance has `binary = "ping6"` set in `telegraf.conf`.
Both the IPv4 and the IPv6 instances also explicitly set `method = "exec"`, since there's a chance that the ping input plugin will move to `method = "native"` in the future, which wouldn't work without changes (if at all?) on FreeBSD, because it needs raw ICMP sockets:
> This plugin has two main methods of operation: exec and native. The recommended method is native, which has greater system compatibility and performance. However, for backwards compatibility the exec method is the default.
When using method = "native" a ping is sent and the results are reported in native Go by the Telegraf process, eliminating the need to execute the system ping command.
When using method = "native", Telegraf will attempt to use privileged raw ICMP sockets.

More info can be found in the [README](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/ping/README.md) for the ping input plugin.

## Testing

![grafik](https://user-images.githubusercontent.com/28812678/93027695-09f1b800-f60f-11ea-8bf0-23c2a58fbd3d.png)

I've tested these changes on my main OPNsense router, and they seem to work fine with a replaced `telegraf` binary.