### PR TITLE
IPv6 support for DigitalOcean dynamic DNS

### DIFF
--- a/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns.inc
+++ b/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns.inc
@@ -108,6 +108,7 @@ function dyndns_list()
         'custom-v6' => 'Custom (v6)',
         'dhs' => 'DHS',
         'digitalocean' => 'DigitalOcean',
+        'digitalocean-v6' => 'DigitalOcean (v6)',
         'dnsexit' => 'DNSexit',
         'dnsomatic' => 'DNS-O-Matic',
         'duckdns' => 'Duck DNS',

--- a/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
+++ b/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
@@ -42,6 +42,7 @@
  *    - regfish IPv6 (regfish.de)
  *    - dynv6 IPv6 (dynv6.com)
  *    - DigitalOcean (digitalocean.com)
+ *    - DigitalOcean IPv6 (digitalocean.com)
  *    - Gandi LiveDNS (gandi.net)
  *    - Azure DNS (azure.microsoft.com)
  *    - Linode (linode.com)
@@ -102,7 +103,8 @@
  *  Amazon Route53 v6           - Last Tested: 19 November 2017
  *  dynv6                       - Last Tested: 25 June 2019
  *  dynv6 v6                    - Last Tested: 25 June 2019
- *  DigitalOcean                - Last Tested: 25 June 2019
+ *  DigitalOcean                - Last Tested: 10 March 2021
+ *  DigitalOcean IPv6           - Last Tested: 10 March 2021
  *  Azure DNS                   - Last Tested: 16 October 2019
  *  Linode                      - Last Tested: 25 February 2020
  *  Linode v6                   - Last Tested: 25 February 2020
@@ -293,6 +295,7 @@ class updatedns
             case 'regfish-v6':
             case 'route53-v6':
             case 'cloudflare-token-v6':
+            case 'digitalocean-v6':
                 $this->_useIPv6 = true;
                 break;
             default:
@@ -347,6 +350,7 @@ class updatedns
                 case 'custom-v6':
                 case 'dhs':
                 case 'digitalocean':
+                case 'digitalocean-v6':
                 case 'gandi-livedns':
                 case 'dnsexit':
                 case 'dnsomatic':
@@ -654,6 +658,7 @@ class updatedns
                 curl_setopt($ch, CURLOPT_URL, $server . 'hostname=' . $this->_dnsHost);
                 break;
             case 'digitalocean':
+            case 'digitalocean-v6':
                 /*
                 * dnsHost should be the root domain
                 * dnsUser should be the record ID
@@ -665,6 +670,9 @@ class updatedns
                 curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
                 curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT');
                 curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+                curl_setopt($ch, CURLOPT_INTERFACE, $this->_dnsRequestIf);
+                curl_setopt($ch, CURLOPT_DNS_LOCAL_IP4, $this->_dnsIP);
+                curl_setopt($ch, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
                 curl_setopt($ch, CURLOPT_HTTPHEADER, array(
                     "Authorization: Bearer {$this->_dnsPass}",
                     'Content-Type: application/json'
@@ -1446,6 +1454,7 @@ class updatedns
                 }
                 break;
             case 'digitalocean':
+            case 'digitalocean-v6':
                 $output = json_decode($data);
                 if ($output->domain_record->data === $this->_dnsIP) {
                     $status = "Dynamic DNS: (Success) Record ID {$this->_dnsUser} updated to {$this->_dnsIP}";

--- a/dns/dyndns/src/www/services_dyndns_edit.php
+++ b/dns/dyndns/src/www/services_dyndns_edit.php
@@ -369,6 +369,7 @@ include("head.inc");
                         <br /><?= gettext('For Custom Entries, Username and Password represent HTTP Authentication username and passwords.') ?>
                         <br /><?= gettext('Gandi LiveDNS: The subdomain / record to update.') ?>
                         <br /><?= gettext('GoDaddy: Enter your API Key Token.') ?>
+                        <br /><?= gettext('DigitalOcean: Enter your DNS record id.') ?>
                       </div>
                     </td>
                   </tr>
@@ -386,6 +387,7 @@ include("head.inc");
                         <br /><?= gettext('Cloudflare: Enter your API token or Global API key.') ?>
                         <br /><?= gettext('Gandi LiveDNS: Enter your API token.') ?>
                         <br /><?= gettext('GoDaddy: Enter your API Secret Token.') ?>
+                        <br /><?= gettext('DigitalOcean: Enter your API token.') ?>
                       </div>
                     </td>
                   </tr>


### PR DESCRIPTION
Hello,

This PR implements IPv6 support for the DigitalOcean dynamic DNS plugin. In fact, the changes are only minor and should not be surprising at all.

## Testing 

Logs are from bottom to top. Retrieved via the web interface (System -> Log Files -> General).

```
2021-03-11T06:35:04 | opnsense[82969] | /usr/local/etc/rc.dyndns: Dynamic DNS: (Success) Record ID 111111111 updated to A:B:C:D |  
-- | -- | -- | --
2021-03-11T06:35:04 | opnsense[82969] | /usr/local/etc/rc.dyndns:  Dynamic DNS: updating cache file  /var/cache/dyndns_wan_example.com_1_v6.cache:  A:B:C:D |  
2021-03-11T06:35:04 | opnsense[82969] | /usr/local/etc/rc.dyndns: Dynamic DNS (example.com): A:B:C:D extracted |  
2021-03-11T06:35:04 | opnsense[82969] | /usr/local/etc/rc.dyndns: Dynamic DNS (example.com): Current Service: digitalocean-v6 |  
2021-03-11T06:35:04 | opnsense[82969] | /usr/local/etc/rc.dyndns: Dynamic DNS (example.com): _checkStatus() starting. |  
2021-03-11T06:35:04 | opnsense[82969] | /usr/local/etc/rc.dyndns: Dynamic DNS (example.com via DigitalOcean (v6)): _update() starting. |  
```

Thanks for the review and your efforts for the project!

BR,
Jonas