### PR TITLE
Allow hyphen / minus sign (-) as a valid hostname character

### DIFF
--- a/net/wireguard/Makefile
+++ b/net/wireguard/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		wireguard
-PLUGIN_VERSION=		1.2
+PLUGIN_VERSION=		1.3
 PLUGIN_COMMENT=		WireGuard VPN service
 PLUGIN_DEPENDS=		wireguard
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net/wireguard/pkg-descr
+++ b/net/wireguard/pkg-descr
@@ -16,6 +16,10 @@ WWW: https://www.wireguard.com/
 Changelog
 ---------
 
+1.3
+
+* Client/peer name validation to use HostnameField
+
 1.2
 
 * Dashboard widget (contributed by D. Domig)

--- a/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Client.xml
+++ b/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Client.xml
@@ -12,8 +12,8 @@
                 <name type="TextField">
                     <default></default>
                     <Required>Y</Required>
-                    <mask>/^([0-9a-zA-Z]){1,32}$/u</mask>
-                    <ValidationMessage>Should be a string between 1 and 32 characters. Allowed characters are 0-9a-zA-Z</ValidationMessage>
+                    <mask>/^([0-9a-zA-Z\-]){1,32}$/u</mask>
+                    <ValidationMessage>Should be a string between 1 and 32 characters. Allowed characters are 0-9a-zA-Z and -</ValidationMessage>
                 </name>
                 <pubkey type="TextField">
                     <Required>N</Required>

--- a/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Client.xml
+++ b/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Client.xml
@@ -9,11 +9,9 @@
                     <default>1</default>
                     <Required>Y</Required>
                 </enabled>
-                <name type="TextField">
+                <name type="HostnameField">
                     <default></default>
                     <Required>Y</Required>
-                    <mask>/^([0-9a-zA-Z\-]){1,32}$/u</mask>
-                    <ValidationMessage>Should be a string between 1 and 32 characters. Allowed characters are 0-9a-zA-Z and -</ValidationMessage>
                 </name>
                 <pubkey type="TextField">
                     <Required>N</Required>

--- a/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Client.xml
+++ b/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Client.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/wireguard/client</mount>
     <description>Wireguard Client configuration</description>
-    <version>0.0.4</version>
+    <version>0.0.5</version>
     <items>
         <clients>
             <client type="ArrayField">


### PR DESCRIPTION
RFC 952 allows the hyphen or minus sign (-) to be a valid hostname character. The WireGuard Client configuration should allow the same. This change has had limited testing with no negative impact.

http://en.wikipedia.org/wiki/Hostname
    The Internet standards (Requests for Comments) for protocols mandate that component hostname labels may contain only the ASCII letters 'a' through 'z' (in a case-insensitive manner), the digits '0' through '9', and the hyphen ('-'). The original specification of hostnames in RFC 952, mandated that labels could not start with a digit or with a hyphen, and must not end with a hyphen. However, a subsequent specification (RFC 1123) permitted hostname labels to start with digits. No other symbols, punctuation characters, or white space are permitted.