### PR TITLE
security/acme-client: Renaming Linode API in Challenge Types, DNS Service for Clarity

### DIFF
--- a/security/acme-client/Makefile
+++ b/security/acme-client/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		acme-client
-PLUGIN_VERSION=		3.3
+PLUGIN_VERSION=		3.4
 PLUGIN_COMMENT=		ACME Client
 PLUGIN_MAINTAINER=	opnsense@moov.de
 PLUGIN_DEPENDS=		acme.sh py${PLUGIN_PYTHON}-dns-lexicon

--- a/security/acme-client/pkg-descr
+++ b/security/acme-client/pkg-descr
@@ -8,6 +8,12 @@ WWW: https://github.com/acmesh-official/acme.sh
 Plugin Changelog
 ================
 
+3.4
+
+Fixed:
+* rename "Linode Cloud API" to "Linode API (v4)"
+* rename "Linode API" to "Linode API (v3 / Deprecated)"
+
 3.3
 
 Added:

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -664,7 +664,7 @@
         <type>text</type>
     </field>
     <field>
-        <label>Linode</label>
+        <label>Linode API (v3 / Deprecated)</label>
         <type>header</type>
         <style>table_dns table_dns_linode</style>
     </field>
@@ -679,7 +679,7 @@
         <type>text</type>
     </field>
     <field>
-        <label>Linode Cloud API</label>
+        <label>Linode API (v4)</label>
         <type>header</type>
         <style>table_dns table_dns_linode_v4</style>
     </field>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -437,8 +437,8 @@
                         <dns_knot>Knot (knsupdate) DNS API</dns_knot>
                         <dns_leaseweb>LeaseWeb API</dns_leaseweb>
                         <dns_lexicon>lexicon DNS API</dns_lexicon>
-                        <dns_linode>Linode API</dns_linode>
-                        <dns_linode_v4>Linode Cloud API</dns_linode_v4>
+                        <dns_linode>Linode API (v3 / Deprecated)</dns_linode>
+                        <dns_linode_v4>Linode API (v4)</dns_linode_v4>
                         <dns_loopia>Loopia API</dns_loopia>
                         <dns_lua>LuaDNS.com API</dns_lua>
                         <dns_miab>MailinaBox API</dns_miab>


### PR DESCRIPTION
At Linode, the API has been updated to v4. In acme.sh, DNS-01 validation using this is called _dns_linode_v4_.

Within acme-client in OPNsense, there are two selections for _Challenge Types_ for Linode, _Linode API_ and _Linode Cloud API_. The selection _Linode Cloud API_ uses the _dns_linode_v4_ validation and is the correct option for new configurations and most users.

Selecting _Linode API_ in DNS Service, the most familiar choice, uses the deprecated v3 API results in a failing challenge. Linode no longer refers to v4 the _Cloud API_, and v4 is now the default, so I propose renaming these selections for clarity.

This pull request is to rename these items in the Challenge Types to the following: 

- "Linode Cloud API" renamed to "Linode API (v4)"
- "Linode API" renamed to "Linode API (v3 / Deprecated)"

For reference, please see [this post from Linode](https://www.linode.com/docs/guides/secure-website-lets-encrypt-acme-sh/) showing how to use acme.sh and dns_linode_v4.