### PR TITLE
www/nginx: quick fix for trusted CAs pem

### DIFF
--- a/www/nginx/src/opnsense/scripts/nginx/setup.php
+++ b/www/nginx/src/opnsense/scripts/nginx/setup.php
@@ -198,16 +198,15 @@ if (isset($nginx['upstream'])) {
             }
             if (!empty($upstream['tls_trusted_certificate'])) {
                 $cas = array();
-                if (is_array($http_server['ca'])) {
-                    foreach ($http_server['ca'] as $caref) {
-                        $ca = find_ca($caref);
-                        if (isset($ca)) {
-                            $cas[] = $ca;
-                        }
-                    }
+                $carefs = explode(",", $upstream['tls_trusted_certificate']);
+                foreach ($carefs as $caref) {
+                   $ca = find_ca($caref);
+                   if (isset($ca)) {
+                       $cas[] = base64_decode($ca['crt']);
+                   }
                 }
                 export_pem_file(
-                    '/usr/local/etc/nginx/key/trust_upstream_' . $upstream_uuid . '.pem',
+                    '/usr/local/etc/nginx/key/trust_upstream_' . $upstream_uuid . '.pem','',
                     implode("\n", $cas)
                 );
             }


### PR DESCRIPTION
Hi. just quick fix for troubles with trust_upstream_*.pem files after update to 1.20 with upstream tls verify enabled and trusted CAs selected