### PR TITLE
security/acme-client: release 2.1

### DIFF
--- a/security/acme-client/Makefile
+++ b/security/acme-client/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		acme-client
-PLUGIN_VERSION=		2.0
+PLUGIN_VERSION=		2.1
 PLUGIN_COMMENT=		Let's Encrypt client
 PLUGIN_MAINTAINER=	opnsense@moov.de
 PLUGIN_DEPENDS=		acme.sh py${PLUGIN_PYTHON}-dns-lexicon

--- a/security/acme-client/pkg-descr
+++ b/security/acme-client/pkg-descr
@@ -23,13 +23,13 @@ Added:
 * add plugin changelog
 
 Fixed:
-* fix bug where configuration could get lost (#1526)
+* fix bug where configuration changes could get lost (#1526)
 * fix Cyon DNS API (password not set)
 
 Changed:
 * now an Automation may run multiple times during bulk issue/renewal (previously only once)
 * rename "Validation Methods" to "Challenge Types" to adopt official LE wording
-* rename Menu entry "Automation" to "Automations"
+* rename menu entry "Automation" to "Automations"
 * specify python version for gcloud SDK
 * rephrase several log messages
 * add more detailed output when debug logging is enabled

--- a/security/acme-client/pkg-descr
+++ b/security/acme-client/pkg-descr
@@ -8,6 +8,11 @@ WWW: https://github.com/acmesh-official/acme.sh
 Plugin Changelog
 ================
 
+2.1
+
+Fixed:
+* fix creation of nsupdate secrets file
+
 2.0
 
 Added:

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsNsupdate.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsNsupdate.php
@@ -39,9 +39,9 @@ class DnsNsupdate extends Base implements LeValidationInterface
 {
     public function prepare()
     {
-        $configdir = (string)sprintf(self::ACME_CONFIG_DIR, $this->cert_uuid);
+        $configdir = (string)sprintf(self::ACME_CONFIG_DIR, $this->cert_id);
         $secret_key_filename = "${configdir}/secret.key";
-        $secret_key_data = (string)$this->config->dns_nsupdate_key . '\n';
+        $secret_key_data = (string)$this->config->dns_nsupdate_key . "\n";
         file_put_contents($secret_key_filename, $secret_key_data);
 
         // Add env variables


### PR DESCRIPTION
This release fixes the dns_nsupdate challenge type.