### PR TITLE
dns/dyndns: Added STRATO IPv6 to DynDNS

### DIFF
--- a/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns.inc
+++ b/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns.inc
@@ -151,6 +151,7 @@ function dyndns_list()
         'route53-v6' => 'Route 53 (v6)',
         'selfhost' => 'SelfHost',
         'strato' => 'STRATO',
+        'strato-v6' => 'STRATO (v6)',
         'zoneedit' => 'ZoneEdit',
     );
 }

--- a/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
+++ b/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
@@ -50,7 +50,8 @@
  *  No-IP                       - Last Tested: 15 May 2020
  *  ODS                         - Last Tested: 02 August 2005
  *  Oray                        - Last Tested: 26 May 2017
- *  STRATO                      - Last Tested: 09 May 2017
+ *  STRATO                      - Last Tested: 08 October 2021
+ *  STRATO V6                   - Last Tested: 08 October 2021
  *  SelfHost                    - Last Tested: 26 December 2011
  *  StaticCling                 - Last Tested: 27 April 2006
  *  deSEC                       - Last Tested: 09 September 2020
@@ -260,6 +261,7 @@ class updatedns
             case 'desec-v4-v6':
             case 'desec-v6':
             case 'hetzner-v6':
+            case 'strato-v6':
                 $this->_useIPv6 = true;
                 break;
             default:
@@ -358,6 +360,7 @@ class updatedns
                 case 'selfhost':
                 case 'staticcling':
                 case 'strato':
+                case 'strato-v6':
                 case 'zoneedit':
                     $this->_update();
                     if ($this->_dnsDummyUpdateDone == true) {
@@ -1019,11 +1022,14 @@ class updatedns
                 curl_setopt($ch, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
                 break;
             case 'strato':
+            case 'strato-v6':
                 $server = "https://dyndns.strato.com/nic/update?hostname={$this->_dnsHost}&myip={$this->_dnsIP}";
                 curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
                 curl_setopt($ch, CURLOPT_USERPWD, $this->_dnsUser . ':' . $this->_dnsPass);
                 curl_setopt($ch, CURLOPT_URL, $server);
-                curl_setopt($ch, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
+                if ($this->_curlIpresolveV4) {
+                    curl_setopt($ch, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
+                }
                 break;
             case '3322':
                 $server = "http://members.3322.net/dyndns/update?hostname={$this->_dnsHost}&myip={$this->_dnsIP}";
@@ -1651,6 +1657,7 @@ class updatedns
             case 'ovh-dynhost':
             case 'selfhost':
             case 'strato':
+            case 'strato-v6':
                 if (preg_match('/notfqdn/i', $data)) {
                     $status = "Dynamic DNS: (Error) Not a FQDN";
                 } elseif (preg_match('/nochg/i', $data)) {


### PR DESCRIPTION
Added support for STRATO IPv6 DynDNS.

There was no build in way for IPv6 so I've added it. It's tested and working. I've also tested STRATO IPv4 and updated it's last checks date.