### PR TITLE
Added (local)Unifi to ACME actions

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogAction.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogAction.xml
@@ -220,4 +220,15 @@
         <label>Password</label>
         <type>password</type>
     </field>
+    <field>
+        <label>Required Parameters</label>
+        <type>header</type>
+        <style>method_table method_table_acme_unifi</style>
+    </field>
+    <field>
+        <id>action.acme_unifi_keystore</id>
+        <label>Unifi keystore file</label>
+        <type>text</type>
+        <help>Path to the Unifi keystore file in the local filesystem, i.e. /usr/local/share/java/unifi/data/keystore.</help>
+    </field>
 </form>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeAutomation/AcmeUnifi.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeAutomation/AcmeUnifi.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright (C) 2021 Frank Wall
+ * Copyright (C) 2021 Alexander Noack
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeAutomation/AcmeUnifi.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeAutomation/AcmeUnifi.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * Copyright (C) 2021 Frank Wall
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\AcmeClient\LeAutomation;
+
+use OPNsense\AcmeClient\LeAutomationInterface;
+
+/**
+ * Run acme.sh deploy hook unifi
+ * @package OPNsense\AcmeClient
+ */
+class AcmeUnifi extends Base implements LeAutomationInterface
+{
+    public function prepare()
+    {
+        $this->acme_env['DEPLOY_UNIFI_KEYSTORE'] = (string)$this->config->acme_unifi_keystore;
+        $this->acme_env['DEPLOY_UNIFI_RELOAD'] = 'service unifi restart';
+        $this->acme_args[] = '--deploy-hook unifi';
+        return true;
+    }
+}

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -1049,6 +1049,7 @@
                         <configd_upload_sftp>Upload certificate via SFTP</configd_upload_sftp>
                         <acme_fritzbox>Upload certificate to FRITZ!Box router</acme_fritzbox>
                         <acme_synology_dsm>Upload certificate to Synology DSM</acme_synology_dsm>
+                        <acme_unifi>Update local Unifi keystore</acme_unifi>
                         <configd_generic>System or Plugin Command</configd_generic>
                     </OptionValues>
                 </type>
@@ -1202,6 +1203,10 @@
                     <mask>/^.{1,1024}$/u</mask>
                     <ValidationMessage>Should be a string between 1 and 1024 characters.</ValidationMessage>
                 </acme_fritzbox_password>
+                <acme_unifi_keystore type="TextField">
+                    <default>/usr/local/share/java/unifi/data/keystore</default>
+                    <Required>N</Required>
+                </acme_unifi_keystore>
             </action>
         </actions>
     </items>


### PR DESCRIPTION
@fraenki I don't know if this is acceptable to you (regarding the unsupported remark here https://github.com/opnsense/plugins/issues/2627#issuecomment-967663228)

I tested this deployment hook using https://github.com/mimugmail/opn-repo/tree/main/net-mgmt/unifi-maxit