### PR TITLE
dns/dyndns: customDns log error details & inject %Host%

### DIFF
--- a/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
+++ b/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
@@ -779,7 +779,7 @@ class updatedns
                     curl_setopt($ch, CURLOPT_USERPWD, "{$this->_dnsUser}:{$this->_dnsPass}");
                 }
                 $server = str_replace("%IP%", $this->_dnsIP, $this->_dnsUpdateURL);
-                $server = str_replace("%Host%", $this->_dnsHost, $server);
+                $server = str_replace("%HOST%", $this->_dnsHost, $server);
                 curl_setopt($ch, CURLOPT_URL, $server);
                 break;
             case 'cloudflare':

--- a/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
+++ b/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
@@ -1527,8 +1527,6 @@ class updatedns
                     $status = "Dynamic DNS: (Success) IP Address Updated Successfully!";
                 } else {
                     $status = "Dynamic DNS: (Error) Result did not match.";
-                    log_error("Dynamic DNS ({$this->_dnsHost}): PAYLOAD: {$data}");
-                    $this->_debug($data);
                 }
                 break;
             case 'cloudflare':

--- a/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
+++ b/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
@@ -779,6 +779,7 @@ class updatedns
                     curl_setopt($ch, CURLOPT_USERPWD, "{$this->_dnsUser}:{$this->_dnsPass}");
                 }
                 $server = str_replace("%IP%", $this->_dnsIP, $this->_dnsUpdateURL);
+                $server = str_replace("%Host%", $this->_dnsHost, $server);
                 curl_setopt($ch, CURLOPT_URL, $server);
                 break;
             case 'cloudflare':
@@ -1526,6 +1527,8 @@ class updatedns
                     $status = "Dynamic DNS: (Success) IP Address Updated Successfully!";
                 } else {
                     $status = "Dynamic DNS: (Error) Result did not match.";
+                    log_error("Dynamic DNS ({$this->_dnsHost}): PAYLOAD: {$data}");
+                    $this->_debug($data);
                 }
                 break;
             case 'cloudflare':

--- a/dns/dyndns/src/www/services_dyndns_edit.php
+++ b/dns/dyndns/src/www/services_dyndns_edit.php
@@ -436,7 +436,8 @@ include("head.inc");
                         <?= gettext("This field should be identical to what your dynamic DNS Provider will return if the update succeeds, leave it blank to disable checking of returned results.");?>
                         <br />
                         <?= gettext("If you need the new IP to be included in the request, put %IP% in its place.") ?>
-                        <?= gettext("If you need the new Host to be included in the request, put %Host% in its place.") ?>
+                        <br />
+                        <?= gettext("If you need the new Host to be included in the request, put %HOST% in its place.") ?>
                         <br />
                         <?= gettext('If you need to include multiple possible values, separate them with a |. If your provider includes a |, escape it with \|') ?>
                         <br />

--- a/dns/dyndns/src/www/services_dyndns_edit.php
+++ b/dns/dyndns/src/www/services_dyndns_edit.php
@@ -421,7 +421,8 @@ include("head.inc");
                         <?= gettext("This is the only field required by for Custom Dynamic DNS, and is only used by Custom Entries.") ?>
                         <br />
                         <?= gettext("If you need the new IP to be included in the request, put %IP% in its place.") ?>
-                        <?= gettext("If you need the new Host to be included in the request, put %Host% in its place.") ?>
+                        <br />
+                        <?= gettext("If you need the new host to be included in the request, put %HOST% in its place.") ?>
                       </div>
                     </td>
                   </tr>

--- a/dns/dyndns/src/www/services_dyndns_edit.php
+++ b/dns/dyndns/src/www/services_dyndns_edit.php
@@ -421,6 +421,7 @@ include("head.inc");
                         <?= gettext("This is the only field required by for Custom Dynamic DNS, and is only used by Custom Entries.") ?>
                         <br />
                         <?= gettext("If you need the new IP to be included in the request, put %IP% in its place.") ?>
+                        <?= gettext("If you need the new Host to be included in the request, put %Host% in its place.") ?>
                       </div>
                     </td>
                   </tr>
@@ -434,6 +435,7 @@ include("head.inc");
                         <?= gettext("This field should be identical to what your dynamic DNS Provider will return if the update succeeds, leave it blank to disable checking of returned results.");?>
                         <br />
                         <?= gettext("If you need the new IP to be included in the request, put %IP% in its place.") ?>
+                        <?= gettext("If you need the new Host to be included in the request, put %Host% in its place.") ?>
                         <br />
                         <?= gettext('If you need to include multiple possible values, separate them with a |. If your provider includes a |, escape it with \|') ?>
                         <br />


### PR DESCRIPTION
Added a Error Log for failed updates - aligning with the rest of the Dynamic DNS Providers

Added the ability to replace the %Host% in the Configured update URL