### PR TITLE
DynDNS - Fix issue with Godaddy Ipv6 not working

### DIFF
--- a/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
+++ b/dns/dyndns/src/etc/inc/plugins.inc.d/dyndns/phpDynDNS.inc
@@ -288,7 +288,7 @@ class updatedns
         if ($this->_dnsVerboseLog) {
             log_error("Dynamic DNS ({$this->_dnsHost}): running dyndns_failover_interface for {$dnsRequestIf}. found {$this->_dnsRequestIf}");
         }
-        $this->_dnsRequestIfIP = $this->_useIPv6 ? get_interface_ipv6($this->_dnsRequestIf) : get_interface_ip($this->_dnsRequestIf);
+        $this->_dnsRequestIfIP = $this->_dnsRequestIf;
         $this->_dnsMaxCacheAgeDays = 25;
         $this->_dnsDummyUpdateDone = false;
         $this->_forceUpdateNeeded = $forceUpdate;


### PR DESCRIPTION
After much hunting around, the variable  $this->_dnsRequestIfIP is used in one place only, and that is  curl_setopt($ch, CURLOPT_INTERFACE, $this->_dnsRequestIfIP);

CURLOPT_INTERFACE specifies an interface is the parameter, not an IP address. For some reason, this works for godaddy V4 even when an IP address is passed, but not for IPv6. Changing it to setting the interface corrects the issue. TBH, I'm baffled why only a couple of us have noticed the problem, perhaps we are the only ones using IPv6?