### PR TITLE
security/tinc: Fix extaddress field validation

### DIFF
--- a/security/tinc/src/opnsense/mvc/app/models/OPNsense/Tinc/Tinc.xml
+++ b/security/tinc/src/opnsense/mvc/app/models/OPNsense/Tinc/Tinc.xml
@@ -23,7 +23,7 @@
                 </hostname>
                 <extaddress type="HostnameField">
                     <Required>N</Required>
-                    <IpAllowed>1</IpAllowed>
+                    <IpAllowed>Y</IpAllowed>
                     <FieldSeparator>,</FieldSeparator>
                     <AsList>Y</AsList>
                 </extaddress>
@@ -136,7 +136,7 @@
                 </extport>
                 <extaddress type="HostnameField">
                     <Required>N</Required>
-                    <IpAllowed>1</IpAllowed>
+                    <IpAllowed>Y</IpAllowed>
                     <FieldSeparator>,</FieldSeparator>
                     <AsList>Y</AsList>
                     <Constraints>


### PR DESCRIPTION
The IpAllowed flag should be 'Y', since any different value is recognized as 'N' ([reference](https://github.com/opnsense/core/blob/de291e62660996b04d589381cad3396db5e9eb80/src/opnsense/mvc/app/models/OPNsense/Base/FieldTypes/HostnameField.php#L70)). This PR fixes external address fields in Tinc configuration not accepting IPv6 addresses after #2110. Closes #2184.

