### PR TITLE
net/freeradius: Allow setting of minimum TLS version

### DIFF
--- a/net/freeradius/pkg-descr
+++ b/net/freeradius/pkg-descr
@@ -18,7 +18,7 @@ Plugin Changelog
 1.9.15
 
 * Fixed validation of CIDR for client network ranges
-* Allow setting min and max TLS version
+* Allow setting of minimum TLS version
 
 1.9.14
 

--- a/net/freeradius/pkg-descr
+++ b/net/freeradius/pkg-descr
@@ -18,6 +18,7 @@ Plugin Changelog
 1.9.15
 
 * Fixed validation of CIDR for client network ranges
+* Allow setting min and max TLS version
 
 1.9.14
 

--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/eap.xml
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/eap.xml
@@ -35,4 +35,10 @@
         <type>checkbox</type>
         <help>Checks that the username given by the user matches the Common-Name of the certificate.</help>
     </field>
+    <field>
+        <id>eap.tls_min_version</id>
+        <label>TLS Minimum Version</label>
+        <type>dropdown</type>
+        <help>Set minimum TLS version. Please be aware that every version below 1.2 is considered as insecure.</help>
+    </field>
 </form>

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Eap.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Eap.xml
@@ -36,5 +36,15 @@
             <default>0</default>
             <Required>Y</Required>
         </check_tls_names>
+        <tls_min_version type="OptionField">
+            <default>Option1</default>
+            <Required>Y</Required>
+            <multiple>N</multiple>
+            <OptionValues>
+                <Option1 value="1.0">1.0</Option1>
+                <Option2 value="1.1">1.1</Option2>
+                <Option3 value="1.2">1.2</Option3>
+            </OptionValues>
+        </tls_min_version>
     </items>
 </model>

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-eap
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-eap
@@ -453,7 +453,7 @@ eap {
                 #
                 #  The values must be in quotes.
                 #
-                tls_min_version = "1.0"
+                tls_min_version = "{{ OPNsense.freeradius.eap.tls_min_version }}"
                 tls_max_version = "1.2"
 
                 #  Elliptical cryptography configuration


### PR DESCRIPTION
Insecure but most compatible default with a security warning. 