### PR TITLE
net/frr: Add support for agentx

### DIFF
--- a/net/frr/Makefile
+++ b/net/frr/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		frr
-PLUGIN_VERSION=		1.22
+PLUGIN_VERSION=		1.23
 PLUGIN_COMMENT=		The FRRouting Protocol Suite
 PLUGIN_DEPENDS=		frr7
 PLUGIN_MAINTAINER=	franz.fabian.94@gmail.com

--- a/net/frr/Makefile
+++ b/net/frr/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		frr
-PLUGIN_VERSION=		1.23
+PLUGIN_VERSION=		1.22
 PLUGIN_COMMENT=		The FRRouting Protocol Suite
 PLUGIN_DEPENDS=		frr7
 PLUGIN_MAINTAINER=	franz.fabian.94@gmail.com

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/general.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/general.xml
@@ -19,6 +19,12 @@
         <help>This will activate the routing service only on the master device.</help>
     </field>
     <field>
+        <id>general.enablesnmp</id>
+        <label>Enable SNMP AgentX Support</label>
+        <type>checkbox</type>
+        <help>This will activate support for Net-SNMP AgentX.</help>
+    </field>
+    <field>
         <id>general.enablesyslog</id>
         <label>Enable logging</label>
         <type>checkbox</type>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/General.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/General.xml
@@ -24,6 +24,10 @@
             <default>1</default>
             <Required>Y</Required>
         </enablesyslog>
+        <enablesnmp type="BooleanField">
+            <default>0</default>
+            <Required>Y</Required>
+        </enablesnmp>
         <sysloglevel type="OptionField">
             <Required>Y</Required>
             <multiple>N</multiple>

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -243,7 +243,7 @@ route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
 !
 {% if helpers.exists('OPNsense.quagga.bgpd.enabled') and OPNsense.quagga.general.enablesnmp == '1' %}
 agentx
-{%   endif %}
+{% endif %}
 !
 line vty
 !

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -11,9 +11,6 @@ log syslog {{ OPNsense.quagga.general.sysloglevel }}
 {%   if helpers.exists('OPNsense.quagga.general.profile') %}
 frr defaults {{ OPNsense.quagga.general.profile }}
 {%   endif %}
-{%   if OPNsense.quagga.general.enablesnmp == '1' %}
-agentx
-{%   endif %}
 {% endif %}
 !
 !

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -11,6 +11,9 @@ log syslog {{ OPNsense.quagga.general.sysloglevel }}
 {%   if helpers.exists('OPNsense.quagga.general.profile') %}
 frr defaults {{ OPNsense.quagga.general.profile }}
 {%   endif %}
+{%   if OPNsense.quagga.general.enablesnmp == '1' %}
+agentx
+{%   endif %}
 {% endif %}
 !
 !
@@ -240,6 +243,10 @@ route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
 {%   endif %}
 !
 {% endif %}
+!
+{% if helpers.exists('OPNsense.quagga.bgpd.enabled') and OPNsense.quagga.general.enablesnmp == '1' %}
+agentx
+{%   endif %}
 !
 line vty
 !

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/frr
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/frr
@@ -17,3 +17,9 @@ start_postcmd="/usr/local/opnsense/scripts/frr/carp_event_handler"
 {% else %}
 frr_enable="NO"
 {% endif %}
+{% if OPNsense.quagga.general.enablesnmp == '1' %}
+zebra_flags="${zebra_flags} -M snmp"
+bgpd_flags="${bgpd_flags} -M snmp"
+ospf_flags="${ospf_flags} -M snmp"
+ospf6_flags="${ospf6_flags} -M snmp"
+{% endif %}

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospf6d.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospf6d.conf
@@ -14,6 +14,9 @@ log syslog {{ OPNsense.quagga.general.sysloglevel }}
 {%   if helpers.exists('OPNsense.quagga.general.profile') %}
 frr defaults {{ OPNsense.quagga.general.profile }}
 {%   endif %}
+{%   if OPNsense.quagga.general.enablesnmp == '1' %}
+agentx
+{%   endif %}
 {% endif %}
 !
 !

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
@@ -14,6 +14,9 @@ log syslog {{ OPNsense.quagga.general.sysloglevel }}
 {%   if helpers.exists('OPNsense.quagga.general.profile') %}
 frr defaults {{ OPNsense.quagga.general.profile }}
 {%   endif %}
+{%   if OPNsense.quagga.general.enablesnmp == '1' %}
+agentx
+{%   endif %}
 {% endif %}
 !
 !

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/zebra.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/zebra.conf
@@ -16,7 +16,7 @@ log syslog {{ OPNsense.quagga.general.sysloglevel }}
 !
 {% if OPNsense.quagga.general.enablesnmp == '1' %}
 agentx
-{%   endif %}
+{% endif %}
 !
 !
 ip forwarding

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/zebra.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/zebra.conf
@@ -13,6 +13,12 @@ log syslog {{ OPNsense.quagga.general.sysloglevel }}
 !
 !
 !
+!
+{% if OPNsense.quagga.general.enablesnmp == '1' %}
+agentx
+{%   endif %}
+!
+!
 ip forwarding
 ipv6 forwarding
 !


### PR DESCRIPTION
I need agentx support in order to gather BGP details via SNMP.  All of the software is built, and only the UI and config files need a change. 

This works for me, and it only changes templates and adds a field for Net-SNMP and Frr.