### PR TITLE
Allow maltrail sensor periodic restart from webGUI

### DIFF
--- a/security/maltrail/src/opnsense/service/conf/actions.d/actions_maltrailsensor.conf
+++ b/security/maltrail/src/opnsense/service/conf/actions.d/actions_maltrailsensor.conf
@@ -15,6 +15,7 @@ command:/usr/local/opnsense/scripts/OPNsense/Maltrail/setup.sh;/usr/local/etc/rc
 parameters:
 type:script
 message:restarting Maltrail sensor
+description:Restart Maltrail sensor
 
 [status]
 command:/usr/local/etc/rc.d/opnsense-maltrailsensor status;exit 0


### PR DESCRIPTION
Maltrail sensor is a memory hog (or it might leak memory), if I don't restart it every few days it crashes with OOM or worst case it takes suricata and/or ntopng with it as well. The commit makes the Maltrail sensor restart option visible under webGUI's cron settings to make restarting convenient.