### PR TITLE
net-mgmt/telegraf: add influxdb2 config parameter support

### DIFF
--- a/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/general.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/general.xml
@@ -12,6 +12,18 @@
         <help>This will start the process with wheel group and root user permission. Please use this with care, currently only needed for Unbound and Suricata.</help>
     </field>
     <field>
+        <id>general.enableinfluxdbconfig</id>
+        <label>Use influxdb2 config</label>
+        <type>checkbox</type>
+        <help>Enable influxdb2 config.</help>
+    </field>
+    <field>
+        <id>general.influxdbconfig</id>
+        <label>Influxdb2 Config</label>
+        <type>text</type>
+        <help>Influxdb config URL</help>
+    </field>
+    <field>
         <id>general.interval</id>
         <label>Interval</label>
         <type>text</type>

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/input.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/input.xml
@@ -139,7 +139,7 @@
     </field>
     <field>
         <id>input.intrusion_detection_alerts</id>
-        <label>Intrusion Dectection Alerts</label>
+        <label>Intrusion Detection Alerts</label>
         <type>checkbox</type>
         <help>Requires Intrustion detection alerts are stored locally.</help>
     </field>

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/General.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/General.xml
@@ -11,6 +11,14 @@
             <default>0</default>
             <Required>Y</Required>
         </wheelgroup>
+        <enableinfluxdbconfig type="BooleanField">
+            <default>0</default>
+            <Required>N</Required>
+        </enableinfluxdbconfig>
+        <influxdbconfig type="TextField">
+            <default></default>
+	        <Required>N</Required>
+	    </influxdbconfig>
         <interval type="IntegerField">
             <default>10</default>
             <Required>Y</Required>

--- a/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf
+++ b/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf
@@ -3,6 +3,9 @@
 telegraf_user="root"
 telegraf_group="wheel"
 {%   endif %}
+{%   if OPNsense.telegraf.general.enableinfluxdbconfig == '1' %}
+telegraf_conf={{ OPNsense.telegraf.general.influxdbconfig|default("") }}
+{%   endif %}
 telegraf_var_script="/usr/local/opnsense/scripts/OPNsense/Telegraf/setup.sh"
 telegraf_enable="YES"
 telegraf_confdir="/usr/local/etc/telegraf.d"

--- a/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf
+++ b/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf
@@ -4,7 +4,7 @@ telegraf_user="root"
 telegraf_group="wheel"
 {%   endif %}
 {%   if OPNsense.telegraf.general.enableinfluxdbconfig == '1' %}
-telegraf_conf={{ OPNsense.telegraf.general.influxdbconfig|default("") }}
+telegraf_conf="{{ OPNsense.telegraf.general.influxdbconfig }}"
 {%   endif %}
 telegraf_var_script="/usr/local/opnsense/scripts/OPNsense/Telegraf/setup.sh"
 telegraf_enable="YES"


### PR DESCRIPTION
Since Telegraf 1.9.2 and Influxdb2, it's possible to manage each endpoint's Telegraf configuration centrally in the Influxdb2 web UI.
By specifying the --config "https://influxdb_endpoint/api/v2/telegrafs/random_uuid" parameter at telegraf's startup, it will pull the configuration defined in the Influxdb2 Web UI instead of the local telegraf.conf
This PR adds support for that feature.