### PR TITLE
net/wireguard: Make tunneladdress an optional parameter

### DIFF
--- a/net/wireguard/Makefile
+++ b/net/wireguard/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		wireguard
-PLUGIN_VERSION=		1.6
+PLUGIN_VERSION=		1.7
 PLUGIN_COMMENT=		WireGuard VPN service
 PLUGIN_DEPENDS=		wireguard-go wireguard-tools
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net/wireguard/pkg-descr
+++ b/net/wireguard/pkg-descr
@@ -16,6 +16,10 @@ WWW: https://www.wireguard.com/
 Changelog
 ---------
 
+1.7
+
+* Make tunnel address (wg interface address) optional
+
 1.6
 
 * Move DNS setting to advanced

--- a/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Server.xml
+++ b/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Server.xml
@@ -43,7 +43,7 @@
                 <tunneladdress type="NetworkField">
                     <default></default>
                     <FieldSeparator>,</FieldSeparator>
-                    <Required>Y</Required>
+                    <Required>N</Required>
                     <asList>Y</asList>
                 </tunneladdress>
                 <disableroutes type="BooleanField">

--- a/net/wireguard/src/opnsense/service/templates/OPNsense/Wireguard/wireguard-server.conf
+++ b/net/wireguard/src/opnsense/service/templates/OPNsense/Wireguard/wireguard-server.conf
@@ -5,7 +5,9 @@
 {%       if server_list.enabled == '1' %}
 [Interface]
 PrivateKey = {{ server_list.privkey }}
+{%         if server_list.tunneladdress|default('') != '' %}
 Address = {{ server_list.tunneladdress }}
+{%         endif %}
 {%         if server_list.port|default('') != '' %}
 ListenPort = {{ server_list.port }}
 {%         endif %}


### PR DESCRIPTION
Tunnel addresses are only needed if wireguard peers need to talk directly to one another over the VPN. In a site-to-site configuration it is perfectly valid to not assign a wireguard interface address and just issue appropriate ranges for AllowedIPs at each end. When configured this way, wireguard is smart enough to handle the routing internally and everything works fine.

The proposed change makes the tunneladdress parameter optional in the web interface, and provides the appropriate if statement in the configuration file generator.

Tested and working with my own site-to-site VPN.