### PR TITLE
Add script support to override vpnc-script for PBR

### DIFF
--- a/security/openconnect/Makefile
+++ b/security/openconnect/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		openconnect
-PLUGIN_VERSION=		1.4.1
+PLUGIN_VERSION=		1.4.2
 PLUGIN_COMMENT=		OpenConnect Client
 PLUGIN_DEPENDS=		openconnect
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/security/openconnect/src/etc/rc.d/opnsense-openconnect
+++ b/security/openconnect/src/etc/rc.d/opnsense-openconnect
@@ -36,6 +36,7 @@ openconnect_status()
 
 openconnect_stop()
 {
+	chmod 755 /usr/local/etc/openconnect-script.sh
         if [ -n "$rc_pid" ]; then
             echo "stopping openconnect"
             ifconfig ocvpn0 name tun30000
@@ -47,6 +48,7 @@ openconnect_stop()
 
 openconnect_start()
 {
+	chmod 755 /usr/local/etc/openconnect-script.sh
         echo "starting openconnect"
 	/usr/local/sbin/openconnect ${openconnect_flags} < /usr/local/etc/openconnect.secret 2>&1 > /dev/null
         sleep 5

--- a/security/openconnect/src/opnsense/mvc/app/controllers/OPNsense/Openconnect/forms/general.xml
+++ b/security/openconnect/src/opnsense/mvc/app/controllers/OPNsense/Openconnect/forms/general.xml
@@ -53,4 +53,11 @@
         <type>dropdown</type>
         <help>Select the protocol to use.</help>
     </field>
+    <field>
+        <id>general.vpncscript</id>
+        <label>Config Script</label>
+        <type>textbox</type>
+        <height>10</height>
+        <help>Optional vpnc-compatible script to replace default vpnc-script.</help>
+    </field>
 </form>

--- a/security/openconnect/src/opnsense/mvc/app/models/OPNsense/Openconnect/General.xml
+++ b/security/openconnect/src/opnsense/mvc/app/models/OPNsense/Openconnect/General.xml
@@ -61,5 +61,8 @@
                     <array>Array Networks AG</array>
                 </OptionValues>
         </protocol>
+        <vpncscript type="TextField">
+            <Required>N</Required>
+        </vpncscript>
     </items>
 </model>

--- a/security/openconnect/src/opnsense/service/templates/OPNsense/Openconnect/+TARGETS
+++ b/security/openconnect/src/opnsense/service/templates/OPNsense/Openconnect/+TARGETS
@@ -1,3 +1,4 @@
 openconnect:/etc/rc.conf.d/opnsense-openconnect
 openconnect.conf:/usr/local/etc/openconnect.conf
 openconnect.secret:/usr/local/etc/openconnect.secret
+openconnect-script.sh:/usr/local/etc/openconnect-script.sh

--- a/security/openconnect/src/opnsense/service/templates/OPNsense/Openconnect/openconnect-script.sh
+++ b/security/openconnect/src/opnsense/service/templates/OPNsense/Openconnect/openconnect-script.sh
@@ -1,0 +1,5 @@
+{% if helpers.exists('OPNsense.openconnect.general.vpncscript') and OPNsense.openconnect.general.vpncscript|default("") != "" %}
+{{ OPNsense.openconnect.general.vpncscript }}
+{% else %}
+{}
+{% endif %}

--- a/security/openconnect/src/opnsense/service/templates/OPNsense/Openconnect/openconnect.conf
+++ b/security/openconnect/src/opnsense/service/templates/OPNsense/Openconnect/openconnect.conf
@@ -22,4 +22,7 @@ sslkey=/usr/local/etc/openconnect_key.pem
 {%   if helpers.exists('OPNsense.openconnect.general.protocol') and OPNsense.openconnect.general.protocol != '' %}
 protocol={{ OPNsense.openconnect.general.protocol }}
 {%   endif %}
+{% if helpers.exists('OPNsense.openconnect.general.vpncscript') and OPNsense.openconnect.general.vpncscript|default("") != "" %}
+script=/usr/local/etc/openconnect-script.sh
+{% endif %}
 {% endif %}


### PR DESCRIPTION
Resolve #661 by allowing user provide a script to override vpnc-script

Reference from man page:
```
       -s,--script=SCRIPT
              Invoke SCRIPT to configure the network after connection. Without this, routing and name service are unlikely to work correctly. The script is expected to be compatible with
              the  vpnc-script which is shipped with the "vpnc" VPN client. See http://www.infradead.org/openconnect/vpnc-script.html for more information. This version of OpenConnect is
              configured to use /etc/vpnc/vpnc-script by default.
```

Note this field is optional, if omit it keeps the old behaviour (using default vpnc-script)