### PR TITLE
security/acme-client: post merge fixes for version 2.0

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeAccount.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeAccount.php
@@ -57,7 +57,7 @@ class LeAccount extends LeCommon
         $this->setEnvironment();
 
         // Store acme filenames
-        $this->acme_args[] = exec_safe('--home %s', self::ACME_HOME_DIR);
+        $this->acme_args[] = LeUtils::execSafe('--home %s', self::ACME_HOME_DIR);
     }
 
     /**
@@ -118,8 +118,8 @@ class LeAccount extends LeCommon
                 $acmecmd = '/usr/local/sbin/acme.sh '
                   . '--createAccountKey '
                   . implode(' ', $this->acme_args) . ' '
-                  . exec_safe('--accountkeylength %s', self::ACME_ACCOUNT_KEY_LENGTH) . ' '
-                  . exec_safe('--accountconf %s', $account_conf_file);
+                  . LeUtils::execSafe('--accountkeylength %s', self::ACME_ACCOUNT_KEY_LENGTH) . ' '
+                  . LeUtils::execSafe('--accountconf %s', $account_conf_file);
                 LeUtils::log_debug('running acme.sh command: ' . (string)$acmecmd, $this->debug);
                 $proc = proc_open($acmecmd, $proc_desc, $proc_pipes, null, $proc_env);
 
@@ -226,7 +226,7 @@ class LeAccount extends LeCommon
             $acmecmd = '/usr/local/sbin/acme.sh '
               . '--registeraccount '
               . implode(' ', $this->acme_args) . ' '
-              . exec_safe('--accountconf %s', $this->account_conf_file);
+              . LeUtils::execSafe('--accountconf %s', $this->account_conf_file);
             LeUtils::log_debug('running acme.sh command: ' . (string)$acmecmd, $this->debug);
             $proc = proc_open($acmecmd, $proc_desc, $proc_pipes, null, $proc_env);
 

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeAccount.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeAccount.php
@@ -57,7 +57,7 @@ class LeAccount extends LeCommon
         $this->setEnvironment();
 
         // Store acme filenames
-        $this->acme_args[] = '--home ' . self::ACME_HOME_DIR;
+        $this->acme_args[] = exec_safe('--home %s', self::ACME_HOME_DIR);
     }
 
     /**
@@ -118,8 +118,8 @@ class LeAccount extends LeCommon
                 $acmecmd = '/usr/local/sbin/acme.sh '
                   . '--createAccountKey '
                   . implode(' ', $this->acme_args) . ' '
-                  . '--accountkeylength ' . self::ACME_ACCOUNT_KEY_LENGTH . ' '
-                  . "--accountconf ${account_conf_file}";
+                  . exec_safe('--accountkeylength %s', self::ACME_ACCOUNT_KEY_LENGTH) . ' '
+                  . exec_safe('--accountconf %s', $account_conf_file);
                 LeUtils::log_debug('running acme.sh command: ' . (string)$acmecmd, $this->debug);
                 $proc = proc_open($acmecmd, $proc_desc, $proc_pipes, null, $proc_env);
 
@@ -226,7 +226,7 @@ class LeAccount extends LeCommon
             $acmecmd = '/usr/local/sbin/acme.sh '
               . '--registeraccount '
               . implode(' ', $this->acme_args) . ' '
-              . '--accountconf ' . $this->account_conf_file;
+              . exec_safe('--accountconf %s', $this->account_conf_file);
             LeUtils::log_debug('running acme.sh command: ' . (string)$acmecmd, $this->debug);
             $proc = proc_open($acmecmd, $proc_desc, $proc_pipes, null, $proc_env);
 

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeCertificate.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeCertificate.php
@@ -88,11 +88,11 @@ class LeCertificate extends LeCommon
         $this->cert_fullchain_file = (string)sprintf(self::ACME_FULLCHAIN_FILE, $this->config->id);
 
         // Store acme filenames
-        $this->acme_args[] = '--home ' . self::ACME_HOME_DIR;
-        $this->acme_args[] = '--certpath ' . $this->cert_file;
-        $this->acme_args[] = '--keypath ' . $this->cert_key_file;
-        $this->acme_args[] = '--capath ' . $this->cert_chain_file;
-        $this->acme_args[] = '--fullchainpath ' . $this->cert_fullchain_file;
+        $this->acme_args[] = exec_safe('--home %s', self::ACME_HOME_DIR);
+        $this->acme_args[] = exec_safe('--certpath %s', $this->cert_file);
+        $this->acme_args[] = exec_safe('--keypath %s', $this->cert_key_file);
+        $this->acme_args[] = exec_safe('--capath %s', $this->cert_chain_file);
+        $this->acme_args[] = exec_safe('--fullchainpath %s', $this->cert_fullchain_file);
     }
 
     /**
@@ -529,7 +529,7 @@ class LeCertificate extends LeCommon
           . '--revoke '
           . implode(' ', $this->acme_args) . ' '
           . exec_safe('--domain %s', (string)$this->config->name) . ' '
-          . "--accountconf ${account_conf_file}";
+          . exec_safe('--accountconf %s', $account_conf_file);
         LeUtils::log_debug('running acme.sh command: ' . (string)$acmecmd, $this->debug);
         $proc = proc_open($acmecmd, $proc_desc, $proc_pipes, null, $proc_env);
 

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeCertificate.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeCertificate.php
@@ -30,7 +30,6 @@ namespace OPNsense\AcmeClient;
 
 // Load legacy functions
 require_once("certs.inc"); // used in import()
-require_once("util.inc"); // for exec_safe()
 
 use OPNsense\Core\Config;
 use OPNsense\AcmeClient\LeAccount;
@@ -88,11 +87,11 @@ class LeCertificate extends LeCommon
         $this->cert_fullchain_file = (string)sprintf(self::ACME_FULLCHAIN_FILE, $this->config->id);
 
         // Store acme filenames
-        $this->acme_args[] = exec_safe('--home %s', self::ACME_HOME_DIR);
-        $this->acme_args[] = exec_safe('--certpath %s', $this->cert_file);
-        $this->acme_args[] = exec_safe('--keypath %s', $this->cert_key_file);
-        $this->acme_args[] = exec_safe('--capath %s', $this->cert_chain_file);
-        $this->acme_args[] = exec_safe('--fullchainpath %s', $this->cert_fullchain_file);
+        $this->acme_args[] = LeUtils::execSafe('--home %s', self::ACME_HOME_DIR);
+        $this->acme_args[] = LeUtils::execSafe('--certpath %s', $this->cert_file);
+        $this->acme_args[] = LeUtils::execSafe('--keypath %s', $this->cert_key_file);
+        $this->acme_args[] = LeUtils::execSafe('--capath %s', $this->cert_chain_file);
+        $this->acme_args[] = LeUtils::execSafe('--fullchainpath %s', $this->cert_fullchain_file);
     }
 
     /**
@@ -437,7 +436,7 @@ class LeCertificate extends LeCommon
         $acmecmd = '/usr/local/sbin/acme.sh '
           . '--remove '
           . implode(' ', $this->acme_args) . ' '
-          . exec_safe('--domain %s', (string)$this->config->name);
+          . LeUtils::execSafe('--domain %s', (string)$this->config->name);
         LeUtils::log_debug('running acme.sh command: ' . (string)$acmecmd, $this->debug);
         $proc = proc_open($acmecmd, $proc_desc, $proc_pipes, null, $proc_env);
 
@@ -528,8 +527,8 @@ class LeCertificate extends LeCommon
         $acmecmd = '/usr/local/sbin/acme.sh '
           . '--revoke '
           . implode(' ', $this->acme_args) . ' '
-          . exec_safe('--domain %s', (string)$this->config->name) . ' '
-          . exec_safe('--accountconf %s', $account_conf_file);
+          . LeUtils::execSafe('--domain %s', (string)$this->config->name) . ' '
+          . LeUtils::execSafe('--accountconf %s', $account_conf_file);
         LeUtils::log_debug('running acme.sh command: ' . (string)$acmecmd, $this->debug);
         $proc = proc_open($acmecmd, $proc_desc, $proc_pipes, null, $proc_env);
 

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeUtils.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeUtils.php
@@ -4,7 +4,11 @@
  * Copyright (C) 2017-2020 Frank Wall
  * Copyright (C) 2015 Deciso B.V.
  * Copyright (C) 2010 Jim Pingle <jimp@pfsense.org>
+ * Copyright (C) 2010 Ermal Luçi
  * Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
+ * Copyright (C) 2005-2006 Colin Smith <ethethlay@gmail.com>
+ * Copyright (C) 2004-2007 Scott Ullrich <sullrich@gmail.com>
+ * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -47,6 +51,27 @@ class LeUtils
     public static function base64url_encode($str)
     {
         return rtrim(strtr(base64_encode($str), '+/', '-_'), '=');
+    }
+
+    /**
+     * Properly escape arguments to prevent shell command injection.
+     * This is a copy of the exec_safe() legacy function.
+     * @param string $format The format string to use.
+     * @param string $args The arguments to escape.
+     * @return array|string The formatted and escaped arguments.
+     */
+    public static function execSafe($format, $args = array())
+    {
+        if (!is_array($args)) {
+            /* just in case there's only one argument */
+            $args = array($args);
+        }
+
+        foreach ($args as $id => $arg) {
+            $args[$id] = escapeshellarg($arg);
+        }
+
+        return vsprintf($format, $args);
     }
 
     // Copied from system_camanager.php.

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeUtils.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeUtils.php
@@ -4,11 +4,7 @@
  * Copyright (C) 2017-2020 Frank Wall
  * Copyright (C) 2015 Deciso B.V.
  * Copyright (C) 2010 Jim Pingle <jimp@pfsense.org>
- * Copyright (C) 2010 Ermal Luçi
  * Copyright (C) 2008 Shrew Soft Inc. <mgrooms@shrew.net>
- * Copyright (C) 2005-2006 Colin Smith <ethethlay@gmail.com>
- * Copyright (C) 2004-2007 Scott Ullrich <sullrich@gmail.com>
- * Copyright (C) 2003-2004 Manuel Kasper <mk@neon1.net>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/Base.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/Base.php
@@ -82,8 +82,8 @@ abstract class Base extends \OPNsense\AcmeClient\LeCommon
         // Store acme hook
         switch ((string)$this->config->method) {
             case 'dns01':
-                $this->acme_args[] = '--dns ' . (string)$this->config->dns_service;
-                $this->acme_args[] = '--dnssleep ' . (string)$this->config->dns_sleep;
+                $this->acme_args[] = exec_safe('--dns %s', (string)$this->config->dns_service);
+                $this->acme_args[] = exec_safe('--dnssleep %s', (string)$this->config->dns_sleep);
                 break;
             case 'http01':
                 $this->acme_args[] = '--webroot /var/etc/acme-client/challenges';
@@ -91,11 +91,11 @@ abstract class Base extends \OPNsense\AcmeClient\LeCommon
         }
 
         // Store acme filenames
-        $this->acme_args[] = '--home ' . self::ACME_HOME_DIR;
-        $this->acme_args[] = '--certpath ' . sprintf(self::ACME_CERT_FILE, $this->cert_id);
-        $this->acme_args[] = '--keypath ' . sprintf(self::ACME_KEY_FILE, $this->cert_id);
-        $this->acme_args[] = '--capath ' . sprintf(self::ACME_CHAIN_FILE, $this->cert_id);
-        $this->acme_args[] = '--fullchainpath ' . sprintf(self::ACME_FULLCHAIN_FILE, $this->cert_id);
+        $this->acme_args[] = exec_safe('--home %s', self::ACME_HOME_DIR);
+        $this->acme_args[] = exec_safe('--certpath %s', sprintf(self::ACME_CERT_FILE, $this->cert_id));
+        $this->acme_args[] = exec_safe('--keypath %s', sprintf(self::ACME_KEY_FILE, $this->cert_id));
+        $this->acme_args[] = exec_safe('--capath %s', sprintf(self::ACME_CHAIN_FILE, $this->cert_id));
+        $this->acme_args[] = exec_safe('--fullchainpath %s', sprintf(self::ACME_FULLCHAIN_FILE, $this->cert_id));
 
         return true;
     }
@@ -165,7 +165,7 @@ abstract class Base extends \OPNsense\AcmeClient\LeCommon
         $acmecmd = '/usr/local/sbin/acme.sh '
           . "--${acme_action} "
           . implode(' ', $this->acme_args) . ' '
-          . "--accountconf ${account_conf_file}";
+          . exec_safe('--accountconf %s', $account_conf_file);
         LeUtils::log_debug('running acme.sh command: ' . (string)$acmecmd, $this->debug);
         $proc = proc_open($acmecmd, $proc_desc, $proc_pipes, null, $proc_env);
 
@@ -215,7 +215,7 @@ abstract class Base extends \OPNsense\AcmeClient\LeCommon
             $key_length = $length;
         }
 
-        $this->acme_args[] = '--keylength ' . $key_length;
+        $this->acme_args[] = exec_safe('--keylength %s', $key_length);
         $this->cert_keylength = $length;
     }
 
@@ -296,6 +296,6 @@ abstract class Base extends \OPNsense\AcmeClient\LeCommon
      */
     public function setRenewal(int $interval = 60)
     {
-        $this->acme_args[] = '--days ' . (string)$interval;
+        $this->acme_args[] = exec_safe('--days %s', (string)$interval);
     }
 }


### PR DESCRIPTION
As discussed in https://github.com/opnsense/plugins/pull/2028 I've made the following changes:

* Use `exec_safe()` in more places to prevent shell command injection.
* Drop dependency on legacy `util.inc` by including a copy of the required function in `LeUtils.php`

Granted, the latter one is not great, because it duplicates code. I think this is still better than depending on the legacy codebase in many places.

When the core team decides to move `exec_safe()` to the new codebase then I'll gladly remove the copy from the LE plugin.