### PR TITLE
net-mgmt/telegraf: Add internet speed input plugin

### DIFF
--- a/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/input.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/input.xml
@@ -50,6 +50,18 @@
         <help>Read metrics about disk IO by device.</help>
     </field>
     <field>
+        <id>input.internet_speed</id>
+        <label>Internet Speed Test</label>
+        <type>checkbox</type>
+        <help>Enable the collection of data about the internet speed on the system.</help>
+    </field>
+    <field>
+        <id>input.internet_speed_file</id>
+        <label>Internet Speed File Download</label>
+        <type>checkbox</type>
+        <help>Enable the file download speed test.</help>
+    </field>
+    <field>
         <id>input.mem</id>
         <label>Memory</label>
         <type>checkbox</type>

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/input.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/input.xml
@@ -62,6 +62,12 @@
         <help>Enable the file download speed test.</help>
     </field>
     <field>
+        <id>input.internet_speed_interval</id>
+        <label>Interval</label>
+        <type>text</type>
+        <help>Default internet speed test interval in seconds.</help>
+    </field>
+    <field>
         <id>input.mem</id>
         <label>Memory</label>
         <type>checkbox</type>

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Input.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Input.xml
@@ -35,6 +35,14 @@
             <default>1</default>
             <Required>N</Required>
         </diskio>
+       <internet_speed type="BooleanField">
+            <default>0</default>
+            <Required>N</Required>
+        </internet_speed>
+        <internet_speed_file type="BooleanField">
+            <default>0</default>
+            <Required>N</Required>
+        </internet_speed_file>
         <mem type="BooleanField">
             <default>1</default>
             <Required>N</Required>

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Input.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Input.xml
@@ -43,6 +43,10 @@
             <default>0</default>
             <Required>N</Required>
         </internet_speed_file>
+        <internet_speed_interval type="IntegerField">
+            <default>360</default>
+            <Required>N</Required>
+        </internet_speed_interval>
         <mem type="BooleanField">
             <default>1</default>
             <Required>N</Required>

--- a/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
+++ b/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
@@ -199,6 +199,13 @@
 [[inputs.diskio]]
 {% endif %}
 
+{% if helpers.exists('OPNsense.telegraf.input.internet_speed') and OPNsense.telegraf.input.internet_speed == '1' %}
+[[inputs.internet_speed]]
+{% if helpers.exists('OPNsense.telegraf.input.internet_speed_file') and OPNsense.telegraf.input.internet_speed_file == '1' %}
+  enable_file_download = true
+{% endif %}
+{% endif %}
+
 {% if helpers.exists('OPNsense.telegraf.input.mem') and OPNsense.telegraf.input.mem == '1' %}
 [[inputs.mem]]
 {% endif %}

--- a/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
+++ b/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
@@ -204,6 +204,9 @@
 {% if helpers.exists('OPNsense.telegraf.input.internet_speed_file') and OPNsense.telegraf.input.internet_speed_file == '1' %}
   enable_file_download = true
 {% endif %}
+{% if helpers.exists('OPNsense.telegraf.input.internet_speed_interval') and OPNsense.telegraf.input.internet_speed_interval != '' %}
+  interval = "{{ OPNsense.telegraf.input.internet_speed_interval }}s"
+{% endif %}
 {% endif %}
 
 {% if helpers.exists('OPNsense.telegraf.input.mem') and OPNsense.telegraf.input.mem == '1' %}


### PR DESCRIPTION
The Internet Speed Monitor plugin collects data about the internet speed on the system.