### PR TITLE
mail/postfix: make `delay_warning_time` configurable

### DIFF
--- a/mail/postfix/Makefile
+++ b/mail/postfix/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		postfix
-PLUGIN_VERSION=		1.19
+PLUGIN_VERSION=		1.20
 PLUGIN_COMMENT=		SMTP mail relay
 PLUGIN_DEPENDS=		postfix-sasl
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/mail/postfix/pkg-descr
+++ b/mail/postfix/pkg-descr
@@ -6,6 +6,10 @@ is completely different.
 Plugin Changelog
 ================
 
+1.20
+
+* Make 'delay_warning_time' configurable in the UI
+
 1.19
 
 * Add TLS server/ client compatibility modes based on Mozilla's TLS configuration recommendations (https://ssl-config.mozilla.org).

--- a/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
+++ b/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
@@ -245,6 +245,6 @@
         <id>general.delay_warning_time</id>
         <label>Delay Warning Time</label>
         <type>text</type>
-        <help>Time until we send a notification to the sender if mail is delayed (in hours) - 0 to disable.</help>
+        <help>Time until we send a notification to the sender if mail is delayed (in hours) - 0 or empty to disable.</help>
     </field>
 </form>

--- a/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
+++ b/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
@@ -241,4 +241,10 @@
         <type>checkbox</type>
         <help>Use Recipient Address Verification. Please keep in mind that this could put significant load onto the next server.</help>
     </field>
+    <field>
+        <id>general.delay_warning_time</id>
+        <label>Delay Warning Time</label>
+        <type>text</type>
+        <help>Time until we send a notification to the sender if mail is delayed (in hours) - 0 to disable.</help>
+    </field>
 </form>

--- a/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
+++ b/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
@@ -190,7 +190,7 @@
             <Required>N</Required>
             <MinimumValue>0</MinimumValue>
             <MaximumValue>24</MaximumValue>
-            <ValidationMessage>Choose a value between 1 and 24 to activate - 0 to disable.</ValidationMessage>
+            <ValidationMessage>Choose a value between 1 and 24 to activate - 0 or empty to disable.</ValidationMessage>
         </delay_warning_time>
     </items>
 </model>

--- a/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
+++ b/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
@@ -185,5 +185,12 @@
             <default>0</default>
             <Required>Y</Required>
         </reject_unverified_recipient>
+        <delay_warning_time type="IntegerField">
+            <default>0</default>
+            <Required>N</Required>
+            <MinimumValue>0</MinimumValue>
+            <MaximumValue>24</MaximumValue>
+            <ValidationMessage>Choose a value between 1 and 24 to activate - 0 to disable.</ValidationMessage>
+        </delay_warning_time>
     </items>
 </model>

--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
@@ -223,6 +223,10 @@ relay_recipient_maps = hash:/usr/local/etc/postfix/recipient_access
 smtpd_recipient_restrictions = {{ smtpd_recipient_restrictions | join(', ') }}
 {% endif %}
 
+{% if helpers.exists('OPNsense.postfix.general.delay_warning_time') and OPNsense.postfix.general.delay_warning_time != '0' %}
+delay_warning_time = {{ OPNsense.postfix.general.delay_warning_time }}h
+{% endif %}
+
 smtpd_helo_required = yes
 
 {% if helpers.exists('OPNsense.postfix.general.extensive_helo_restrictions') and OPNsense.postfix.general.extensive_helo_restrictions == '1' %}


### PR DESCRIPTION
At least my users prefer to receive a notification if a mail stays in the queue for an extended amount of time. Make that parameter configurable instead of forcing the default (disabled).