### PR TITLE
emulators/qemu-guest-agent: release initial version

### DIFF
--- a/emulators/qemu-guest-agent/Makefile
+++ b/emulators/qemu-guest-agent/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		qemu-guest-agent
-PLUGIN_VERSION=		0.1
+PLUGIN_VERSION=		1.0
 PLUGIN_COMMENT=		QEMU Guest Agent for OPNsense
 PLUGIN_DEPENDS=		qemu-guest-agent
 PLUGIN_MAINTAINER=	opnsense@moov.de

--- a/emulators/qemu-guest-agent/Makefile
+++ b/emulators/qemu-guest-agent/Makefile
@@ -1,6 +1,5 @@
 PLUGIN_NAME=		qemu-guest-agent
 PLUGIN_VERSION=		0.1
-PLUGIN_DEVEL=		yes
 PLUGIN_COMMENT=		QEMU Guest Agent for OPNsense
 PLUGIN_DEPENDS=		qemu-guest-agent
 PLUGIN_MAINTAINER=	opnsense@moov.de


### PR DESCRIPTION
I did another test of the -devel version on 21.1.5 and it works as expected – at least for me :)
So let's finally release this thing.