### PR TITLE
Update mods-enabled-ldap for compatibility with FreeIPA

### DIFF
--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-ldap
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-ldap
@@ -28,6 +28,7 @@ ldap {
                 control:LM-Password             := 'sambaLmPassword'
                 control:NT-Password             := 'sambaNtPassword'
                 control:LM-Password             := 'dBCSPwd'
+                control:NT-Password             := 'ipaNTHash'
                 control:Password-With-Header    += 'userPassword'
                 control:SMB-Account-CTRL-TEXT   := 'acctFlags'
                 control:Expiration              := 'radiusExpiration'


### PR DESCRIPTION
Add NT-Password entry for FreeIPA compatibility.
FreeIPA requires control:NT-Password   := 'ipaNTHash'