### PR TITLE
net/chrony: add NTS peer mode

### DIFF
--- a/net/chrony/Makefile
+++ b/net/chrony/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		chrony
-PLUGIN_VERSION=		1.0
+PLUGIN_VERSION=		1.1
 PLUGIN_COMMENT=		Chrony time synchronisation
 PLUGIN_DEPENDS=		chrony
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net/chrony/pkg-descr
+++ b/net/chrony/pkg-descr
@@ -4,6 +4,10 @@ better in virtual environments.
 Plugin Changelog
 ----------------
 
+1.1
+
+* Add NTS support
+
 1.0
 
 * Allow to adjust the listening port

--- a/net/chrony/src/opnsense/mvc/app/controllers/OPNsense/Chrony/forms/general.xml
+++ b/net/chrony/src/opnsense/mvc/app/controllers/OPNsense/Chrony/forms/general.xml
@@ -12,6 +12,12 @@
         <help>Set the port chrony listen to.</help>
     </field>
     <field>
+        <id>general.ntsclient</id>
+        <label>NTS Client Support</label>
+        <type>checkbox</type>
+        <help>Enable NTS in client mode. This will add another layer of security for peers when OPNsense is the client. Every server in Peers has to support NTS.</help>
+    </field>
+    <field>
         <id>general.peers</id>
         <label>NTP Peers</label>
         <style>tokenize</style>

--- a/net/chrony/src/opnsense/mvc/app/models/OPNsense/Chrony/General.xml
+++ b/net/chrony/src/opnsense/mvc/app/models/OPNsense/Chrony/General.xml
@@ -11,6 +11,10 @@
             <default>323</default>
             <Required>Y</Required>
         </port>
+        <ntsclient type="BooleanField">
+            <default>0</default>
+            <Required>Y</Required>
+        </ntsclient>
         <peers type="HostnameField">
             <default>0.opnsense.pool.ntp.org</default>
             <Required>Y</Required>

--- a/net/chrony/src/opnsense/scripts/OPNsense/Chrony/setup.sh
+++ b/net/chrony/src/opnsense/scripts/OPNsense/Chrony/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-mkdir -p /var/db/chrony/ /var/lib/chrony/ /var/run/chrony/
-chown -R chronyd:chronyd /var/db/chrony/ /var/lib/chrony/ /var/run/chrony/
-chmod 750 /var/db/chrony/ /var/lib/chrony/ /var/run/chrony/
+mkdir -p /var/db/chrony /var/lib/chrony /var/run/chrony
+chown -R chronyd:chronyd /var/db/chrony /var/lib/chrony /var/run/chrony
+chmod 750 /var/db/chrony /var/lib/chrony /var/run/chrony

--- a/net/chrony/src/opnsense/scripts/OPNsense/Chrony/setup.sh
+++ b/net/chrony/src/opnsense/scripts/OPNsense/Chrony/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-mkdir -p /var/db/chrony/ /var/run/chrony/
-chown -R chronyd:chronyd /var/db/chrony/ /var/run/chrony/
-chmod 750 /var/db/chrony/ /var/run/chrony/
+mkdir -p /var/db/chrony/ /var/lib/chrony/ /var/run/chrony/
+chown -R chronyd:chronyd /var/db/chrony/ /var/lib/chrony/ /var/run/chrony/
+chmod 750 /var/db/chrony/ /var/lib/chrony/ /var/run/chrony/

--- a/net/chrony/src/opnsense/service/templates/OPNsense/Chrony/chrony.conf
+++ b/net/chrony/src/opnsense/service/templates/OPNsense/Chrony/chrony.conf
@@ -4,9 +4,15 @@ port {{ OPNsense.chrony.general.port }}
 driftfile /var/db/chrony/drift
 pidfile /var/run/chrony/chronyd.pid
 
+{%   if helpers.exists('OPNsense.chrony.general.ntsclient') and OPNsense.chrony.general.ntsclient == '1' %}
+ntsdumpdir /var/lib/chrony
+ntstrustedcerts /etc/ssl/cert.pem
+nosystemcert
+{%   endif %}
+
 {%   if not helpers.empty('OPNsense.chrony.general.peers') %}
 {%     for peer in OPNsense.chrony.general.peers.split(',') %}
-server {{ peer }} iburst
+server {{ peer }} iburst {% if helpers.exists('OPNsense.chrony.general.ntsclient') and OPNsense.chrony.general.ntsclient == '1' %}nts{% endif %}
 {%     endfor %}
 {%   endif %}
 

--- a/net/chrony/src/opnsense/service/templates/OPNsense/Chrony/chrony.conf
+++ b/net/chrony/src/opnsense/service/templates/OPNsense/Chrony/chrony.conf
@@ -13,6 +13,7 @@ nosystemcert
 {%   if not helpers.empty('OPNsense.chrony.general.peers') %}
 {%     for peer in OPNsense.chrony.general.peers.split(',') %}
 server {{ peer }} iburst {% if helpers.exists('OPNsense.chrony.general.ntsclient') and OPNsense.chrony.general.ntsclient == '1' %}nts{% endif %}
+
 {%     endfor %}
 {%   endif %}
 


### PR DESCRIPTION
Add NTS for peers to chrony which was introduced in 4.0

https://blog.apnic.net/2019/11/08/network-time-security-new-ntp-authentication-mechanism/