### PR TITLE
net/FreeRADIUS: Fix issue with being unable to specify a CIDR

### DIFF
--- a/net/freeradius/Makefile
+++ b/net/freeradius/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		freeradius
-PLUGIN_VERSION=		1.9.14
+PLUGIN_VERSION=		1.9.15
 PLUGIN_COMMENT=		RADIUS Authentication, Authorization and Accounting Server
 PLUGIN_DEPENDS=		freeradius3
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net/freeradius/pkg-descr
+++ b/net/freeradius/pkg-descr
@@ -15,6 +15,10 @@ The server is fast, feature-rich, modular, and scalable.
 Plugin Changelog
 ================
 
+1.9.15
+
+* Fixed validation of CIDR for client network ranges
+
 1.9.14
 
 * Updates comments in mods-enabled-eap to match upstream version 3.0.22

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Client.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Client.xml
@@ -15,7 +15,7 @@
                 <secret type="TextField">
                     <Required>Y</Required>
                 </secret>
-                <ip type="HostnameField">
+                <ip type="NetworkField">
                     <Required>N</Required>
                 </ip>
             </client>

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Client.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Client.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/freeradius/client</mount>
     <description>FreeRADIUS client configuration</description>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <items>
         <clients>
             <client type="ArrayField">


### PR DESCRIPTION
It seems the current model parses the client IP as a HostnameField, meaning it fails validation if the user attempts to use a CIDR. 

A NetworkField seems to correct that.