### PR TITLE
net/ntopng - Improved config options for ntopng 4.2

### DIFF
--- a/net/ntopng/Makefile
+++ b/net/ntopng/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		ntopng
-PLUGIN_VERSION=		1.2
+PLUGIN_VERSION=		1.3
 PLUGIN_REVISION=	1
 PLUGIN_COMMENT=		Traffic Analysis and Flow Collection
 PLUGIN_DEPENDS=		ntopng

--- a/net/ntopng/pkg-descr
+++ b/net/ntopng/pkg-descr
@@ -8,6 +8,14 @@ and on Windows as well.
 Plugin Changelog
 ================
 
+1.3
+
+* Allow multiple interfaces to be selected
+* Allow login bypass
+* (Advanced) Allow entry of local network
+* Combined http and https ports togerher
+* use https if cert is selected, http if no cert
+
 1.2
 
 * Changed data directory to avoid warning

--- a/net/ntopng/src/opnsense/mvc/app/controllers/OPNsense/Ntopng/forms/general.xml
+++ b/net/ntopng/src/opnsense/mvc/app/controllers/OPNsense/Ntopng/forms/general.xml
@@ -6,23 +6,30 @@
         <help>This will activate ntopng.</help>
     </field>
     <field>
+        <id>general.authbypass</id>
+        <label>Bypass login</label>
+        <type>checkbox</type>
+        <help>This will disable login for all hosts.</help>
+    </field>    
+    <field>
         <id>general.interface</id>
         <label>Interfaces</label>
-        <type>dropdown</type>
-        <advanced>true</advanced>
-        <help>Select the interface to listen to. Set to none if you want to choose the interface via ntopng UI.</help>
+        <type>select_multiple</type>
+        <style>selectpicker</style>
+        <help>Select the interfaces to listen to. Leave empty to choose the interface in ntopng or to connect to nProbe only.</help>
     </field>
+    <field>
+        <id>general.localnet</id>
+        <label>Local Networks</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>Configure the local networks (CIDR format, comma-separated list).</help>
+    </field>    
     <field>
         <id>general.httpport</id>
-        <label>HTTP Port</label>
+        <label>HTTP(S) Port</label>
         <type>text</type>
-        <help>HTTP Port this service listens on.</help>
-    </field>
-    <field>
-        <id>general.httpsport</id>
-        <label>HTTPS Port</label>
-        <type>text</type>
-        <help>HTTPS Port this service listens on. If you enable HTTPS you will be redirected from HTTP to HTTPS. Please select a certificate below</help>
+        <help>HTTP port this service listens on. To enable HTTPS on this port please select a certificate below.</help>
     </field>
     <field>
         <id>general.cert</id>

--- a/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/General.xml
+++ b/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/General.xml
@@ -7,26 +7,22 @@
             <default>0</default>
             <Required>Y</Required>
         </enabled>
+        <authbypass type="BooleanField">
+            <default>0</default>
+            <Required>Y</Required>
+        </authbypass>
         <interface type="InterfaceField">
             <Required>N</Required>
-            <Multiple>N</Multiple>
+            <Multiple>Y</Multiple>
         </interface>
+        <localnet type="TextField">
+            <Required>N</Required>
+            <default></default>
+        </localnet>        
         <httpport type="PortField">
             <Required>Y</Required>
             <default>3000</default>
         </httpport>
-        <httpsport type="PortField">
-            <Required>N</Required>
-            <Constraints>
-                <check001>
-                    <ValidationMessage>Please select a HTTPS port and a valid certificate</ValidationMessage>
-                    <type>AllOrNoneConstraint</type>
-                    <addFields>
-                        <field1>cert</field1>
-                    </addFields>
-                </check001>
-            </Constraints>
-        </httpsport>
         <cert type="CertificateField">
             <Type>cert</Type>
             <Required>N</Required>

--- a/net/ntopng/src/opnsense/mvc/app/views/OPNsense/Ntopng/general.volt
+++ b/net/ntopng/src/opnsense/mvc/app/views/OPNsense/Ntopng/general.volt
@@ -26,7 +26,6 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
 #}
-
 <div class="alert alert-warning" role="alert" id="missing_redis" style="display:none;min-height:65px;">
     <div style="margin-top: 8px;">{{ lang._('No Redis plugin found, please install via System > Firmware > Plugins and enable the service.')}}</div>
 </div>
@@ -43,17 +42,37 @@ POSSIBILITY OF SUCH DAMAGE.
             <div class="col-md-12">
                 <hr />
                 <button class="btn btn-primary" id="saveAct" type="button"><b>{{ lang._('Save') }}</b> <i id="saveAct_progress"></i></button>
+                <hr />
+                <span id='ntopngLinkBox'></span>
             </div>
         </div>
     </div>
 </div>
 
 <script>
+let http_prefix = "http://";
+let hostname = '';
+let port = 3000;
+
+function updateNtopngURL() {
+  port = document.getElementById("general.httpport").value;
+  let cert = document.getElementById("general.cert").value.trim();
+  if (cert !== '') http_prefix = "https://";
+  let ntopng_url = http_prefix + hostname + ':' + port;
+  $("#ntopngLinkBox").html("").html("Once ntopng is running <a href='" + ntopng_url + "' target='_blank'>click here to open the Web Interface</a>.");
+}
+
 $( document ).ready(function() {
+    // read hostname from URL
+    var l = document.createElement("a");
+    l.href = window.location.href;
+    hostname = l.hostname;
+
     var data_get_map = {'frm_general_settings':"/api/ntopng/general/get"};
     mapDataToFormUI(data_get_map).done(function(data){
         formatTokenizersUI();
         $('.selectpicker').selectpicker('refresh');
+    	updateNtopngURL();
     });
 
     updateServiceControlUI('ntopng');
@@ -71,6 +90,7 @@ $( document ).ready(function() {
             ajaxCall(url="/api/ntopng/service/reconfigure", sendData={}, callback=function(data,status) {
 		updateServiceControlUI('ntopng');
                 $("#saveAct_progress").removeClass("fa fa-spinner fa-pulse");
+                updateNtopngURL();
             });
         });
     });

--- a/net/ntopng/src/opnsense/service/templates/OPNsense/Ntopng/ntopng.conf
+++ b/net/ntopng/src/opnsense/service/templates/OPNsense/Ntopng/ntopng.conf
@@ -1,16 +1,29 @@
 {% if helpers.exists('OPNsense.ntopng.general.enabled') and OPNsense.ntopng.general.enabled == '1' %}
 {% from 'OPNsense/Macros/interface.macro' import physical_interface %}
-{%   if helpers.exists('OPNsense.ntopng.general.interface') and OPNsense.ntopng.general.interface != '' %}
--i={{ physical_interface(OPNsense.ntopng.general.interface) }}
+{%   if not helpers.empty('OPNsense.ntopng.general.interface') %}
+{%     for interface in OPNsense.ntopng.general.interface.split(',') %}
+-i={{ physical_interface(interface) }}
+{%     endfor %}
 {%   endif %}
-{%   if helpers.exists('OPNsense.ntopng.general.httpport') and OPNsense.ntopng.general.httpport != '' %}
+{%   if not helpers.empty('OPNsense.ntopng.general.localnet') %}
+-m={{ OPNsense.ntopng.general.localnet }}
+{%   endif %}
+{%   if not helpers.empty('OPNsense.ntopng.general.cert') %}
+{%     if not helpers.empty('OPNsense.ntopng.general.httpport') %}
+-w=0
+-W={{ OPNsense.ntopng.general.httpport }}
+{%     endif %}
+{%   else %}
+{%     if not helpers.empty('OPNsense.ntopng.general.httpport') %}
 -w={{ OPNsense.ntopng.general.httpport }}
+-W=0
+{%     endif %}
 {%   endif %}
-{%   if helpers.exists('OPNsense.ntopng.general.httpsport') and OPNsense.ntopng.general.httpsport != '' %}
--W={{ OPNsense.ntopng.general.httpsport }}
-{%   endif %}
-{%   if helpers.exists('OPNsense.ntopng.general.dnsmode') and OPNsense.ntopng.general.dnsmode != '' %}
+{%   if not helpers.empty('OPNsense.ntopng.general.dnsmode') %}
 -n={{ OPNsense.ntopng.general.dnsmode }}
+{%   endif %}
+{%   if not helpers.empty('OPNsense.ntopng.general.authbypass') %}
+-l={{ OPNsense.ntopng.general.authbypass }}
 {%   endif %}
 -d=/var/db/ntopng
 {% endif %}


### PR DESCRIPTION
Alignment of community plugin with a commercial plugin written by ntop:
- Due to the similarity of fields, this allows a seamless transition from 3.4 Community to 4.3 Enterprise
- multiple interfaces can be selected
- allowed bypassing authentication
- combined HTTP and https port fields (if cert is selected, https is used. without cert, HTTP is used)
- (advanced) selection of local networks

I reviewed and validated this more than I am willing to admit. :-)