### PR TITLE
security/acme-client: added support for custom ACME CAs

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogAccount.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogAccount.xml
@@ -33,6 +33,12 @@
         <type>dropdown</type>
         <help><![CDATA[The ACME CA that should be used for this account and all associated certificates. Note that some of them offer paid services and may require a subscription. Check the <a href="https://github.com/acmesh-official/acme.sh/wiki/Server" target="_blank">acme.sh documentation</a> for a list of supported CAs.]]></help>
     </field>
+		<field>
+				<id>account.custom_ca</id>
+				<label>Custom ACME CA URL</label>
+				<type>text</type>
+				<help><![CDATA[The HTTPS URL of the custom ACME CA that should be used for this account and all associated certificates. If using your own CA, make sure the Root CA is added to OPNsense's trust store.]]></help>
+		</field>
     <field>
         <label>Optional EAB Credentials</label>
         <type>header</type>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeCommon.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeCommon.php
@@ -84,6 +84,7 @@ abstract class LeCommon
     protected $config;              # AcmeClient config object
     protected $debug;               # Debug logging (bool)
     protected $ca;                  # ACME CA
+    protected $custom_ca;           # Custom ACME CA URL
     protected $ca_compat;           # ACME CA for compat with old LE CA names
     protected $force;               # Force operation
     protected $model;               # AcmeClient model object
@@ -154,8 +155,18 @@ abstract class LeCommon
         $acme_ca = (string)$obj->ca;
         $this->ca = $acme_ca;
 
+        // Extract custom ACME CA URL
+        $acme_custom_ca = (string)$obj->custom_ca;
+        $this->custom_ca = $acme_custom_ca;
+
         // Add CA to acme arguments
-        $this->acme_args[] = LeUtils::execSafe('--server %s', $acme_ca);
+        if ($renew == true) {
+            // Custom CA
+            $this->acme_args[] = LeUtils::execSafe('--server %s', $acme_custom_ca);
+        } else {
+            // Normal CAs
+            $this->acme_args[] = LeUtils::execSafe('--server %s', $acme_ca);
+        }
 
         // Evaluate how the CA should be represented in filenames.
         // This is a compatibility layer. It ensures that old files that

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -146,8 +146,14 @@
                         <letsencrypt_test>Let's Encrypt Test CA</letsencrypt_test>
                         <sslcom>SSL.com</sslcom>
                         <zerossl>ZeroSSL</zerossl>
+												<custom>Custom CA URL</custom>
                     </OptionValues>
                 </ca>
+								<custom_ca type="TextField">
+                    <Required>N</Required>
+										<mask>/^https?:\/\/.*[^\/]$/</mask>
+										<ValidationMessage>The url must be a valid ACME endpoint without a trailing slash. For example: https://acme-v02.api.letsencrypt.org/directory or https://ca.internal/acme/directory</ValidationMessage>
+                </custom_ca>
                 <eab_kid type="TextField">
                     <Required>N</Required>
                     <mask>/^.{1,8192}$/u</mask>


### PR DESCRIPTION
A simple patch that adds the ability to set a custom ACME CA URL.
This should address issues #2173 and #1569.
It seemed like a simple thing to implement with the new ACME-Client 3.0 release, but this is my first pull request to this codebase, so if I missed something or made a mistake, please let me know! I'm also not sure how to install this as a test patch, so if someone could point me in the right direction, that would be great. Thanks!