### PR TITLE
Update pkg-descr

### DIFF
--- a/net/igmp-proxy/pkg-descr
+++ b/net/igmp-proxy/pkg-descr
@@ -1,4 +1,4 @@
 Igmpproxy is a simple multicast routing daemon based on mrouted.
 It uses IGMP forwarding to dynamically route multicast traffic.
 
-WWW: http://igmpproxy.sourceforge.net/
+WWW: https://github.com/pali/igmpproxy


### PR DESCRIPTION
According to the SF website the project can now be found on github; not sure if the URL in here has to match something else but if not, this updates the url so it points to the current home of the igmpproxy.