### PR TITLE
Replace stop action by the reload option in reconfigureForceRestart

### DIFF
--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/Api/ServiceController.php
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/Api/ServiceController.php
@@ -57,27 +57,6 @@ class ServiceController extends ApiMutableServiceControllerBase
      * @throws \Exception when configd action fails
      * @throws \ReflectionException when model can't be instantiated
      */
-    public function reconfigureAction()
-    {
-        if ($this->request->isPost()) {
-            $this->sessionClose();
-            $model = $this->getModel();
-            $backend = new Backend();
-            if ($this->reconfigureForceRestart()) {
-                $backend->configdRun('nginx reload');
-            }
-            $backend->configdRun('template reload OPNsense/Nginx');
-            $runStatus = $this->statusAction();
-            if ($runStatus['status'] != 'running') {
-                $backend->configdRun('nginx start');
-            } else {
-                $backend->configdRun('nginx reload');
-            }
-            return array('status' => 'ok');
-        } else {
-            return array('status' => 'failed');
-        }
-    }
 
     /**
      * retrieve status of service
@@ -117,4 +96,10 @@ class ServiceController extends ApiMutableServiceControllerBase
         $this->response->setStatusCode(404, "Not Found");
         return array();
     }
+    
+       protected function reconfigureForceRestart()
+    {
+        return 0;
+    }
+
 }

--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/Api/ServiceController.php
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/Api/ServiceController.php
@@ -97,9 +97,7 @@ class ServiceController extends ApiMutableServiceControllerBase
         return array();
     }
     
-       protected function reconfigureForceRestart()
-    {
+    protected function reconfigureForceRestart() {
         return 0;
     }
-
 }

--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/Api/ServiceController.php
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/Api/ServiceController.php
@@ -64,7 +64,7 @@ class ServiceController extends ApiMutableServiceControllerBase
             $model = $this->getModel();
             $backend = new Backend();
             if ($this->reconfigureForceRestart()) {
-                $backend->configdRun('nginx stop');
+                $backend->configdRun('nginx reload');
             }
             $backend->configdRun('template reload OPNsense/Nginx');
             $runStatus = $this->statusAction();

--- a/www/nginx/src/opnsense/service/conf/actions.d/actions_nginx.conf
+++ b/www/nginx/src/opnsense/service/conf/actions.d/actions_nginx.conf
@@ -62,7 +62,7 @@ parameters:
 type:script_output
 
 [reload]
-command:/usr/local/etc/rc.d/nginx reload;exit 0
+command:/usr/local/etc/rc.d/nginx reload
 parameters:
 type:script_output
 message:reloading nginx

--- a/www/nginx/src/opnsense/service/conf/actions.d/actions_nginx.conf
+++ b/www/nginx/src/opnsense/service/conf/actions.d/actions_nginx.conf
@@ -60,3 +60,9 @@ type:script
 command:/usr/local/opnsense/scripts/nginx/vts.php
 parameters:
 type:script_output
+
+[reload]
+command:/usr/local/etc/rc.d/nginx reload;exit 0
+parameters:
+type:script_output
+message:reloading nginx


### PR DESCRIPTION
It seems that the reload option is better than the stop option, because stop action stop WebRTC communication. I have configured the reload option in another pull request.