### PR TITLE
www/nginx: Rework security header forms and adding CSP frame-ancestors and HSTS preload directives

### DIFF
--- a/www/nginx/Makefile
+++ b/www/nginx/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		nginx
-PLUGIN_VERSION=		1.25
+PLUGIN_VERSION=		1.26
 PLUGIN_COMMENT=		Nginx HTTP server and reverse proxy
 PLUGIN_DEPENDS=		nginx
 PLUGIN_MAINTAINER=	franz.fabian.94@gmail.com

--- a/www/nginx/README.md
+++ b/www/nginx/README.md
@@ -33,11 +33,11 @@ Most are standard but some endpoints support maps, which are not
 supported by OPNsense core.
 
 You can detect them simply as they are doing more than just a mapping
-to the *base methods.
+to the \*base methods.
 
 Such mappings work in the way that they catch up the request,
 map the internal data first, and then forward their UUIDs
-to the *base method.
+to the \*base method.
 
 ## The nginx plugin as infrastucture
 

--- a/www/nginx/pkg-descr
+++ b/www/nginx/pkg-descr
@@ -13,7 +13,7 @@ Plugin Changelog
 1.26
 
 * Enhancement of security headers (contributed by Manuel Faux)
-  Add Frame-Ancestors, add "preload", removed depricated HPKP
+  Add Frame-Ancestors, add "preload", removed deprecated HPKP
 * Performance enhancements for log display
 * Fixed display of vts and logs for non-default styles
 

--- a/www/nginx/pkg-descr
+++ b/www/nginx/pkg-descr
@@ -10,6 +10,13 @@ WWW: https://nginx.org/
 Plugin Changelog
 ================
 
+1.26
+
+* Enhancement of security headers (contributed by Manuel Faux)
+  Add Frame-Ancestors, add "preload", removed depricated HPKP
+* Performance enhancements for log display
+* Fixed display of vts and logs for non-default styles
+
 1.25
 
 * Reworked logging frontent to support filtering and historic view (contributed by Manuel Faux)

--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/Api/SettingsController.php
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/Api/SettingsController.php
@@ -343,7 +343,7 @@ class SettingsController extends ApiMutableModelControllerBase
     public function searchsecurityHeaderAction()
     {
         $data = $this->searchBase('security_header',
-            ['description', 'referrer', 'xssprotection', 'strict_transport_security_time', 'hpkp_keys', 'hpkp_time',
+            ['description', 'referrer', 'xssprotection', 'strict_transport_security_time',
             'enable_csp', 'csp_report_only', 'csp_default_src_enabled', 'csp_script_src_enabled', 'csp_img_src_enabled',
             'csp_style_src_enabled', 'csp_media_src_enabled', 'csp_font_src_enabled', 'csp_frame_src_enabled',
             'csp_frame_ancestors_enabled', 'csp_form_action_enabled']);
@@ -351,19 +351,9 @@ class SettingsController extends ApiMutableModelControllerBase
         // Create "hsts" column (disabled/time)
         foreach ($data['rows'] as &$row) {
             if (intval($row['strict_transport_security_time']) > 0) {
-                $row['hsts'] = sprintf(gettext("%d sec"), intval($row['strict_transport_security_time'])));
+                $row['hsts'] = sprintf(gettext("%d sec"), intval($row['strict_transport_security_time']));
             } else {
                 $row['hsts'] = gettext('disabled');
-            }
-        }
-
-
-        // Create "hpkp" column (enabled/disabled)
-        foreach ($data['rows'] as &$row) {
-            if (!empty($row['hpkp_keys']) && intval($row['hpkp_time']) > 0) {
-                $row['hpkp'] = sprintf("%d %s", intval($row['hpkp_time']), gettext("sec"));
-            } else {
-                $row['hpkp'] = gettext('disabled');
             }
         }
 

--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/Api/SettingsController.php
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/Api/SettingsController.php
@@ -342,7 +342,69 @@ class SettingsController extends ApiMutableModelControllerBase
     // http security headers
     public function searchsecurityHeaderAction()
     {
-        return $this->searchBase('security_header', array('description'));
+        $data = $this->searchBase('security_header',
+            ['description', 'referrer', 'xssprotection', 'strict_transport_security_time', 'hpkp_keys', 'hpkp_time',
+            'enable_csp', 'csp_report_only', 'csp_default_src_enabled', 'csp_script_src_enabled', 'csp_img_src_enabled',
+            'csp_style_src_enabled', 'csp_media_src_enabled', 'csp_font_src_enabled', 'csp_frame_src_enabled',
+            'csp_frame_ancestors_enabled', 'csp_form_action_enabled']);
+
+        // Create "hsts" column (disabled/time)
+        foreach ($data['rows'] as &$row) {
+            if (intval($row['strict_transport_security_time']) > 0) {
+                $row['hsts'] = sprintf("%d %s", intval($row['strict_transport_security_time']), gettext("sec"));
+            } else {
+                $row['hsts'] = gettext('disabled');
+            }
+        }
+
+
+        // Create "hpkp" column (enabled/disabled)
+        foreach ($data['rows'] as &$row) {
+            if (!empty($row['hpkp_keys']) && intval($row['hpkp_time']) > 0) {
+                $row['hpkp'] = sprintf("%d %s", intval($row['hpkp_time']), gettext("sec"));
+            } else {
+                $row['hpkp'] = gettext('disabled');
+            }
+        }
+
+        // Create "csp" column (enabled/report only/disabled)
+        foreach ($data['rows'] as &$row) {
+            if ($row['enable_csp']) {
+                if ($row['csp_report_only']) {
+                    $row['csp'] = gettext('report only');
+                } else {
+                    $row['csp'] = gettext('enabled');
+                }
+            } else {
+                $row['csp'] = gettext('disabled');
+            }
+        }
+
+        // Create "csp_details" column
+        foreach ($data['rows'] as &$row) {
+            if ($row['enable_csp']) {
+                $enabled = [];
+                if ($row['csp_default_src_enabled']) $enabled[] = gettext("Default Source");
+                if ($row['csp_script_src_enabled']) $enabled[] = gettext("Script Source");
+                if ($row['csp_img_src_enabled']) $enabled[] = gettext("Image Source");
+                if ($row['csp_style_src_enabled']) $enabled[] = gettext("Style Source");
+                if ($row['csp_media_src_enabled']) $enabled[] = gettext("Media Source");
+                if ($row['csp_font_src_enabled']) $enabled[] = gettext("Font Source");
+                if ($row['csp_frame_src_enabled']) $enabled[] = gettext("Frame Source");
+                if ($row['csp_frame_ancestors_enabled']) $enabled[] = gettext("Frame Ancestors");
+                if ($row['csp_form_action_enabled']) $enabled[] = gettext("Form Action");
+
+                if (count($enabled)) {
+                    $row['csp_details'] = implode(', ', $enabled);
+                } else {
+                    $row['csp_details'] = gettext('none');
+                }
+            } else {
+                $row['csp_details'] = '';
+            }
+        }
+
+        return $data;
     }
 
     public function getsecurityHeaderAction($uuid = null)

--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/Api/SettingsController.php
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/Api/SettingsController.php
@@ -351,7 +351,7 @@ class SettingsController extends ApiMutableModelControllerBase
         // Create "hsts" column (disabled/time)
         foreach ($data['rows'] as &$row) {
             if (intval($row['strict_transport_security_time']) > 0) {
-                $row['hsts'] = sprintf("%d %s", intval($row['strict_transport_security_time']), gettext("sec"));
+                $row['hsts'] = sprintf(gettext("%d sec"), intval($row['strict_transport_security_time'])));
             } else {
                 $row['hsts'] = gettext('disabled');
             }

--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/security_headers.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/security_headers.xml
@@ -58,6 +58,12 @@
       <help>If checked, also subdomains are affected.</help>
     </field>
     <field>
+      <id>security_header.strict_transport_security_preload</id>
+      <label>Preload</label>
+      <type>checkbox</type>
+      <help><![CDATA[If checked, the preload directive is added. Google maintains <a href="https://hstspreload.org/">an HSTS preload service</a>. By following the guidelines and successfully submitting your domain, browsers will never connect to your domain using an insecure connection. While the service is hosted by Google, all browsers have stated an intent to use (or actually started using) the preload list. However, it is not part of the HSTS specification and should not be treated as official.]]></help>
+    </field>
+    <field>
       <type>header</type>
       <label>HTTP Public Key Pinning (HPKP)</label>
       <hint>This feature is no longer recommended. Though some browsers might still support it, it may have already been removed from the relevant web standards, maybe in the process of being dropped, or may only be kept for compatibility purposes. Avoid using it, and update existing code if possible.</hint>

--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/security_headers.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/security_headers.xml
@@ -98,6 +98,7 @@
     <field>
       <type>header</type>
       <label>Content Security Policy: Default Source</label>
+      <hint><![CDATA[The setting <em>Content Security Policy: Enable</em> on the <em>General</em> tab needs to be enabled to activate this header.]]></hint>
     </field>
     <field>
       <id>security_header.csp_default_src_enabled</id>
@@ -166,6 +167,7 @@
     <field>
       <type>header</type>
       <label>Content Security Policy: Script Source</label>
+      <hint><![CDATA[The setting <em>Content Security Policy: Enable</em> on the <em>General</em> tab needs to be enabled to activate this header.]]></hint>
     </field>
     <field>
       <id>security_header.csp_script_src_enabled</id>
@@ -234,6 +236,7 @@
     <field>
       <type>header</type>
       <label>Content Security Policy: Image Source</label>
+      <hint><![CDATA[The setting <em>Content Security Policy: Enable</em> on the <em>General</em> tab needs to be enabled to activate this header.]]></hint>
     </field>
     <field>
       <id>security_header.csp_img_src_enabled</id>
@@ -302,6 +305,7 @@
     <field>
       <type>header</type>
       <label>Content Security Policy: Stylesheet Source</label>
+      <hint><![CDATA[The setting <em>Content Security Policy: Enable</em> on the <em>General</em> tab needs to be enabled to activate this header.]]></hint>
     </field>
     <field>
       <id>security_header.csp_style_src_enabled</id>
@@ -370,6 +374,7 @@
     <field>
       <type>header</type>
       <label>Content Security Policy: Media Source</label>
+      <hint><![CDATA[The setting <em>Content Security Policy: Enable</em> on the <em>General</em> tab needs to be enabled to activate this header.]]></hint>
     </field>
     <field>
       <id>security_header.csp_media_src_enabled</id>
@@ -438,6 +443,7 @@
     <field>
       <type>header</type>
       <label>Content Security Policy: Font Source</label>
+      <hint><![CDATA[The setting <em>Content Security Policy: Enable</em> on the <em>General</em> tab needs to be enabled to activate this header.]]></hint>
     </field>
     <field>
       <id>security_header.csp_font_src_enabled</id>
@@ -506,6 +512,7 @@
     <field>
       <type>header</type>
       <label>Content Security Policy: Form Action</label>
+      <hint><![CDATA[The setting <em>Content Security Policy: Enable</em> on the <em>General</em> tab needs to be enabled to activate this header.]]></hint>
     </field>
     <field>
       <id>security_header.csp_form_action_enabled</id>

--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/security_headers.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/security_headers.xml
@@ -1,553 +1,573 @@
 <form>
-  <field>
-    <id>security_header.description</id>
-    <label>Description</label>
-    <type>text</type>
-    <help>This is only for your reference.</help>
-  </field>
-  <field>
-    <id>security_header.referrer</id>
-    <label>Referrer</label>
-    <style>selectpicker</style>
-    <type>dropdown</type>
-    <help><![CDATA[
-      <ul>
-        <li>Same Origin: The header will be sent if you stay on the same server using the same protocol (no data leak)</li>
-        <li>No Referrer When Downgrade: Prevents sending a referrer when switching from HTTPS to HTTP</li>
-        <li>Origin, Strict-Origin: Always send the header but no path or query information. Strict Origin additionally suppressed the header on downgrades.</li>
-        <li>(Strict) Origin When Cross Origin: Full Referrer on the same origin, and like (Strict) Origin when cross domain.</li>
-        <li>Unsafe URL: Sends the full URL to all pages</li>
-      </ul> ]]></help>
-  </field>
-  <field>
-    <id>security_header.xssprotection</id>
-    <label>XSS Protection</label>
-    <style>selectpicker</style>
-    <type>dropdown</type>
-    <help><![CDATA[
-      <ul>
-        <li>Block: The browser should block the response</li>
-        <li>Off: Allow Anything</li>
-        <li>On: The Browser decides how to handle it.</li>
-      </ul> ]]></help>
-  </field>
-  <field>
-    <id>security_header.content_type_options</id>
-    <label>Don't Sniff Content Type</label>
-    <type>checkbox</type>
-  </field>
-  <field>
-    <id>security_header.strict_transport_security_time</id>
-    <label>Strict Transport Security: Time</label>
-    <type>text</type>
-    <help>A time in seconds in which the transport security (TLS) should be enforced.</help>
-  </field>
-  <field>
-    <id>security_header.strict_transport_security_include_subdomains</id>
-    <label>Strict Transport Security: Include Subdomains</label>
-    <type>checkbox</type>
-    <help>If checked, also subdomains are affected.</help>
-  </field>
-  <field>
-    <id>security_header.hpkp_keys</id>
-    <label>HTTP Public Key Pinning: Fingerprints</label>
-    <type>select_multiple</type>
-    <style>tokenize</style>
-    <allownew>true</allownew>
-    <help><![CDATA[ Enter a comma separated list of public key fingerprints here.
-    You can find some documentetion about this feature in the
-    <a href="https://developer.mozilla.org/de/docs/Web/Security/Public_Key_Pinning">Mozilla Wiki</a>.
-    It is not recommended to use this feature with short lived certificates.]]></help>
-  </field>
-  <field>
-    <id>security_header.hpkp_report_only</id>
-    <label>HTTP Public Key Pinning: Report Only</label>
-    <type>checkbox</type>
-    <help>If you only want to test it, you can check this box (policy will be deployed but not enforced).</help>
-  </field>
-  <field>
-    <id>security_header.hpkp_time</id>
-    <label>HTTP Public Key Pinning: Max Age</label>
-    <type>text</type>
-  </field>
-  <field>
-    <id>security_header.hpkp_include_subdomains</id>
-    <label>HTTP Public Key Pinning: Include Subdomains</label>
-    <type>checkbox</type>
-    <help>If checked, also subdomains are affected.</help>
-  </field>
-  <field>
-    <id>security_header.enable_csp</id>
-    <label>Content Security Policy: Enable</label>
-    <type>checkbox</type>
-    <help>If checked, the CSP is enabled.</help>
-  </field>
-  <field>
-    <id>security_header.csp_report_only</id>
-    <label>Content Security Policy: Report Only</label>
-    <type>checkbox</type>
-    <help>If checked, the CSP is not enforced (learning mode).</help>
-  </field>
-  <field>
-    <type>header</type>
-    <label>Content Security Policy: Default Source</label>
-  </field>
-  <field>
-    <id>security_header.csp_default_src_enabled</id>
-    <label>Enable</label>
-    <type>checkbox</type>
-    <help>If checked, this part of the CSP is enabled.</help>
-  </field>
-  <field>
-    <id>security_header.csp_default_src_data_urls</id>
-    <label>Enable Data URLs</label>
-    <help>Data URLs are used to embed files into HTML (for example images written directly into the src attribute).</help>
-    <type>checkbox</type>
-  </field>
-  <field>
-    <id>security_header.csp_default_src_http_urls</id>
-    <label>Enable HTTP(S) URLs</label>
-    <type>select_multiple</type>
-    <allownew>true</allownew>
-    <style>tokenize</style>
-    <help>Allow loading files over HTTP(S) allows downloading of content over other domains or CDNs.
-      You can use wildcards here like https://*.exmaple.com.</help>
-  </field>
-  <field>
-    <id>security_header.csp_default_src_inline</id>
-    <label>Enable Inline Scripting</label>
-    <type>checkbox</type>
-    <help>Checking this directive allows to use scripts or styles directly embedded in in the HTML content.
-      Examples are the script and the style tags.</help>
-  </field>
-  <field>
-    <id>security_header.csp_default_src_eval</id>
-    <label>Enable Eval</label>
-    <type>checkbox</type>
-    <help>Checking this box allows functions like eval or createFunction in JS, or style attributes for CSS.</help>
-  </field>
-  <field>
-    <id>security_header.csp_default_src_self</id>
-    <label>Enable Same Origin (recommended)</label>
-    <type>checkbox</type>
-    <help>Allows everything from the same site (path can differ, but host, protocol and port need to be the same).</help>
-  </field>
-  <field>
-    <id>security_header.csp_default_src_blob</id>
-    <label>Enable Blobs</label>
-    <type>checkbox</type>
-    <help>Allows to use blobs as a data source. This usually is content, which is somehow generated in JavaScript.</help>
-  </field>
-  <field>
-    <id>security_header.csp_default_src_mediastream</id>
-    <label>Enable Media Streams</label>
-    <type>checkbox</type>
-  </field>
-  <field>
-    <id>security_header.csp_default_src_filesystem</id>
-    <label>Enable File System URLs</label>
-    <type>checkbox</type>
-  </field>
-  <field>
-    <id>security_header.csp_default_src_none</id>
-    <label>Forbid Explicitly</label>
-    <type>checkbox</type>
-    <help>If this checkbox is checked, all other settings for this directive are ignored and everything will be forbidden.</help>
-  </field>
-  <field>
-    <type>header</type>
-    <label>Content Security Policy: Script Source</label>
-  </field>
-  <field>
-    <id>security_header.csp_script_src_enabled</id>
-    <label>Enable</label>
-    <type>checkbox</type>
-    <help>If checked, this part of the CSP is enabled.</help>
-  </field>
-  <field>
-    <id>security_header.csp_script_src_data_urls</id>
-    <label>Enable Data URLs</label>
-    <help>Data URLs are used to embed files into HTML (for example images written directly into the src attribute).</help>
-    <type>checkbox</type>
-  </field>
-  <field>
-    <id>security_header.csp_script_src_http_urls</id>
-    <label>Enable HTTP(S) URLs</label>
-    <type>select_multiple</type>
-    <allownew>true</allownew>
-    <style>tokenize</style>
-    <help>Allow loading files over HTTP(S) allows downloading of content over other domains or CDNs.
-      You can use wildcards here like https://*.exmaple.com.</help>
-  </field>
-  <field>
-    <id>security_header.csp_script_src_inline</id>
-    <label>Enable Inline Scripting</label>
-    <type>checkbox</type>
-    <help>Checking this directive allows to use scripts or styles directly embedded in in the HTML content.
-      Examples are the script and the style tags.</help>
-  </field>
-  <field>
-    <id>security_header.csp_script_src_eval</id>
-    <label>Enable Eval</label>
-    <type>checkbox</type>
-    <help>Checking this box allows functions like eval or createFunction in JS, or style attributes for CSS.</help>
-  </field>
-  <field>
-    <id>security_header.csp_script_src_self</id>
-    <label>Enable Same Origin (recommended)</label>
-    <type>checkbox</type>
-    <help>Allows everything from the same site (path can differ, but host, protocol and port need to be the same).</help>
-  </field>
-  <field>
-    <id>security_header.csp_script_src_blob</id>
-    <label>Enable Blobs</label>
-    <type>checkbox</type>
-    <help>Allows to use blobs as a data source. This usually is content, which is somehow generated in JavaScript.</help>
-  </field>
-  <field>
-    <id>security_header.csp_script_src_mediastream</id>
-    <label>Enable Media Streams</label>
-    <type>checkbox</type>
-  </field>
-  <field>
-    <id>security_header.csp_script_src_filesystem</id>
-    <label>Enable File System URLs</label>
-    <type>checkbox</type>
-  </field>
-  <field>
-    <id>security_header.csp_script_src_none</id>
-    <label>Forbid Explicitly</label>
-    <type>checkbox</type>
-    <help>If this checkbox is checked, all other settings for this directive are ignored and everything will be forbidden.</help>
-  </field>
-  <field>
-    <type>header</type>
-    <label>Content Security Policy: Image Source</label>
-  </field>
-  <field>
-    <id>security_header.csp_img_src_enabled</id>
-    <label>Enable</label>
-    <type>checkbox</type>
-    <help>If checked, this part of the CSP is enabled.</help>
-  </field>
-  <field>
-    <id>security_header.csp_img_src_data_urls</id>
-    <label>Enable Data URLs</label>
-    <help>Data URLs are used to embed files into HTML (for example images written directly into the src attribute).</help>
-    <type>checkbox</type>
-  </field>
-  <field>
-    <id>security_header.csp_img_src_http_urls</id>
-    <label>Enable HTTP(S) URLs</label>
-    <type>select_multiple</type>
-    <allownew>true</allownew>
-    <style>tokenize</style>
-    <help>Allow loading files over HTTP(S) allows downloading of content over other domains or CDNs.
-      You can use wildcards here like https://*.exmaple.com.</help>
-  </field>
-  <field>
-    <id>security_header.csp_img_src_inline</id>
-    <label>Enable Inline Scripting</label>
-    <type>checkbox</type>
-    <help>Checking this directive allows to use scripts or styles directly embedded in in the HTML content.
-      Examples are the script and the style tags.</help>
-  </field>
-  <field>
-    <id>security_header.csp_img_src_eval</id>
-    <label>Enable Eval</label>
-    <type>checkbox</type>
-    <help>Checking this box allows functions like eval or createFunction in JS, or style attributes for CSS.</help>
-  </field>
-  <field>
-    <id>security_header.csp_img_src_self</id>
-    <label>Enable Same Origin (recommended)</label>
-    <type>checkbox</type>
-    <help>Allows everything from the same site (path can differ, but host, protocol and port need to be the same).</help>
-  </field>
-  <field>
-    <id>security_header.csp_img_src_blob</id>
-    <label>Enable Blobs</label>
-    <type>checkbox</type>
-    <help>Allows to use blobs as a data source. This usually is content, which is somehow generated in JavaScript.</help>
-  </field>
-  <field>
-    <id>security_header.csp_img_src_mediastream</id>
-    <label>Enable Media Streams</label>
-    <type>checkbox</type>
-  </field>
-  <field>
-    <id>security_header.csp_img_src_filesystem</id>
-    <label>Enable File System URLs</label>
-    <type>checkbox</type>
-  </field>
-  <field>
-    <id>security_header.csp_img_src_none</id>
-    <label>Forbid Explicitly</label>
-    <type>checkbox</type>
-    <help>If this checkbox is checked, all other settings for this directive are ignored and everything will be forbidden.</help>
-  </field>
-  <field>
-    <type>header</type>
-    <label>Content Security Policy: Stylesheet Source</label>
-  </field>
-  <field>
-    <id>security_header.csp_style_src_enabled</id>
-    <label>Enable</label>
-    <type>checkbox</type>
-    <help>If checked, this part of the CSP is enabled.</help>
-  </field>
-  <field>
-    <id>security_header.csp_style_src_data_urls</id>
-    <label>Enable Data URLs</label>
-    <help>Data URLs are used to embed files into HTML (for example images written directly into the src attribute).</help>
-    <type>checkbox</type>
-  </field>
-  <field>
-    <id>security_header.csp_style_src_http_urls</id>
-    <label>Enable HTTP(S) URLs</label>
-    <type>select_multiple</type>
-    <allownew>true</allownew>
-    <style>tokenize</style>
-    <help>Allow loading files over HTTP(S) allows downloading of content over other domains or CDNs.
-      You can use wildcards here like https://*.exmaple.com.</help>
-  </field>
-  <field>
-    <id>security_header.csp_style_src_inline</id>
-    <label>Enable Inline Scripting</label>
-    <type>checkbox</type>
-    <help>Checking this directive allows to use scripts or styles directly embedded in in the HTML content.
-      Examples are the script and the style tags.</help>
-  </field>
-  <field>
-    <id>security_header.csp_style_src_eval</id>
-    <label>Enable Eval</label>
-    <type>checkbox</type>
-    <help>Checking this box allows functions like eval or createFunction in JS, or style attributes for CSS.</help>
-  </field>
-  <field>
-    <id>security_header.csp_style_src_self</id>
-    <label>Enable Same Origin (recommended)</label>
-    <type>checkbox</type>
-    <help>Allows everything from the same site (path can differ, but host, protocol and port need to be the same).</help>
-  </field>
-  <field>
-    <id>security_header.csp_style_src_blob</id>
-    <label>Enable Blobs</label>
-    <type>checkbox</type>
-    <help>Allows to use blobs as a data source. This usually is content, which is somehow generated in JavaScript.</help>
-  </field>
-  <field>
-    <id>security_header.csp_style_src_mediastream</id>
-    <label>Enable Media Streams</label>
-    <type>checkbox</type>
-  </field>
-  <field>
-    <id>security_header.csp_style_src_filesystem</id>
-    <label>Enable File System URLs</label>
-    <type>checkbox</type>
-  </field>
-  <field>
-    <id>security_header.csp_style_src_none</id>
-    <label>Forbid Explicitly</label>
-    <type>checkbox</type>
-    <help>If this checkbox is checked, all other settings for this directive are ignored and everything will be forbidden.</help>
-  </field>
-  <field>
-    <type>header</type>
-    <label>Content Security Policy: Media Source</label>
-  </field>
-  <field>
-    <id>security_header.csp_media_src_enabled</id>
-    <label>Enable</label>
-    <type>checkbox</type>
-    <help>If checked, this part of the CSP is enabled.</help>
-  </field>
-  <field>
-    <id>security_header.csp_media_src_data_urls</id>
-    <label>Enable Data URLs</label>
-    <help>Data URLs are used to embed files into HTML (for example images written directly into the src attribute).</help>
-    <type>checkbox</type>
-  </field>
-  <field>
-    <id>security_header.csp_media_src_http_urls</id>
-    <label>Enable HTTP(S) URLs</label>
-    <type>select_multiple</type>
-    <allownew>true</allownew>
-    <style>tokenize</style>
-    <help>Allow loading files over HTTP(S) allows downloading of content over other domains or CDNs.
-      You can use wildcards here like https://*.exmaple.com.</help>
-  </field>
-  <field>
-    <id>security_header.csp_media_src_inline</id>
-    <label>Enable Inline Scripting</label>
-    <type>checkbox</type>
-    <help>Checking this directive allows to use scripts or styles directly embedded in in the HTML content.
-      Examples are the script and the style tags.</help>
-  </field>
-  <field>
-    <id>security_header.csp_media_src_eval</id>
-    <label>Enable Eval</label>
-    <type>checkbox</type>
-    <help>Checking this box allows functions like eval or createFunction in JS, or style attributes for CSS.</help>
-  </field>
-  <field>
-    <id>security_header.csp_media_src_self</id>
-    <label>Enable Same Origin (recommended)</label>
-    <type>checkbox</type>
-    <help>Allows everything from the same site (path can differ, but host, protocol and port need to be the same).</help>
-  </field>
-  <field>
-    <id>security_header.csp_media_src_blob</id>
-    <label>Enable Blobs</label>
-    <type>checkbox</type>
-    <help>Allows to use blobs as a data source. This usually is content, which is somehow generated in JavaScript.</help>
-  </field>
-  <field>
-    <id>security_header.csp_media_src_mediastream</id>
-    <label>Enable Media Streams</label>
-    <type>checkbox</type>
-  </field>
-  <field>
-    <id>security_header.csp_media_src_filesystem</id>
-    <label>Enable File System URLs</label>
-    <type>checkbox</type>
-  </field>
-  <field>
-    <id>security_header.csp_media_src_none</id>
-    <label>Forbid Explicitly</label>
-    <type>checkbox</type>
-    <help>If this checkbox is checked, all other settings for this directive are ignored and everything will be forbidden.</help>
-  </field>
-  <field>
-    <type>header</type>
-    <label>Content Security Policy: Font Source</label>
-  </field>
-  <field>
-    <id>security_header.csp_font_src_enabled</id>
-    <label>Enable</label>
-    <type>checkbox</type>
-    <help>If checked, this part of the CSP is enabled.</help>
-  </field>
-  <field>
-    <id>security_header.csp_font_src_data_urls</id>
-    <label>Enable Data URLs</label>
-    <help>Data URLs are used to embed files into HTML (for example images written directly into the src attribute).</help>
-    <type>checkbox</type>
-  </field>
-  <field>
-    <id>security_header.csp_font_src_http_urls</id>
-    <label>Enable HTTP(S) URLs</label>
-    <type>select_multiple</type>
-    <allownew>true</allownew>
-    <style>tokenize</style>
-    <help>Allow loading files over HTTP(S) allows downloading of content over other domains or CDNs.
-      You can use wildcards here like https://*.exmaple.com.</help>
-  </field>
-  <field>
-    <id>security_header.csp_font_src_inline</id>
-    <label>Enable Inline Scripting</label>
-    <type>checkbox</type>
-    <help>Checking this directive allows to use scripts or styles directly embedded in in the HTML content.
-      Examples are the script and the style tags.</help>
-  </field>
-  <field>
-    <id>security_header.csp_font_src_eval</id>
-    <label>Enable Eval</label>
-    <type>checkbox</type>
-    <help>Checking this box allows functions like eval or createFunction in JS, or style attributes for CSS.</help>
-  </field>
-  <field>
-    <id>security_header.csp_font_src_self</id>
-    <label>Enable Same Origin (recommended)</label>
-    <type>checkbox</type>
-    <help>Allows everything from the same site (path can differ, but host, protocol and port need to be the same).</help>
-  </field>
-  <field>
-    <id>security_header.csp_font_src_blob</id>
-    <label>Enable Blobs</label>
-    <type>checkbox</type>
-    <help>Allows to use blobs as a data source. This usually is content, which is somehow generated in JavaScript.</help>
-  </field>
-  <field>
-    <id>security_header.csp_font_src_mediastream</id>
-    <label>Enable Media Streams</label>
-    <type>checkbox</type>
-  </field>
-  <field>
-    <id>security_header.csp_font_src_filesystem</id>
-    <label>Enable File System URLs</label>
-    <type>checkbox</type>
-  </field>
-  <field>
-    <id>security_header.csp_font_src_none</id>
-    <label>Forbid Explicitly</label>
-    <type>checkbox</type>
-    <help>If this checkbox is checked, all other settings for this directive are ignored and everything will be forbidden.</help>
-  </field>
-  <field>
-    <type>header</type>
-    <label>Content Security Policy: Form Action</label>
-  </field>
-  <field>
-    <id>security_header.csp_form_action_enabled</id>
-    <label>Enable</label>
-    <type>checkbox</type>
-    <help>If checked, this part of the CSP is enabled.</help>
-  </field>
-  <field>
-    <id>security_header.csp_form_action_data_urls</id>
-    <label>Enable Data URLs</label>
-    <help>Data URLs are used to embed files into HTML (for example images written directly into the src attribute).</help>
-    <type>checkbox</type>
-  </field>
-  <field>
-    <id>security_header.csp_form_action_http_urls</id>
-    <label>Enable HTTP(S) URLs</label>
-    <type>select_multiple</type>
-    <allownew>true</allownew>
-    <style>tokenize</style>
-    <help>Allow loading files over HTTP(S) allows downloading of content over other domains or CDNs.
-      You can use wildcards here like https://*.exmaple.com.</help>
-  </field>
-  <field>
-    <id>security_header.csp_form_action_inline</id>
-    <label>Enable Inline Scripting</label>
-    <type>checkbox</type>
-    <help>Checking this directive allows to use scripts or styles directly embedded in in the HTML content.
-      Examples are the script and the style tags.</help>
-  </field>
-  <field>
-    <id>security_header.csp_form_action_eval</id>
-    <label>Enable Eval</label>
-    <type>checkbox</type>
-    <help>Checking this box allows functions like eval or createFunction in JS, or style attributes for CSS.</help>
-  </field>
-  <field>
-    <id>security_header.csp_form_action_self</id>
-    <label>Enable Same Origin (recommended)</label>
-    <type>checkbox</type>
-    <help>Allows everything from the same site (path can differ, but host, protocol and port need to be the same).</help>
-  </field>
-  <field>
-    <id>security_header.csp_form_action_blob</id>
-    <label>Enable Blobs</label>
-    <type>checkbox</type>
-    <help>Allows to use blobs as a data source. This usually is content, which is somehow generated in JavaScript.</help>
-  </field>
-  <field>
-    <id>security_header.csp_form_action_mediastream</id>
-    <label>Enable Media Streams</label>
-    <type>checkbox</type>
-  </field>
-  <field>
-    <id>security_header.csp_form_action_filesystem</id>
-    <label>Enable File System URLs</label>
-    <type>checkbox</type>
-  </field>
-  <field>
-    <id>security_header.csp_form_action_none</id>
-    <label>Forbid Explicitly</label>
-    <type>checkbox</type>
-    <help>If this checkbox is checked, all other settings for this directive are ignored and everything will be forbidden.</help>
-  </field>
+  <tab id="general" description="General">
+    <field>
+      <type>header</type>
+      <label>General</label>
+    </field>
+    <field>
+      <id>security_header.description</id>
+      <label>Description</label>
+      <type>text</type>
+      <help>This is only for your reference.</help>
+    </field>
+    <field>
+      <id>security_header.referrer</id>
+      <label>Referrer</label>
+      <style>selectpicker</style>
+      <type>dropdown</type>
+      <help><![CDATA[
+        <ul>
+          <li>Same Origin: The header will be sent if you stay on the same server using the same protocol (no data leak)</li>
+          <li>No Referrer When Downgrade: Prevents sending a referrer when switching from HTTPS to HTTP</li>
+          <li>Origin, Strict-Origin: Always send the header but no path or query information. Strict Origin additionally suppressed the header on downgrades.</li>
+          <li>(Strict) Origin When Cross Origin: Full Referrer on the same origin, and like (Strict) Origin when cross domain.</li>
+          <li>Unsafe URL: Sends the full URL to all pages</li>
+        </ul> ]]></help>
+    </field>
+    <field>
+      <id>security_header.xssprotection</id>
+      <label>XSS Protection</label>
+      <style>selectpicker</style>
+      <type>dropdown</type>
+      <help><![CDATA[
+        <ul>
+          <li>Block: The browser should block the response</li>
+          <li>Off: Allow Anything</li>
+          <li>On: The Browser decides how to handle it.</li>
+        </ul> ]]></help>
+    </field>
+    <field>
+      <id>security_header.content_type_options</id>
+      <label>Don't Sniff Content Type</label>
+      <type>checkbox</type>
+    </field>
+    <field>
+      <id>security_header.strict_transport_security_time</id>
+      <label>Strict Transport Security: Time</label>
+      <type>text</type>
+      <help>A time in seconds in which the transport security (TLS) should be enforced.</help>
+    </field>
+    <field>
+      <id>security_header.strict_transport_security_include_subdomains</id>
+      <label>Strict Transport Security: Include Subdomains</label>
+      <type>checkbox</type>
+      <help>If checked, also subdomains are affected.</help>
+    </field>
+    <field>
+      <id>security_header.hpkp_keys</id>
+      <label>HTTP Public Key Pinning: Fingerprints</label>
+      <type>select_multiple</type>
+      <style>tokenize</style>
+      <allownew>true</allownew>
+      <help><![CDATA[ Enter a comma separated list of public key fingerprints here.
+      You can find some documentetion about this feature in the
+      <a href="https://developer.mozilla.org/de/docs/Web/Security/Public_Key_Pinning">Mozilla Wiki</a>.
+      It is not recommended to use this feature with short lived certificates.]]></help>
+    </field>
+    <field>
+      <id>security_header.hpkp_report_only</id>
+      <label>HTTP Public Key Pinning: Report Only</label>
+      <type>checkbox</type>
+      <help>If you only want to test it, you can check this box (policy will be deployed but not enforced).</help>
+    </field>
+    <field>
+      <id>security_header.hpkp_time</id>
+      <label>HTTP Public Key Pinning: Max Age</label>
+      <type>text</type>
+    </field>
+    <field>
+      <id>security_header.hpkp_include_subdomains</id>
+      <label>HTTP Public Key Pinning: Include Subdomains</label>
+      <type>checkbox</type>
+      <help>If checked, also subdomains are affected.</help>
+    </field>
+    <field>
+      <id>security_header.enable_csp</id>
+      <label>Content Security Policy: Enable</label>
+      <type>checkbox</type>
+      <help>If checked, the CSP is enabled.</help>
+    </field>
+    <field>
+      <id>security_header.csp_report_only</id>
+      <label>Content Security Policy: Report Only</label>
+      <type>checkbox</type>
+      <help>If checked, the CSP is not enforced (learning mode).</help>
+    </field>
+  </tab>
+  <tab id="default_source" description="Default Source">
+    <field>
+      <type>header</type>
+      <label>Content Security Policy: Default Source</label>
+    </field>
+    <field>
+      <id>security_header.csp_default_src_enabled</id>
+      <label>Enable</label>
+      <type>checkbox</type>
+      <help>If checked, this part of the CSP is enabled.</help>
+    </field>
+    <field>
+      <id>security_header.csp_default_src_data_urls</id>
+      <label>Enable Data URLs</label>
+      <help>Data URLs are used to embed files into HTML (for example images written directly into the src attribute).</help>
+      <type>checkbox</type>
+    </field>
+    <field>
+      <id>security_header.csp_default_src_http_urls</id>
+      <label>Enable HTTP(S) URLs</label>
+      <type>select_multiple</type>
+      <allownew>true</allownew>
+      <style>tokenize</style>
+      <help>Allow loading files over HTTP(S) allows downloading of content over other domains or CDNs.
+        You can use wildcards here like https://*.exmaple.com.</help>
+    </field>
+    <field>
+      <id>security_header.csp_default_src_inline</id>
+      <label>Enable Inline Scripting</label>
+      <type>checkbox</type>
+      <help>Checking this directive allows to use scripts or styles directly embedded in in the HTML content.
+        Examples are the script and the style tags.</help>
+    </field>
+    <field>
+      <id>security_header.csp_default_src_eval</id>
+      <label>Enable Eval</label>
+      <type>checkbox</type>
+      <help>Checking this box allows functions like eval or createFunction in JS, or style attributes for CSS.</help>
+    </field>
+    <field>
+      <id>security_header.csp_default_src_self</id>
+      <label>Enable Same Origin (recommended)</label>
+      <type>checkbox</type>
+      <help>Allows everything from the same site (path can differ, but host, protocol and port need to be the same).</help>
+    </field>
+    <field>
+      <id>security_header.csp_default_src_blob</id>
+      <label>Enable Blobs</label>
+      <type>checkbox</type>
+      <help>Allows to use blobs as a data source. This usually is content, which is somehow generated in JavaScript.</help>
+    </field>
+    <field>
+      <id>security_header.csp_default_src_mediastream</id>
+      <label>Enable Media Streams</label>
+      <type>checkbox</type>
+    </field>
+    <field>
+      <id>security_header.csp_default_src_filesystem</id>
+      <label>Enable File System URLs</label>
+      <type>checkbox</type>
+    </field>
+    <field>
+      <id>security_header.csp_default_src_none</id>
+      <label>Forbid Explicitly</label>
+      <type>checkbox</type>
+      <help>If this checkbox is checked, all other settings for this directive are ignored and everything will be forbidden.</help>
+    </field>
+  </tab>
+  <tab id="script-src" description="Script">
+    <field>
+      <type>header</type>
+      <label>Content Security Policy: Script Source</label>
+    </field>
+    <field>
+      <id>security_header.csp_script_src_enabled</id>
+      <label>Enable</label>
+      <type>checkbox</type>
+      <help>If checked, this part of the CSP is enabled.</help>
+    </field>
+    <field>
+      <id>security_header.csp_script_src_data_urls</id>
+      <label>Enable Data URLs</label>
+      <help>Data URLs are used to embed files into HTML (for example images written directly into the src attribute).</help>
+      <type>checkbox</type>
+    </field>
+    <field>
+      <id>security_header.csp_script_src_http_urls</id>
+      <label>Enable HTTP(S) URLs</label>
+      <type>select_multiple</type>
+      <allownew>true</allownew>
+      <style>tokenize</style>
+      <help>Allow loading files over HTTP(S) allows downloading of content over other domains or CDNs.
+        You can use wildcards here like https://*.exmaple.com.</help>
+    </field>
+    <field>
+      <id>security_header.csp_script_src_inline</id>
+      <label>Enable Inline Scripting</label>
+      <type>checkbox</type>
+      <help>Checking this directive allows to use scripts or styles directly embedded in in the HTML content.
+        Examples are the script and the style tags.</help>
+    </field>
+    <field>
+      <id>security_header.csp_script_src_eval</id>
+      <label>Enable Eval</label>
+      <type>checkbox</type>
+      <help>Checking this box allows functions like eval or createFunction in JS, or style attributes for CSS.</help>
+    </field>
+    <field>
+      <id>security_header.csp_script_src_self</id>
+      <label>Enable Same Origin (recommended)</label>
+      <type>checkbox</type>
+      <help>Allows everything from the same site (path can differ, but host, protocol and port need to be the same).</help>
+    </field>
+    <field>
+      <id>security_header.csp_script_src_blob</id>
+      <label>Enable Blobs</label>
+      <type>checkbox</type>
+      <help>Allows to use blobs as a data source. This usually is content, which is somehow generated in JavaScript.</help>
+    </field>
+    <field>
+      <id>security_header.csp_script_src_mediastream</id>
+      <label>Enable Media Streams</label>
+      <type>checkbox</type>
+    </field>
+    <field>
+      <id>security_header.csp_script_src_filesystem</id>
+      <label>Enable File System URLs</label>
+      <type>checkbox</type>
+    </field>
+    <field>
+      <id>security_header.csp_script_src_none</id>
+      <label>Forbid Explicitly</label>
+      <type>checkbox</type>
+      <help>If this checkbox is checked, all other settings for this directive are ignored and everything will be forbidden.</help>
+    </field>
+  </tab>
+  <tab id="image-src" description="Image">
+    <field>
+      <type>header</type>
+      <label>Content Security Policy: Image Source</label>
+    </field>
+    <field>
+      <id>security_header.csp_img_src_enabled</id>
+      <label>Enable</label>
+      <type>checkbox</type>
+      <help>If checked, this part of the CSP is enabled.</help>
+    </field>
+    <field>
+      <id>security_header.csp_img_src_data_urls</id>
+      <label>Enable Data URLs</label>
+      <help>Data URLs are used to embed files into HTML (for example images written directly into the src attribute).</help>
+      <type>checkbox</type>
+    </field>
+    <field>
+      <id>security_header.csp_img_src_http_urls</id>
+      <label>Enable HTTP(S) URLs</label>
+      <type>select_multiple</type>
+      <allownew>true</allownew>
+      <style>tokenize</style>
+      <help>Allow loading files over HTTP(S) allows downloading of content over other domains or CDNs.
+        You can use wildcards here like https://*.exmaple.com.</help>
+    </field>
+    <field>
+      <id>security_header.csp_img_src_inline</id>
+      <label>Enable Inline Scripting</label>
+      <type>checkbox</type>
+      <help>Checking this directive allows to use scripts or styles directly embedded in in the HTML content.
+        Examples are the script and the style tags.</help>
+    </field>
+    <field>
+      <id>security_header.csp_img_src_eval</id>
+      <label>Enable Eval</label>
+      <type>checkbox</type>
+      <help>Checking this box allows functions like eval or createFunction in JS, or style attributes for CSS.</help>
+    </field>
+    <field>
+      <id>security_header.csp_img_src_self</id>
+      <label>Enable Same Origin (recommended)</label>
+      <type>checkbox</type>
+      <help>Allows everything from the same site (path can differ, but host, protocol and port need to be the same).</help>
+    </field>
+    <field>
+      <id>security_header.csp_img_src_blob</id>
+      <label>Enable Blobs</label>
+      <type>checkbox</type>
+      <help>Allows to use blobs as a data source. This usually is content, which is somehow generated in JavaScript.</help>
+    </field>
+    <field>
+      <id>security_header.csp_img_src_mediastream</id>
+      <label>Enable Media Streams</label>
+      <type>checkbox</type>
+    </field>
+    <field>
+      <id>security_header.csp_img_src_filesystem</id>
+      <label>Enable File System URLs</label>
+      <type>checkbox</type>
+    </field>
+    <field>
+      <id>security_header.csp_img_src_none</id>
+      <label>Forbid Explicitly</label>
+      <type>checkbox</type>
+      <help>If this checkbox is checked, all other settings for this directive are ignored and everything will be forbidden.</help>
+    </field>
+  </tab>
+  <tab id="styleseet-src" description="Stylesheet">
+    <field>
+      <type>header</type>
+      <label>Content Security Policy: Stylesheet Source</label>
+    </field>
+    <field>
+      <id>security_header.csp_style_src_enabled</id>
+      <label>Enable</label>
+      <type>checkbox</type>
+      <help>If checked, this part of the CSP is enabled.</help>
+    </field>
+    <field>
+      <id>security_header.csp_style_src_data_urls</id>
+      <label>Enable Data URLs</label>
+      <help>Data URLs are used to embed files into HTML (for example images written directly into the src attribute).</help>
+      <type>checkbox</type>
+    </field>
+    <field>
+      <id>security_header.csp_style_src_http_urls</id>
+      <label>Enable HTTP(S) URLs</label>
+      <type>select_multiple</type>
+      <allownew>true</allownew>
+      <style>tokenize</style>
+      <help>Allow loading files over HTTP(S) allows downloading of content over other domains or CDNs.
+        You can use wildcards here like https://*.exmaple.com.</help>
+    </field>
+    <field>
+      <id>security_header.csp_style_src_inline</id>
+      <label>Enable Inline Scripting</label>
+      <type>checkbox</type>
+      <help>Checking this directive allows to use scripts or styles directly embedded in in the HTML content.
+        Examples are the script and the style tags.</help>
+    </field>
+    <field>
+      <id>security_header.csp_style_src_eval</id>
+      <label>Enable Eval</label>
+      <type>checkbox</type>
+      <help>Checking this box allows functions like eval or createFunction in JS, or style attributes for CSS.</help>
+    </field>
+    <field>
+      <id>security_header.csp_style_src_self</id>
+      <label>Enable Same Origin (recommended)</label>
+      <type>checkbox</type>
+      <help>Allows everything from the same site (path can differ, but host, protocol and port need to be the same).</help>
+    </field>
+    <field>
+      <id>security_header.csp_style_src_blob</id>
+      <label>Enable Blobs</label>
+      <type>checkbox</type>
+      <help>Allows to use blobs as a data source. This usually is content, which is somehow generated in JavaScript.</help>
+    </field>
+    <field>
+      <id>security_header.csp_style_src_mediastream</id>
+      <label>Enable Media Streams</label>
+      <type>checkbox</type>
+    </field>
+    <field>
+      <id>security_header.csp_style_src_filesystem</id>
+      <label>Enable File System URLs</label>
+      <type>checkbox</type>
+    </field>
+    <field>
+      <id>security_header.csp_style_src_none</id>
+      <label>Forbid Explicitly</label>
+      <type>checkbox</type>
+      <help>If this checkbox is checked, all other settings for this directive are ignored and everything will be forbidden.</help>
+    </field>
+  </tab>
+  <tab id="media-src" description="Media">
+    <field>
+      <type>header</type>
+      <label>Content Security Policy: Media Source</label>
+    </field>
+    <field>
+      <id>security_header.csp_media_src_enabled</id>
+      <label>Enable</label>
+      <type>checkbox</type>
+      <help>If checked, this part of the CSP is enabled.</help>
+    </field>
+    <field>
+      <id>security_header.csp_media_src_data_urls</id>
+      <label>Enable Data URLs</label>
+      <help>Data URLs are used to embed files into HTML (for example images written directly into the src attribute).</help>
+      <type>checkbox</type>
+    </field>
+    <field>
+      <id>security_header.csp_media_src_http_urls</id>
+      <label>Enable HTTP(S) URLs</label>
+      <type>select_multiple</type>
+      <allownew>true</allownew>
+      <style>tokenize</style>
+      <help>Allow loading files over HTTP(S) allows downloading of content over other domains or CDNs.
+        You can use wildcards here like https://*.exmaple.com.</help>
+    </field>
+    <field>
+      <id>security_header.csp_media_src_inline</id>
+      <label>Enable Inline Scripting</label>
+      <type>checkbox</type>
+      <help>Checking this directive allows to use scripts or styles directly embedded in in the HTML content.
+        Examples are the script and the style tags.</help>
+    </field>
+    <field>
+      <id>security_header.csp_media_src_eval</id>
+      <label>Enable Eval</label>
+      <type>checkbox</type>
+      <help>Checking this box allows functions like eval or createFunction in JS, or style attributes for CSS.</help>
+    </field>
+    <field>
+      <id>security_header.csp_media_src_self</id>
+      <label>Enable Same Origin (recommended)</label>
+      <type>checkbox</type>
+      <help>Allows everything from the same site (path can differ, but host, protocol and port need to be the same).</help>
+    </field>
+    <field>
+      <id>security_header.csp_media_src_blob</id>
+      <label>Enable Blobs</label>
+      <type>checkbox</type>
+      <help>Allows to use blobs as a data source. This usually is content, which is somehow generated in JavaScript.</help>
+    </field>
+    <field>
+      <id>security_header.csp_media_src_mediastream</id>
+      <label>Enable Media Streams</label>
+      <type>checkbox</type>
+    </field>
+    <field>
+      <id>security_header.csp_media_src_filesystem</id>
+      <label>Enable File System URLs</label>
+      <type>checkbox</type>
+    </field>
+    <field>
+      <id>security_header.csp_media_src_none</id>
+      <label>Forbid Explicitly</label>
+      <type>checkbox</type>
+      <help>If this checkbox is checked, all other settings for this directive are ignored and everything will be forbidden.</help>
+    </field>
+  </tab>
+  <tab id="font-src" description="Font">
+    <field>
+      <type>header</type>
+      <label>Content Security Policy: Font Source</label>
+    </field>
+    <field>
+      <id>security_header.csp_font_src_enabled</id>
+      <label>Enable</label>
+      <type>checkbox</type>
+      <help>If checked, this part of the CSP is enabled.</help>
+    </field>
+    <field>
+      <id>security_header.csp_font_src_data_urls</id>
+      <label>Enable Data URLs</label>
+      <help>Data URLs are used to embed files into HTML (for example images written directly into the src attribute).</help>
+      <type>checkbox</type>
+    </field>
+    <field>
+      <id>security_header.csp_font_src_http_urls</id>
+      <label>Enable HTTP(S) URLs</label>
+      <type>select_multiple</type>
+      <allownew>true</allownew>
+      <style>tokenize</style>
+      <help>Allow loading files over HTTP(S) allows downloading of content over other domains or CDNs.
+        You can use wildcards here like https://*.exmaple.com.</help>
+    </field>
+    <field>
+      <id>security_header.csp_font_src_inline</id>
+      <label>Enable Inline Scripting</label>
+      <type>checkbox</type>
+      <help>Checking this directive allows to use scripts or styles directly embedded in in the HTML content.
+        Examples are the script and the style tags.</help>
+    </field>
+    <field>
+      <id>security_header.csp_font_src_eval</id>
+      <label>Enable Eval</label>
+      <type>checkbox</type>
+      <help>Checking this box allows functions like eval or createFunction in JS, or style attributes for CSS.</help>
+    </field>
+    <field>
+      <id>security_header.csp_font_src_self</id>
+      <label>Enable Same Origin (recommended)</label>
+      <type>checkbox</type>
+      <help>Allows everything from the same site (path can differ, but host, protocol and port need to be the same).</help>
+    </field>
+    <field>
+      <id>security_header.csp_font_src_blob</id>
+      <label>Enable Blobs</label>
+      <type>checkbox</type>
+      <help>Allows to use blobs as a data source. This usually is content, which is somehow generated in JavaScript.</help>
+    </field>
+    <field>
+      <id>security_header.csp_font_src_mediastream</id>
+      <label>Enable Media Streams</label>
+      <type>checkbox</type>
+    </field>
+    <field>
+      <id>security_header.csp_font_src_filesystem</id>
+      <label>Enable File System URLs</label>
+      <type>checkbox</type>
+    </field>
+    <field>
+      <id>security_header.csp_font_src_none</id>
+      <label>Forbid Explicitly</label>
+      <type>checkbox</type>
+      <help>If this checkbox is checked, all other settings for this directive are ignored and everything will be forbidden.</help>
+    </field>
+  </tab>
+  <tab id="form-action" description="Form">
+    <field>
+      <type>header</type>
+      <label>Content Security Policy: Form Action</label>
+    </field>
+    <field>
+      <id>security_header.csp_form_action_enabled</id>
+      <label>Enable</label>
+      <type>checkbox</type>
+      <help>If checked, this part of the CSP is enabled.</help>
+    </field>
+    <field>
+      <id>security_header.csp_form_action_data_urls</id>
+      <label>Enable Data URLs</label>
+      <help>Data URLs are used to embed files into HTML (for example images written directly into the src attribute).</help>
+      <type>checkbox</type>
+    </field>
+    <field>
+      <id>security_header.csp_form_action_http_urls</id>
+      <label>Enable HTTP(S) URLs</label>
+      <type>select_multiple</type>
+      <allownew>true</allownew>
+      <style>tokenize</style>
+      <help>Allow loading files over HTTP(S) allows downloading of content over other domains or CDNs.
+        You can use wildcards here like https://*.exmaple.com.</help>
+    </field>
+    <field>
+      <id>security_header.csp_form_action_inline</id>
+      <label>Enable Inline Scripting</label>
+      <type>checkbox</type>
+      <help>Checking this directive allows to use scripts or styles directly embedded in in the HTML content.
+        Examples are the script and the style tags.</help>
+    </field>
+    <field>
+      <id>security_header.csp_form_action_eval</id>
+      <label>Enable Eval</label>
+      <type>checkbox</type>
+      <help>Checking this box allows functions like eval or createFunction in JS, or style attributes for CSS.</help>
+    </field>
+    <field>
+      <id>security_header.csp_form_action_self</id>
+      <label>Enable Same Origin (recommended)</label>
+      <type>checkbox</type>
+      <help>Allows everything from the same site (path can differ, but host, protocol and port need to be the same).</help>
+    </field>
+    <field>
+      <id>security_header.csp_form_action_blob</id>
+      <label>Enable Blobs</label>
+      <type>checkbox</type>
+      <help>Allows to use blobs as a data source. This usually is content, which is somehow generated in JavaScript.</help>
+    </field>
+    <field>
+      <id>security_header.csp_form_action_mediastream</id>
+      <label>Enable Media Streams</label>
+      <type>checkbox</type>
+    </field>
+    <field>
+      <id>security_header.csp_form_action_filesystem</id>
+      <label>Enable File System URLs</label>
+      <type>checkbox</type>
+    </field>
+    <field>
+      <id>security_header.csp_form_action_none</id>
+      <label>Forbid Explicitly</label>
+      <type>checkbox</type>
+      <help>If this checkbox is checked, all other settings for this directive are ignored and everything will be forbidden.</help>
+    </field>
+  </tab>
 </form>

--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/security_headers.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/security_headers.xml
@@ -42,20 +42,29 @@
       <type>checkbox</type>
     </field>
     <field>
+      <type>header</type>
+      <label>HTTP Strict Transport Security (HSTS)</label>
+    </field>
+    <field>
       <id>security_header.strict_transport_security_time</id>
-      <label>Strict Transport Security: Time</label>
+      <label>Time (Max Age)</label>
       <type>text</type>
       <help>A time in seconds in which the transport security (TLS) should be enforced.</help>
     </field>
     <field>
       <id>security_header.strict_transport_security_include_subdomains</id>
-      <label>Strict Transport Security: Include Subdomains</label>
+      <label>Include Subdomains</label>
       <type>checkbox</type>
       <help>If checked, also subdomains are affected.</help>
     </field>
     <field>
+      <type>header</type>
+      <label>HTTP Public Key Pinning (HPKP)</label>
+      <hint>This feature is no longer recommended. Though some browsers might still support it, it may have already been removed from the relevant web standards, maybe in the process of being dropped, or may only be kept for compatibility purposes. Avoid using it, and update existing code if possible.</hint>
+    </field>
+    <field>
       <id>security_header.hpkp_keys</id>
-      <label>HTTP Public Key Pinning: Fingerprints</label>
+      <label>Fingerprints</label>
       <type>select_multiple</type>
       <style>tokenize</style>
       <allownew>true</allownew>
@@ -66,30 +75,34 @@
     </field>
     <field>
       <id>security_header.hpkp_report_only</id>
-      <label>HTTP Public Key Pinning: Report Only</label>
+      <label>Report Only</label>
       <type>checkbox</type>
       <help>If you only want to test it, you can check this box (policy will be deployed but not enforced).</help>
     </field>
     <field>
       <id>security_header.hpkp_time</id>
-      <label>HTTP Public Key Pinning: Max Age</label>
+      <label>Time (Max Age)</label>
       <type>text</type>
     </field>
     <field>
       <id>security_header.hpkp_include_subdomains</id>
-      <label>HTTP Public Key Pinning: Include Subdomains</label>
+      <label>Include Subdomains</label>
       <type>checkbox</type>
       <help>If checked, also subdomains are affected.</help>
     </field>
     <field>
+      <type>header</type>
+      <label>Content Security Policy (CSP)</label>
+    </field>
+    <field>
       <id>security_header.enable_csp</id>
-      <label>Content Security Policy: Enable</label>
+      <label>Enable</label>
       <type>checkbox</type>
-      <help>If checked, the CSP is enabled.</help>
+      <help>If checked, the Content Security Policy (CSP) header is enabled. A detailed configuration is still required via the other tabs of this sheet.</help>
     </field>
     <field>
       <id>security_header.csp_report_only</id>
-      <label>Content Security Policy: Report Only</label>
+      <label>Report Only</label>
       <type>checkbox</type>
       <help>If checked, the CSP is not enforced (learning mode).</help>
     </field>

--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/security_headers.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/security_headers.xml
@@ -439,6 +439,129 @@
       <help>If this checkbox is checked, all other settings for this directive are ignored and everything will be forbidden.</help>
     </field>
   </tab>
+  <tab id="frame" description="Frame">
+    <field>
+      <type>header</type>
+      <label>Content Security Policy: Frame Source</label>
+      <hint><![CDATA[The setting <em>Content Security Policy: Enable</em> on the <em>General</em> tab needs to be enabled to activate this header.]]></hint>
+    </field>
+    <field>
+      <id>security_header.csp_frame_src_enabled</id>
+      <label>Enable</label>
+      <type>checkbox</type>
+      <help>If checked, this part of the CSP is enabled.</help>
+    </field>
+    <field>
+      <id>security_header.csp_frame_src_data_urls</id>
+      <label>Enable Data URLs</label>
+      <help>Data URLs are used to embed files into HTML (for example images written directly into the src attribute).</help>
+      <type>checkbox</type>
+    </field>
+    <field>
+      <id>security_header.csp_frame_src_http_urls</id>
+      <label>Enable HTTP(S) URLs</label>
+      <type>select_multiple</type>
+      <allownew>true</allownew>
+      <style>tokenize</style>
+      <help>Allow loading files over HTTP(S) allows downloading of content over other domains or CDNs.
+        You can use wildcards here like https://*.exmaple.com.</help>
+    </field>
+    <field>
+      <id>security_header.csp_frame_src_inline</id>
+      <label>Enable Inline Scripting</label>
+      <type>checkbox</type>
+      <help>Checking this directive allows to use scripts or styles directly embedded in in the HTML content.
+        Examples are the script and the style tags.</help>
+    </field>
+    <field>
+      <id>security_header.csp_frame_src_eval</id>
+      <label>Enable Eval</label>
+      <type>checkbox</type>
+      <help>Checking this box allows functions like eval or createFunction in JS, or style attributes for CSS.</help>
+    </field>
+    <field>
+      <id>security_header.csp_frame_src_self</id>
+      <label>Enable Same Origin (recommended)</label>
+      <type>checkbox</type>
+      <help>Allows everything from the same site (path can differ, but host, protocol and port need to be the same).</help>
+    </field>
+    <field>
+      <id>security_header.csp_frame_src_blob</id>
+      <label>Enable Blobs</label>
+      <type>checkbox</type>
+      <help>Allows to use blobs as a data source. This usually is content, which is somehow generated in JavaScript.</help>
+    </field>
+    <field>
+      <id>security_header.csp_frame_src_mediastream</id>
+      <label>Enable Media Streams</label>
+      <type>checkbox</type>
+    </field>
+    <field>
+      <id>security_header.csp_frame_src_filesystem</id>
+      <label>Enable File System URLs</label>
+      <type>checkbox</type>
+    </field>
+    <field>
+      <id>security_header.csp_frame_src_none</id>
+      <label>Forbid Explicitly</label>
+      <type>checkbox</type>
+      <help>If this checkbox is checked, all other settings for this directive are ignored and everything will be forbidden.</help>
+    </field>
+    <field>
+      <type>header</type>
+      <label>Content Security Policy: Frame Ancestors</label>
+      <hint><![CDATA[The setting <em>Content Security Policy: Enable</em> on the <em>General</em> tab needs to be enabled to activate this header.]]></hint>
+    </field>
+    <field>
+      <id>security_header.csp_frame_ancestors_enabled</id>
+      <label>Enable</label>
+      <type>checkbox</type>
+      <help>If checked, this part of the CSP is enabled.</help>
+    </field>
+    <field>
+      <id>security_header.csp_frame_ancestors_data_urls</id>
+      <label>Enable Data URLs</label>
+      <help>Data URLs are used to embed files into HTML (for example images written directly into the src attribute).</help>
+      <type>checkbox</type>
+    </field>
+    <field>
+      <id>security_header.csp_frame_ancestors_http_urls</id>
+      <label>Enable HTTP(S) URLs</label>
+      <type>select_multiple</type>
+      <allownew>true</allownew>
+      <style>tokenize</style>
+      <help>Allow loading files over HTTP(S) allows downloading of content over other domains or CDNs.
+        You can use wildcards here like https://*.exmaple.com.</help>
+    </field>
+    <field>
+      <id>security_header.csp_frame_ancestors_self</id>
+      <label>Enable Same Origin (recommended)</label>
+      <type>checkbox</type>
+      <help>Allows everything from the same site (path can differ, but host, protocol and port need to be the same).</help>
+    </field>
+    <field>
+      <id>security_header.csp_frame_ancestors_blob</id>
+      <label>Enable Blobs</label>
+      <type>checkbox</type>
+      <help>Allows to use blobs as a data source. This usually is content, which is somehow generated in JavaScript.</help>
+    </field>
+    <field>
+      <id>security_header.csp_frame_ancestors_mediastream</id>
+      <label>Enable Media Streams</label>
+      <type>checkbox</type>
+    </field>
+    <field>
+      <id>security_header.csp_frame_ancestors_filesystem</id>
+      <label>Enable File System URLs</label>
+      <type>checkbox</type>
+    </field>
+    <field>
+      <id>security_header.csp_frame_ancestors_none</id>
+      <label>Forbid Explicitly</label>
+      <type>checkbox</type>
+      <help>If this checkbox is checked, all other settings for this directive are ignored and everything will be forbidden.</help>
+    </field>
+  </tab>
   <tab id="font-src" description="Font">
     <field>
       <type>header</type>

--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/security_headers.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/security_headers.xml
@@ -65,39 +65,6 @@
     </field>
     <field>
       <type>header</type>
-      <label>HTTP Public Key Pinning (HPKP)</label>
-      <hint>This feature is no longer recommended. Though some browsers might still support it, it may have already been removed from the relevant web standards, maybe in the process of being dropped, or may only be kept for compatibility purposes. Avoid using it, and update existing code if possible.</hint>
-    </field>
-    <field>
-      <id>security_header.hpkp_keys</id>
-      <label>Fingerprints</label>
-      <type>select_multiple</type>
-      <style>tokenize</style>
-      <allownew>true</allownew>
-      <help><![CDATA[ Enter a comma separated list of public key fingerprints here.
-      You can find some documentetion about this feature in the
-      <a href="https://developer.mozilla.org/de/docs/Web/Security/Public_Key_Pinning">Mozilla Wiki</a>.
-      It is not recommended to use this feature with short lived certificates.]]></help>
-    </field>
-    <field>
-      <id>security_header.hpkp_report_only</id>
-      <label>Report Only</label>
-      <type>checkbox</type>
-      <help>If you only want to test it, you can check this box (policy will be deployed but not enforced).</help>
-    </field>
-    <field>
-      <id>security_header.hpkp_time</id>
-      <label>Time (Max Age)</label>
-      <type>text</type>
-    </field>
-    <field>
-      <id>security_header.hpkp_include_subdomains</id>
-      <label>Include Subdomains</label>
-      <type>checkbox</type>
-      <help>If checked, also subdomains are affected.</help>
-    </field>
-    <field>
-      <type>header</type>
       <label>Content Security Policy (CSP)</label>
     </field>
     <field>

--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
@@ -1194,6 +1194,10 @@
         <Required>Y</Required>
         <default>1</default>
       </strict_transport_security_include_subdomains>
+      <strict_transport_security_preload type="BooleanField">
+        <Required>Y</Required>
+        <default>0</default>
+      </strict_transport_security_preload>
       <hpkp_keys type="CSVListField">
         <Required>N</Required>
         <mask>/[a-z0-9\+\/=]+(,[a-z0-9\+\/=]+)*/i</mask>

--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
@@ -1448,6 +1448,76 @@
         <Required>Y</Required>
         <default>0</default>
       </csp_font_src_none>
+      <csp_frame_src_enabled type="BooleanField">
+        <Required>Y</Required>
+        <default>0</default>
+      </csp_frame_src_enabled>
+      <csp_frame_src_data_urls type="BooleanField">
+        <Required>Y</Required>
+        <default>0</default>
+      </csp_frame_src_data_urls>
+      <csp_frame_src_http_urls type="CSVListField">
+        <Required>N</Required>
+      </csp_frame_src_http_urls>
+      <csp_frame_src_inline type="BooleanField">
+        <Required>Y</Required>
+        <default>0</default>
+      </csp_frame_src_inline>
+      <csp_frame_src_eval type="BooleanField">
+        <Required>Y</Required>
+        <default>0</default>
+      </csp_frame_src_eval>
+      <csp_frame_src_self type="BooleanField">
+        <Required>Y</Required>
+        <default>0</default>
+      </csp_frame_src_self>
+      <csp_frame_src_blob type="BooleanField">
+        <Required>Y</Required>
+        <default>0</default>
+      </csp_frame_src_blob>
+      <csp_frame_src_mediastream type="BooleanField">
+        <Required>Y</Required>
+        <default>0</default>
+      </csp_frame_src_mediastream>
+      <csp_frame_src_filesystem type="BooleanField">
+        <Required>Y</Required>
+        <default>0</default>
+      </csp_frame_src_filesystem>
+      <csp_frame_src_none type="BooleanField">
+        <Required>Y</Required>
+        <default>0</default>
+      </csp_frame_src_none>
+      <csp_frame_ancestors_enabled type="BooleanField">
+        <Required>Y</Required>
+        <default>0</default>
+      </csp_frame_ancestors_enabled>
+      <csp_frame_ancestors_data_urls type="BooleanField">
+        <Required>Y</Required>
+        <default>0</default>
+      </csp_frame_ancestors_data_urls>
+      <csp_frame_ancestors_http_urls type="CSVListField">
+        <Required>N</Required>
+      </csp_frame_ancestors_http_urls>
+      <csp_frame_ancestors_self type="BooleanField">
+        <Required>Y</Required>
+        <default>0</default>
+      </csp_frame_ancestors_self>
+      <csp_frame_ancestors_blob type="BooleanField">
+        <Required>Y</Required>
+        <default>0</default>
+      </csp_frame_ancestors_blob>
+      <csp_frame_ancestors_mediastream type="BooleanField">
+        <Required>Y</Required>
+        <default>0</default>
+      </csp_frame_ancestors_mediastream>
+      <csp_frame_ancestors_filesystem type="BooleanField">
+        <Required>Y</Required>
+        <default>0</default>
+      </csp_frame_ancestors_filesystem>
+      <csp_frame_ancestors_none type="BooleanField">
+        <Required>Y</Required>
+        <default>0</default>
+      </csp_frame_ancestors_none>
       <csp_form_action_enabled type="BooleanField">
         <Required>Y</Required>
         <default>0</default>

--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
@@ -1198,19 +1198,6 @@
         <Required>Y</Required>
         <default>0</default>
       </strict_transport_security_preload>
-      <hpkp_keys type="CSVListField">
-        <Required>N</Required>
-        <mask>/[a-z0-9\+\/=]+(,[a-z0-9\+\/=]+)*/i</mask>
-      </hpkp_keys>
-      <hpkp_report_only type="BooleanField">
-        <Required>Y</Required>
-      </hpkp_report_only>
-      <hpkp_time type="IntegerField">
-        <Required>N</Required>
-      </hpkp_time>
-      <hpkp_include_subdomains type="BooleanField">
-        <Required>Y</Required>
-      </hpkp_include_subdomains>
       <enable_csp type="BooleanField">
         <Required>Y</Required>
       </enable_csp>

--- a/www/nginx/src/opnsense/mvc/app/views/OPNsense/Nginx/index.volt
+++ b/www/nginx/src/opnsense/mvc/app/views/OPNsense/Nginx/index.volt
@@ -478,6 +478,12 @@
             <thead>
                 <tr>
                     <th data-column-id="description" data-type="string" data-sortable="true" data-visible="true">{{ lang._('Description') }}</th>
+                    <th data-column-id="referrer" data-type="string" data-sortable="true" data-visible="false">{{ lang._('Referrer') }}</th>
+                    <th data-column-id="xssprotection" data-type="string" data-sortable="true" data-visible="true">{{ lang._('XSS Protection') }}</th>
+                    <th data-column-id="hsts" data-type="string" data-sortable="true" data-visible="true">{{ lang._('HSTS') }}</th>
+                    <th data-column-id="hpkp" data-type="string" data-sortable="true" data-visible="true">{{ lang._('HPKP') }}</th>
+                    <th data-column-id="csp" data-type="string" data-sortable="true" data-visible="true">{{ lang._('CSP') }}</th>
+                    <th data-column-id="csp_details" data-type="string" data-sortable="true" data-visible="false">{{ lang._('CSP Rules') }}</th>
                     <th data-column-id="commands" data-width="7em" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
                 </tr>
             </thead>

--- a/www/nginx/src/opnsense/mvc/app/views/OPNsense/Nginx/index.volt
+++ b/www/nginx/src/opnsense/mvc/app/views/OPNsense/Nginx/index.volt
@@ -481,7 +481,6 @@
                     <th data-column-id="referrer" data-type="string" data-sortable="true" data-visible="false">{{ lang._('Referrer') }}</th>
                     <th data-column-id="xssprotection" data-type="string" data-sortable="true" data-visible="true">{{ lang._('XSS Protection') }}</th>
                     <th data-column-id="hsts" data-type="string" data-sortable="true" data-visible="true">{{ lang._('HSTS') }}</th>
-                    <th data-column-id="hpkp" data-type="string" data-sortable="true" data-visible="true">{{ lang._('HPKP') }}</th>
                     <th data-column-id="csp" data-type="string" data-sortable="true" data-visible="true">{{ lang._('CSP') }}</th>
                     <th data-column-id="csp_details" data-type="string" data-sortable="true" data-visible="false">{{ lang._('CSP Rules') }}</th>
                     <th data-column-id="commands" data-width="7em" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>

--- a/www/nginx/src/opnsense/mvc/app/views/OPNsense/Nginx/index.volt
+++ b/www/nginx/src/opnsense/mvc/app/views/OPNsense/Nginx/index.volt
@@ -691,7 +691,7 @@
 {{ partial("layout_partials/base_dialog",['fields': httprewrite,'id':'httprewritedlg', 'label':lang._('Edit URL Rewrite')]) }}
 {{ partial("layout_partials/base_dialog",['fields': naxsi_custom_policy,'id':'custompolicydlg', 'label':lang._('Edit WAF Policy')]) }}
 {{ partial("layout_partials/base_dialog",['fields': naxsi_rule,'id':'naxsiruledlg', 'label':lang._('Edit Naxsi Rule')]) }}
-{{ partial("layout_partials/base_dialog",['fields': security_headers,'id':'security_headersdlg', 'label':lang._('Edit Security Headers')]) }}
+{{ partial("OPNsense/Nginx/tabbed_dialog",['fields': security_headers,'id':'security_headersdlg', 'label':lang._('Edit Security Headers')]) }}
 {{ partial("layout_partials/base_dialog",['fields': limit_request_connection,'id':'limit_request_connectiondlg', 'label':lang._('Edit Request Connection Limit')]) }}
 {{ partial("layout_partials/base_dialog",['fields': limit_zone,'id':'limit_zonedlg', 'label':lang._('Edit Limit Zone')]) }}
 {{ partial("layout_partials/base_dialog",['fields': cache_path,'id':'cache_pathdlg', 'label':lang._('Edit Cache Path')]) }}

--- a/www/nginx/src/opnsense/mvc/app/views/OPNsense/Nginx/tabbed_dialog.volt
+++ b/www/nginx/src/opnsense/mvc/app/views/OPNsense/Nginx/tabbed_dialog.volt
@@ -149,7 +149,12 @@
                                     </colgroup>
                                     <thead>
                                         <tr{% if field['advanced']|default(false)=='true' %} data-advanced="true"{% endif %}>
-                                            <th colspan="3"><h2>{{field['label']}}</h2></th>
+                                            <th colspan="3">
+                                                <h2>{{field['label']}}</h2>
+                                                {%- if field['hint']|default(false) %}
+                                                <small>{{field['hint']}}</small>
+                                                {%- endif %}
+                                            </th>
                                         </tr>
                                     </thead>
                                     <tbody>

--- a/www/nginx/src/opnsense/mvc/app/views/OPNsense/Nginx/tabbed_dialog.volt
+++ b/www/nginx/src/opnsense/mvc/app/views/OPNsense/Nginx/tabbed_dialog.volt
@@ -84,7 +84,7 @@
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="{{ lang._('Close') }}"><span aria-hidden="true">&times;</span></button>
                 <h4 class="modal-title" id="{{base_dialog_id}}Label">{{base_dialog_label}}</h4>
             </div>
             <div class="modal-body">

--- a/www/nginx/src/opnsense/mvc/app/views/OPNsense/Nginx/tabbed_dialog.volt
+++ b/www/nginx/src/opnsense/mvc/app/views/OPNsense/Nginx/tabbed_dialog.volt
@@ -57,7 +57,7 @@
 {% endfor %}
 
 <script>
-    $(document).ready(function() {
+    $(function() {
         // hook into on-show event to extend validation
         $('#{{base_dialog_id}}').on('shown.bs.modal', function (e) {
             $('.nav-tabs a[href="#frm_{{base_dialog_id}}-tab_general"]').tab('show');

--- a/www/nginx/src/opnsense/mvc/app/views/OPNsense/Nginx/tabbed_dialog.volt
+++ b/www/nginx/src/opnsense/mvc/app/views/OPNsense/Nginx/tabbed_dialog.volt
@@ -1,0 +1,178 @@
+{#
+ # Copyright (c) 2021 Manuel Faux
+ # OPNsense® is Copyright © 2014-2021 by Deciso B.V.
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1. Redistributions of source code must retain the above copyright notice,
+ #    this list of conditions and the following disclaimer.
+ #
+ # 2. Redistributions in binary form must reproduce the above copyright notice,
+ #    this list of conditions and the following disclaimer in the documentation
+ #    and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #}
+
+{#
+ # Generate input dialog, uses the following parameters (as associative array):
+ #
+ # fields          :   list of field type objects, see form_input_tr tag for details
+ # id              :   form id, used as unique id for this modal form. inner form to place data is called frm_[id]
+ #                     save button is identified by btn_[id]_save
+ # label           :   dialog label
+ #}
+
+{# Volt templates in php7 have issues with scope sometimes, copy input values to make them more unique #}
+{% set base_dialog_id=id %}
+{% set base_dialog_fields=fields %}
+{% set base_dialog_label=label %}
+
+{# Find if there are help supported or advanced field on this page #}
+{% set base_dialog_help=false %}
+{% set base_dialog_advanced=false %}
+{% for field in base_dialog_fields|default({})%}
+    {% for name,element in field %}
+        {% if name=='help' %}
+            {% set base_dialog_help=true %}
+        {% endif %}
+        {% if name=='advanced' %}
+            {% set base_dialog_advanced=true %}
+        {% endif %}
+    {% endfor %}
+    {% if base_dialog_help|default(false) and base_dialog_advanced|default(false) %}
+        {% break %}
+    {% endif %}
+{% endfor %}
+
+<script>
+    $(document).ready(function() {
+        // hook into on-show event to extend validation
+        $('#{{base_dialog_id}}').on('shown.bs.modal', function (e) {
+            $('.nav-tabs a[href="#frm_{{base_dialog_id}}-tab_general"]').tab('show');
+
+            $("#btn_{{base_dialog_id}}_save").click(function() {
+                // TODO: Search for tab with validation errors, but currently only the first tab has even validation rules
+                $('.nav-tabs a[href="#frm_{{base_dialog_id}}-tab_general"]').tab('show');
+            });
+        })
+
+        // Read currently selected tab in main form and store for later
+        $('#{{base_dialog_id}}').on('show.bs.modal', function (e) {
+            $('#{{base_dialog_id}}').attr("data-inittab", window.location.hash);
+        });
+        // Restore selected tab of main form as URL was modified by dialog tabs
+        $('#{{base_dialog_id}}').on('hide.bs.modal', function (e) {
+            window.location.hash = $('#{{base_dialog_id}}').attr("data-inittab");
+        });
+    });
+</script>
+
+<div class="modal fade" id="{{base_dialog_id}}" tabindex="-1" role="dialog" aria-labelledby="{{base_dialog_id}}Label" aria-hidden="true">
+    <div class="modal-backdrop fade in"></div>
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="{{base_dialog_id}}Label">{{base_dialog_label}}</h4>
+            </div>
+            <div class="modal-body">
+                <ul class="nav nav-tabs" role="tablist" id="dialogtabs">
+                    {% for field in base_dialog_fields['tabs']|default({})%}
+                    <li>
+                        <a data-toggle="tab" href="#frm_{{base_dialog_id}}-tab_{{field[0]}}"><b>{{field[1]}}</b></a>
+                    </li>
+                    {% endfor %}
+                </ul>
+                <form id="frm_{{base_dialog_id}}">
+                    <div class="content-box tab-content">
+                        <div class="table-responsive">
+                            <table class="table table-striped table-condensed">
+                                <colgroup>
+                                    <col class="col-md-3"/>
+                                    <col class="col-md-{{ 12-3-msgzone_width|default(5) }}"/>
+                                    <col class="col-md-{{ msgzone_width|default(5) }}"/>
+                                </colgroup>
+                                <tbody>
+                                {%  if base_dialog_advanced|default(false) or base_dialog_help|default(false) %}
+                                    <tr>
+                                        <td>{% if base_dialog_advanced|default(false) %}<a href="#"><i class="fa fa-toggle-off text-danger" id="show_advanced_formDialog{{base_dialog_id}}"></i></a> <small>{{ lang._('advanced mode') }}</small>{% endif %}</td>
+                                        <td colspan="2" style="text-align:right;">
+                                            {% if base_dialog_help|default(false) %}<small>{{ lang._('full help') }}</small> <a href="#"><i class="fa fa-toggle-off text-danger" id="show_all_help_formDialog{{base_dialog_id}}"></i></a>{% endif %}
+                                        </td>
+                                    </tr>
+                                {% endif %}
+                                </tbody>
+                            </table>
+                        </div>
+                        {% for tab in base_dialog_fields['tabs']|default({})%}
+                        <div id="frm_{{base_dialog_id}}-tab_{{tab[0]}}" class="tab-pane fade">
+                            <div class="table-responsive">
+                                <table class="table table-striped table-condensed">
+                                    <colgroup>
+                                        <col class="col-md-3"/>
+                                        <col class="col-md-{{ 12-3-msgzone_width|default(5) }}"/>
+                                        <col class="col-md-{{ msgzone_width|default(5) }}"/>
+                                    </colgroup>
+                                    <tbody>
+                            {% for field in tab[2]|default({})%}
+                                {# looks a bit buggy in the volt templates, field parameters won't reset properly here #}
+                                {% set advanced=false %}
+                                {% set help=false %}
+                                {% set hint=false %}
+                                {% set style=false %}
+                                {% set maxheight=false %}
+                                {% set width=false %}
+                                {% set allownew=false %}
+                                {% set readonly=false %}
+                                {% if field['type'] == 'header' %}
+                                    </tbody>
+                                </table>
+                            </div>
+                            <div class="table-responsive {{field['style']|default('')}}">
+                                <table class="table table-striped table-condensed">
+                                    <colgroup>
+                                        <col class="col-md-3"/>
+                                        <col class="col-md-{{ 12-3-msgzone_width|default(5) }}"/>
+                                        <col class="col-md-{{ msgzone_width|default(5) }}"/>
+                                    </colgroup>
+                                    <thead>
+                                        <tr{% if field['advanced']|default(false)=='true' %} data-advanced="true"{% endif %}>
+                                            <th colspan="3"><h2>{{field['label']}}</h2></th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                {% else %}
+                                  {{ partial("layout_partials/form_input_tr",field)}}
+                                {% endif %}
+                            {% endfor %}
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                        {% endfor %}
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                {% if hasSaveBtn|default('true') == 'true' %}
+                <button type="button" class="btn btn-default" data-dismiss="modal">{{ lang._('Cancel') }}</button>
+                <button type="button" class="btn btn-primary" id="btn_{{base_dialog_id}}_save">{{ lang._('Save') }} <i id="btn_{{base_dialog_id}}_save_progress" class=""></i></button>
+                {% else %}
+                <button type="button" class="btn btn-default" data-dismiss="modal">{{ lang._('Close') }}</button>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</div>

--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/security_rule.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/security_rule.conf
@@ -14,8 +14,8 @@
 {% if security_rule.strict_transport_security_time is defined %}
 {% do our_headers.append('Strict-Transport-Security') %}
     add_header Strict-Transport-Security "max-age={{ security_rule.strict_transport_security_time }}{%
-  if security_rule.strict_transport_security_include_subdomains is defined and
-     security_rule.strict_transport_security_include_subdomains == '1' %}; includeSubDomains{% endif %}" always;
+  if security_rule.strict_transport_security_include_subdomains|default('0') == '1' %}; includeSubDomains{% endif %}{%
+  if security_rule.strict_transport_security_preload|default('0') == '1' %}; preload{% endif %}" always;
 {% endif %}
 {% if security_rule.hpkp_keys is defined and security_rule.hpkp_time is defined %}
 {% do our_headers.append('Public-Key-Pins') %}

--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/security_rule.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/security_rule.conf
@@ -1,3 +1,4 @@
+    # security rules
 {% if security_rule.referrer is defined %}
 {% do our_headers.append('Referrer-Policy') %}
     add_header Referrer-Policy "{{ security_rule.referrer }}" always;
@@ -27,7 +28,7 @@
 {% endif %}
 {% if security_rule.enable_csp is defined and security_rule.enable_csp == '1' %}
 {% set hash_csp = {} %}
-{%   for csp_category in ['default-src', 'script-src', 'img-src', 'style-src', 'media-src', 'font-src', 'form-action'] %}
+{%   for csp_category in ['default-src', 'script-src', 'img-src', 'style-src', 'media-src', 'font-src', 'frame-src', 'frame-ancestors', 'form-action'] %}
 {%     set prefix = 'csp_' + csp_category.replace('-', '_') + '_' %}
 {%     if security_rule[prefix + 'enabled'] == '1' %}
 {%       set current_list = [] %}

--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/security_rule.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/security_rule.conf
@@ -17,15 +17,6 @@
   if security_rule.strict_transport_security_include_subdomains|default('0') == '1' %}; includeSubDomains{% endif %}{%
   if security_rule.strict_transport_security_preload|default('0') == '1' %}; preload{% endif %}" always;
 {% endif %}
-{% if security_rule.hpkp_keys is defined and security_rule.hpkp_time is defined %}
-{% do our_headers.append('Public-Key-Pins') %}
-{% do our_headers.append('Public-Key-Pins-Report-Only') %}
-    add_header Public-Key-Pins{% if security_rule.hpkp_report_only is defined and security_rule.hpkp_report_only == '1'
-  %}-Report-Only{% endif %} "{% for key in security_rule.hpkp_keys.split(',')
-  %}pin-sha256={{ key }}; {% endfor %}max-age={{ security_rule.hpkp_time }}{%
-  if security_rule.hpkp_include_subdomains is defined and
-     security_rule.hpkp_include_subdomains == '1' %}; includeSubDomains{% endif %}" always;
-{% endif %}
 {% if security_rule.enable_csp is defined and security_rule.enable_csp == '1' %}
 {% set hash_csp = {} %}
 {%   for csp_category in ['default-src', 'script-src', 'img-src', 'style-src', 'media-src', 'font-src', 'frame-src', 'frame-ancestors', 'form-action'] %}


### PR DESCRIPTION
The security header edit dialog contains many fields and a tabbed interface for the dialog itself allows better configuration of the headers. Parameter names can be shorted when having a tabbed interface.
Also the grid view lacks columns to have an overview of the rules (is HSTS enabled? is CSP enabled? etc.)

This PR reworks the security header grid, the add/edit form and also adds two new header directives:
  * The CSP _frame-ancestors_ and _frame-src_ is added.
  * The HSTS _preload_ directive is added.

New dialog:
![image](https://user-images.githubusercontent.com/5854959/145675168-4e5c12f2-932f-4415-8032-51b3544958f0.png)

New grid:
![image](https://user-images.githubusercontent.com/5854959/145694356-79f1d4e0-ba11-4d05-a4a6-a977b61a8f54.png)

