### PR TITLE
dns/bind: allow signed zone transfers

### DIFF
--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindDomain.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindDomain.xml
@@ -43,6 +43,18 @@
         <help>Set the IP address of master server when using slave mode.</help>
     </field>
     <field>
+        <id>domain.transferkeyalgo</id>
+        <label>Transfer Key Algorithm</label>
+        <type>dropdown</type>
+        <help>Set the authentication algorithm for the TSIG key.</help>
+    </field>
+    <field>
+        <id>domain.transferkey</id>
+        <label>Transfer Key</label>
+        <type>text</type>
+        <help>The TSIG key used to transfer domain data from the master server.</help>
+    </field>
+    <field>
         <id>domain.allownotifyslave</id>
         <label>Allow Notfiy</label>
         <style>tokenize</style>

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Domain.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Domain.xml
@@ -22,6 +22,21 @@
                     <FieldSeparator>,</FieldSeparator>
                     <asList>Y</asList>
                 </masterip>
+                <transferkeyalgo type="OptionField">
+                    <Required>N</Required>
+                    <OptionValues>
+                        <hmac-sha512>HMAC-SHA512</hmac-sha512>
+                        <hmac-sha384>HMAC-SHA384</hmac-sha384>
+                        <hmac-sha256>HMAC-SHA256</hmac-sha256>
+                        <hmac-sha224>HMAC-SHA224</hmac-sha224>
+                        <hmac-sha1>HMAC-SHA1</hmac-sha1>
+                        <hmac-md5>HMAC-MD5</hmac-md5>
+                    </OptionValues>
+                </transferkeyalgo>
+                <transferkey type="TextField">
+                    <Required>N</Required>
+                    <default></default>
+                </transferkey>
                 <allownotifyslave type="NetworkField">
                     <Required>N</Required>
                     <FieldSeparator>,</FieldSeparator>

--- a/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/general.volt
+++ b/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/general.volt
@@ -275,6 +275,14 @@ $( document ).ready(function() {
         });
     });
 
+    $('#domain\\.transferkeyalgo').on('change', function(e) {
+        if (e.target.selectedIndex === 0) {
+            $('#domain\\.transferkey').val('').attr('readonly', true);
+        } else {
+            $('#domain\\.transferkey').attr('readonly', false);
+        }
+    });
+
     // Hide options that are irrelevant in this context.
     $('#dialogEditBindDomain').on('shown.bs.modal', function (e) {
         $("#domain\\.type").change(function(){

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
@@ -122,17 +122,6 @@ zone "rpzbing" { type master; file "/usr/local/etc/namedb/master/bing.db"; notif
 {%   endif %}
 {% endif %}
 
-{%       if domain.type == 'slave' and domain.transferkey is defined %}
-{%         set key_name = 'tsig-transferkey-' ~ domain.domainname.replace('.', '-') %}
-key "{{ key_name }}" {
-        algorithm "{{ domain.transferkeyalgo }}";
-        secret "{{ domain.transferkey }}";
-};
-server {{ domain.masterip }} {
-        keys { "{{ key_name }}" };
-};
-{%       endif %}
-
 {% if helpers.exists('OPNsense.bind.domain.domains.domain') %}
 {%   for domain in helpers.toList('OPNsense.bind.domain.domains.domain') %}
 {%     if domain.enabled == '1' %}
@@ -156,6 +145,16 @@ zone "{{ domain.domainname }}" {
         allow-query { {{ allow_query.name }}; };
 {%       endif %}
 };
+{%       if domain.type == 'slave' and domain.transferkey is defined %}
+{%         set key_name = 'tsig-transferkey-' ~ domain.domainname.replace('.', '-') %}
+key "{{ key_name }}" {
+        algorithm "{{ domain.transferkeyalgo }}";
+        secret "{{ domain.transferkey }}";
+};
+server {{ domain.masterip }} {
+        keys { "{{ key_name }}" };
+};
+{%       endif %}
 {%     endif %}
 {%   endfor %}
 {% endif %}

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
@@ -138,7 +138,24 @@ server {{ domain.masterip }} {
 {%     if domain.enabled == '1' %}
 {%     set allow_transfer = helpers.getUUID(domain.allowtransfer) %}
 {%     set allow_query = helpers.getUUID(domain.allowquery) %}
-zone "{{ domain.domainname }}" { type {{ domain.type }}; {% if domain.type == 'slave' %}masters { {{ domain.masterip.replace(',', '; ') }}; }; {% if domain.allownotifyslave is defined %} allow-notify { {{ domain.allownotifyslave.replace(',', '; ') }}; };{% endif %} file "/usr/local/etc/namedb/slave/{{ domain.domainname }}.db"; {% else %}file "/usr/local/etc/namedb/master/{{ domain.domainname }}.db"; {% endif %}{% if domain.allowtransfer is defined %} allow-transfer { {{ allow_transfer.name }}; };{% endif %}{% if domain.allowquery is defined %} allow-query { {{ allow_query.name }}; };{% endif %} };
+zone "{{ domain.domainname }}" {
+        type {{ domain.type }};
+{%       if domain.type == 'slave' %}
+        masters { {{ domain.masterip.replace(',', '; ') }}; };
+{%         if domain.allownotifyslave is defined %}
+        allow-notify { {{ domain.allownotifyslave.replace(',', '; ') }}; };
+{%         endif %}
+        file "/usr/local/etc/namedb/slave/{{ domain.domainname }}.db";
+{%       else %}
+        file "/usr/local/etc/namedb/master/{{ domain.domainname }}.db";
+{%       endif %}
+{%       if domain.allowtransfer is defined %}
+        allow-transfer { {{ allow_transfer.name }}; };
+{%       endif %}
+{%       if domain.allowquery is defined %}
+        allow-query { {{ allow_query.name }}; };
+{%       endif %}
+};
 {%     endif %}
 {%   endfor %}
 {% endif %}

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
@@ -122,6 +122,17 @@ zone "rpzbing" { type master; file "/usr/local/etc/namedb/master/bing.db"; notif
 {%   endif %}
 {% endif %}
 
+{%       if domain.type == 'slave' and domain.transferkey is defined %}
+{%         set key_name = 'tsig-transferkey-' ~ domain.domainname.replace('.', '-') %}
+key "{{ key_name }}" {
+        algorithm "{{ domain.transferkeyalgo }}";
+        secret "{{ domain.transferkey }}";
+};
+server {{ domain.masterip }} {
+        keys { "{{ key_name }}" };
+};
+{%       endif %}
+
 {% if helpers.exists('OPNsense.bind.domain.domains.domain') %}
 {%   for domain in helpers.toList('OPNsense.bind.domain.domains.domain') %}
 {%     if domain.enabled == '1' %}


### PR DESCRIPTION
This allows you to add a TSIG key to your secondary zones so the primary can authenticate your request.