### PR TITLE
www/nginx: Regex validation constraint for location

### DIFF
--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Base/Constraints/NgxRegexPatternConstraint.php
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Base/Constraints/NgxRegexPatternConstraint.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+* Copyright (C) 2022 Manuel Faux <mfaux@conf.at>
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+* INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+* AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+* OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+namespace OPNsense\Base\Constraints;
+
+use Phalcon\Messages\Message;
+use Phalcon\Validation;
+use Phalcon\Validation\Validator\Regex as RegexValidator;
+
+/**
+ * Check a string for a valid PREG regex pattern when the matchtype
+ * field is set to expect a regex (e.g. '~' or '~*').
+ *
+ * Class NgxRegexPatternConstraint
+ * @package OPNsense\Nginx\Constraints
+ */
+class NgxRegexPatternConstraint extends BaseConstraint
+{
+    public function validate(Validation $validator, $attribute): bool
+    {
+        $node = $this->getOption('node');
+        if ($node) {
+            $value = (string)$node;
+            $parentNode = $node->getParentNode();
+            $matchtype = $this->getOption('matchtype');
+
+            // Validate regex
+            if (!empty((string)$parentNode->$matchtype) && ((string)$parentNode->$matchtype)[0] == '~') {
+                $value = str_replace('#', '\#', $value);
+                if (@preg_match("#$value#", '') === false) {
+                    $validator->appendMessage(new Message(gettext("Valid regular expression expected"), $attribute));
+                }
+            }
+        }
+
+        return true;
+    }
+}

--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
@@ -186,6 +186,12 @@
       </description>
       <urlpattern type="TextField">
         <Required>Y</Required>
+        <Constraints>
+          <check001>
+            <type>NgxRegexPatternConstraint</type>
+            <matchtype>matchtype</matchtype>
+          </check001>
+        </Constraints>
       </urlpattern>
       <matchtype type="OptionField">
         <OptionValues>
@@ -195,6 +201,11 @@
           <option4 value="^~">Don't check regular expressions on logest prefix match ("^~")</option4>
         </OptionValues>
         <Required>N</Required>
+        <Constraints>
+          <check001>
+            <reference>urlpattern.check001</reference>
+          </check001>
+        </Constraints>
       </matchtype>
       <enable_secrules type="BooleanField">
         <default>0</default>


### PR DESCRIPTION
The _URL pattern_ field of a location expects either a string (_Match Type_ is empty, "=" or "^\~") or a valid regular expression (_Match Type_ is "\~" or "\~*"). The regex is currently not validated, which is implemented in this PR.

### Open points/to discuss:
* How to implement the model migration - what to do with invalid regexes during migration?