### PR TITLE
mail/rspamd+redis: Use Unix socket-based Rspamd→Redis connection

### DIFF
--- a/databases/redis/src/opnsense/mvc/app/controllers/OPNsense/Redis/forms/settings.xml
+++ b/databases/redis/src/opnsense/mvc/app/controllers/OPNsense/Redis/forms/settings.xml
@@ -24,7 +24,7 @@
         <id>redis.general.port</id>
         <label>TCP Listen Port</label>
         <type>text</type>
-        <help>Enter a valid TCP port.</help>
+        <help>Enter a valid TCP port. Set this value to 0 if you only want to use a local Unix socket connection.</help>
       </field>
       <field>
         <id>redis.general.log_level</id>

--- a/databases/redis/src/opnsense/mvc/app/models/OPNsense/Redis/Redis.xml
+++ b/databases/redis/src/opnsense/mvc/app/models/OPNsense/Redis/Redis.xml
@@ -1,6 +1,7 @@
 <model>
   <mount>//OPNsense/redis</mount>
   <description>Redis DB</description>
+  <version>1.0.1</version>
   <items>
     <general>
       <enabled type="BooleanField">
@@ -16,7 +17,7 @@
         <Required>Y</Required>
       </protected_mode>
       <port type="IntegerField">
-        <MinimumValue>1</MinimumValue>
+        <MinimumValue>0</MinimumValue>
         <MaximumValue>65536</MaximumValue>
         <Required>N</Required>
         <default>6379</default>

--- a/databases/redis/src/opnsense/scripts/redis/setup.sh
+++ b/databases/redis/src/opnsense/scripts/redis/setup.sh
@@ -8,3 +8,8 @@ done
 
 touch /var/log/redis/redis.log
 chown redis:redis /var/log/redis/redis.log
+
+# Add 'rspamd' user to 'redis' group to allow Unix socket access
+if [ -f "/usr/local/bin/rspamd" ]; then
+  /usr/sbin/pw group mod redis -m rspamd
+fi

--- a/databases/redis/src/opnsense/service/templates/OPNsense/Redis/redis.conf
+++ b/databases/redis/src/opnsense/service/templates/OPNsense/Redis/redis.conf
@@ -108,7 +108,7 @@ tcp-backlog 511
 # on a unix socket when not specified.
 #
 unixsocket /var/run/redis/redis.sock
-unixsocketperm 700
+unixsocketperm 770
 
 # Close the connection after a client is idle for N seconds (0 to disable)
 timeout 0

--- a/mail/rspamd/src/opnsense/scripts/rspamd/setup.sh
+++ b/mail/rspamd/src/opnsense/scripts/rspamd/setup.sh
@@ -11,3 +11,8 @@ chmod o+rx /usr/local/etc/rspamd/local.d
 chown -R rspamd:rspamd /var/db/rspamd
 chown -R rspamd:rspamd /var/log/rspamd
 chown -R rspamd:rspamd /var/run/rspamd
+
+# Add 'rspamd' user to 'redis' group to allow Unix socket access
+if [ -f "/usr/local/bin/rspamd" ]; then
+  /usr/sbin/pw group mod redis -m rspamd
+fi

--- a/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/redis.conf
+++ b/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/redis.conf
@@ -16,7 +16,7 @@
 {% if helpers.exists('OPNsense.Rspamd.general.enable_redis_plugin') and OPNsense.Rspamd.general.enable_redis_plugin == '1' %}
 {%   if helpers.exists('OPNsense.redis.general.enabled') and OPNsense.redis.general.enabled == '1' %}
 
-servers = "[::1]{% if helpers.exists('OPNsense.redis.general.port') and OPNsense.redis.general.port != '' %}:{{ OPNsense.redis.general.port }}{% endif %}";
+servers = "/var/run/redis/redis.sock";
 timeout = 10s;
 #db = "0";
 {%     if helpers.exists('OPNsense.redis.security.password') and OPNsense.redis.security.password != '' %}


### PR DESCRIPTION
Since 20090ccdb98877aac00c4687571a395753d40ead Postfix is using a Unix socket connection for talking to Rspamd's proxy worker (thanks a lot for merging!) in order to fix duplicate messages. 

I mentioned in #2133 that it would make sense to use a Unix socket connection for the `rspamd -> redis` communication as well. 
Strictly speaking this does not seem necessary, because the TCP-connection appears to work, but it may be prettier from a design standpoint to use Unix sockets for everything  `postfix`/ `rspamd` releated. 
(*There is a user mentioning Redis connection issues #2177, but of course not sure if Unix sockets may help.*)

At #2133 I mentioned that the permissions for `/var/run/redis/redis.sock` could either be set to `777` or `770`. 
I went for the more sophisticated `770` variant. ~Of course there is not benefit in there at the moment, but it would allow us to lock down the Redis database a bit more in the future.~ I have allowed to use the '0' port number in the Redis settings to disable TCP-Listeners completely. 

