### PR TITLE
LLDPD | Identify correctly as Network Connectivity Device (Class 4).

### DIFF
--- a/net-mgmt/lldpd/src/opnsense/service/templates/OPNsense/Lldpd/lldpd
+++ b/net-mgmt/lldpd/src/opnsense/service/templates/OPNsense/Lldpd/lldpd
@@ -1,6 +1,6 @@
 {% if helpers.exists('OPNsense.lldpd.general.enabled') and OPNsense.lldpd.general.enabled == '1' %}
 lldpd_enable="YES"
-lldpd_flags="{% if helpers.exists('OPNsense.lldpd.general.cdp') and OPNsense.lldpd.general.cdp == '1' %}-c{% endif %}{% if helpers.exists('OPNsense.lldpd.general.fdp') and OPNsense.lldpd.general.fdp == '1' %} -f{% endif %}{% if helpers.exists('OPNsense.lldpd.general.edp') and OPNsense.lldpd.general.edp == '1' %} -e{% endif %}{% if helpers.exists('OPNsense.lldpd.general.sonmp') and OPNsense.lldpd.general.sonmp == '1' %} -s{% endif %}{% if helpers.exists('OPNsense.lldpd.general.interface') and OPNsense.lldpd.general.interface != '' %} -I {{ OPNsense.lldpd.general.interface }}{% endif %}"
+lldpd_flags="{% if helpers.exists('OPNsense.lldpd.general.cdp') and OPNsense.lldpd.general.cdp == '1' %}-c{% endif %}{% if helpers.exists('OPNsense.lldpd.general.fdp') and OPNsense.lldpd.general.fdp == '1' %} -f{% endif %}{% if helpers.exists('OPNsense.lldpd.general.edp') and OPNsense.lldpd.general.edp == '1' %} -e{% endif %}{% if helpers.exists('OPNsense.lldpd.general.sonmp') and OPNsense.lldpd.general.sonmp == '1' %} -s{% endif %}{% if helpers.exists('OPNsense.lldpd.general.interface') and OPNsense.lldpd.general.interface != '' %} -I {{ OPNsense.lldpd.general.interface }}{% endif %} -M 4"
 {% else %}
 lldpd_enable="NO"
 {% endif %}


### PR DESCRIPTION
Identify correctly as Network Connectivity Device (Class 4).

https://lldpd.github.io/usage.html

     -M class
             Enable emission of LLDP-MED frame. Depending on the selected
             class, the standard defines which set of TLV should be trans-
             mitted. See section 10.2.1. Some devices may be strict about
             this aspect. The class should be one of the following value:
             1     Generic Endpoint (Class I)
             2     Media Endpoint (Class II). In this case, the standard re-
                   quires to define at least one network policy through
                   lldpcli.
             3     Communication Device Endpoints (Class III). In this case,
                   the standard requires to define at least one network pol-
                   icy through lldpcli.
             **4     Network Connectivity Device**