### PR TITLE
stunnel: add intermediate certs to stunnel instance/service cert bundle

### DIFF
--- a/security/stunnel/Makefile
+++ b/security/stunnel/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		stunnel
-PLUGIN_VERSION=		1.0.2
+PLUGIN_VERSION=		1.0.3
 PLUGIN_COMMENT=		stunnel TLS proxy
 PLUGIN_MAINTAINER=	ad@opnsense.org
 PLUGIN_DEPENDS=		stunnel

--- a/security/stunnel/src/opnsense/scripts/stunnel/generate_certs.php
+++ b/security/stunnel/src/opnsense/scripts/stunnel/generate_certs.php
@@ -28,6 +28,8 @@
  */
 
 require_once('plugins.inc');
+require_once('certs.inc');
+require_once('config.inc');
 require_once("legacy_bindings.inc");
 
 use OPNsense\Stunnel\Stunnel;
@@ -45,6 +47,10 @@ foreach ($stunnel->services->service->__items as $service) {
             if ($srv_certid == (string)$cert->refid) {
                 $all_certs["{$base_path}/{$this_uuid}.crt"] =
                     base64_decode((string)$cert->crt) . "\n" . base64_decode((string)$cert->prv);
+                if (!empty((string)$cert->caref)) {
+                    $cert = (array)$cert;
+                    $all_certs["{$base_path}/{$this_uuid}.crt"] .= ca_chain($cert);
+                }
             }
         }
         if (!empty((string)$service->cacert)) {


### PR DESCRIPTION
Currently stunnel only presents its configured certificate to its clients. For a setup without intermediate CAs this is fine.

However if you would like to use the ACME generated LE certificates clients cannot validate the single cert without the server presenting the intermediate certs AKA chain.

This has nothing to do with including the intermediate certs into the already present CA option. 