### PR TITLE
dns/dyndns hetzner: add asterisk for wildcard fqdn

### DIFF
--- a/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
+++ b/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
@@ -861,6 +861,9 @@ class updatedns
             case 'hetzner-v6':
                 $baseUrl = 'https://dns.hetzner.com/api/v1';
                 $fqdn = str_replace(' ', '', $this->_dnsHost);
+                if ($this->_dnsWildcard == 'ON') {
+                      $fqdn = "*.$fqdn";
+                }
                 $recordType = ($this->_useIPv6) ? 'AAAA' : 'A';
                 $ttlData = intval($this->_dnsTTL) < 1 ? 120 : intval($this->_dnsTTL);
                 $hostData = [


### PR DESCRIPTION
Add an asterisk in front of the fqdn if the flag wildcard is enabled. As hetzner uses a full dns api you need to supply the full domainname with an asterisk in its name.
Its shameless copied from the linode implementation.