### PR TITLE
net/frr: replace U+00A0 with an actual space

### DIFF
--- a/net/frr/src/opnsense/service/conf/actions.d/actions_quagga.conf
+++ b/net/frr/src/opnsense/service/conf/actions.d/actions_quagga.conf
@@ -206,7 +206,7 @@ message:FRR diagnostics "show ip ospf database"
 command:/usr/local/opnsense/scripts/frr/legacy-diagnostics.py --ospf-database
 parameters:
 type:script_output
-message:FRR diagnostics "show ip ospf database json"
+message:FRR diagnostics "show ip ospf database json"
 
 [diagnostics.ospf_interface]
 command:/usr/local/bin/vtysh -c "show ip ospf interface"


### PR DESCRIPTION
didn't seem to cause any trouble, but my editor noticed it