### PR TITLE
Check wg-public key format

### DIFF
--- a/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Client.xml
+++ b/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Client.xml
@@ -15,12 +15,10 @@
                 </name>
                 <pubkey type="Base64Field">
                     <Required>N</Required>
-                    <mask>/^[a-zA-Z0-9+=\/]{44}$/</mask>
                     <ValidationMessage>Should be a base64-encoded 32 byte string.</ValidationMessage>
                 </pubkey>
                 <psk type="Base64Field">
                     <Required>N</Required>
-                    <mask>/^[a-zA-Z0-9+=\/]{44}$/</mask>
                     <ValidationMessage>Should be a base64-encoded 32 byte string.</ValidationMessage>
                 </psk>
                 <tunneladdress type="NetworkField">

--- a/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Client.xml
+++ b/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Client.xml
@@ -14,13 +14,13 @@
                     <Required>Y</Required>
                 </name>
                 <pubkey type="Base64Field">
-                    <Required>Y</Required>
-                    <mask>/^[a-zA-Z0-9+\/]{43}=$/</mask>
+                    <Required>N</Required>
+                    <mask>/^[a-zA-Z0-9+=\/]{44}$/</mask>
                     <ValidationMessage>Should be a base64-encoded 32 byte string.</ValidationMessage>
                 </pubkey>
                 <psk type="Base64Field">
                     <Required>N</Required>
-                    <mask>/^[a-zA-Z0-9+\/]{43}=$/</mask>
+                    <mask>/^[a-zA-Z0-9+=\/]{44}$/</mask>
                     <ValidationMessage>Should be a base64-encoded 32 byte string.</ValidationMessage>
                 </psk>
                 <tunneladdress type="NetworkField">

--- a/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Client.xml
+++ b/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Client.xml
@@ -15,6 +15,8 @@
                 </name>
                 <pubkey type="TextField">
                     <Required>N</Required>
+                    <mask>/^[a-zA-Z0-9+\/]{43}=$/</mask>
+                    <ValidationMessage>Should be a base64-encoded 32 byte string.</ValidationMessage>
                 </pubkey>
                 <psk type="TextField">
                     <Required>N</Required>

--- a/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Client.xml
+++ b/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Client.xml
@@ -13,12 +13,12 @@
                     <default></default>
                     <Required>Y</Required>
                 </name>
-                <pubkey type="TextField">
-                    <Required>N</Required>
+                <pubkey type="Base64Field">
+                    <Required>Y</Required>
                     <mask>/^[a-zA-Z0-9+\/]{43}=$/</mask>
                     <ValidationMessage>Should be a base64-encoded 32 byte string.</ValidationMessage>
                 </pubkey>
-                <psk type="TextField">
+                <psk type="Base64Field">
                     <Required>N</Required>
                     <mask>/^[a-zA-Z0-9+\/]{43}=$/</mask>
                     <ValidationMessage>Should be a base64-encoded 32 byte string.</ValidationMessage>


### PR DESCRIPTION
Adding a peer with a wrong public key format to a tunnel configuration makes the wall tunnel hang silently when trying to save configuration (and then restart the service). This should prevent wrong configuration but some checks may be done server side to, at least, log some error and display some warning.