### PR TITLE
Fix for digitalocean-v6

### DIFF
--- a/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
+++ b/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
@@ -324,6 +324,7 @@ class updatedns
                 case 'desec-v6':
                 case 'dhs':
                 case 'digitalocean':
+                case 'digitalocean-v6':
                 case 'gandi-livedns':
                 case 'dnsexit':
                 case 'dnsomatic':


### PR DESCRIPTION
added digitalocean-v6 to switch, it was missing and returning error 6 'Dynamic DNS: (ERROR!) The Dynamic DNS Service provided is not yet supported.'