### PR TITLE
net-mgmt/zabbix-agent: add syslog option

### DIFF
--- a/net-mgmt/zabbix-agent/src/opnsense/mvc/app/controllers/OPNsense/ZabbixAgent/forms/settings.xml
+++ b/net-mgmt/zabbix-agent/src/opnsense/mvc/app/controllers/OPNsense/ZabbixAgent/forms/settings.xml
@@ -42,6 +42,13 @@
             <help><![CDATA[List of IP addresses (or hostnames) of Zabbix servers. Incoming connections will be accepted only from the hosts listed here.]]></help>
         </field>
         <field>
+            <id>zabbixagent.settings.main.syslogEnable</id>
+            <label>Log to syslog</label>
+            <type>text</type>
+            <help><![CDATA[Use syslog, instead of logging to file.]]></help>
+            <advanced>true</advanced>
+        </field>
+        <field>
             <id>zabbixagent.settings.main.logFileSize</id>
             <label>Log File Size</label>
             <type>text</type>

--- a/net-mgmt/zabbix-agent/src/opnsense/mvc/app/models/OPNsense/ZabbixAgent/ZabbixAgent.xml
+++ b/net-mgmt/zabbix-agent/src/opnsense/mvc/app/models/OPNsense/ZabbixAgent/ZabbixAgent.xml
@@ -45,6 +45,10 @@
                     <mask>/^.{1,255}$/u</mask>
                     <ValidationMessage>Should be a string between 1 and 255 characters.</ValidationMessage>
                 </sourceIP>
+                <syslogEnable type="BooleanField">
+                    <default>0</default>
+                    <Required>N</Required>
+                </syslogEnable>
                 <logFileSize type="IntegerField">
                     <default>100</default>
                     <MinimumValue>1</MinimumValue>

--- a/net-mgmt/zabbix-agent/src/opnsense/service/templates/OPNsense/ZabbixAgent/zabbix_agentd.conf
+++ b/net-mgmt/zabbix-agent/src/opnsense/service/templates/OPNsense/ZabbixAgent/zabbix_agentd.conf
@@ -7,10 +7,17 @@
 ############ GENERAL PARAMETERS #################
 
 PidFile=/var/run/zabbix/zabbix_agentd.pid
+
+
+{% if helpers.exists('OPNsense.ZabbixAgent.settings.main.syslogEnable') and OPNsense.ZabbixAgent.settings.main.syslogEnable|default('0') == '1' %}
+LogType=system
+{% else %}
 LogType=file
 LogFile=/var/log/zabbix/zabbix_agentd.log
-
 LogFileSize={{OPNsense.ZabbixAgent.settings.main.logFileSize}}
+{% endif %}
+
+
 DebugLevel={{OPNsense.ZabbixAgent.settings.main.debugLevel|replace("val_", "")}}
 
 {% if helpers.exists('OPNsense.ZabbixAgent.settings.main.sourceIP') %}


### PR DESCRIPTION
Add option to switch Zabbix Agent logging between syslog and (current) logging to file, per #2332

I'm not sure if I've covered all the places this type of simple option change would appear. Please let me know if I should look anywhere else.