### PR TITLE
mail/postfix: Add TLS compatibility modes

### DIFF
--- a/mail/postfix/Makefile
+++ b/mail/postfix/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		postfix
-PLUGIN_VERSION=		1.18
+PLUGIN_VERSION=		1.19
 PLUGIN_COMMENT=		SMTP mail relay
 PLUGIN_DEPENDS=		postfix-sasl
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/mail/postfix/pkg-descr
+++ b/mail/postfix/pkg-descr
@@ -6,6 +6,10 @@ is completely different.
 Plugin Changelog
 ================
 
+1.19
+
+* Add TLS server/ client compatibility modes based on Mozilla's TLS configuration recommendations (https://ssl-config.mozilla.org).
+
 1.18
 
 * Add 'milter_default_action' choice

--- a/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
+++ b/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
@@ -90,10 +90,16 @@
         <help>Disable SSLv2 and SSLv3, only TLS allowed.</help>
     </field>
     <field>
-        <id>general.disable_weak_ciphers</id>
-        <label>Disable Weak Ciphers And Algorithms</label>
-        <type>checkbox</type>
-        <help>This will disable known weak ciphers like DES, RC4 or MD5.</help>
+        <id>general.tls_server_compatibility</id>
+        <label>TLS Server Compatibility</label>
+        <type>dropdown</type>
+        <help>TLS version/ cipher compatibility of the SMTP service</help>
+    </field>
+    <field>
+        <id>general.tls_client_compatibility</id>
+        <label>TLS Client Compatibility</label>
+        <type>dropdown</type>
+        <help>TLS version/ cipher compatibility of the SMTP Client</help>
     </field>
     <field>
         <id>general.tlswrappermode</id>

--- a/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
+++ b/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/postfix/general</mount>
     <description>Postfix configuration</description>
-    <version>1.2.5</version>
+    <version>1.2.6</version>
     <items>
         <enabled type="BooleanField">
             <default>0</default>

--- a/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
+++ b/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
@@ -61,14 +61,24 @@
             <mask>/^([0-9a-z\.\-\_]{1,128})(,[0-9a-z\.\-\_]{1,128})*$/ui</mask>
             <ValidationMessage>Only up to 128 of the following characters are allowed: 0-9a-zA-Z.-_</ValidationMessage>
         </masquerade_domains>
-        <disable_ssl type="BooleanField">
-            <default>1</default>
+        <tls_server_compatibility type="OptionField">
+            <default>intermediate</default>
             <Required>Y</Required>
-        </disable_ssl>
-        <disable_weak_ciphers type="BooleanField">
-            <default>1</default>
+            <OptionValues>
+                <modern>Modern</modern>
+                <intermediate>Intermediate</intermediate>
+                <old>Old</old>
+            </OptionValues>
+        </tls_server_compatibility>
+        <tls_client_compatibility type="OptionField">
+            <default>intermediate</default>
             <Required>Y</Required>
-        </disable_weak_ciphers>
+            <OptionValues>
+                <modern>Modern</modern>
+                <intermediate>Intermediate</intermediate>
+                <old>Old</old>
+            </OptionValues>
+        </tls_client_compatibility>
         <tlswrappermode type="BooleanField">
             <default>0</default>
             <Required>Y</Required>

--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
@@ -83,29 +83,66 @@ message_size_limit = {{ OPNsense.postfix.general.message_size_limit }}
 {% if helpers.exists('OPNsense.postfix.general.masquerade_domains') and OPNsense.postfix.general.masquerade_domains != '' %}
 masquerade_domains = {{ OPNsense.postfix.general.masquerade_domains }}
 {% endif %}
-{% if helpers.exists('OPNsense.postfix.general.disable_ssl') and OPNsense.postfix.general.disable_ssl == '1' %}
-smtpd_tls_mandatory_protocols=!SSLv2,!SSLv3
-smtp_tls_mandatory_protocols=!SSLv2,!SSLv3
-smtpd_tls_protocols=!SSLv2,!SSLv3
-smtp_tls_protocols=!SSLv2,!SSLv3
-{% endif %}
-{% if helpers.exists('OPNsense.postfix.general.disable_weak_ciphers') and OPNsense.postfix.general.disable_weak_ciphers == '1' %}
-smtpd_tls_exclude_ciphers = aNULL, eNULL, EXPORT, DES, RC4, MD5, PSK, aECDH, EDH-DSS-DES-CBC3-SHA, EDH-RSA-DES-CDC3-SHA, KRB5-DE5, CBC3-SHA
-{% endif %}
 {% if helpers.exists('OPNsense.postfix.general.tlswrappermode') and OPNsense.postfix.general.tlswrappermode == '1' %}
 smtp_tls_wrappermode = yes
 {% endif %}
+
 {% if helpers.exists('OPNsense.postfix.general.smtpclient_security') and OPNsense.postfix.general.smtpclient_security != '' %}
 smtp_tls_security_level = {{ OPNsense.postfix.general.smtpclient_security }}
+smtp_tls_loglevel = 1
+{% endif %}
+{% if helpers.exists('OPNsense.postfix.general.tls_client_compatibility') %}
+{% if OPNsense.postfix.general.tls_client_compatibility == 'modern' %}
+smtp_tls_mandatory_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1, !TLSv1.2
+{% elif OPNsense.postfix.general.tls_client_compatibility == 'intermediate' %}
+smtp_tls_mandatory_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
+smtp_tls_mandatory_ciphers = medium
+{% elif OPNsense.postfix.general.tls_client_compatibility == 'old' %}
+smtp_tls_mandatory_protocols = !SSLv2, !SSLv3
+smtp_tls_mandatory_ciphers = low
+{% endif %}
+smtp_tls_protocols = $smtp_tls_mandatory_protocols
+{% if OPNsense.postfix.general.tls_client_compatibility != 'modern' %}
+smtp_tls_ciphers = $smtp_tls_mandatory_ciphers
+{% endif %}
 {% endif %}
 {% if helpers.exists('OPNsense.postfix.general.certificate') and OPNsense.postfix.general.certificate != '' %}
 smtpd_use_tls = yes
+smtpd_tls_auth_only = yes
+smtpd_tls_loglevel = 1
+smtpd_tls_received_header = yes
 smtpd_tls_cert_file = /usr/local/etc/postfix/cert_opn.pem
 {% endif %}
 {% if helpers.exists('OPNsense.postfix.general.ca') and OPNsense.postfix.general.ca != '' %}
 smtpd_tls_CAfile = /usr/local/etc/postfix/ca_opn.pem
 {% endif %}
+{% if helpers.exists('OPNsense.postfix.general.tls_server_compatibility') %}
+{% if OPNsense.postfix.general.tls_server_compatibility == 'modern' %}
+smtpd_tls_mandatory_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1, !TLSv1.2
+{% elif OPNsense.postfix.general.tls_server_compatibility == 'intermediate' %}
+smtpd_tls_mandatory_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
+smtpd_tls_dh1024_param_file = /usr/local/etc/dh-parameters.2048
+smtpd_tls_mandatory_ciphers = medium
+{% elif OPNsense.postfix.general.tls_server_compatibility == 'old' %}
+smtpd_tls_mandatory_protocols = !SSLv2, !SSLv3
+smtpd_tls_dh1024_param_file = /usr/local/etc/dh-parameters.2048
+smtpd_tls_mandatory_ciphers = low
+{% endif %}
+smtpd_tls_protocols = $smtpd_tls_mandatory_protocols
+{% if OPNsense.postfix.general.tls_server_compatibility != 'modern' %}
+smtpd_tls_ciphers = $smtpd_tls_mandatory_ciphers
+{% endif %}
+{% if helpers.exists('OPNsense.postfix.general.tls_client_compatibility') or helpers.exists('OPNsense.postfix.general.tls_server_compatibility') %}
+tls_low_cipherlist = ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA
+tls_medium_cipherlist = ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
+{% if OPNsense.postfix.general.tls_server_compatibility == 'old' %}
+tls_preempt_cipherlist = yes
+{% else %}
+tls_preempt_cipherlist = no
+{% endif %}
+{% endif%}
 
+{% endif %}
 {% if helpers.exists('OPNsense.postfix.general.relayhost') and OPNsense.postfix.general.relayhost != '' %}
 relayhost = {{ OPNsense.postfix.general.relayhost }}
 {% endif %}


### PR DESCRIPTION
## Issue 

The default TLS client/ server configurations of `mail/postfix` are not really up to the best practices anymore.

## My solution

Therefore I have added three compatibility modes:

* Old
* Intermediate
* Modern

for both `smtpd` (server) and `smtp` (client). I configured those different compatibility levels according to [Mozilla's TLS configuration recommendations](https://ssl-config.mozilla.org/#server=postfix) for Postfix.
With those, the user is easily able to choose between different compatibility levels depending on particular requirements/ philosophy regarding backwards compatibility. 

## Results

The results for different compatibility levels for `smtpd` look quite promising: 

<details>
<summary>Old compatibility</summary>
<p>

```
$ sslyze --starttls=smtp opnsense.local:25

 CHECKING HOST(S) AVAILABILITY
 -----------------------------

   opnsense.local:25                        => opnsense.local




 SCAN RESULTS FOR opnsense.local:25 - opnsense.local
 ---------------------------------------------

[...]

 * SSL 3.0 Cipher Suites:
     Attempted to connect using 80 cipher suites; the server rejected all cipher suites.

 * SSL 2.0 Cipher Suites:
     Attempted to connect using 7 cipher suites; the server rejected all cipher suites.

 * TLS 1.2 Cipher Suites:
     Attempted to connect using 156 cipher suites.

     The server accepted the following 18 cipher suites:
        TLS_RSA_WITH_AES_256_GCM_SHA384                   256                      
        TLS_RSA_WITH_AES_256_CBC_SHA256                   256                      
        TLS_RSA_WITH_AES_256_CBC_SHA                      256                      
        TLS_RSA_WITH_AES_128_GCM_SHA256                   128                      
        TLS_RSA_WITH_AES_128_CBC_SHA256                   128                      
        TLS_RSA_WITH_AES_128_CBC_SHA                      128                      
        TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256       256       ECDH: X25519 (253 bits)
        TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384             256       ECDH: prime256v1 (256 bits)
        TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384             256       ECDH: prime256v1 (256 bits)
        TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA                256       ECDH: prime256v1 (256 bits)
        TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256             128       ECDH: prime256v1 (256 bits)
        TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256             128       ECDH: prime256v1 (256 bits)
        TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA                128       ECDH: prime256v1 (256 bits)
        TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256         256       DH (2048 bits) 
        TLS_DHE_RSA_WITH_AES_256_GCM_SHA384               256       DH (2048 bits) 
        TLS_DHE_RSA_WITH_AES_256_CBC_SHA256               256       DH (2048 bits) 
        TLS_DHE_RSA_WITH_AES_128_GCM_SHA256               128       DH (2048 bits) 
        TLS_DHE_RSA_WITH_AES_128_CBC_SHA256               128       DH (2048 bits) 

     The group of cipher suites supported by the server has the following properties:
       Forward Secrecy                    OK - Supported
       Legacy RC4 Algorithm               OK - Not Supported


 * Certificates Information:
       Hostname sent for SNI:             opnsense.local
       Number of certificates detected:   1

 * TLS 1.1 Cipher Suites:
     Attempted to connect using 80 cipher suites.

     The server accepted the following 4 cipher suites:
        TLS_RSA_WITH_AES_256_CBC_SHA                      256                      
        TLS_RSA_WITH_AES_128_CBC_SHA                      128                      
        TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA                256       ECDH: prime256v1 (256 bits)
        TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA                128       ECDH: prime256v1 (256 bits)

     The group of cipher suites supported by the server has the following properties:
       Forward Secrecy                    OK - Supported
       Legacy RC4 Algorithm               OK - Not Supported


 * Deflate Compression:
                                          OK - Compression disabled

 * TLS 1.0 Cipher Suites:
     Attempted to connect using 80 cipher suites.

     The server accepted the following 4 cipher suites:
        TLS_RSA_WITH_AES_256_CBC_SHA                      256                      
        TLS_RSA_WITH_AES_128_CBC_SHA                      128                      
        TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA                256       ECDH: prime256v1 (256 bits)
        TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA                128       ECDH: prime256v1 (256 bits)

     The group of cipher suites supported by the server has the following properties:
       Forward Secrecy                    OK - Supported
       Legacy RC4 Algorithm               OK - Not Supported


 * ROBOT Attack:
                                          OK - Not vulnerable.

 * OpenSSL Heartbleed:
                                          OK - Not vulnerable to Heartbleed

 * TLS 1.2 Session Resumption Support:
      With Session IDs: NOT SUPPORTED (0 successful resumptions out of 5 attempts).
      With TLS Tickets: OK - Supported.

 * Session Renegotiation:
       Client Renegotiation DoS Attack:   VULNERABLE - Server honors client-initiated renegotiations
       Secure Renegotiation:              OK - Supported

 * TLS 1.3 Cipher Suites:
     Attempted to connect using 5 cipher suites.

     The server accepted the following 3 cipher suites:
        TLS_CHACHA20_POLY1305_SHA256                      256       ECDH: X25519 (253 bits)
        TLS_AES_256_GCM_SHA384                            256       ECDH: X25519 (253 bits)
        TLS_AES_128_GCM_SHA256                            128       ECDH: X25519 (253 bits)


 * OpenSSL CCS Injection:
                                          OK - Not vulnerable to OpenSSL CCS injection

 * Elliptic Curve Key Exchange:
       Supported curves:                  X25519, X448, prime256v1, secp384r1, secp521r1
       Rejected curves:                   prime192v1, secp160k1, secp160r1, secp160r2, secp192k1, secp224k1, secp224r1, secp256k1, sect163k1, sect163r1, sect163r2, sect193r1, sect193r2, sect233k1, sect233r1, sect239k1, sect283k1, sect283r1, sect409k1, sect409r1, sect571k1, sect571r1

 * Downgrade Attacks:
       TLS_FALLBACK_SCSV:                 OK - Supported


 SCAN COMPLETED IN 8.58 S
 ------------------------
```
</p>
</details>

<details>
<summary>Intermediate compatibility</summary>
<p>

```
$ sslyze --starttls=smtp opnsense.local

 CHECKING HOST(S) AVAILABILITY
 -----------------------------

   opnsense.local                        => opnsense.local 




 SCAN RESULTS FOR opnsense.local:25 - opnsense.local
 ---------------------------------------------

[...]

 * TLS 1.0 Cipher Suites:
     Attempted to connect using 80 cipher suites; the server rejected all cipher suites.

 * TLS 1.2 Session Resumption Support:
      With Session IDs: NOT SUPPORTED (0 successful resumptions out of 5 attempts).
      With TLS Tickets: OK - Supported.

 * Session Renegotiation:
       Client Renegotiation DoS Attack:   VULNERABLE - Server honors client-initiated renegotiations
       Secure Renegotiation:              OK - Supported

 * TLS 1.2 Cipher Suites:
     Attempted to connect using 156 cipher suites.

     The server accepted the following 5 cipher suites:
        TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256       256       ECDH: X25519 (253 bits)
        TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384             256       ECDH: prime256v1 (256 bits)
        TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256             128       ECDH: prime256v1 (256 bits)
        TLS_DHE_RSA_WITH_AES_256_GCM_SHA384               256       DH (2048 bits) 
        TLS_DHE_RSA_WITH_AES_128_GCM_SHA256               128       DH (2048 bits) 

     The group of cipher suites supported by the server has the following properties:
       Forward Secrecy                    OK - Supported
       Legacy RC4 Algorithm               OK - Not Supported


 * Deflate Compression:
                                          OK - Compression disabled

 * OpenSSL Heartbleed:
                                          OK - Not vulnerable to Heartbleed

 * SSL 2.0 Cipher Suites:
     Attempted to connect using 7 cipher suites; the server rejected all cipher suites.

 * TLS 1.3 Cipher Suites:
     Attempted to connect using 5 cipher suites.

     The server accepted the following 3 cipher suites:
        TLS_CHACHA20_POLY1305_SHA256                      256       ECDH: X25519 (253 bits)
        TLS_AES_256_GCM_SHA384                            256       ECDH: X25519 (253 bits)
        TLS_AES_128_GCM_SHA256                            128       ECDH: X25519 (253 bits)


 * Elliptic Curve Key Exchange:
       Supported curves:                  X25519, X448, prime256v1, secp384r1, secp521r1
       Rejected curves:                   prime192v1, secp160k1, secp160r1, secp160r2, secp192k1, secp224k1, secp224r1, secp256k1, sect163k1, sect163r1, sect163r2, sect193r1, sect193r2, sect233k1, sect233r1, sect239k1, sect283k1, sect283r1, sect409k1, sect409r1, sect571k1, sect571r1

 * Downgrade Attacks:
       TLS_FALLBACK_SCSV:                 OK - Supported

 * ROBOT Attack:
                                          OK - Not vulnerable, RSA cipher suites not supported.

 * TLS 1.1 Cipher Suites:
     Attempted to connect using 80 cipher suites; the server rejected all cipher suites.

 * SSL 3.0 Cipher Suites:
     Attempted to connect using 80 cipher suites; the server rejected all cipher suites.

 * OpenSSL CCS Injection:
                                          OK - Not vulnerable to OpenSSL CCS injection


 SCAN COMPLETED IN 8.11 S
 ------------------------
```
</p>
</details>

<details>
<summary>Modern compatibility</summary>
<p>

```
$ sslyze --starttls=smtp opnsense.local:25

 CHECKING HOST(S) AVAILABILITY
 -----------------------------

   opnsense.local:25                        => opnsense.local




 SCAN RESULTS FOR opnsense.local:25 - opnsense.local
 ---------------------------------------------

 * TLS 1.0 Cipher Suites:
     Attempted to connect using 80 cipher suites; the server rejected all cipher suites.

 * TLS 1.2 Session Resumption Support:
      With Session IDs: OK - Server only supports TLS 1.3 which doesn't support Session IDs.
      With TLS Tickets: OK - Server only supports TLS 1.3 which doesn't support TLS tickets.

 * Session Renegotiation:
       Client Renegotiation DoS Attack:   OK - Not vulnerable
       Secure Renegotiation:              OK - Supported

 * TLS 1.1 Cipher Suites:
     Attempted to connect using 80 cipher suites; the server rejected all cipher suites.

 * Elliptic Curve Key Exchange:
       Supported curves:                  X25519, X448, prime256v1, secp384r1, secp521r1
       Rejected curves:                   prime192v1, secp160k1, secp160r1, secp160r2, secp192k1, secp224k1, secp224r1, secp256k1, sect163k1, sect163r1, sect163r2, sect193r1, sect193r2, sect233k1, sect233r1, sect239k1, sect283k1, sect283r1, sect409k1, sect409r1, sect571k1, sect571r1

 * ROBOT Attack:
                                          OK - Not vulnerable, RSA cipher suites not supported.

 * OpenSSL CCS Injection:
                                          OK - Not vulnerable to OpenSSL CCS injection

 * TLS 1.3 Cipher Suites:
     Attempted to connect using 5 cipher suites.

     The server accepted the following 3 cipher suites:
        TLS_CHACHA20_POLY1305_SHA256                      256       ECDH: X25519 (253 bits)
        TLS_AES_256_GCM_SHA384                            256       ECDH: X25519 (253 bits)
        TLS_AES_128_GCM_SHA256                            128       ECDH: X25519 (253 bits)


 * SSL 3.0 Cipher Suites:
     Attempted to connect using 80 cipher suites; the server rejected all cipher suites.

 * SSL 2.0 Cipher Suites:
     Attempted to connect using 7 cipher suites; the server rejected all cipher suites.

 * TLS 1.2 Cipher Suites:
     Attempted to connect using 156 cipher suites; the server rejected all cipher suites.

 * Deflate Compression:
                                          OK - Compression disabled

 * Downgrade Attacks:
       TLS_FALLBACK_SCSV:                 OK - Supported

[...]

 * OpenSSL Heartbleed:
                                          OK - Not vulnerable to Heartbleed


 SCAN COMPLETED IN 7.95 S
 ------------------------
```
</p>
</details>

## Test it

Feel free to test it:

```
$ sudo opnsense-patch -a windgmbh -c plugins -r opnsense-plugins 7701d0f3a156b9bd99e27382f485b6574330071a
```