### PR TITLE
Fix FreeDNS update in DynDNS plugin

### DIFF
--- a/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
+++ b/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
@@ -587,7 +587,7 @@ class updatedns
                 $this->_checkStatus(0, $code);
                 break;
             case 'freedns':
-                curl_setopt($ch, CURLOPT_URL, 'https://freedns.afraid.org/dynamic/update.php?' . $this->_dnsPass);
+                curl_setopt($ch, CURLOPT_URL, 'https://sync.afraid.org/u/' . $this->_dnsPass . '/');
                 break;
             case 'dnsexit':
                 curl_setopt($ch, CURLOPT_URL, 'https://update.dnsexit.com/RemoteUpdate.sv?login=' . urlencode($this->_dnsUser) . '&password=' . $this->_dnsPass . '&host=' . $this->_dnsHost . '&myip=' . $this->_dnsIP);
@@ -1329,7 +1329,7 @@ class updatedns
                 }
                 break;
             case 'freedns':
-                if (preg_match("/has not changed./i", $data)) {
+                if (preg_match("/No IP change detected.*skipping update/i", $data)) {
                     $status = "Dynamic DNS ({$this->_dnsHost}): (Success) No Change In IP Address";
                     $successful_update = true;
                 } elseif (preg_match("/Updated/i", $data)) {

--- a/dns/dyndns/src/www/services_dyndns_edit.php
+++ b/dns/dyndns/src/www/services_dyndns_edit.php
@@ -369,6 +369,7 @@ include("head.inc");
                         <br /><?= gettext('For Custom Entries, Username and Password represent HTTP Authentication username and passwords.') ?>
                         <br /><?= gettext('Gandi LiveDNS: The subdomain / record to update.') ?>
                         <br /><?= gettext('GoDaddy: Enter your API Key Token.') ?>
+                        <br /><?= gettext('FreeDNS: Leave blank.') ?>
                       </div>
                     </td>
                   </tr>


### PR DESCRIPTION
Current implementation of FreeDNS update in DynDNS plugin is broken.
DynDNS changed its interface and switched to "v2".
The URL in current implementation getting response `PAYLOAD: ERROR: Invalid update URL (2)`

This PR fixes endpoint, documentation and expected responses to make it work.

## Testing

Logs are backwards. Also includes piece of log "before". IP/DNS are sanitized.

```
/usr/local/etc/rc.dyndns: Dynamic DNS (abcd.mooo.com): (Success) No Change In IP Address
/usr/local/etc/rc.dyndns: Dynamic DNS: updating cache file /var/cache/dyndns_wan_abcd.mooo.com_2.cache: A.B.C.D
/usr/local/etc/rc.dyndns: Dynamic DNS (abcd.mooo.com): A.B.C.D extracted
/usr/local/etc/rc.dyndns: Dynamic DNS (abcd.mooo.com): Current Service: freedns
/usr/local/etc/rc.dyndns: Dynamic DNS (abcd.mooo.com): _checkStatus() starting.
/usr/local/etc/rc.dyndns: Dynamic DNS (abcd.mooo.com via freeDNS): _update() starting.
/usr/local/etc/rc.dyndns: Dynamic DNS (abcd.mooo.com): running dyndns_failover_interface for wan. found em0
/usr/local/etc/rc.dyndns: Dynamic DNS (abcd.mooo.com): A.B.C.D extracted

/services_dyndns_edit.php: Dynamic DNS (abcd.mooo.com): (Success) IP Address Changed Successfully!
/services_dyndns_edit.php: Dynamic DNS: updating cache file /var/cache/dyndns_wan_abcd.mooo.com_2.cache: A.B.C.D
/services_dyndns_edit.php: Dynamic DNS (abcd.mooo.com): A.B.C.D extracted
/services_dyndns_edit.php: Dynamic DNS (abcd.mooo.com): Current Service: freedns
/services_dyndns_edit.php: Dynamic DNS (abcd.mooo.com): _checkStatus() starting.
/services_dyndns_edit.php: Dynamic DNS (abcd.mooo.com via freeDNS): _update() starting.
/services_dyndns_edit.php: Dynamic DNS (abcd.mooo.com): running dyndns_failover_interface for wan. found em0
/services_dyndns_edit.php: Dynamic DNS (abcd.mooo.com): A.B.C.D extracted

/services_dyndns_edit.php: Dynamic DNS (abcd.mooo.com): (Success) No Change In IP Address
/services_dyndns_edit.php: Dynamic DNS: updating cache file /var/cache/dyndns_wan_abcd.mooo.com_2.cache: A.B.C.D
/services_dyndns_edit.php: Dynamic DNS (abcd.mooo.com): A.B.C.D extracted
/services_dyndns_edit.php: Dynamic DNS (abcd.mooo.com): Current Service: freedns
/services_dyndns_edit.php: Dynamic DNS (abcd.mooo.com): _checkStatus() starting.
/services_dyndns_edit.php: Dynamic DNS (abcd.mooo.com via freeDNS): _update() starting.
/services_dyndns_edit.php: Dynamic DNS (abcd.mooo.com): running dyndns_failover_interface for wan. found em0
/services_dyndns_edit.php: Dynamic DNS (abcd.mooo.com): A.B.C.D extracted

/services_dyndns_edit.php: Dynamic DNS (abcd.mooo.com): (Unknown Response)
/services_dyndns_edit.php: Dynamic DNS (abcd.mooo.com): PAYLOAD: ERROR: Invalid update URL (2)
/services_dyndns_edit.php: Dynamic DNS (abcd.mooo.com): Current Service: freedns
/services_dyndns_edit.php: Dynamic DNS (abcd.mooo.com): _checkStatus() starting.
/services_dyndns_edit.php: Dynamic DNS (abcd.mooo.com via freeDNS): _update() starting.
/services_dyndns_edit.php: Dynamic DNS (abcd.mooo.com): running dyndns_failover_interface for wan. found em0
/services_dyndns_edit.php: Dynamic DNS (abcd.mooo.com): A.B.C.D extracted

```