### PR TITLE
Add description and message to wol action

### DIFF
--- a/net/wol/src/opnsense/service/conf/actions.d/actions_wol.conf
+++ b/net/wol/src/opnsense/service/conf/actions.d/actions_wol.conf
@@ -3,4 +3,4 @@ command:/usr/local/bin/wol -i
 parameters: %s %s
 type:script
 description:Wake-On-LAN for host with broadcast IP and MAC
-message:Waking up host
+message:Waking up host %s %s

--- a/net/wol/src/opnsense/service/conf/actions.d/actions_wol.conf
+++ b/net/wol/src/opnsense/service/conf/actions.d/actions_wol.conf
@@ -2,3 +2,5 @@
 command:/usr/local/bin/wol -i
 parameters: %s %s
 type:script
+description:Wake-On-LAN for host with broadcast IP and MAC
+message:Waking up host


### PR DESCRIPTION
Without a description the wol action cannot be used to create a cron job via the OPNsense web gui. Therefore I added one. To add a cron job triggering a wol packet, one has to add the broadcast IP address and MAC address of the target network and host as parameters for the cron job.

This addresses https://github.com/opnsense/core/issues/873