### PR TITLE
Improving config options for ntopng 4.2

### DIFF
--- a/net/ntopng/Makefile
+++ b/net/ntopng/Makefile
@@ -1,6 +1,6 @@
 PLUGIN_NAME=		ntopng
 PLUGIN_VERSION=		1.2
-PLUGIN_REVISION=	1
+PLUGIN_REVISION=	2
 PLUGIN_COMMENT=		Traffic Analysis and Flow Collection
 PLUGIN_DEPENDS=		ntopng
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net/ntopng/Makefile
+++ b/net/ntopng/Makefile
@@ -1,6 +1,6 @@
 PLUGIN_NAME=		ntopng
-PLUGIN_VERSION=		1.2
-PLUGIN_REVISION=	2
+PLUGIN_VERSION=		1.3
+PLUGIN_REVISION=	1
 PLUGIN_COMMENT=		Traffic Analysis and Flow Collection
 PLUGIN_DEPENDS=		ntopng
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net/ntopng/pkg-descr
+++ b/net/ntopng/pkg-descr
@@ -8,6 +8,12 @@ and on Windows as well.
 Plugin Changelog
 ================
 
+1.2 r2
+
+* allow multiple interfaces to be selected
+* allow http port to be 0 (whichs disables http listener)
+* added the checkbox to bypass user login validation
+
 1.2
 
 * Changed data directory to avoid warning

--- a/net/ntopng/pkg-descr
+++ b/net/ntopng/pkg-descr
@@ -1,4 +1,4 @@
-tontopng is the next generation version of the original ntop,
+ntopng is the next generation version of the original ntop,
 a network traffic probe that monitors network usage. ntopng
 is based on libpcap and it has been written in a portable
 way in order to virtually run on every Unix platform, MacOSX

--- a/net/ntopng/pkg-descr
+++ b/net/ntopng/pkg-descr
@@ -1,4 +1,4 @@
-ntopng is the next generation version of the original ntop,
+tontopng is the next generation version of the original ntop,
 a network traffic probe that monitors network usage. ntopng
 is based on libpcap and it has been written in a portable
 way in order to virtually run on every Unix platform, MacOSX
@@ -8,11 +8,12 @@ and on Windows as well.
 Plugin Changelog
 ================
 
-1.2 r2
+1.3
 
 * allow multiple interfaces to be selected
-* allow http port to be 0 (whichs disables http listener)
-* added the checkbox to bypass user login validation
+* if cert is chosen, https is enabled. No cert, http is enabled
+* checkbox to bypass user login validation
+* allow explicit selection of community version 
 
 1.2
 

--- a/net/ntopng/src/opnsense/mvc/app/controllers/OPNsense/Ntopng/forms/general.xml
+++ b/net/ntopng/src/opnsense/mvc/app/controllers/OPNsense/Ntopng/forms/general.xml
@@ -46,7 +46,7 @@
         <help>Sets the DNS resolution mode.</help>
     </field>
     <field>
-        <id>license.community</id>
+        <id>general.community</id>
         <label>Community Mode</label>
         <type>checkbox</type>
         <advanced>true</advanced>

--- a/net/ntopng/src/opnsense/mvc/app/controllers/OPNsense/Ntopng/forms/general.xml
+++ b/net/ntopng/src/opnsense/mvc/app/controllers/OPNsense/Ntopng/forms/general.xml
@@ -13,10 +13,10 @@
     </field>
     <field>
         <id>general.interface</id>
-        <label>Listening interfaces</label>
+        <label>Tracked interfaces</label>
         <type>select_multiple</type>
         <advanced>true</advanced>
-        <help>Select interfaces to listen to. Set to none if you want to choose the interface via ntopng UI.</help>
+        <help>Select interfaces that ntopng will monitor. Set to none if you want to choose the interface via ntopng UI.</help>
     </field>
     <field>
         <id>general.httpport</id>

--- a/net/ntopng/src/opnsense/mvc/app/controllers/OPNsense/Ntopng/forms/general.xml
+++ b/net/ntopng/src/opnsense/mvc/app/controllers/OPNsense/Ntopng/forms/general.xml
@@ -9,37 +9,47 @@
         <id>general.disablelogin</id>
         <label>Disable ntopng user authentication</label>
         <type>checkbox</type>
-        <help>Select to skip ntopng login authentication screen, allowing anyone to access ntopng GUI.</help>
+        <help>Remove login splashscreen and launch ntopng portal without authentication.</help>
     </field>
     <field>
         <id>general.interface</id>
         <label>Monitored interfaces</label>
         <type>select_multiple</type>
+        <style>selectpicker</style>        
         <advanced>true</advanced>
-        <help>Select interfaces that ntopng will monitor. Set to none if you want to choose the interface via ntopng UI.</help>
+        <help>Select interfaces that ntopng will monitor. Set to none if you want ntopng to monitor all available interfaces.</help>
     </field>
+    <field>
+        <id>general.localnet</id>
+        <label>Local Networks</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>Configure the local networks (CIDR format, comma-separated list).</help>
+    </field>    
     <field>
         <id>general.httpport</id>
-        <label>HTTP Port</label>
+        <label>HTTP/S Port</label>
         <type>text</type>
-        <help>HTTP Port this service listens on. Set to 0 to disable http listener. </help>
-    </field>
-    <field>
-        <id>general.httpsport</id>
-        <label>HTTPS Port</label>
-        <type>text</type>
-        <help>HTTPS Port this service listens on. If you enable HTTPS you will be redirected from HTTP to HTTPS. Please select a certificate below</help>
+        <help>HTTP/S Port for ntopng UI. To enable HTTPS, select a certificate below.</help>
     </field>
     <field>
         <id>general.cert</id>
         <label>Certificate</label>
         <type>dropdown</type>
-        <help>Set the certificate to use for HTTPS connections.</help>
+        <help>Set the certificate to use with HTTPS. Select None for HTTP.</help>
     </field>
     <field>
         <id>general.dnsmode</id>
         <label>DNS Mode</label>
         <type>dropdown</type>
+        <advanced>true</advanced>
         <help>Sets the DNS resolution mode.</help>
+    </field>
+    <field>
+        <id>license.community</id>
+        <label>Community Mode</label>
+        <type>checkbox</type>
+        <advanced>true</advanced>
+        <help>Run ntopng in Community mode, a license is not required.</help>
     </field>
 </form>

--- a/net/ntopng/src/opnsense/mvc/app/controllers/OPNsense/Ntopng/forms/general.xml
+++ b/net/ntopng/src/opnsense/mvc/app/controllers/OPNsense/Ntopng/forms/general.xml
@@ -13,7 +13,7 @@
     </field>
     <field>
         <id>general.interface</id>
-        <label>Tracked interfaces</label>
+        <label>Monitored interfaces</label>
         <type>select_multiple</type>
         <advanced>true</advanced>
         <help>Select interfaces that ntopng will monitor. Set to none if you want to choose the interface via ntopng UI.</help>

--- a/net/ntopng/src/opnsense/mvc/app/controllers/OPNsense/Ntopng/forms/general.xml
+++ b/net/ntopng/src/opnsense/mvc/app/controllers/OPNsense/Ntopng/forms/general.xml
@@ -6,17 +6,23 @@
         <help>This will activate ntopng.</help>
     </field>
     <field>
+        <id>general.disablelogin</id>
+        <label>Disable ntopng user authentication</label>
+        <type>checkbox</type>
+        <help>Select to skip ntopng login authentication screen, allowing anyone to access ntopng GUI.</help>
+    </field>
+    <field>
         <id>general.interface</id>
-        <label>Interfaces</label>
-        <type>dropdown</type>
+        <label>Listening interfaces</label>
+        <type>select_multiple</type>
         <advanced>true</advanced>
-        <help>Select the interface to listen to. Set to none if you want to choose the interface via ntopng UI.</help>
+        <help>Select interfaces to listen to. Set to none if you want to choose the interface via ntopng UI.</help>
     </field>
     <field>
         <id>general.httpport</id>
         <label>HTTP Port</label>
         <type>text</type>
-        <help>HTTP Port this service listens on.</help>
+        <help>HTTP Port this service listens on. Set to 0 to disable http listener. </help>
     </field>
     <field>
         <id>general.httpsport</id>

--- a/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/General.xml
+++ b/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/General.xml
@@ -15,33 +15,13 @@
             <Required>N</Required>
             <Multiple>Y</Multiple>
         </interface>
-        <httpport type="IntegerField">
+        <httpport type="PortField">
             <Required>Y</Required>
             <default>3000</default>
-            <MinimumValue>0</MinimumValue>
-            <MaximumValue>65565</MaximumValue>
-            <ValidationMessage>Port must be between 0 and 65535</ValidationMessage>
         </httpport>
-        <httpsport type="PortField">
-            <Required>N</Required>
-            <Constraints>
-                <check001>
-                    <ValidationMessage>Please select a HTTPS port and a valid certificate</ValidationMessage>
-                    <type>AllOrNoneConstraint</type>
-                    <addFields>
-                        <field1>cert</field1>
-                    </addFields>
-                </check001>
-            </Constraints>
-        </httpsport>
         <cert type="CertificateField">
             <Type>cert</Type>
             <Required>N</Required>
-            <Constraints>
-                <check001>
-                    <reference>httpsport.check001</reference>
-                </check001>
-            </Constraints>
         </cert>
         <dnsmode type="OptionField">
             <Required>N</Required>
@@ -52,5 +32,13 @@
                 <Option3 value="3">Do not decode DNS responses and do not resolve numeric IPs</Option3>
             </OptionValues>
         </dnsmode>
+        <localnet type="TextField">
+            <Required>N</Required>
+            <default></default>
+        </localnet>
+        <community type="BooleanField">
+            <default>0</default>
+            <Required>Y</Required>
+        </community>        
     </items>
 </model>

--- a/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/General.xml
+++ b/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/General.xml
@@ -15,10 +15,12 @@
             <Required>N</Required>
             <Multiple>Y</Multiple>
         </interface>
-        <httpport type="PortField">
+        <httpport type="IntegerField">
             <Required>Y</Required>
             <default>3000</default>
-        </httpport>
+            <MinimumValue>0</MinimumValue>
+            <MaximumValue>65565</MaximumValue>
+            <ValidationMessage>Port must be between 0 and 65535</ValidationMessage>
         <httpsport type="PortField">
             <Required>N</Required>
             <Constraints>

--- a/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/General.xml
+++ b/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/General.xml
@@ -21,6 +21,7 @@
             <MinimumValue>0</MinimumValue>
             <MaximumValue>65565</MaximumValue>
             <ValidationMessage>Port must be between 0 and 65535</ValidationMessage>
+        </httpport>
         <httpsport type="PortField">
             <Required>N</Required>
             <Constraints>

--- a/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/General.xml
+++ b/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/General.xml
@@ -7,9 +7,13 @@
             <default>0</default>
             <Required>Y</Required>
         </enabled>
+        <disablelogin type="BooleanField">
+            <default>0</default>        
+            <Required>N</Required>
+        </disablelogin>         
         <interface type="InterfaceField">
             <Required>N</Required>
-            <Multiple>N</Multiple>
+            <Multiple>Y</Multiple>
         </interface>
         <httpport type="PortField">
             <Required>Y</Required>

--- a/net/ntopng/src/opnsense/mvc/app/views/OPNsense/Ntopng/general.volt
+++ b/net/ntopng/src/opnsense/mvc/app/views/OPNsense/Ntopng/general.volt
@@ -43,17 +43,34 @@ POSSIBILITY OF SUCH DAMAGE.
             <div class="col-md-12">
                 <hr />
                 <button class="btn btn-primary" id="saveAct" type="button"><b>{{ lang._('Save') }}</b> <i id="saveAct_progress"></i></button>
+                <hr />
+                <span id='ntopngLinkBox'></span>
             </div>
         </div>
     </div>
 </div>
 
 <script>
+let http_prefix = "http://";
+let hostname = '';
+let port = 3000;
+function updateNtopngURL() {
+  port = document.getElementById("general.httpport").value;
+  let cert = document.getElementById("general.cert").value.trim();
+  if (cert !== '') http_prefix = "https://";
+  let ntopng_url = http_prefix + hostname + ':' + port;
+  $("#ntopngLinkBox").html("").html("Once ntopng is running <a href='" + ntopng_url + "' target='_blank'>click here to open the Web Interface</a>.");
+}
 $( document ).ready(function() {
+    // read hostname from URL
+    var l = document.createElement("a");
+    l.href = window.location.href;
+    hostname = l.hostname;    
     var data_get_map = {'frm_general_settings':"/api/ntopng/general/get"};
     mapDataToFormUI(data_get_map).done(function(data){
         formatTokenizersUI();
         $('.selectpicker').selectpicker('refresh');
+        updateNtopngURL();
     });
 
     updateServiceControlUI('ntopng');
@@ -71,9 +88,9 @@ $( document ).ready(function() {
             ajaxCall(url="/api/ntopng/service/reconfigure", sendData={}, callback=function(data,status) {
 		updateServiceControlUI('ntopng');
                 $("#saveAct_progress").removeClass("fa fa-spinner fa-pulse");
+                updateNtopngURL();
             });
         });
     });
-
 });
 </script>

--- a/net/ntopng/src/opnsense/service/templates/OPNsense/Ntopng/ntopng.conf
+++ b/net/ntopng/src/opnsense/service/templates/OPNsense/Ntopng/ntopng.conf
@@ -1,8 +1,13 @@
 {% if helpers.exists('OPNsense.ntopng.general.enabled') and OPNsense.ntopng.general.enabled == '1' %}
 {% from 'OPNsense/Macros/interface.macro' import physical_interface %}
 {%   if helpers.exists('OPNsense.ntopng.general.interface') and OPNsense.ntopng.general.interface != '' %}
--i={{ physical_interface(OPNsense.ntopng.general.interface) }}
+{%       for listen_interface in OPNsense.ntopng.general.interface.split(',') %}
+-i={{ physical_interface(listen_interface) }}
+{%       endfor %}
 {%   endif %}
+{%   if helpers.exists('OPNsense.ntopng.general.disablelogin') and OPNsense.ntopng.general.disablelogin != '' %}
+-l={{ OPNsense.ntopng.general.disablelogin }}
+{% endif %}
 {%   if helpers.exists('OPNsense.ntopng.general.httpport') and OPNsense.ntopng.general.httpport != '' %}
 -w={{ OPNsense.ntopng.general.httpport }}
 {%   endif %}

--- a/net/ntopng/src/opnsense/service/templates/OPNsense/Ntopng/ntopng.conf
+++ b/net/ntopng/src/opnsense/service/templates/OPNsense/Ntopng/ntopng.conf
@@ -1,20 +1,20 @@
 {% if helpers.exists('OPNsense.ntopng.general.enabled') and OPNsense.ntopng.general.enabled == '1' %}
 {% from 'OPNsense/Macros/interface.macro' import physical_interface %}
-{%   if helpers.exists('OPNsense.ntopng.general.interface') and OPNsense.ntopng.general.interface != '' %}
-{%       for listen_interface in OPNsense.ntopng.general.interface.split(',') %}
+{%   if not helpers.empty('OPNsense.ntopng.general.interface') %}
+{%     for listen_interface in OPNsense.ntopng.general.interface.split(',') %}
 -i={{ physical_interface(listen_interface) }}
-{%       endfor %}
+{%     endfor %}
 {%   endif %}
-{%   if helpers.exists('OPNsense.ntopng.general.disablelogin') and OPNsense.ntopng.general.disablelogin != '' %}
+{%   if not helpers.empty('OPNsense.ntopng.general.disablelogin') %}
 -l={{ OPNsense.ntopng.general.disablelogin }}
 {% endif %}
-{%   if helpers.exists('OPNsense.ntopng.general.httpport') and OPNsense.ntopng.general.httpport != '' %}
+{%   if helpers.exists('OPNsense.ntopng.general.httpport') %}
 -w={{ OPNsense.ntopng.general.httpport }}
 {%   endif %}
-{%   if helpers.exists('OPNsense.ntopng.general.httpsport') and OPNsense.ntopng.general.httpsport != '' %}
+{%   if not helpers.empty('OPNsense.ntopng.general.httpsport') %}
 -W={{ OPNsense.ntopng.general.httpsport }}
 {%   endif %}
-{%   if helpers.exists('OPNsense.ntopng.general.dnsmode') and OPNsense.ntopng.general.dnsmode != '' %}
+{%   if not helpers.empty('OPNsense.ntopng.general.dnsmode') %}
 -n={{ OPNsense.ntopng.general.dnsmode }}
 {%   endif %}
 -d=/var/db/ntopng

--- a/net/ntopng/src/opnsense/service/templates/OPNsense/Ntopng/ntopng.conf
+++ b/net/ntopng/src/opnsense/service/templates/OPNsense/Ntopng/ntopng.conf
@@ -8,14 +8,25 @@
 {%   if not helpers.empty('OPNsense.ntopng.general.disablelogin') %}
 -l={{ OPNsense.ntopng.general.disablelogin }}
 {% endif %}
-{%   if helpers.exists('OPNsense.ntopng.general.httpport') %}
+{%   if not helpers.empty('OPNsense.ntopng.general.cert') %}
+{%     if not helpers.empty('OPNsense.ntopng.general.httpport') %}
+-w=0
+-W={{ OPNsense.ntopng.general.httpport }}
+{%     endif %}
+{%   else %}
+{%     if not helpers.empty('OPNsense.ntopng.general.httpport') %}
 -w={{ OPNsense.ntopng.general.httpport }}
+-W=0
+{%     endif %}
 {%   endif %}
-{%   if not helpers.empty('OPNsense.ntopng.general.httpsport') %}
--W={{ OPNsense.ntopng.general.httpsport }}
+{%   if not helpers.empty('OPNsense.ntopng.general.localnet') %}
+-m={{ OPNsense.ntopng.general.localnet }}
 {%   endif %}
 {%   if not helpers.empty('OPNsense.ntopng.general.dnsmode') %}
 -n={{ OPNsense.ntopng.general.dnsmode }}
+{%   endif %}
+{%   if not helpers.empty('OPNsense.ntopng.license.community')  %}
+--community
 {%   endif %}
 -d=/var/db/ntopng
 {% endif %}


### PR DESCRIPTION
1. Fixing issues #2229 and #2096: allow multiple interfaces to be selected for ntopng
2. Adding  --disable-login (-l)  for ntopng to allow login-free access to ntopng GUI
3. Adding clarification text for httpport field: "Set to 0 to disable http listener."