### PR TITLE
security/acme-client: Fix sftp re-deployment of readonly certs

### DIFF
--- a/security/acme-client/pkg-descr
+++ b/security/acme-client/pkg-descr
@@ -8,6 +8,11 @@ WWW: https://github.com/acmesh-official/acme.sh
 Plugin Changelog
 ================
 
+2.6
+
+Fixed:
+* sftp update of write protected cert files with a numeric owner
+
 2.5
 
 Added:


### PR DESCRIPTION
Fixes a problem in the sftp upload automation that a re-deployment of certificates with permissions set to readonly (= default) fail on SSH/SFTP servers that return file owners of existing files as numeric values.

The failure is caused by the fact that the detection whether the connecting user owns an existing cert file on the remote location currently does not work when the SSH server returns the owner as numeric value. Without ownership detection, the upload automation will not attempt to remove the readonly flag from existing files and will fail to overwrite certs (in this case only the initial upload works).

As a workaround the automation can be configured to leave cert file uploads writable, which is not a good option.
