### PR TITLE
Update vnStat's help to be descriptive of how the plugin actually works.

### DIFF
--- a/net/vnstat/src/opnsense/mvc/app/controllers/OPNsense/Vnstat/forms/general.xml
+++ b/net/vnstat/src/opnsense/mvc/app/controllers/OPNsense/Vnstat/forms/general.xml
@@ -9,6 +9,6 @@
         <id>general.interface</id>
         <label>Interface</label>
         <type>select_multiple</type>
-        <help>Set the interface to listen on.</help>
+        <help>Choose which interface’s statistics to view. If multiple interfaces are chosen, statistics will be reported as an aggregate of all of the selected interfaces. There is roughly a four interface limit for aggregate statistics due to a 31 character limit within vnStat.</help>
     </field>
 </form>


### PR DESCRIPTION
The help on the vnStat's plugin is very misleading. It states "Set the interface to listen on." The plugin listens on all interfaces by default. The drop down actually chooses which interface(s) to show statistics for in the hourly/weekly/monthly tab. Additionally, if multiple interfaces are chosen, an aggregate is shown which is not necessarily obvious or intuitive. Hopefully this clarifies how the plugin works.