### PR TITLE
www/nginx: 1.24.0 migration fix

### DIFF
--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
@@ -662,12 +662,6 @@
         <Required>N</Required>
         <multiple>Y</multiple>
       </syslog_targets>
-      <listen_http_port type="PortField">
-        <Required>N</Required>
-      </listen_http_port>
-      <listen_https_port type="PortField">
-        <Required>N</Required>
-      </listen_https_port>
       <listen_http_address type="CSVListField">
         <Required>N</Required>
         <multiple>Y</multiple>
@@ -943,9 +937,6 @@
     </http_server>
 
     <stream_server type="ArrayField">
-      <listen_port type="PortField">
-        <Required>N</Required>
-      </listen_port>
       <listen_address type="CSVListField">
         <Required>N</Required>
         <multiple>Y</multiple>

--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
@@ -662,6 +662,12 @@
         <Required>N</Required>
         <multiple>Y</multiple>
       </syslog_targets>
+      <listen_http_port type="PortField">
+        <Required>N</Required>
+      </listen_http_port>
+      <listen_https_port type="PortField">
+        <Required>N</Required>
+      </listen_https_port>
       <listen_http_address type="CSVListField">
         <Required>N</Required>
         <multiple>Y</multiple>
@@ -937,6 +943,9 @@
     </http_server>
 
     <stream_server type="ArrayField">
+      <listen_port type="PortField">
+        <Required>N</Required>
+      </listen_port>
       <listen_address type="CSVListField">
         <Required>N</Required>
         <multiple>Y</multiple>


### PR DESCRIPTION
Hi!
based on my experience with test 20.7.7 -> 21.7.7 migrations  and forum posts, there are problems updating nginx plugin to 1.24.0 version.
(nginx refuses to load, multiple errors in logs).
ref. https://forum.opnsense.org/index.php?topic=26266.0 https://forum.opnsense.org/index.php?topic=25830.0
in my experience: after an update, all servers are assigned a default listening address. if I understand correctly, since there are no `listen_http_port`, `listen_https_port` and `listen_port` fields in the new model there is no port-to-address conversion at https://github.com/opnsense/plugins/blob/01fb8a8abbb220c1bbcee437fa099f08e8a68889/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Migrations/M1_24_0.php#L38

I do not know if there is a correct way to remove a field from the model using its value beforehand (did not find pre-action). maybe it makes sense to keep this fields in model (migration works correctly for me with these changes)?

Thanks!

upd. or is it correct to read the config and take the current fields values from there since data is not serailized back yet ?
like https://github.com/opnsense/plugins/commit/b7d07650575366391d5f83ba7f22e2aa27d7c683 (seems to work without the need to keep fields in model)