### PR TITLE
www/nginx: Add X-Forwarded-Port and  X-Forwarded-Host headers

### DIFF
--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/location.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/location.conf
@@ -153,6 +153,8 @@ location {{ location.matchtype }} {{ location.urlpattern }} {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Port $server_port;
+    proxy_set_header X-Forwarded-Host $host;
     proxy_set_header X-TLS-Client-Intercepted $tls_intercepted;
 {%   if location.proxy_read_timeout is defined and location.proxy_read_timeout != '' %}
     proxy_read_timeout {{ location.proxy_read_timeout }}s;


### PR DESCRIPTION
Some applications as Keycloak when running behind Nginx proxy need these flags configured 

proxy_set_header X-Forwarded-Port $server_port;
proxy_set_header X-Forwarded-Host $host;

This cause no impact in other applications already configured, at least for my applications