### PR TITLE
net/freeradius: Fix bad default

### DIFF
--- a/net/freeradius/Makefile
+++ b/net/freeradius/Makefile
@@ -1,5 +1,6 @@
 PLUGIN_NAME=		freeradius
 PLUGIN_VERSION=		1.9.17
+PLUGIN_REVISION=  1
 PLUGIN_COMMENT=		RADIUS Authentication, Authorization and Accounting Server
 PLUGIN_DEPENDS=		freeradius3
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Eap.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Eap.xml
@@ -46,7 +46,7 @@
             <Required>Y</Required>
         </check_tls_names>
         <tls_min_version type="OptionField">
-            <default>Option1</default>
+            <default>1.0</default>
             <Required>Y</Required>
             <multiple>N</multiple>
             <OptionValues>


### PR DESCRIPTION
Got a couple of reports that starting FR failes. 
When applying on EAP correct default is set and daemon starts.