### PR TITLE
Add option to enable/disable local query logs

### DIFF
--- a/dns/dnscrypt-proxy/src/opnsense/mvc/app/controllers/OPNsense/Dnscryptproxy/forms/general.xml
+++ b/dns/dnscrypt-proxy/src/opnsense/mvc/app/controllers/OPNsense/Dnscryptproxy/forms/general.xml
@@ -165,4 +165,11 @@
         <allownew>true</allownew>
         <help><![CDATA[Set a list of <a href="https://dnscrypt.info/public-servers">known servers</a> e.g. if you want to stick with Cisco only. You can also put your manually added servers here. Please use on your own risk.]]></help>
     </field>
+    </field>
+        <field>
+        <id>general.query_logs</id>
+        <label>Enable query logs</label>
+        <type>checkbox</type>
+        <help>This will enable/disable local logs. This includes both [query_log] and [nx_log] as described in the DNSCrypt-Proxy documentation.</help>
+    </field>
 </form>

--- a/dns/dnscrypt-proxy/src/opnsense/mvc/app/models/OPNsense/Dnscryptproxy/General.xml
+++ b/dns/dnscrypt-proxy/src/opnsense/mvc/app/models/OPNsense/Dnscryptproxy/General.xml
@@ -136,5 +136,9 @@
         <serverlist type="CSVListField">
             <Required>N</Required>
         </serverlist>
+        <query_logs type="BooleanField">
+            <default>1</default>
+            <Required>Y</Required>
+        </query_logs>
     </items>
 </model>

--- a/dns/dnscrypt-proxy/src/opnsense/service/templates/OPNsense/Dnscryptproxy/dnscrypt-proxy.toml
+++ b/dns/dnscrypt-proxy/src/opnsense/service/templates/OPNsense/Dnscryptproxy/dnscrypt-proxy.toml
@@ -118,6 +118,7 @@ cache_neg_max_ttl = {{ OPNsense.dnscryptproxy.general.cache_neg_max_ttl }}
 cache = false
 {%   endif %}
 
+{%   if helpers.exists('OPNsense.dnscryptproxy.general.query_logs') and OPNsense.dnscryptproxy.general.query_logs == '1' %}
 [query_log]
   file = '/var/log/dnscrypt-proxy/query.log'
   format = 'tsv'
@@ -125,6 +126,7 @@ cache = false
 [nx_log]
   file = '/var/log/dnscrypt-proxy/nx.log'
   format = 'tsv'
+{%   endif %}
 
 [whitelist]
   whitelist_file = 'whitelist.txt'


### PR DESCRIPTION
This adds an option to the DNSCrypt-Proxy plugin to enable/disable local logging for both [query_log] and [nx_log]. This brings the plugin into parity with other DNS plugins like Dnsmasq that already include the option in the GUI, and makes it easier for users to disable local logging if they choose to do so.