### PR TITLE
net-mgmt/zabbix-proxy: release 1.6

### DIFF
--- a/net-mgmt/zabbix-proxy/Makefile
+++ b/net-mgmt/zabbix-proxy/Makefile
@@ -2,10 +2,13 @@ PLUGIN_NAME=		zabbix-proxy
 PLUGIN_VERSION=		1.5
 PLUGIN_COMMENT=		Zabbix monitoring proxy
 PLUGIN_MAINTAINER=	m.muenz@gmail.com
-PLUGIN_VARIANTS=	zabbix5 zabbix4
+PLUGIN_VARIANTS=	zabbix5 zabbix54 zabbix4
 
 zabbix5_NAME=		zabbix5-proxy
 zabbix5_DEPENDS=	zabbix5-proxy
+
+zabbix54_NAME=		zabbix54-proxy
+zabbix54_DEPENDS=	zabbix54-proxy
 
 zabbix4_NAME=		zabbix4-proxy
 zabbix4_DEPENDS=	zabbix4-proxy

--- a/net-mgmt/zabbix-proxy/Makefile
+++ b/net-mgmt/zabbix-proxy/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		zabbix-proxy
-PLUGIN_VERSION=		1.5
+PLUGIN_VERSION=		1.6
 PLUGIN_COMMENT=		Zabbix monitoring proxy
 PLUGIN_MAINTAINER=	m.muenz@gmail.com
 PLUGIN_VARIANTS=	zabbix5 zabbix54 zabbix4

--- a/net-mgmt/zabbix-proxy/pkg-descr
+++ b/net-mgmt/zabbix-proxy/pkg-descr
@@ -12,6 +12,10 @@ WWW: https://www.zabbix.com/
 Plugin Changelog
 ----------------
 
+1.6
+
+* Fix upgrade path by using a new db file for each version (#1943)
+
 1.5
 
 * Add log file to web GUI (contributed by Starkstromkonsument)

--- a/net-mgmt/zabbix-proxy/pkg-descr
+++ b/net-mgmt/zabbix-proxy/pkg-descr
@@ -15,6 +15,7 @@ Plugin Changelog
 1.6
 
 * Fix upgrade path by using a new db file for each version (#1943)
+* Add plugin variant for Zabbix Proxy 5.4
 
 1.5
 

--- a/net-mgmt/zabbix-proxy/src/opnsense/service/templates/OPNsense/Zabbixproxy/zabbix_proxy.conf.in
+++ b/net-mgmt/zabbix-proxy/src/opnsense/service/templates/OPNsense/Zabbixproxy/zabbix_proxy.conf.in
@@ -22,7 +22,7 @@ SourceIP={{ OPNsense.zabbixproxy.general.sourceip }}
 {% endif %}
 LogFile=/var/log/zabbix/zabbix_proxy.log
 PidFile=/var/run/zabbix/zabbix_proxy.pid
-DBName=/var/db/zabbix/zabbix_proxy.db
+DBName=/var/db/zabbix/%%PLUGIN_VARIANT%%_proxy.db
 {% if helpers.exists('OPNsense.zabbixproxy.general.proxyofflinebuffer') and OPNsense.zabbixproxy.general.proxyofflinebuffer != '' %}
 ProxyOfflineBuffer={{ OPNsense.zabbixproxy.general.proxyofflinebuffer }}
 {% endif %}


### PR DESCRIPTION
Changes in this PR:

* Fix upgrade path by using a new db file for each version (#1943)
* Add plugin variant for Zabbix Proxy 5.4 (depends on https://github.com/opnsense/tools/pull/252)

@mimugmail, please review :)