### PR TITLE
Update Server.xml

### DIFF
--- a/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Server.xml
+++ b/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/Server.xml
@@ -17,7 +17,7 @@
                 </name>
                 <instance type="AutoNumberField">
                     <MinimumValue>0</MinimumValue>
-                    <MaximumValue>19</MaximumValue>
+                    <MaximumValue>49</MaximumValue>
                     <ValidationMessage>Maximum number of instances reached</ValidationMessage>
                     <Required>Y</Required>
                 </instance>


### PR DESCRIPTION
It was not possible to create enough Wireguard instances for my needs due to the limitation in the GUI. I increased the restriction in the GUI on creating Wireguard interfaces from 20 to 50 although I'm not sure why there is a limit imposed on this. 

Tested on OPNsense 21.1.8_1-amd64 with 35 interfaces.