### PR TITLE
security/acme-client: add support for cPanel HTTP API

### DIFF
--- a/security/acme-client/pkg-descr
+++ b/security/acme-client/pkg-descr
@@ -8,6 +8,11 @@ WWW: https://github.com/acmesh-official/acme.sh
 Plugin Changelog
 ================
 
+3.8
+
+Added:
+* add support for cPanel HTTP API
+
 3.7
 
 Fixed:

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -1399,4 +1399,26 @@
         <label>HTTP Token</label>
         <type>password</type>
     </field>
+     <field>
+        <label>cPanel HTTP API</label>
+        <type>header</type>
+        <style>table_dns table_dns_cpanel</style>
+    </field>
+    <field>
+        <id>validation.dns_cpanel_user</id>
+        <label>cPanel Username</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_cpanel_token</id>
+        <label>cPanel API Token</label>
+        <type>password</type>
+        <help>Ref: https://docs.cpanel.net/cpanel/security/manage-api-tokens-in-cpanel/</help>
+    </field>
+    <field>
+        <id>validation.dns_cpanel_hostname</id>
+        <label>cPanel Hostname</label>
+        <type>text</type>
+        <help>EX: https://hostname:2083</help>
+    </field>
 </form>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsCpanel.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsCpanel.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * Copyright (C) 2021 Axelrtgs
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\AcmeClient\LeValidation;
+
+use OPNsense\AcmeClient\LeValidationInterface;
+use OPNsense\Core\Config;
+
+/**
+ * CF DNS API
+ * @package OPNsense\AcmeClient
+ */
+class DnsCpanel extends Base implements LeValidationInterface
+{
+    public function prepare()
+    {
+        # https://github.com/acmesh-official/acme.sh/wiki/dnsapi#136-use-cpanel-dns-systems
+        $this->acme_env['cPanel_Username'] = (string)$this->config->dns_cpanel_user;
+        $this->acme_env['cPanel_Apitoken'] = (string)$this->config->dns_cpanel_token;
+        $this->acme_env['cPanel_Hostname'] = (string)$this->config->dns_cpanel_hostname;
+    }
+}

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -429,6 +429,7 @@
                         <dns_cf>CloudFlare.com API</dns_cf>
                         <dns_cx>CloudXNS.com API</dns_cx>
                         <dns_cn>Core-Networks API</dns_cn>
+                        <dns_cpanel>cPanel API</dns_cpanel>
                         <dns_cyon>cyon.ch API</dns_cyon>
                         <dns_ddnss>DDNSS API</dns_ddnss>
                         <dns_desec>deSEC.io API</dns_desec>
@@ -1049,6 +1050,15 @@
                 <dns_dynv6_token type="TextField">
                     <Required>N</Required>
                 </dns_dynv6_token>
+                <dns_cpanel_user type="TextField">
+                    <Required>N</Required>
+                </dns_cpanel_user>
+                <dns_cpanel_token type="TextField">
+                    <Required>N</Required>
+                </dns_cpanel_token>
+                <dns_cpanel_hostname type="TextField">
+                    <Required>N</Required>
+                </dns_cpanel_hostname>
             </validation>
         </validations>
         <actions>


### PR DESCRIPTION
This adds support for the cPanel API to the plugin already included into acme.sh https://github.com/acmesh-official/acme.sh/wiki/dnsapi#136-use-cpanel-dns-systems