### PR TITLE
 net/freeradius: add description for restart action

### DIFF
--- a/net/freeradius/src/opnsense/service/conf/actions.d/actions_freeradius.conf
+++ b/net/freeradius/src/opnsense/service/conf/actions.d/actions_freeradius.conf
@@ -14,6 +14,7 @@ message:stopping FreeRADIUS
 command:/usr/local/opnsense/scripts/Freeradius/setup.sh;/usr/local/etc/rc.d/radiusd restart
 parameters:
 type:script
+description:Restart FreeRADIUS service
 message:restarting FreeRADIUS
 
 [status]


### PR DESCRIPTION
Add description for restart action so it can be used in automations (e.g. after acme cert update, restart freeradius which uses it)