### PR TITLE
os-smart: Add new action and API parameter for JSON info from smartctl.

### DIFF
--- a/sysutils/smart/src/opnsense/mvc/app/controllers/OPNsense/Smart/Api/ServiceController.php
+++ b/sysutils/smart/src/opnsense/mvc/app/controllers/OPNsense/Smart/Api/ServiceController.php
@@ -57,6 +57,7 @@ class ServiceController extends ApiControllerBase
         if ($this->request->isPost()) {
             $device = $this->request->getPost('device');
             $type   = $this->request->getPost('type');
+            $json   = $this->request->getPost('json');
 
             if (!in_array($device, $this->getDevices())) {
                 return array("message" => "Invalid device name");
@@ -70,7 +71,15 @@ class ServiceController extends ApiControllerBase
 
             $backend = new Backend();
 
-            $output = $backend->configdpRun("smart", array("info", $type, "/dev/" . $device));
+            $params = array("info", $type, "/dev/" . $device);
+            if ($json != NULL) {
+                $params[0] = "info_json";
+            }
+
+            $output = $backend->configdpRun("smart", $params);
+            if ($json != NULL) {
+                $output = json_decode($output, true);
+            }
 
             return array("output" => $output);
         }

--- a/sysutils/smart/src/opnsense/service/conf/actions.d/actions_smart.conf
+++ b/sysutils/smart/src/opnsense/service/conf/actions.d/actions_smart.conf
@@ -10,35 +10,17 @@ parameters:
 type:script_output
 message:list installed devices
 
-[info.i]
-command:/usr/local/sbin/smartctl -i
-parameters:%s; exit 0
+[info]
+command:/usr/local/sbin/smartctl
+parameters:-%s %s; exit 0
 type:script_output
-message:Get identity info for device %s
+message:exec smartctl -%s for device %s
 
-[info.H]
-command:/usr/local/sbin/smartctl -H
-parameters:%s; exit 0
+[info_json]
+command:/usr/local/sbin/smartctl
+parameters:-%s --json=c %s; exit 0
 type:script_output
-message:Get SMART health status info for device %s
-
-[info.c]
-command:/usr/local/sbin/smartctl -c
-parameters:%s; exit 0
-type:script_output
-message:Get capabilities for device %s
-
-[info.A]
-command:/usr/local/sbin/smartctl -A
-parameters:%s; exit 0
-type:script_output
-message:Get vendor-specific attributes for device %s
-
-[info.a]
-command:/usr/local/sbin/smartctl -a
-parameters:%s; exit 0
-type:script_output
-message:Get all SMART info for device %s
+message:exec smartctl -%s (JSON) for device %s
 
 [log.error]
 command:/usr/local/sbin/smartctl -l error


### PR DESCRIPTION
os-smart: Add new action and API parameter for JSON info from smartctl.

- The existing `smart info.*` actions have been merged into one `smart info`
  action that takes the type as a parameter.

- There is now a `smart info_json` action that runs the same `smartctl` command
  with an additional `--json=c` parameter for JSON output.

- The `/api/smart/service/info` API now takes an optional `"json": true`
  request body parameter that changes the response `"output"` value from
  a string to a JSON object. The JSON object is the output of
  the `smart info_json` action.

Fixes #2283