### PR TITLE
net/vnstat: added yearly table to vnstat service

### DIFF
--- a/net/vnstat/Makefile
+++ b/net/vnstat/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		vnstat
-PLUGIN_VERSION=		1.2
+PLUGIN_VERSION=		1.3
 PLUGIN_REVISION=	1
 PLUGIN_COMMENT=		vnStat is a console-based network traffic monitor
 PLUGIN_DEPENDS=		vnstat

--- a/net/vnstat/pkg-descr
+++ b/net/vnstat/pkg-descr
@@ -9,6 +9,11 @@ ensures light use of system resources.
 Plugin Changelog
 ================
 
+1.3
+
+* Added Yearly statistics.
+* Fixed typo leftover from removing weekly statistics.
+
 1.2
 
 * Remove Weekly statistics, unsupported since vnStat v2

--- a/net/vnstat/src/opnsense/mvc/app/controllers/OPNsense/Vnstat/Api/ServiceController.php
+++ b/net/vnstat/src/opnsense/mvc/app/controllers/OPNsense/Vnstat/Api/ServiceController.php
@@ -79,6 +79,17 @@ class ServiceController extends ApiMutableServiceControllerBase
     }
 
     /**
+     * list yearly statistics
+     * @return array
+     */
+    public function yearlyAction()
+    {
+        $backend = new Backend();
+        $response = $backend->configdRun("vnstat yearly");
+        return array("response" => $response);
+    }
+
+    /**
      * remove database folder
      * @return array
      */

--- a/net/vnstat/src/opnsense/mvc/app/views/OPNsense/Vnstat/general.volt
+++ b/net/vnstat/src/opnsense/mvc/app/views/OPNsense/Vnstat/general.volt
@@ -53,6 +53,7 @@
     </div>
     <div id="monthly" class="tab-pane fade in">
       <pre id="listmonthly"></pre>
+    </div>
     <div id="yearly" class="tab-pane fade in">
       <pre id="listyearly"></pre>
     </div>

--- a/net/vnstat/src/opnsense/mvc/app/views/OPNsense/Vnstat/general.volt
+++ b/net/vnstat/src/opnsense/mvc/app/views/OPNsense/Vnstat/general.volt
@@ -31,6 +31,7 @@
     <li><a data-toggle="tab" href="#hourly">{{ lang._('Hourly Statistics') }}</a></li>
     <li><a data-toggle="tab" href="#daily">{{ lang._('Daily Statistics') }}</a></li>
     <li><a data-toggle="tab" href="#monthly">{{ lang._('Monthly Statistics') }}</a></li>
+    <li><a data-toggle="tab" href="#yearly">{{ lang._('Yearly Statistics') }}</a></li>
 </ul>
 
 <div class="tab-content content-box tab-content">
@@ -52,6 +53,8 @@
     </div>
     <div id="monthly" class="tab-pane fade in">
       <pre id="listmonthly"></pre>
+    <div id="yearly" class="tab-pane fade in">
+      <pre id="listyearly"></pre>
     </div>
 </div>
 
@@ -73,6 +76,11 @@ function update_monthly() {
         $("#listmonthly").text(data['response']);
     });
 }
+function update_yearly() {
+    ajaxCall(url="/api/vnstat/service/yearly", sendData={}, callback=function(data,status) {
+        $("#listyearly").text(data['response']);
+    });
+}
 
 $( document ).ready(function() {
     var data_get_map = {'frm_general_settings':"/api/vnstat/general/get"};
@@ -87,6 +95,7 @@ $( document ).ready(function() {
     setInterval(update_hourly, 3000);
     setInterval(update_daily, 3000);
     setInterval(update_monthly, 3000);
+    setInterval(update_yearly, 3000);
 
     $("#saveAct").click(function(){
         saveFormToEndpoint(url="/api/vnstat/general/set", formid='frm_general_settings',callback_ok=function(){

--- a/net/vnstat/src/opnsense/service/conf/actions.d/actions_vnstat.conf
+++ b/net/vnstat/src/opnsense/service/conf/actions.d/actions_vnstat.conf
@@ -40,6 +40,12 @@ parameters:
 type:script_output
 message:request Vnstat monthly status
 
+[yearly]
+command:/usr/local/bin/vnstat -y
+parameters:
+type:script_output
+message:request Vnstat yearly status
+
 [resetdb]
 command:rm -rf /var/lib/vnstat
 parameters:

--- a/net/vnstat/src/opnsense/service/conf/actions.d/actions_vnstat.conf
+++ b/net/vnstat/src/opnsense/service/conf/actions.d/actions_vnstat.conf
@@ -38,7 +38,7 @@ message:request Vnstat daily status
 command:/usr/local/bin/vnstat -m
 parameters:
 type:script_output
-message:request Vnstat weekly status
+message:request Vnstat monthly status
 
 [resetdb]
 command:rm -rf /var/lib/vnstat


### PR DESCRIPTION
currently the vnstat service offers hourly/daily/monthly - vnstat tracks yearly too so why not.

marking as draft for now as i don't have a machine spare to test this on, might be a few days.