### PR TITLE
Show WG widget timestamps in system timezone

### DIFF
--- a/net/wireguard/src/www/widgets/widgets/wireguard.widget.php
+++ b/net/wireguard/src/www/widgets/widgets/wireguard.widget.php
@@ -55,6 +55,7 @@ $empty = strlen($data) == 0;
         $latest = "-";
         if ($epoch > 0):
             $dt = new DateTime("@$epoch");
+            $dt->setTimezone(new DateTimeZone(date_default_timezone_get()));
             $latest = $dt->format(gettext("Y-m-d H:i:sP"));
         endif; ?>
 


### PR DESCRIPTION
This change shows each latest handshake time in the WireGuard widget in the timezone of the system, rather than UTC as currently. The change is intended to implement this forum request: https://forum.opnsense.org/index.php?topic=20530.msg95463#msg95463.

As a disclaimer, I am by no means a PHP programmer, but this commit is based on my research. It works when I tested it.