### PR TITLE
os-smart: Re-add descriptions for cron actions

### DIFF
--- a/sysutils/smart/src/opnsense/service/conf/actions.d/actions_smart.conf
+++ b/sysutils/smart/src/opnsense/service/conf/actions.d/actions_smart.conf
@@ -57,27 +57,32 @@ command:/usr/local/sbin/smartctl -t offline
 parameters:%s; exit 0
 type:script_output
 message:Testing device %s (offline)
+description:Run SMART test (offline)
 
 [test.short]
 command:/usr/local/sbin/smartctl -t short
 parameters:%s; exit 0
 type:script_output
 message:Testing device %s (short)
+description:Run SMART test (short)
 
 [test.long]
 command:/usr/local/sbin/smartctl -t long
 parameters:%s; exit 0
 type:script_output
 message:Testing device %s (long)
+description:Run SMART test (long)
 
 [test.conveyance]
 command:/usr/local/sbin/smartctl -t conveyance
 parameters:%s; exit 0
 type:script_output
 message:Testing device %s (conveyance)
+description:Run SMART test (conveyance)
 
 [abort]
 command:/usr/local/sbin/smartctl -X
 parameters:%s; exit 0
 type:script_output
 message:Abort test on device %s
+description:Abort SMART tests


### PR DESCRIPTION
The "description" fields were removed to not flood the UI with duplicate
items but some of them are actually useful for cron.
Descriptions for actions related to tests were re-added with unique
content to enable periodic SMART tests via cron.