### PR TITLE
www/nginx: 1.24.0 migration fix

### DIFF
--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Migrations/M1_24_0.php
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Migrations/M1_24_0.php
@@ -29,25 +29,36 @@
 namespace OPNsense\Nginx\Migrations;
 
 use OPNsense\Base\BaseModelMigration;
+use OPNsense\Core\Config;
 
 class M1_24_0 extends BaseModelMigration
 {
     public function run($model)
     {
-        foreach ($model->getNodeByReference('http_server')->iterateItems() as $http_server) {
-            if ($http_server->listen_http_port != '') {
-                $http_server->listen_http_address = $http_server->listen_http_port . ',[::]:' . $http_server->listen_http_port;
-                $http_server->listen_http_port = null;
+        $cfgObj = Config::getInstance()->object();
+        $ports = array();
+        if (!empty($cfgObj->OPNsense->Nginx)) {
+            foreach ($cfgObj->OPNsense->Nginx->http_server as $cfg_http_server) {
+                $uuid = (string)$cfg_http_server->attributes()['uuid'];
+                $ports[$uuid]['http_port'] = (isset($cfg_http_server->listen_http_port) && $cfg_http_server->listen_http_port != '') ? $cfg_http_server->listen_http_port : null;
+                $ports[$uuid]['https_port'] = (isset($cfg_http_server->listen_https_port) && $cfg_http_server->listen_https_port != '') ? $cfg_http_server->listen_https_port : null;
             }
-            if ($http_server->listen_https_port != '') {
-                $http_server->listen_https_address = $http_server->listen_https_port . ',[::]:' . $http_server->listen_https_port;
-                $http_server->listen_https_port = null;
+            foreach ($cfgObj->OPNsense->Nginx->stream_server as $cfg_stream_server) {
+                $uuid = (string)$cfg_stream_server->attributes()['uuid'];
+                $ports[$uuid]['listen_port'] = (isset($cfg_stream_server->listen_port) && $cfg_stream_server->listen_port != '') ? $cfg_stream_server->listen_port : null;
+            }
+        }
+        foreach ($model->getNodeByReference('http_server')->iterateItems() as $http_server) {
+            $m_uuid = (string)$http_server->getAttributes()['uuid'];
+            if (isset($ports[$m_uuid])) {
+                $http_server->listen_http_address = (isset($ports[$m_uuid]['http_port'])) ? $ports[$m_uuid]['http_port'] . ',[::]:' . $ports[$m_uuid]['http_port'] : null;
+                $http_server->listen_https_address = (isset($ports[$m_uuid]['https_port'])) ? $ports[$m_uuid]['https_port'] . ',[::]:' . $ports[$m_uuid]['https_port'] : null;
             }
         }
         foreach ($model->getNodeByReference('stream_server')->iterateItems() as $server) {
-            if ($server->listen_port != '') {
-                $server->listen_address = $server->listen_port . ',[::]:' . $server->listen_port;
-                $server->listen_port = null;
+            $m_uuid = (string)$server->getAttributes()['uuid'];
+            if (isset($ports[$m_uuid])) {
+                $server->listen_address = (isset($ports[$m_uuid]['listen_port'])) ? $ports[$m_uuid]['listen_port'] . ',[::]:' . $ports[$m_uuid]['listen_port'] : null;
             }
         }
     }


### PR DESCRIPTION
Hi!
Imho  there are problems updating nginx plugin to 1.24.0 version.
(nginx refuses to load, multiple errors in logs).
ref. https://forum.opnsense.org/index.php?topic=26266.0 https://forum.opnsense.org/index.php?topic=25830.0
in my experience: after an update, all servers are assigned a default listening address. if I understand correctly, since there are no `listen_http_port`, `listen_https_port` and `listen_port` fields in the new model there is no port-to-address conversion at
https://github.com/opnsense/plugins/blob/01fb8a8abbb220c1bbcee437fa099f08e8a68889/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Migrations/M1_24_0.php#L38

PR  reads the config, take the current fields values from there and use it in port-to-address conversion

