### PR TITLE
WIP net/frr: Add BGP password support

### DIFF
--- a/net/frr/Makefile
+++ b/net/frr/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		frr
-PLUGIN_VERSION=		1.23
+PLUGIN_VERSION=		1.24
 PLUGIN_COMMENT=		The FRRouting Protocol Suite
 PLUGIN_DEPENDS=		frr7
 PLUGIN_MAINTAINER=	franz.fabian.94@gmail.com

--- a/net/frr/pkg-descr
+++ b/net/frr/pkg-descr
@@ -11,6 +11,10 @@ switching and routing, Internet access routers, and Internet peering.
 Plugin Changelog
 ================
 
+1.24
+
+* Add BGP password authentication
+
 1.23
 
 * Add route-reflector-client to BGP neighbor config

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/Api/BgpController.php
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/Api/BgpController.php
@@ -45,6 +45,8 @@ class BgpController extends ApiMutableModelControllerBase
                   "description",
                   "address",
                   "remoteas",
+                  "password",
+                  "localip",
                   "updatesource",
                   "nexthopself",
                   "multihop",

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPNeighbor.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPNeighbor.xml
@@ -23,6 +23,13 @@
     <help>Neighbor AS.</help>
   </field>
   <field>
+    <id>neighbor.password</id>
+    <label>BGP MD5 Password</label>
+    <type>text</type>
+    <advanced>true</advanced>
+    <help>Set a password for BGP authentication.</help>
+  </field>
+  <field>
     <id>neighbor.updatesource</id>
     <label>Update-Source Interface</label>
     <type>select_multiple</type>

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPNeighbor.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPNeighbor.xml
@@ -30,6 +30,13 @@
     <help>Set a password for BGP authentication.</help>
   </field>
   <field>
+    <id>neighbor.localip</id>
+    <label>Local Initiater IP</label>
+    <type>text</type>
+    <advanced>true</advanced>
+    <help>Set the local IP connecting to the neighbor. This is only required for BGP authentication.</help>
+  </field>
+  <field>
     <id>neighbor.updatesource</id>
     <label>Update-Source Interface</label>
     <type>select_multiple</type>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
@@ -13,12 +13,6 @@
             <MinimumValue>1</MinimumValue>
             <MaximumValue>4294967295</MaximumValue>
         </asnumber>
-        <password type="TextField">
-            <Required>N</Required>
-        </password>
-        <localip type="NetworkField">
-            <Required>N</Required>
-        </localip>
         <routerid type="TextField">
             <Required>N</Required>
             <mask>/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/</mask>
@@ -63,6 +57,12 @@
                                 <MinimumValue>1</MinimumValue>
                                 <MaximumValue>4294967295</MaximumValue>
                         </remoteas>
+                        <password type="TextField">
+                                <Required>N</Required>
+                        </password>
+                        <localip type="NetworkField">
+                                <Required>N</Required>
+                        </localip>
                         <updatesource type="InterfaceField">
                                 <default></default>
                                 <Required>N</Required>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/quagga/bgp</mount>
     <description>BGP Routing configuration</description>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
     <items>
         <enabled type="BooleanField">
             <default>0</default>
@@ -13,6 +13,9 @@
             <MinimumValue>1</MinimumValue>
             <MaximumValue>4294967295</MaximumValue>
         </asnumber>
+        <password type="TextField">
+            <Required>N</Required>
+        </password>
         <routerid type="TextField">
             <Required>N</Required>
             <mask>/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/</mask>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
@@ -16,6 +16,9 @@
         <password type="TextField">
             <Required>N</Required>
         </password>
+        <localip type="NetworkField">
+            <Required>N</Required>
+        </localip>
         <routerid type="TextField">
             <Required>N</Required>
             <mask>/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/</mask>

--- a/net/frr/src/opnsense/scripts/quagga/setup.sh
+++ b/net/frr/src/opnsense/scripts/quagga/setup.sh
@@ -18,3 +18,6 @@ chown -R $user:$group /var/run/frr
 # logfile (if used)
 touch /var/log/frr.log
 chown $user:$group /var/log/frr.log
+
+setkey -f /usr/local/etc/frr/spddelete.conf
+setkey -f /usr/local/etc/frr/spdadd.conf

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/+TARGETS
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/+TARGETS
@@ -4,6 +4,8 @@ ospfd.conf:/usr/local/etc/frr/ospfd.conf
 ospfd_carp.conf:/usr/local/etc/frr/ospfd_carp.conf
 ospf6d.conf:/usr/local/etc/frr/ospf6d.conf
 ripd.conf:/usr/local/etc/frr/ripd.conf
+spdadd.conf:/usr/local/etc/frr/spdadd.conf
+spddelete.conf:/usr/local/etc/frr/spddelete.conf
 frr:/etc/rc.conf.d/frr
 zebra.conf:/usr/local/etc/frr/zebra.conf
 vtysh.conf:/usr/local/etc/frr/vtysh.conf

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -57,6 +57,9 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%         if 'bfd' in neighbor and neighbor.bfd == '1' %}
  neighbor {{ neighbor.address }} bfd
 {%         endif %}
+{%         if 'password' in neighbor and neighbor.password != '' %}
+ neighbor {{ neighbor.address }} password {{ neighbor.password }}
+{%         endif %}
 {%         if ':' not in neighbor.address and 'updatesource' in neighbor and neighbor.updatesource != '' %}
  neighbor {{ neighbor.address }} update-source {{ physical_interface(neighbor.updatesource) }}
 {%         endif %}

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/spdadd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/spdadd.conf
@@ -1,0 +1,12 @@
+{% if helpers.exists('OPNsense.quagga.bgp.enabled') and OPNsense.quagga.bgp.enabled == '1' %}
+{%   if helpers.exists('OPNsense.quagga.bgp.neighbors.neighbor') %}
+{%     for neighbor in helpers.toList('OPNsense.quagga.bgp.neighbors.neighbor') %}
+{%       if neighbor.enabled == '1' %}
+{%         if 'password' in neighbor and neighbor.password != '' %}
+add -4 {{ neighbor.localip }} {{ neighbor.address }} tcp 0x1000 -A tcp-md5 "{{ neighbor.password }}";
+add -4 {{ neighbor.address }} {{ neighbor.localip }} tcp 0x1000 -A tcp-md5 "{{ neighbor.password }}";
+{%         endif %}
+{%       endif %}
+{%     endfor %}
+{%   endif %}
+{% endif %}

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/spddelete.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/spddelete.conf
@@ -3,8 +3,8 @@
 {%     for neighbor in helpers.toList('OPNsense.quagga.bgp.neighbors.neighbor') %}
 {%       if neighbor.enabled == '1' %}
 {%         if 'password' in neighbor and neighbor.password != '' %}
-del -4 {{ neighbor.localip }} {{ neighbor.address }} tcp 0x1000;
-del -4 {{ neighbor.address }} {{ neighbor.localip }} tcp 0x1000;
+delete -4 {{ neighbor.localip }} {{ neighbor.address }} tcp 0x1000;
+delete -4 {{ neighbor.address }} {{ neighbor.localip }} tcp 0x1000;
 {%         endif %}
 {%       endif %}
 {%     endfor %}

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/spddelete.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/spddelete.conf
@@ -1,0 +1,12 @@
+{% if helpers.exists('OPNsense.quagga.bgp.enabled') and OPNsense.quagga.bgp.enabled == '1' %}
+{%   if helpers.exists('OPNsense.quagga.bgp.neighbors.neighbor') %}
+{%     for neighbor in helpers.toList('OPNsense.quagga.bgp.neighbors.neighbor') %}
+{%       if neighbor.enabled == '1' %}
+{%         if 'password' in neighbor and neighbor.password != '' %}
+del -4 {{ neighbor.localip }} {{ neighbor.address }} tcp 0x1000 -A tcp-md5 "{{ neighbor.password }}";
+del -4 {{ neighbor.address }} {{ neighbor.localip }} tcp 0x1000 -A tcp-md5 "{{ neighbor.password }}";
+{%         endif %}
+{%       endif %}
+{%     endfor %}
+{%   endif %}
+{% endif %}

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/spddelete.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/spddelete.conf
@@ -3,8 +3,8 @@
 {%     for neighbor in helpers.toList('OPNsense.quagga.bgp.neighbors.neighbor') %}
 {%       if neighbor.enabled == '1' %}
 {%         if 'password' in neighbor and neighbor.password != '' %}
-del -4 {{ neighbor.localip }} {{ neighbor.address }} tcp 0x1000 -A tcp-md5 "{{ neighbor.password }}";
-del -4 {{ neighbor.address }} {{ neighbor.localip }} tcp 0x1000 -A tcp-md5 "{{ neighbor.password }}";
+del -4 {{ neighbor.localip }} {{ neighbor.address }} tcp 0x1000;
+del -4 {{ neighbor.address }} {{ neighbor.localip }} tcp 0x1000;
 {%         endif %}
 {%       endif %}
 {%     endfor %}


### PR DESCRIPTION
Currently only supports v4 as it is a base for discussion first.
As discusses with @AdSchellevis we should do this right from the beginning as it interacts with setkey/SPD and IPsec.
The current approach only adds and deletes the line without any flushing. To me this looks ok so far.

Also adding @g-a-c for feedback if interested.