### PR TITLE
security/tinc: Fix switch mode (again)

### DIFF
--- a/security/tinc/src/opnsense/scripts/OPNsense/Tinc/lib/objects.py
+++ b/security/tinc/src/opnsense/scripts/OPNsense/Tinc/lib/objects.py
@@ -141,7 +141,7 @@ class Host(NetwConfObject):
         self._connectTo = value.text
 
     def get_subnets(self):
-        if not self._payload['subnet']:
+        if not 'subnet' in self._payload:
             return
         yield from self._payload['subnet'].split(',')
 


### PR DESCRIPTION
In switch mode the subnet field is empty, thus the 'subnet' key does not exist in the '_payload' dictionary. This PR fixes switch mode after #2110.