### PR TITLE
security/stunnel: Add client mode option to services

### DIFF
--- a/security/stunnel/src/opnsense/mvc/app/controllers/OPNsense/Stunnel/forms/dialogService.xml
+++ b/security/stunnel/src/opnsense/mvc/app/controllers/OPNsense/Stunnel/forms/dialogService.xml
@@ -61,17 +61,17 @@
             ]]></help>
     </field>
     <field>
+        <id>service.clientmode</id>
+        <label>Client mode</label>
+        <type>checkbox</type>
+        <help><![CDATA[Use client mode for this tunnel. Connect to an SSL server, do not act as an SSL server.]]></help>
+    </field>
+    <field>
         <id>service.ciphers</id>
         <label>Ciphers</label>
         <type>select_multiple</type>
         <help><![CDATA[Select all accepted TLS ciphers.]]></help>
         <advanced>true</advanced>
-    </field>
-    <field>
-        <id>service.client_mode</id>
-        <label>Client mode</label>
-        <type>checkbox</type>
-        <help><![CDATA[Use client mode for this tunnel (i.e. connect to an SSL server, do not act as an SSL server).]]></help>
     </field>
     <field>
         <id>service.description</id>

--- a/security/stunnel/src/opnsense/mvc/app/controllers/OPNsense/Stunnel/forms/dialogService.xml
+++ b/security/stunnel/src/opnsense/mvc/app/controllers/OPNsense/Stunnel/forms/dialogService.xml
@@ -68,6 +68,12 @@
         <advanced>true</advanced>
     </field>
     <field>
+        <id>service.client_mode</id>
+        <label>Client mode</label>
+        <type>checkbox</type>
+        <help><![CDATA[Use client mode for this tunnel (i.e. connect to an SSL server, do not act as an SSL server).]]></help>
+    </field>
+    <field>
         <id>service.description</id>
         <label>Description</label>
         <type>text</type>

--- a/security/stunnel/src/opnsense/mvc/app/models/OPNsense/Stunnel/Stunnel.xml
+++ b/security/stunnel/src/opnsense/mvc/app/models/OPNsense/Stunnel/Stunnel.xml
@@ -63,6 +63,10 @@
                     <default>0</default>
                     <Required>Y</Required>
                 </enableCRL>
+                <client_mode type="BooleanField">
+                    <default>0</default>
+                    <Required>Y</Required>
+                </client_mode>
                 <ciphers type="JsonKeyValueStoreField">
                     <default>TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-RSA-AES128-GCM-SHA256,ECDHE-ECDSA-AES256-GCM-SHA384,ECDHE-RSA-AES256-GCM-SHA384,ECDHE-ECDSA-CHACHA20-POLY1305,ECDHE-RSA-CHACHA20-POLY1305,DHE-RSA-AES128-GCM-SHA256,DHE-RSA-AES256-GCM-SHA384</default>
                     <Required>Y</Required>

--- a/security/stunnel/src/opnsense/mvc/app/models/OPNsense/Stunnel/Stunnel.xml
+++ b/security/stunnel/src/opnsense/mvc/app/models/OPNsense/Stunnel/Stunnel.xml
@@ -63,10 +63,10 @@
                     <default>0</default>
                     <Required>Y</Required>
                 </enableCRL>
-                <client_mode type="BooleanField">
+                <clientmode type="BooleanField">
                     <default>0</default>
                     <Required>Y</Required>
-                </client_mode>
+                </clientmode>
                 <ciphers type="JsonKeyValueStoreField">
                     <default>TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-RSA-AES128-GCM-SHA256,ECDHE-ECDSA-AES256-GCM-SHA384,ECDHE-RSA-AES256-GCM-SHA384,ECDHE-ECDSA-CHACHA20-POLY1305,ECDHE-RSA-CHACHA20-POLY1305,DHE-RSA-AES128-GCM-SHA256,DHE-RSA-AES256-GCM-SHA384</default>
                     <Required>Y</Required>

--- a/security/stunnel/src/opnsense/mvc/app/models/OPNsense/Stunnel/Stunnel.xml
+++ b/security/stunnel/src/opnsense/mvc/app/models/OPNsense/Stunnel/Stunnel.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/Stunnel</mount>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <description>
         Stunnel TLS encryption proxy
     </description>

--- a/security/stunnel/src/opnsense/service/templates/OPNsense/Stunnel/stunnel.conf
+++ b/security/stunnel/src/opnsense/service/templates/OPNsense/Stunnel/stunnel.conf
@@ -31,7 +31,7 @@ verifyChain = yes
 CRLpath = {% if helpers.empty('OPNsense.Stunnel.general.chroot') %}/var/run/stunnel{% endif %}/certs/
 {%         endif %}
 {%       endif %}
-{% if service.clientmode %}
+{% if service.clientmode|default('0') == '1' %}
 client = yes
 {% endif %}
 {%       set ciphers =[] %}

--- a/security/stunnel/src/opnsense/service/templates/OPNsense/Stunnel/stunnel.conf
+++ b/security/stunnel/src/opnsense/service/templates/OPNsense/Stunnel/stunnel.conf
@@ -31,6 +31,9 @@ verifyChain = yes
 CRLpath = {% if helpers.empty('OPNsense.Stunnel.general.chroot') %}/var/run/stunnel{% endif %}/certs/
 {%         endif %}
 {%       endif %}
+{% if service.client_mode %}
+client = yes
+{% endif %}
 {%       set ciphers =[] %}
 {%       set ciphersuites =[] %}
 {%       for cipher in service.ciphers.split(',') %}

--- a/security/stunnel/src/opnsense/service/templates/OPNsense/Stunnel/stunnel.conf
+++ b/security/stunnel/src/opnsense/service/templates/OPNsense/Stunnel/stunnel.conf
@@ -31,7 +31,7 @@ verifyChain = yes
 CRLpath = {% if helpers.empty('OPNsense.Stunnel.general.chroot') %}/var/run/stunnel{% endif %}/certs/
 {%         endif %}
 {%       endif %}
-{% if service.client_mode %}
+{% if service.clientmode %}
 client = yes
 {% endif %}
 {%       set ciphers =[] %}


### PR DESCRIPTION
### Problem
I need to connect to an LDAP server using stunnel client mode.
In the services form, there is no option to enable client mode.

### Solution
This adds a checkbox to enable client mode in the service creation/edit form.
When the checkbox is enabled, the option
`client = yes`
is added to relative service config.