### PR TITLE
www/nginx: Naxsi whitelist improvements

### DIFF
--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/naxsi_rule.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/naxsi_rule.xml
@@ -20,7 +20,7 @@
         <id>naxsi_rule.identifier</id>
         <label>ID</label>
         <type>text</type>
-       <help>The unique numerical ID of the rule, that will be used in logs and in whitelists. IDs inferior to 1000 are reserved for Naxsi internal rules (protocol mismatch etc.)</help>
+        <help>The unique numerical ID of the rule, that will be used in logs and in whitelists. IDs inferior to 1000 are reserved for Naxsi internal rules (protocol mismatch etc.)</help>
     </field>
     <field>
         <id>naxsi_rule.ruletype</id>
@@ -31,7 +31,7 @@
         <id>naxsi_rule.regex</id>
         <label>Use Regular Expressions</label>
         <type>checkbox</type>
-       <help>If enabled, the match value, the URL, named parameters and headers are matched using regular expressions; otherwise only exact matches trigger the rule.</help>
+        <help>If enabled, the match value, the URL, named parameters and headers are matched using regular expressions; otherwise only exact matches trigger the rule.</help>
     </field>
     <field>
         <id>naxsi_rule.match_value</id>
@@ -48,7 +48,7 @@
         <id>naxsi_rule.args</id>
         <label>Search in any GET Argument</label>
         <type>checkbox</type>
-       <help>Search for matchs in a request's GET arguments.</help>
+        <help>Search for matchs in a request's GET arguments.</help>
     </field>
     <field>
         <id>naxsi_rule.url</id>
@@ -60,7 +60,7 @@
         <id>naxsi_rule.headers</id>
         <label>Search in any HTTP Header</label>
         <type>checkbox</type>
-       <help>Search for matchs in a request's HTTP headers.</help>
+        <help>Search for matchs in a request's HTTP headers.</help>
     </field>
     <field>
         <id>naxsi_rule.body</id>

--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/naxsi_rule.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/naxsi_rule.xml
@@ -20,12 +20,13 @@
         <id>naxsi_rule.identifier</id>
         <label>ID</label>
         <type>text</type>
-        <help>The unique numerical ID of the rule, that will be used in logs and in whitelists. IDs inferior to 1000 are reserved for Naxsi internal rules (protocol mismatch etc.)</help>
+        <help>For blacklist rules, the unique numerical ID of the rule, that will be used in logs and in whitelists. IDs inferior to 1000 are reserved for Naxsi internal rules (protocol mismatch etc.)&lt;br&gt;For whitelists, specify one or more comma separated IDs to whitelist. 0 whitelists all rules.</help>
     </field>
     <field>
         <id>naxsi_rule.ruletype</id>
         <label>Rule Type</label>
         <type>dropdown</type>
+        <help>Main rules increase the policiy's score if matched. Basic rules are added directly to the location and match immeditaly. Basic rules are specifically useful for whitelist rules. Also basic rules need to be added to a policy to allow association with a location.</help>
     </field>
     <field>
         <id>naxsi_rule.regex</id>
@@ -43,6 +44,7 @@
         <label>Match Type</label>
         <type>dropdown</type>
         <style>selectpicker</style>
+        <help>A blacklist rule increases the policy's score if the pattern matches. A whitelist rule instructs Naxsi to ignore specific rules under specific conditions.</help>
     </field>
     <field>
         <id>naxsi_rule.args</id>

--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/naxsi_rule.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/naxsi_rule.xml
@@ -19,7 +19,10 @@
     <field>
         <id>naxsi_rule.identifier</id>
         <label>ID</label>
-        <type>text</type>
+        <type>select_multiple</type>
+        <allownew>true</allownew>
+        <style>tokenize</style>
+        <type>select_multiple</type>
         <help>For blacklist rules, the unique numerical ID of the rule, that will be used in logs and in whitelists. IDs inferior to 1000 are reserved for Naxsi internal rules (protocol mismatch etc.)&lt;br&gt;For whitelists, specify one or more comma separated IDs to whitelist. 0 whitelists all rules.</help>
     </field>
     <field>

--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Base/Constraints/NaxsiIdentifierConstraint.php
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Base/Constraints/NaxsiIdentifierConstraint.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+* Copyright (C) 2020 Manuel Faux
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+* INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+* AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+* OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+namespace OPNsense\Base\Constraints;
+
+use Phalcon\Validation\Message;
+
+/**
+ * a very specific nginx check for Naxsi rule IDs - not reusable
+ *
+ * Class NaxsiIdentifierConstraint
+ * @package OPNsense\Nginx\Constraints
+ */
+class NaxsiIdentifierConstraint extends BaseConstraint
+{
+    public function validate(\Phalcon\Validation $validator, $attribute)
+    {
+        $node = $this->getOption('node');
+        if ($node) {
+            $parentNode = $node->getParentNode();
+
+            // Validate whitelist IDs
+            if ($parentNode->match_type == 'wl') {
+                // Whitelists can use several IDs
+                $vals = explode(",", (string)$node);
+                $pos = 0;
+                $neg = 0;
+                // Check each ID
+                foreach ($vals as $val) {
+                    $intval = intval($val);
+
+                    // Check if numeric
+                    if (!is_numeric($val)) {
+                        $validator->appendMessage(new Message(
+                            gettext("All rule IDs need to be numeric."),
+                            $attribute
+                        ));
+                    }
+                    // 0 can only be used solely
+                    elseif ($intval == 0 && count($vals) > 1) {
+                        $validator->appendMessage(new Message(
+                            gettext("If ID 0 is specified, no other IDs can be listed."),
+                            $attribute
+                        ));
+                    }
+                    elseif ($intval < 0) {
+                        $neg++;
+                    }
+                    elseif ($intval > 0) {
+                        $pos++;
+                    }
+                }
+
+                // If numeric, all IDs need to be positive or all negative
+                if ($neg > 0 && $pos > 0) {
+                    $validator->appendMessage(new Message(
+                        gettext("Negative and positive IDs cannot be mixed."),
+                        $attribute
+                    ));
+                }
+            }
+            // Validate rule IDs
+            else {
+                $val = (string)$node;
+                // Check if numeric
+                if (!is_numeric($val)) {
+                    // Did the user try to specify multiple IDs?
+                    if (strpos($val, ',')) {
+                        $validator->appendMessage(new Message(
+                            gettext("Rules can only have a single ID."),
+                            $attribute
+                        ));
+                    }
+                    else {
+                        $validator->appendMessage(new Message(
+                            gettext("Rule IDs need to be numeric."),
+                            $attribute
+                        ));
+                    }
+                }
+                // Check that no internal ID was used
+                elseif (intval($val) < 1000) {
+                    $validator->appendMessage(new Message(
+                        gettext("Rule IDs lower than 1000 are reserved for internal rules."),
+                        $attribute
+                    ));
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Base/Constraints/NaxsiIdentifierConstraint.php
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Base/Constraints/NaxsiIdentifierConstraint.php
@@ -46,27 +46,20 @@ class NaxsiIdentifierConstraint extends BaseConstraint
 
             // Validate whitelist IDs
             if ($parentNode->match_type == 'wl') {
-                // Whitelists can use several IDs
-                $vals = explode(",", (string)$node);
+                $vals = explode(",", (string)$node); // Whitelists can use several IDs
                 $pos = 0;
                 $neg = 0;
+
                 // Check each ID
                 foreach ($vals as $val) {
                     $intval = intval($val);
 
-                    // Check if numeric
                     if (!is_numeric($val)) {
-                        $validator->appendMessage(new Message(
-                            gettext("All rule IDs need to be numeric."),
-                            $attribute
-                        ));
+                        $validator->appendMessage(new Message(gettext("All rule IDs need to be numeric."), $attribute));
                     }
                     // 0 can only be used solely
                     elseif ($intval == 0 && count($vals) > 1) {
-                        $validator->appendMessage(new Message(
-                            gettext("If ID 0 is specified, no other IDs can be listed."),
-                            $attribute
-                        ));
+                        $validator->appendMessage(new Message(gettext("If ID 0 is specified, no other IDs can be listed."), $attribute));
                     }
                     elseif ($intval < 0) {
                         $neg++;
@@ -76,42 +69,30 @@ class NaxsiIdentifierConstraint extends BaseConstraint
                     }
                 }
 
-                // If numeric, all IDs need to be positive or all negative
+                // All IDs need to be positive or all negative
                 if ($neg > 0 && $pos > 0) {
-                    $validator->appendMessage(new Message(
-                        gettext("Negative and positive IDs cannot be mixed."),
-                        $attribute
-                    ));
+                    $validator->appendMessage(new Message(gettext("Negative and positive IDs cannot be mixed."), $attribute));
                 }
             }
             // Validate rule IDs
             else {
                 $val = (string)$node;
-                // Check if numeric
                 if (!is_numeric($val)) {
                     // Did the user try to specify multiple IDs?
                     if (strpos($val, ',')) {
-                        $validator->appendMessage(new Message(
-                            gettext("Rules can only have a single ID."),
-                            $attribute
-                        ));
+                        $validator->appendMessage(new Message(gettext("Rules can only have a single ID."), $attribute));
                     }
                     else {
-                        $validator->appendMessage(new Message(
-                            gettext("Rule IDs need to be numeric."),
-                            $attribute
-                        ));
+                        $validator->appendMessage(new Message(gettext("Rule IDs need to be numeric."), $attribute));
                     }
                 }
                 // Check that no internal ID was used
                 elseif (intval($val) < 1000) {
-                    $validator->appendMessage(new Message(
-                        gettext("Rule IDs lower than 1000 are reserved for internal rules."),
-                        $attribute
-                    ));
+                    $validator->appendMessage(new Message(gettext("Rule IDs lower than 1000 are reserved for internal rules."), $attribute));
                 }
             }
         }
+
         return true;
     }
 }

--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
@@ -533,9 +533,9 @@
       <identifier type="TextField">
         <Required>Y</Required>
         <Constraints>
-            <check001>
-                <type>NaxsiIdentifierConstraint</type>
-            </check001>
+          <check001>
+            <type>NaxsiIdentifierConstraint</type>
+          </check001>
         </Constraints>
       </identifier>
       <dollar_url type="TextField">
@@ -561,6 +561,11 @@
           <id>Blacklist</id>
           <wl>Whitelist</wl>
         </OptionValues>
+        <Constraints>
+          <check001>
+            <reference>identifier.check001</reference>
+          </check001>
+        </Constraints>
       </match_type>
       <negate type="BooleanField">
         <Required>Y</Required>

--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
@@ -1,6 +1,6 @@
 <model>
   <mount>//OPNsense/Nginx</mount>
-  <version>1.21.0</version>
+  <version>1.20.1</version>
   <description>nginx web server, reverse proxy and waf</description>
   <items>
     <general>

--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
@@ -1,6 +1,6 @@
 <model>
   <mount>//OPNsense/Nginx</mount>
-  <version>1.20.0</version>
+  <version>1.21.0</version>
   <description>nginx web server, reverse proxy and waf</description>
   <items>
     <general>
@@ -530,9 +530,13 @@
           </check001>
         </Constraints>
       </message>
-      <identifier type="IntegerField">
+      <identifier type="TextField">
         <Required>Y</Required>
-        <minValue>1000</minValue>
+        <Constraints>
+            <check001>
+                <type>NaxsiIdentifierConstraint</type>
+            </check001>
+        </Constraints>
       </identifier>
       <dollar_url type="TextField">
         <Required>N</Required>

--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
@@ -530,7 +530,7 @@
           </check001>
         </Constraints>
       </message>
-      <identifier type="TextField">
+      <identifier type="CSVListField">
         <Required>Y</Required>
         <Constraints>
           <check001>

--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/naxsirule.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/naxsirule.conf
@@ -45,13 +45,13 @@
 {{ mz_matches|join('|') }}
 {%- endmacro %}
 {% macro naxsi_rule(uuid, rule, ruletype) -%}
-{%   if rule.message is defined and rule.match_value is defined %}
+{%   if rule.match_type == 'id' %}
     {{ ruletype }}{% if rule.negate is defined and rule.negate == '1' %} negative{% endif
-    %} {{ rule.match_type }}:{{ rule.identifier }} "{% if rule.regex == '1' %}rx{% else %}str{% endif
+    %} id:{{ rule.identifier }} "{% if rule.regex == '1' %}rx{% else %}str{% endif
     %}:{{ rule.match_value }}" "msg:{{ rule.message }}" "mz:{{ naxsi_mzhelper(rule)
     }}" "s:$policy{{ uuid.replace('-', '') }}:{{ rule.score }}";
-{%   else %}
-    {{ ruletype }} {{ rule.match_type }}:{{ rule.identifier }};
+{%   elif rule.match_type == 'wl' %}
+    {{ ruletype }} wl:{{ rule.identifier }}{% if naxsi_mzhelper(rule) != '' %} "mz:{{ naxsi_mzhelper(rule) }}"{% endif %};
 {%   endif %}
 {%- endmacro %}
 {% if naxsi_ruletype == 'basic' %}


### PR DESCRIPTION
Naxsi whitelist configuration has some drawbacks as elaborated in #2151. Here some improvements:

- Allow specifying multiple IDs for whitelist rules
  - The user can specify _1,2,3_ to whitelist rule IDs 1, 2 and 3 with one single whitelist entry.
  - The user can specify _-1,-2,-3_ to whitelist all rules except rules 1, 2 and 3.
- Improvement in config generation
  - `wl:` rules do not take any `msg:` nor `rx:` or `str:` parts (as these parts are not specified in [Naxsi whitelist documentation](https://github.com/nbs-system/naxsi/wiki/whitelists-bnf)).
  - `id:` rules always generate `rx:` or `str:`. Previous implementation allowed generation of `id:` rules without actual value. I do not see any valid use-case for these.
- Add help texts for Rule Type and Match Type attributes in the UI