### PR TITLE
[Freeradius] Create option to set EAP-TTLS-GTC for FreeRadius

### DIFF
--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Eap.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Eap.xml
@@ -13,6 +13,7 @@
                 <peap>PEAP</peap>
                 <tls>TLS</tls>
                 <ttls>TTLS</ttls>
+				<ttls-gtc>TTLS-GTC</ttls-gtc>
             </OptionValues>
         </default_eap_type>
         <enable_client_cert type="BooleanField">

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Eap.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Eap.xml
@@ -13,7 +13,7 @@
                 <peap>PEAP</peap>
                 <tls>TLS</tls>
                 <ttls>TTLS</ttls>
-				<ttls-gtc>TTLS-GTC</ttls-gtc>
+                <ttls-gtc>TTLS-GTC</ttls-gtc>
             </OptionValues>
         </default_eap_type>
         <enable_client_cert type="BooleanField">

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-eap
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-eap
@@ -628,8 +628,11 @@ eap {
                 #  EAP conversation, then this configuration entry is
                 #  ignored.
                 #
+                {% if helpers.exists('OPNsense.freeradius.eap.default_eap_type') and OPNsense.freeradius.eap.default_eap_type == 'ttls-gtc' %}
+                default_eap_type = gtc
+                {% else %}
                 default_eap_type = md5
-
+                {% endif %}
                 #  The tunneled authentication request does not usually
                 #  contain useful attributes like 'Calling-Station-Id',
                 #  etc.  These attributes are outside of the tunnel,


### PR DESCRIPTION
As discussed in #2085

Creates a option to set freeradius to use EAP-TTLS-GTC.
This can, for example, be used to connect to LDAP databases with hashed passwords.

Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>