### PR TITLE
change input validation for hostname

### DIFF
--- a/dns/dyndns/src/www/services_dyndns_edit.php
+++ b/dns/dyndns/src/www/services_dyndns_edit.php
@@ -129,7 +129,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                 break;
         }
 
-        if (!is_domain($host_to_check)) {
+        if (!is_hostname($host_to_check)) {
             $input_errors[] = gettext("The Hostname contains invalid characters.");
         }
     }


### PR DESCRIPTION
DNS names can and frequently do include underscores. The is_hostname() function is a good match but is slightly problematic since actual _hostnames_ do not allow underscores. I'm assuming that the is_hostname() function would not be changed in the future to exclude underscore.

Note that DNS names have no limitations except a length of 255 octets ([RFC2181 sec 11](https://datatracker.ietf.org/doc/html/rfc2181#section-11)) but in practice they are limited to letters, digits, hyphen and underscore.  For this reason, I don't think a separate validation function just for DNS names is justified.

#2122 