### PR TITLE
mail/postfix: Duplicate Message Fix, Milter Default Action Choice and Recipient Address Verification

### DIFF
--- a/mail/postfix/Makefile
+++ b/mail/postfix/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		postfix
-PLUGIN_VERSION=		1.17
+PLUGIN_VERSION=		1.18
 PLUGIN_COMMENT=		SMTP mail relay
 PLUGIN_DEPENDS=		postfix-sasl
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/mail/postfix/pkg-descr
+++ b/mail/postfix/pkg-descr
@@ -6,6 +6,11 @@ is completely different.
 Plugin Changelog
 ================
 
+1.18
+
+* Add 'milter_default_action' choice
+* Fix Milter Protocol
+
 1.17
 
 * Add smtpd_sasl_auth_enable to configuration (by @fhloston)

--- a/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/antispam.xml
+++ b/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/antispam.xml
@@ -5,4 +5,10 @@
         <type>checkbox</type>
         <help>This will allow Postfix to connect to rspamd via milter protocol.</help>
     </field>
+    <field>
+        <id>antispam.default_action</id>
+        <label>Milter Default Action</label>
+        <type>dropdown</type>
+        <help>What Postfix will do when Rspamd becomes temporarily unavailable.</help>
+    </field>
 </form>

--- a/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/antispam.xml
+++ b/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/antispam.xml
@@ -5,10 +5,4 @@
         <type>checkbox</type>
         <help>This will allow Postfix to connect to rspamd via milter protocol.</help>
     </field>
-    <field>
-        <id>antispam.milter_rspamd</id>
-        <label>Milter IP Version</label>
-        <type>dropdown</type>
-        <help>Select the IP version for connecting to rspamd.</help>
-    </field>
 </form>

--- a/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
+++ b/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
@@ -229,4 +229,10 @@
         <label>Reject Unauthenticated Destination</label>
         <type>checkbox</type>
     </field>
+    <field>
+        <id>general.reject_unverified_recipient</id>
+        <label>Reject Unverified Recipient</label>
+        <type>checkbox</type>
+        <help>Use Recipient Address Verification. Please keep in mind that this could put significant load onto the next server.</help>
+    </field>
 </form>

--- a/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Antispam.xml
+++ b/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Antispam.xml
@@ -7,5 +7,13 @@
             <default>0</default>
             <Required>Y</Required>
         </enable_rspamd>
+        <default_action type="OptionField">
+            <default>accept</default>
+            <Required>Y</Required>
+            <OptionValues>
+                <accept>accept</accept>
+                <tempfail>tempfail</tempfail>
+            </OptionValues>
+        </default_action>
     </items>
 </model>

--- a/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Antispam.xml
+++ b/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Antispam.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/postfix/antispam</mount>
     <description>Postfix Antispam configuration</description>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <items>
         <enable_rspamd type="BooleanField">
             <default>0</default>

--- a/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Antispam.xml
+++ b/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Antispam.xml
@@ -7,13 +7,5 @@
             <default>0</default>
             <Required>Y</Required>
         </enable_rspamd>
-        <milter_rspamd type="OptionField">
-            <default>6</default>
-            <Required>Y</Required>
-            <OptionValues>
-                <Option1 value="6">IPv6</Option1>
-                <Option2 value="4">IPv4</Option2>
-            </OptionValues>
-        </milter_rspamd>
     </items>
 </model>

--- a/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
+++ b/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
@@ -171,5 +171,9 @@
             <default>1</default>
             <Required>Y</Required>
         </reject_unauth_destination>
+        <reject_unverified_recipient type="BooleanField">
+            <default>0</default>
+            <Required>Y</Required>
+        </reject_unverified_recipient>
     </items>
 </model>

--- a/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
+++ b/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/postfix/general</mount>
     <description>Postfix configuration</description>
-    <version>1.2.4</version>
+    <version>1.2.5</version>
     <items>
         <enabled type="BooleanField">
             <default>0</default>

--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
@@ -124,7 +124,6 @@ smtpd_sasl_auth_enable = yes
 smtpd_milters = inet:localhost:11332
 non_smtpd_milters = inet:localhost:11332
 milter_protocol = 6
-milter_mail_macros =  i {mail_addr} {client_addr} {client_name} {auth_authen}
 milter_default_action = accept
 {% endif %}
 

--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
@@ -123,7 +123,7 @@ smtpd_sasl_auth_enable = yes
 {% if helpers.exists('OPNsense.postfix.antispam.enable_rspamd') and OPNsense.postfix.antispam.enable_rspamd == '1' %}
 smtpd_milters = inet:localhost:11332
 non_smtpd_milters = inet:localhost:11332
-milter_protocol = {{ OPNsense.postfix.antispam.milter_rspamd }}
+milter_protocol = 6
 milter_mail_macros =  i {mail_addr} {client_addr} {client_name} {auth_authen}
 milter_default_action = accept
 {% endif %}

--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
@@ -178,6 +178,9 @@ relay_recipient_maps = hash:/usr/local/etc/postfix/recipient_access
 {% if helpers.exists('OPNsense.postfix.general.reject_unauth_destination') and OPNsense.postfix.general.reject_unauth_destination == '1' %}
 {% do smtpd_recipient_restrictions.append('reject_unauth_destination') %}
 {% endif %}
+{% if helpers.exists('OPNsense.postfix.general.reject_unverified_recipient') and OPNsense.postfix.general.reject_unverified_recipient == '1' %}
+{% do smtpd_recipient_restrictions.append('reject_unverified_recipient') %}
+{% endif %}
 
 {% if smtpd_recipient_restrictions|length >= 1 %}
 smtpd_recipient_restrictions = {{ smtpd_recipient_restrictions | join(', ') }}

--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
@@ -124,7 +124,7 @@ smtpd_sasl_auth_enable = yes
 smtpd_milters = inet:localhost:11332
 non_smtpd_milters = inet:localhost:11332
 milter_protocol = 6
-milter_default_action = accept
+milter_default_action = {{ OPNsense.postfix.antispam.default_action }}
 {% endif %}
 
 {% if helpers.exists('OPNsense.postfix.general.enforce_recipient_check') and OPNsense.postfix.general.enforce_recipient_check == '1' %}

--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
@@ -121,8 +121,8 @@ smtpd_sasl_auth_enable = yes
 {% endif %}
 
 {% if helpers.exists('OPNsense.postfix.antispam.enable_rspamd') and OPNsense.postfix.antispam.enable_rspamd == '1' %}
-smtpd_milters = inet:localhost:11332
-non_smtpd_milters = inet:localhost:11332
+smtpd_milters = unix:/var/run/rspamd/milter.sock
+non_smtpd_milters = $smtpd_milters
 milter_protocol = 6
 milter_default_action = {{ OPNsense.postfix.antispam.default_action }}
 {% endif %}

--- a/mail/rspamd/Makefile
+++ b/mail/rspamd/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		rspamd
-PLUGIN_VERSION=		1.10
+PLUGIN_VERSION=		1.11
 PLUGIN_COMMENT=		Protect your network from spam
 PLUGIN_DEPENDS=		rspamd
 PLUGIN_MAINTAINER=	franz.fabian.94@gmail.com

--- a/mail/rspamd/pkg-descr
+++ b/mail/rspamd/pkg-descr
@@ -5,6 +5,10 @@ lua.
 Plugin Changelog
 ----------------
 
+1.11
+
+* Fix Milter Protocol by binding to Unix Sockets
+
 1.10
 
 * Add nameserver option

--- a/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/+TARGETS
+++ b/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/+TARGETS
@@ -22,3 +22,5 @@ spamtrap-map:/usr/local/etc/rspamd/maps.d/spamtrap.map
 classifier-bayes.conf:/usr/local/etc/rspamd/local.d/classifier-bayes.conf
 history_redis.conf:/usr/local/etc/rspamd/local.d/history_redis.conf
 options.inc:/usr/local/etc/rspamd/local.d/options.inc
+worker-normal.inc:/usr/local/etc/rspamd/local.d/worker-normal.inc
+worker-proxy.inc:/usr/local/etc/rspamd/local.d/worker-proxy.inc

--- a/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/worker-normal.inc
+++ b/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/worker-normal.inc
@@ -1,0 +1,3 @@
+{% if helpers.exists('OPNsense.Rspamd.general.enabled') and OPNsense.Rspamd.general.enabled == '1' %}
+bind_socket = "/var/run/rspamd/normal.sock mode=0666 owner=rspamd";
+{% endif %}

--- a/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/worker-proxy.inc
+++ b/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/worker-proxy.inc
@@ -1,0 +1,7 @@
+{% if helpers.exists('OPNsense.Rspamd.general.enabled') and OPNsense.Rspamd.general.enabled == '1' %}
+upstream "local" {
+  default = yes;
+  hosts = "/var/run/rspamd/normal.sock";
+}
+bind_socket = "/var/run/rspamd/milter.sock mode=0666 owner=rspamd";
+{% endif %}


### PR DESCRIPTION
## (Really) Fix Duplicate Message Issue #1591

Issue #1591 concerning duplicate E-Mails was not fixed, because it was anticipated that Postfix 'milter_protocol' version would specify the IP version. Instead this specifies the [version of Sendmail's Milter Protocol](http://www.postfix.org/postconf.5.html#milter_protocol), which in Postfix+Rspamd's case should always be version 6.

To really fix the issue I have set Postfix', Rspamd Proxy's and Rspamd Worker's Connection to Unix Sockets. Because in OPNsense Postfix and Rspamd are set up to run on the same host, there is really no need to use TCP-Connections, which makes this the most ideal solution. 

```
Postfix ---/var/run/rspamd/milter.sock---> Rspamd Proxy Worker ---/var/run/rspamd/normal.sock---> Rspamd Normal Worker 
```

## Add `milter_default_action` choice
At the moment, if Rspamd becomes unavailable to Postfix, Postfix will accept the message. I have added a choice to use the 'tempfail' action. With this one, a 4xx Status Code is given until Rspamd becomes available again. 
This would prevent for example that a overloaded system would accept all (spam) messages. 

## Delete Milter Macros
Rspamd's [documentation](https://rspamd.com/doc/integration.html#configuring-postfix) does not require to add milter macros in Postfix' configuration anymore, because the Milter Protocol Version 6 is fully supported. 

## Add Recipient Address Verification
I have added a choice to enable Postfix' Recipient Address Verification. Although this may but a little bit more load onto the next SMTP hop, this may be a desired feature for many users. #1926 
Although there [some limitations](http://www.postfix.org/ADDRESS_VERIFICATION_README.html#limitations) of this feature, this is certainly something that a user should be able to choose.  