### PR TITLE
sysutils/hw-probe: add full parameters to configd call

### DIFF
--- a/sysutils/hw-probe/src/opnsense/service/conf/actions.d/actions_hwprobe.conf
+++ b/sysutils/hw-probe/src/opnsense/service/conf/actions.d/actions_hwprobe.conf
@@ -1,5 +1,5 @@
 [report]
-command:/usr/local/bin/hw-probe
+command:/usr/local/bin/hw-probe -all -upload
 parameters:
 type:script_output
 message:collecting hardware diagnostics


### PR DESCRIPTION
Future versions will prevent execution without parameters.