### PR TITLE
add insecure_skip_verify as an option for Influx v1 output

### DIFF
--- a/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/output.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/output.xml
@@ -36,6 +36,12 @@
         <help>Set the password for authentication.</help>
     </field>
     <field>
+        <id>output.influx_ssl_verify</id>
+        <label>Disable SSL verification</label>
+        <type>checkbox</type>
+        <help>This will skip chain and host verification.</help>
+    </field>
+    <field>
         <id>output.influx_v2_enable</id>
         <label>Enable Influx v2 Output</label>
         <type>checkbox</type>

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Output.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Output.xml
@@ -27,6 +27,10 @@
             <default></default>
             <Required>N</Required>
         </influx_password>
+        <influx_ssl_verify type="BooleanField">
+            <default>0</default>
+            <Required>N</Required>
+        </influx_ssl_verify>
         <graphite_enable type="BooleanField">
             <default>0</default>
             <Required>N</Required>

--- a/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
+++ b/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
@@ -73,6 +73,11 @@
 {% if helpers.exists('OPNsense.telegraf.output.influx_password') and OPNsense.telegraf.output.influx_password != '' %}
   password = "{{ OPNsense.telegraf.output.influx_password }}"
 {%   endif %}
+{% if helpers.exists('OPNsense.telegraf.output.influx_ssl_verify') and OPNsense.telegraf.output.influx_ssl_verify == '0' %}
+  insecure_skip_verify = true
+{%   else %}
+  insecure_skip_verify = false
+{%   endif %}
 {% endif %}
 
 {% if helpers.exists('OPNsense.telegraf.output.datadog_enable') and OPNsense.telegraf.output.datadog_enable == '1' %}


### PR DESCRIPTION
If using a self-signed certificate for HTTPS, Telegraf fails to connect due to insecure_skip_verify being false as default.

Steps to reproduce the behavior:

    Set up Influx Output
    Configure InfluxDB to use a self signed certificate
    Start Telegraf
    Telegraf fails to connect to InfluxDB with "x509: certificate signed by unknown authority" error

Expected behavior
Telegraf plugin should have an option to set the insecure_skip_verify variable
If I edit the telegraf conf file and add insecure_skip_verify = true, Telegraf is able to connect to InfluxDB.