### PR TITLE
net/haproxy: add syslog-ng socket

### DIFF
--- a/net/haproxy/src/etc/inc/plugins.inc.d/haproxy.inc
+++ b/net/haproxy/src/etc/inc/plugins.inc.d/haproxy.inc
@@ -37,7 +37,7 @@ function haproxy_syslog()
     $syslogconf = array();
 
     $syslogconf['haproxy'] = array(
-        'facility' => array('haproxy')
+        'facility' => array('haproxy'),
     );
 
     return $syslogconf;

--- a/net/haproxy/src/etc/inc/plugins.inc.d/haproxy.inc
+++ b/net/haproxy/src/etc/inc/plugins.inc.d/haproxy.inc
@@ -37,8 +37,7 @@ function haproxy_syslog()
     $syslogconf = array();
 
     $syslogconf['haproxy'] = array(
-        'local' => '/var/haproxy/var/run/log',
-        'facility' => array('haproxy'),
+        'facility' => array('haproxy')
     );
 
     return $syslogconf;

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/+TARGETS
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/+TARGETS
@@ -1,3 +1,4 @@
 haproxy.conf:/usr/local/etc/haproxy.conf.staging
 rc.conf.d:/etc/rc.conf.d/haproxy
 sslCerts.yaml:/usr/local/etc/haproxy/sslCerts.yaml
+log_socket.conf:/usr/local/opnsense/service/templates/OPNsense/Syslog/sources/haproxy.conf

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/log_socket.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/log_socket.conf
@@ -1,0 +1,1 @@
+    unix-dgram("/var/haproxy/var/run/log" dir_perm(0755) flags(syslog-protocol));

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/log_socket.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/log_socket.conf
@@ -1,1 +1,2 @@
+
     unix-dgram("/var/haproxy/var/run/log" dir_perm(0755) flags(syslog-protocol));


### PR DESCRIPTION
Hi
for discussion on https://github.com/opnsense/plugins/issues/2587#issuecomment-954598043
drop 'local'
add log socket
if i'm not mistaken this can be applied as a patch without waiting for the https://github.com/opnsense/core/commit/a763313d138258b0044c3285de0e8ac55d308160
Thanks!