### PR TITLE
[RFE] Introduce the master/slave plugin concept

### DIFF
--- a/net-mgmt/zabbix-agent/Makefile
+++ b/net-mgmt/zabbix-agent/Makefile
@@ -1,7 +1,10 @@
-PLUGIN_NAME=		zabbix-agent
+PLUGIN_NAME?=		zabbix-agent
 PLUGIN_VERSION=		1.8
 PLUGIN_COMMENT=		Zabbix monitoring agent
-PLUGIN_DEPENDS=		zabbix5-agent
+PLUGIN_DEPENDS?=	zabbix5-agent
+PLUGIN_CONFLICTS?=	zabbix4-agent zabbix52-agent
 PLUGIN_MAINTAINER=	opnsense@moov.de
 
+.if !defined(PLUGIN_SLAVE)
 .include "../../Mk/plugins.mk"
+.endif

--- a/net-mgmt/zabbix4-agent/Makefile
+++ b/net-mgmt/zabbix4-agent/Makefile
@@ -1,0 +1,10 @@
+PLUGIN_SLAVE=		yes
+MASTERDIR=		${.CURDIR}/../zabbix-agent
+.include "${MASTERDIR}/Makefile"
+
+PLUGIN_VARIANT=		4
+PLUGIN_NAME=        zabbix${PLUGIN_VARIANT}-agent
+PLUGIN_DEPENDS=		zabbix4-agent
+PLUGIN_CONFLICTS=   zabbix-agent zabbix52-agent
+
+.include "../../Mk/plugins.mk"

--- a/net-mgmt/zabbix52-agent/Makefile
+++ b/net-mgmt/zabbix52-agent/Makefile
@@ -1,0 +1,10 @@
+PLUGIN_SLAVE=		yes
+MASTERDIR=		${.CURDIR}/../zabbix-agent
+.include "${MASTERDIR}/Makefile"
+
+PLUGIN_VARIANT=		52
+PLUGIN_NAME=        zabbix${PLUGIN_VARIANT}-agent
+PLUGIN_DEPENDS=		zabbix52-agent
+PLUGIN_CONFLICTS=   zabbix-agent zabbix4-agent
+
+.include "../../Mk/plugins.mk"


### PR DESCRIPTION
### Problem description

Several vendors provide *multiple* supported versions of their applications for an (extended) period of time. These versions may also be incompatible to each other, forcing the user to use a specific version.

Popular examples are Zabbix Proxy and Zabbix Agent (but other software could be considered too). In the past multiple users have complained that Zabbix Agent/Proxy was updated in OPNsense and that they need a different version than the one that is included in OPNsense.

That's a major drawback, because a user would have to upgrade his Zabbix monitoring infrastructure when OPNsense decides to upgrade Zabbix – or a user would not be able to upgrade Zabbix at all because OPNsense uses an older version. (FWIW, I've been affected by this issue multiple times, but I'm in the comfortable position of having my own poudriere server around to build my own Zabbix packages.)

@mimugmail has been doing a great job maintaining two versions of Zabbix Proxy. This is much appreciated! However, as the maintainer of Zabbix Agent I have always rejected to maintain multiple versions of the same plugin because this would impose additional maintenance efforts, requires code duplication, etc.

In the case of Zabbix Proxy the issue was solved by simply copying the `src` folder and create another plugin. However, this approach imposes the risk that the code of both plugins may drift apart. And changes to one of these plugins must be reproduced for the other one. It's a time-consuming and ultimately unsatisfying experience.


### Proposed solution

I propose to introduce a master/slave plugin system, pretty much the same mechanic that is used in FreeBSD's ports system.

The "master" plugin contains all code (the `src` folder). It is the version that is "supported" and recommended by the maintainer.

The "slave" plugin is just a pointer to the "master" plugin code, it does _not_ include a `src` folder nor any other code additions. Instead it just consumes the "master" plugin and overwrites very few meta values, i.e. the list of required packages, conflicts, etc.

In case of Zabbix we would declare the following master plugins:

* zabbix-agent
* zabbix-proxy

And the following slave plugins would be conceivable:

* zabbix4-agent
* zabbix52-agent

* zabbix4-proxy
* zabbix52-proxy

With this approach all supported Zabbix versions would be covered. The maintenance effort would be very low for contributors and the core team. And users would have the choice to use the version they need.

| Pro | Contra |
| :--- | :--- |
| :green_circle: K.I.S.S. :) | :no_entry_sign: PLUGIN_CONFLICTS must be maintained |
| :green_circle: no code duplication | :no_entry_sign: more packages to build/distribute |
| :green_circle: (almost) no additional maintenance efforts | :no_entry_sign: plugin must handle incompatibilities in code |
| :green_circle: satisfy more user requirements |  |
| :green_circle: lower burden to add a new plugin version (as slave plugin) |  |
| :green_circle: plugin version can easily be up-/downgraded |  |
| :green_circle: plugin maintainers may issue version upgrades more frequently |  |


### Example

The following example demonstrates this concept. A user should be able to freely choose between Zabbix Agent 4.0, 5.0 or 5.2 – the 3 currently supported Zabbix versions. (The plugin packages are not in a repo yet, so I'll use my local package files and the FreeBSD pkg repo for this test.)

```
# master/slave plugin packages are identical
$ pkg query --file net-mgmt/zabbix4-agent/work/pkg/os-zabbix4-agent-devel-1.8.txz '%#F files, %sh'
21 files, 48.9KiB
$ pkg query --file net-mgmt/zabbix-agent/work/pkg/os-zabbix-agent-devel-1.8.txz '%#F files, %sh'
21 files, 48.9KiB
$ pkg query --file net-mgmt/zabbix52-agent/work/pkg/os-zabbix52-agent-devel-1.8.txz '%#F files, %sh'
21 files, 48.9KiB
```


```
# master port is labeled RECOMMENDED
$ pkg query --file net-mgmt/zabbix-agent/work/pkg/os-zabbix-agent-devel-1.8.txz '%n: %c' 
os-zabbix-agent-devel: Zabbix monitoring agent [RECOMMENDED]

# slave port is labeled UNSUPPORTED
$ pkg query --file net-mgmt/zabbix52-agent/work/pkg/os-zabbix52-agent-devel-1.8.txz '%n: %c'
os-zabbix52-agent-devel: Zabbix monitoring agent [UNSUPPORTED]
```


```
# installation of the master plugin
$ pkg install net-mgmt/zabbix-agent/work/pkg/os-zabbix-agent-devel-1.8.txz

New packages to be INSTALLED:
	os-zabbix-agent-devel: 1.8 [unknown-repository]
	zabbix5-agent: 5.0.5 [FreeBSD]

# installation of a slave plugin
$ pkg install net-mgmt/zabbix4-agent/work/pkg/os-zabbix4-agent-devel-1.8.txz

New packages to be INSTALLED:
	os-zabbix4-agent-devel: 1.8 [unknown-repository]
	zabbix4-agent: 4.0.25 [FreeBSD]

# installation of another slave plugin
$ pkg install net-mgmt/zabbix52-agent/work/pkg/os-zabbix52-agent-devel-1.8.txz

New packages to be INSTALLED:
	os-zabbix52-agent-devel: 1.8 [unknown-repository]
	zabbix52-agent: 5.2.1 [FreeBSD]
```

(Of course, master and slave plugins cannot be installed at the same time. I just wanted to keep the example as simple as possible.)

### Suggested conventions

I am aware that a master/slave plugin system may cause some confusion without rules, so here's my take:

* Master plugins:
  * A master plugin is always the recommended version.
  * The master plugin will be updated by the maintainer as usual, i.e. Zabbix version 4.0 to 5.0.
  * It's name MUST NOT include a version number, i.e. zabbix-agent instead of zabbix4-agent.
  * Version numbers in config filenames MUST be avoided.
* Slave plugins:
  * Slave plugin MUST include a version number in their name: zabbix4-agent, zabbix52-agent
  * Slave plugins do NOT receive version updates, i.e. not from Zabbix version 4.0 to 5.0 (but from 4.0.1 to 4.0.2).
  * A slave plugin is phased out when the version is EOL'ed upstream.
  * A slave plugin is phased out when the master plugin is upgraded to the same version.
  * Ideally the maintainer would provide an upgrade path for phased out slave plugins.

### Things to consider

* Master/slave plugins should be clearly labeled in their description as a way to communicate their status to end-users. (included in this PR)
  * i.e. by adding "RECOMMENDED" for master and "UNSUPPORTED" for slave plugins
* In some (rare) circumstances additional plugin code is required to handle differences/incompatibilities between multiple plugin versions.
* The master/slave names are just for demonstration purposes, please suggest alternative names, i.e. primary/secondary.


### Next steps

If the core team greenlights this idea then I'll first complete the Zabbix Agent example by submitting PRs for https://github.com/opnsense/ports and https://github.com/opnsense/tools. Afterwards I'd start to prepare PRs for Zabbix Proxy slave ports if @mimugmail agrees.
