### PR TITLE
Make regfish DynDNS work for IPv4 and IPv6

### DIFF
--- a/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
+++ b/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
@@ -1038,9 +1038,11 @@ class updatedns
                 curl_setopt($ch, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
                 break;
             case 'regfish':
+                $server = "https://dyndns.regfish.de/?fqdn={$this->_dnsHost}&ipv4={$this->_dnsIP}&forcehost=1&token=" . urlencode($this->_dnsUser);
+                curl_setopt($ch, CURLOPT_URL, $server);
+                break;
             case 'regfish-v6':
-                $family = $this->_useIPv6 ? 'ipv6' : 'ipv4';
-                $server = "https://dyndns.regfish.de/?fqdn={$this->_dnsHost}&{$family}={$this->_dnsIP}&forcehost=1&token=" . urlencode($this->_dnsUser);
+                $server = "https://dyndns6.regfish.de/?fqdn={$this->_dnsHost}&ipv6={$this->_dnsIP}&forcehost=1&token=" . urlencode($this->_dnsUser);
                 curl_setopt($ch, CURLOPT_URL, $server);
                 break;
             case 'linode':


### PR DESCRIPTION
regfish requires 2 different URIs to update, depending on the IP family. 
https://dyndns.regfish.de is for IPv4 
https://dyndns6.regfish.de is for IPv6. 

For reference: https://www.regfish.de/domains/dyndns/dokumentation