### PR TITLE
sysutils/munin-node: fix description typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ sysutils/git-backup -- Track config changes using git
 sysutils/hw-probe -- Collect hardware diagnostics
 sysutils/lcdproc-sdeclcd -- LCDProc for SDEC LCD devices
 sysutils/mail-backup -- Send configuration file backup by e-mail
-sysutils/munin-node -- Munin monitorin agent
+sysutils/munin-node -- Munin monitoring agent
 sysutils/node_exporter -- Prometheus exporter for machine metrics
 sysutils/nut -- Network UPS Tools
 sysutils/smart -- SMART tools

--- a/sysutils/munin-node/Makefile
+++ b/sysutils/munin-node/Makefile
@@ -1,7 +1,7 @@
 PLUGIN_NAME=		munin-node
 PLUGIN_VERSION=		1.0
 PLUGIN_REVISION=	1
-PLUGIN_COMMENT=		Munin monitorin agent
+PLUGIN_COMMENT=		Munin monitoring agent
 PLUGIN_DEPENDS=		munin-node
 PLUGIN_MAINTAINER=	m.muenz@gmail.com
 


### PR DESCRIPTION
No revision bump since this is a minor non-functional typo.