### PR TITLE
 net-mgmt/telegraf: fixed #2369 if statements in wrong spot and wrong model form

### DIFF
--- a/net-mgmt/telegraf/Makefile
+++ b/net-mgmt/telegraf/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		telegraf
-PLUGIN_VERSION=		1.10.0
+PLUGIN_VERSION=		1.10.1
 PLUGIN_COMMENT=		Agent for collecting metrics and data
 PLUGIN_DEPENDS=		telegraf
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net-mgmt/telegraf/pkg-descr
+++ b/net-mgmt/telegraf/pkg-descr
@@ -11,6 +11,9 @@ WWW: https://www.influxdata.com/time-series-platform/telegraf/
 
 Plugin Changelog
 ================
+1.10.1
+
+* Fix Suricata input controller being the output section and incorrect in statement in conf
 
 1.10.0
 

--- a/net-mgmt/telegraf/pkg-descr
+++ b/net-mgmt/telegraf/pkg-descr
@@ -11,6 +11,7 @@ WWW: https://www.influxdata.com/time-series-platform/telegraf/
 
 Plugin Changelog
 ================
+
 1.10.1
 
 * Fix Suricata input controller being the output section and incorrect in statement in conf

--- a/net-mgmt/telegraf/pkg-descr
+++ b/net-mgmt/telegraf/pkg-descr
@@ -14,7 +14,7 @@ Plugin Changelog
 
 1.10.1
 
-* Fix Suricata input controller being the output section and incorrect in statement in conf
+* Fix Suricata input controller being the output section and incorrect statement
 
 1.10.0
 

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Input.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Input.xml
@@ -89,5 +89,9 @@
             <default>0</default>
             <Required>N</Required>
         </ntpq_dns_lookup>
+        <intrusion_detection_alerts type="BooleanField">
+            <default>0</default>
+            <Required>N</Required>
+        </intrusion_detection_alerts>
     </items>
 </model>

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Output.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Output.xml
@@ -121,9 +121,5 @@
             <default></default>
             <Required>N</Required>
         </datadog_apikey>
-        <intrusion_detection_alerts type="BooleanField">
-            <default>0</default>
-            <Required>N</Required>
-        </intrusion_detection_alerts>
     </items>
 </model>

--- a/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
+++ b/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
@@ -247,7 +247,7 @@
 
 {% if helpers.exists('OPNsense.telegraf.input.ntpq') and OPNsense.telegraf.input.ntpq == '1' %}
 [[inputs.ntpq]]
-{% if helpers.exists('OPNsense.telegraf.input.ntpq_dns_lookup') and OPNsense.telegraf.input.ntpq_dns_lookup == '1' %}
+{%   if helpers.exists('OPNsense.telegraf.input.ntpq_dns_lookup') and OPNsense.telegraf.input.ntpq_dns_lookup == '1' %}
   dns_lookup = true
 {%   else %}
   dns_lookup = false

--- a/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
+++ b/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
@@ -247,11 +247,13 @@
 
 {% if helpers.exists('OPNsense.telegraf.input.ntpq') and OPNsense.telegraf.input.ntpq == '1' %}
 [[inputs.ntpq]]
-{%   if helpers.exists('OPNsense.telegraf.input.ntpq_dns_lookup') and OPNsense.telegraf.input.ntpq_dns_lookup == '1' %}
+{% if helpers.exists('OPNsense.telegraf.input.ntpq_dns_lookup') and OPNsense.telegraf.input.ntpq_dns_lookup == '1' %}
   dns_lookup = true
 {%   else %}
   dns_lookup = false
 {%   endif %}
+{% endif %}
+
 {% if helpers.exists('OPNsense.telegraf.input.intrusion_detection_alerts') and OPNsense.telegraf.input.intrusion_detection_alerts == '1' %}
 [[inputs.tail]]
   data_format = "json"
@@ -259,7 +261,6 @@
   name_override = "suricata"
   tag_keys = ["event_type","src_ip","src_port","dest_ip","dest_port"]
   json_string_fields = ["*"]
-{% endif %}
 {% endif %}
 
 {% endif %}


### PR DESCRIPTION
The if statements were out of order in the telegraf.conf file and this feature was using the output the model instead of the input model