### PR TITLE
mail/postfix: Set compatibility_level to 3.6

### DIFF
--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
@@ -5,7 +5,7 @@
 ##########################
 alias_database = hash:/usr/local/etc/postfix/aliases
 alias_maps = hash:/usr/local/etc/postfix/aliases
-compatibility_level = 2
+compatibility_level = 3.6
 queue_directory = /var/spool/postfix
 command_directory = /usr/local/sbin
 daemon_directory = /usr/local/libexec/postfix


### PR DESCRIPTION
This is part of the required steps for Postfix 3.6.x compatibility (https://github.com/opnsense/plugins/issues/2409)

This commit simply sets the Postfix `compatibility_level` from `2` to `3.6`.

This **MUST NOT** be merged until and *SHOULD* be merged when either:
* Postfix 3.6.x (https://github.com/opnsense/ports/issues/128) or
* Postfix > 3.5.11 (https://github.com/opnsense/ports/pull/130)

become available in the [`ports`](https://github.com/opnsense/ports/).