### PR TITLE
security/acme-client: Added native support for Vultr DNS API

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -973,6 +973,21 @@
         <type>text</type>
     </field>
     <field>
+        <label>Vultr Cloud API</label>
+        <type>header</type>
+        <style>table_dns table_dns_vultr</style>
+    </field>
+    <field>
+        <label>NOTE: A DNS sleep time of at least 1000 is recommended.</label>
+        <type>header</type>
+        <style>table_dns table_dns_vultr</style>
+    </field>
+    <field>
+        <id>validation.dns_vultr_key</id>
+        <label>Key</label>
+        <type>text</type>
+    </field>
+    <field>
         <label>Yandex</label>
         <type>header</type>
         <style>table_dns table_dns_yandex</style>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsVultr.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsVultr.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Copyright (C) 2020 Frank Wall
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\AcmeClient\LeValidation;
+
+use OPNsense\AcmeClient\LeValidationInterface;
+use OPNsense\Core\Config;
+
+/**
+ * Vultr DNS API
+ * @package OPNsense\AcmeClient
+ */
+class DnsVultr extends Base implements LeValidationInterface
+{
+    public function prepare()
+    {
+        $this->acme_env['VULTR_API_KEY'] = (string)$this->config->dns_vultr_key;
+    }
+}

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -853,6 +853,9 @@
                 <dns_vscale_key type="TextField">
                     <Required>N</Required>
                 </dns_vscale_key>
+                <dns_vultr_key type="TextField">
+                    <Required>N</Required>
+                </dns_vultr_key>
                 <dns_yandex_token type="TextField">
                     <Required>N</Required>
                 </dns_yandex_token>


### PR DESCRIPTION
After trying to debug issues we were having with Lexicon I decided to add Vultr natively as it's now supported by acme.sh