### PR TITLE
net/haproxy: Release 3.10

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		haproxy
-PLUGIN_VERSION=		3.9
+PLUGIN_VERSION=		3.10
 PLUGIN_COMMENT=		Reliable, high performance TCP/HTTP load balancer
 PLUGIN_DEPENDS=		haproxy24
 PLUGIN_MAINTAINER=	opnsense@moov.de

--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -1,7 +1,7 @@
 PLUGIN_NAME=		haproxy
 PLUGIN_VERSION=		3.9
 PLUGIN_COMMENT=		Reliable, high performance TCP/HTTP load balancer
-PLUGIN_DEPENDS=		haproxy22
+PLUGIN_DEPENDS=		haproxy24
 PLUGIN_MAINTAINER=	opnsense@moov.de
 
 .include "../../Mk/plugins.mk"

--- a/net/haproxy/pkg-descr
+++ b/net/haproxy/pkg-descr
@@ -13,6 +13,7 @@ which may result in incompatible changes for some users.
 
 Changed:
 * upgrade to HAProxy 2.4 release series (#2644)
+* disable strict-limits for safekeeping (#2644)
 
 Removed:
 * remove deprecated option tune.chksize (#2644)

--- a/net/haproxy/pkg-descr
+++ b/net/haproxy/pkg-descr
@@ -14,6 +14,9 @@ which may result in incompatible changes for some users.
 Changed:
 * upgrade to HAProxy 2.4 release series (#2644)
 
+Removed:
+* remove deprecated option tune.chksize (#2644)
+
 3.9
 
 Added:

--- a/net/haproxy/pkg-descr
+++ b/net/haproxy/pkg-descr
@@ -11,6 +11,9 @@ Plugin Changelog
 WARNING: This release switches to the HAProxy 2.4 release series,
 which may result in incompatible changes for some users.
 
+Added:
+* add support for DNS resolution over TCP (#2644)
+
 Changed:
 * upgrade to HAProxy 2.4 release series (#2644)
 * disable strict-limits for safekeeping (#2644)

--- a/net/haproxy/pkg-descr
+++ b/net/haproxy/pkg-descr
@@ -6,6 +6,14 @@ very high loads while needing persistence or Layer7 processing.
 Plugin Changelog
 ================
 
+3.10
+
+WARNING: This release switches to the HAProxy 2.4 release series,
+which may result in incompatible changes for some users.
+
+Changed:
+* upgrade to HAProxy 2.4 release series (#2644)
+
 3.9
 
 Added:
@@ -117,6 +125,7 @@ Fixed:
 * prevent the deletion of items that are still referenced elsewhere (core/#1897)
 
 Changed:
+* upgrade to HAProxy 2.2 release series (#2092)
 * change default SSL version to TLSv1.2 (ssl-min-ver)
 * remove weak ciphers from (default) SSL settings
 * remove default SSL bind options that would conflict with ssl-min-ver

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogAction.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogAction.xml
@@ -89,7 +89,7 @@
         <id>action.http_request_redirect</id>
         <label>HTTP Redirect</label>
         <type>text</type>
-        <help><![CDATA[Use HAProxy's redirect function to return a HTTP redirection. See <a href="http://cbonte.github.io/haproxy-dconv/2.2/configuration.html#redirect">HAProxy's documentation</a> for further details and examples.]]></help>
+        <help><![CDATA[Use HAProxy's redirect function to return a HTTP redirection. See <a href="http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#redirect">HAProxy's documentation</a> for further details and examples.]]></help>
     </field>
     <field>
         <label>Parameters</label>
@@ -128,7 +128,7 @@
         <id>action.http_request_add_header_content</id>
         <label>Header Content</label>
         <type>text</type>
-        <help><![CDATA[The value that should be set for the specified HTTP header. Note that it is possible to use pre-defined variables, see <a href="http://cbonte.github.io/haproxy-dconv/2.2/configuration.html#8.2.4">HAProxy's documentation</a> for further details and examples.]]></help>
+        <help><![CDATA[The value that should be set for the specified HTTP header. Note that it is possible to use pre-defined variables, see <a href="http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#8.2.4">HAProxy's documentation</a> for further details and examples.]]></help>
     </field>
     <field>
         <label>Parameters</label>
@@ -145,7 +145,7 @@
         <id>action.http_request_set_header_content</id>
         <label>Header Content</label>
         <type>text</type>
-        <help><![CDATA[The value that should be set for the specified HTTP header. Note that it's possible to use pre-defined variables, see <a href="http://cbonte.github.io/haproxy-dconv/2.2/configuration.html#8.2.4">HAProxy's documentation</a> for further details and examples.]]></help>
+        <help><![CDATA[The value that should be set for the specified HTTP header. Note that it's possible to use pre-defined variables, see <a href="http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#8.2.4">HAProxy's documentation</a> for further details and examples.]]></help>
     </field>
     <field>
         <label>Parameters</label>
@@ -251,7 +251,7 @@
         <id>action.http_response_add_header_content</id>
         <label>Header Content</label>
         <type>text</type>
-        <help><![CDATA[The value that should be set for the specified HTTP header. Note that it's possible to use pre-defined variables, see <a href="http://cbonte.github.io/haproxy-dconv/2.2/configuration.html#8.2.4">HAProxy's documentation</a> for further details and examples.]]></help>
+        <help><![CDATA[The value that should be set for the specified HTTP header. Note that it's possible to use pre-defined variables, see <a href="http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#8.2.4">HAProxy's documentation</a> for further details and examples.]]></help>
     </field>
     <field>
         <label>Parameters</label>
@@ -268,7 +268,7 @@
         <id>action.http_response_set_header_content</id>
         <label>Header Content</label>
         <type>text</type>
-        <help><![CDATA[The value that should be set for the specified HTTP header. Note that it's possible to use pre-defined variables, see <a href="http://cbonte.github.io/haproxy-dconv/2.2/configuration.html#8.2.4">HAProxy's documentation</a> for further details and examples.]]></help>
+        <help><![CDATA[The value that should be set for the specified HTTP header. Note that it's possible to use pre-defined variables, see <a href="http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#8.2.4">HAProxy's documentation</a> for further details and examples.]]></help>
     </field>
     <field>
         <label>Parameters</label>

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogBackend.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogBackend.xml
@@ -28,7 +28,7 @@
         <id>backend.algorithm</id>
         <label>Balancing Algorithm</label>
         <type>dropdown</type>
-        <help><![CDATA[Define the load balancing algorithm to be used in a Backend Pool. See the <a target="_blank" href="http://cbonte.github.io/haproxy-dconv/2.2/configuration.html#balance">HAProxy documentation</a> for a full description.]]></help>
+        <help><![CDATA[Define the load balancing algorithm to be used in a Backend Pool. See the <a target="_blank" href="http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#balance">HAProxy documentation</a> for a full description.]]></help>
         <hint>Choose a load balancing algorithm.</hint>
     </field>
     <field>
@@ -42,7 +42,7 @@
         <id>backend.proxyProtocol</id>
         <label>Proxy Protocol</label>
         <type>dropdown</type>
-        <help><![CDATA[Enforces use of the PROXY protocol over any connection established to the configured servers. The PROXY protocol informs the other end about the layer 3/4 addresses of the incoming connection, so that it can know the client's address or the public address it accessed to, whatever the upper layer protocol. This setting must not be used if the servers are not aware of the PROXY protocol. See the <a target="_blank" href="http://cbonte.github.io/haproxy-dconv/2.2/configuration.html#send-proxy">HAProxy documentation</a> for a full description.]]></help>
+        <help><![CDATA[Enforces use of the PROXY protocol over any connection established to the configured servers. The PROXY protocol informs the other end about the layer 3/4 addresses of the incoming connection, so that it can know the client's address or the public address it accessed to, whatever the upper layer protocol. This setting must not be used if the servers are not aware of the PROXY protocol. See the <a target="_blank" href="http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#send-proxy">HAProxy documentation</a> for a full description.]]></help>
         <advanced>true</advanced>
     </field>
     <field>
@@ -186,7 +186,7 @@
         <id>backend.persistence_cookiemode</id>
         <label>Cookie handling</label>
         <type>dropdown</type>
-        <help><![CDATA[Usually it is better to reuse an existing cookie. In this case HAProxy prefixes the cookie with the required information. See the <a target="_blank" href="http://cbonte.github.io/haproxy-dconv/2.2/configuration.html#4.2-cookie">HAProxy documentation</a> for a full description.]]></help>
+        <help><![CDATA[Usually it is better to reuse an existing cookie. In this case HAProxy prefixes the cookie with the required information. See the <a target="_blank" href="http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#4.2-cookie">HAProxy documentation</a> for a full description.]]></help>
     </field>
     <field>
         <id>backend.persistence_cookiename</id>
@@ -208,14 +208,14 @@
         <id>backend.stickiness_pattern</id>
         <label>Table type</label>
         <type>dropdown</type>
-        <help><![CDATA[Choose a request pattern to associate a user to a server. See the <a target="_blank" href="http://cbonte.github.io/haproxy-dconv/2.2/configuration.html#stick on">HAProxy documentation</a> for a full description.<br/><div class="text-info"><b>NOTE:</b> Consider not using this feature in multi-process mode, it can result in random behaviours.</div>]]></help>
+        <help><![CDATA[Choose a request pattern to associate a user to a server. See the <a target="_blank" href="http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#stick on">HAProxy documentation</a> for a full description.<br/><div class="text-info"><b>NOTE:</b> Consider not using this feature in multi-process mode, it can result in random behaviours.</div>]]></help>
         <hint>Choose a persistence type.</hint>
     </field>
     <field>
         <id>backend.stickiness_dataTypes</id>
         <label>Stored data types</label>
         <type>select_multiple</type>
-        <help><![CDATA[This is used to store additional information in the stick-table. It may be used by ACLs in order to control various criteria related to the activity of the client matching the stick-table. Note that this directly impacts memory usage. See the <a target="_blank" href="http://cbonte.github.io/haproxy-dconv/2.2/configuration.html#stick-table">HAProxy documentation</a> for a full description.]]></help>
+        <help><![CDATA[This is used to store additional information in the stick-table. It may be used by ACLs in order to control various criteria related to the activity of the client matching the stick-table. Note that this directly impacts memory usage. See the <a target="_blank" href="http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#stick-table">HAProxy documentation</a> for a full description.]]></help>
     </field>
     <field>
         <id>backend.stickiness_expire</id>

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogFrontend.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogFrontend.xml
@@ -322,14 +322,14 @@
         <id>frontend.stickiness_pattern</id>
         <label>Table type</label>
         <type>dropdown</type>
-        <help><![CDATA[Choose the type of data that should be stored in this stick-table. Note that this stick-table cannot be used for session persistence, it is only used to store additional per-connection data (select below). See the <a target="_blank" href="http://cbonte.github.io/haproxy-dconv/2.2/configuration.html#stick-table">HAProxy documentation</a> for further information.]]></help>
+        <help><![CDATA[Choose the type of data that should be stored in this stick-table. Note that this stick-table cannot be used for session persistence, it is only used to store additional per-connection data (select below). See the <a target="_blank" href="http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#stick-table">HAProxy documentation</a> for further information.]]></help>
         <hint>Choose a stick-table type.</hint>
     </field>
     <field>
         <id>frontend.stickiness_dataTypes</id>
         <label>Stored data types</label>
         <type>select_multiple</type>
-        <help><![CDATA[This is used to store additional information in the stick-table. It may be used by ACLs in order to control various criteria related to the activity of the client matching the stick-table. Note that this directly impacts memory usage. See the <a target="_blank" href="http://cbonte.github.io/haproxy-dconv/2.2/configuration.html#stick-table">HAProxy documentation</a> for a full description.]]></help>
+        <help><![CDATA[This is used to store additional information in the stick-table. It may be used by ACLs in order to control various criteria related to the activity of the client matching the stick-table. Note that this directly impacts memory usage. See the <a target="_blank" href="http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#stick-table">HAProxy documentation</a> for a full description.]]></help>
     </field>
     <field>
         <id>frontend.stickiness_expire</id>
@@ -356,7 +356,7 @@
         <id>frontend.stickiness_counter_key</id>
         <label>Sticky counter key</label>
         <type>text</type>
-        <help><![CDATA[It describes what elements of the incoming request or connection will be analyzed, extracted, combined, and used to select which table entry to update the counters. Defaults to "src" to track elements of the source IP. See the <a target="_blank" href="http://cbonte.github.io/haproxy-dconv/2.2/configuration.html#tcp-request connection">HAProxy documentation</a> for a full description.]]></help>
+        <help><![CDATA[It describes what elements of the incoming request or connection will be analyzed, extracted, combined, and used to select which table entry to update the counters. Defaults to "src" to track elements of the source IP. See the <a target="_blank" href="http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#tcp-request connection">HAProxy documentation</a> for a full description.]]></help>
         <advanced>true</advanced>
     </field>
     <field>

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogMapfile.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogMapfile.xml
@@ -15,6 +15,6 @@
         <id>mapfile.content</id>
         <label>Content</label>
         <type>textbox</type>
-        <help><![CDATA[Paste the content of your map file here. See the <a target="_blank" href="http://cbonte.github.io/haproxy-dconv/2.2/configuration.html#map">HAProxy documentation</a> for a full description.]]></help>
+        <help><![CDATA[Paste the content of your map file here. See the <a target="_blank" href="http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#map">HAProxy documentation</a> for a full description.]]></help>
     </field>
 </form>

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogResolver.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogResolver.xml
@@ -24,7 +24,7 @@
         <style>tokenize</style>
         <allownew>true</allownew>
         <sortable>true</sortable>
-        <help><![CDATA[Add nameservers to this resolver configuration, i.e. 127.0.0.1:53 or 192.168.1.1:53. Use TAB key to complete typing.]]></help>
+        <help><![CDATA[Add nameservers to this resolver configuration. They may be prefixed with either tcp@ or udp@ to use the TCP or UDP protocol respectively. For example 192.168.1.1:53, tcp@192.168.1.1:53 or udp@192.168.1.1:53. Use TAB key to complete typing.]]></help>
         <hint>Enter ip:port here. Finish with TAB.</hint>
     </field>
     <field>
@@ -55,7 +55,7 @@
         <id>resolver.accepted_payload_size</id>
         <label>Max DNS answer size</label>
         <type>text</type>
-        <help><![CDATA[Defines the maximum payload size accepted by HAProxy and announced to all the name servers configured in this resolvers section. The default is 512 bytes, the maximum allowed is 8192.]]></help>
+        <help><![CDATA[Defines the maximum payload size accepted by HAProxy and announced to all the name servers configured in this resolvers section. The default is 512 bytes, the maximum allowed is 8192 for UDP and 65535 for TCP.]]></help>
         <advanced>true</advanced>
     </field>
     <field>

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/generalTuning.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/generalTuning.xml
@@ -27,7 +27,7 @@
         <id>haproxy.general.tuning.maxConnections</id>
         <label>Maximum connections</label>
         <type>text</type>
-        <help><![CDATA[Sets the maximum number of concurrent connections per HAProxy process.<br/><div class="text-info"><b>NOTE:</b> Consider raising the settings for kern.maxfiles and kern.maxfilesperproc in <a target="_blank" href="/ui/haproxy#general-settings">System: Settings: Tunables</a>, otherwise HAProxy will fail to open the specified number of connections.</div>]]></help>
+        <help><![CDATA[Sets the maximum number of concurrent connections per HAProxy process.<br/><div class="text-info"><b>NOTE:</b> Consider raising the settings for kern.maxfiles and kern.maxfilesperproc in <a target="_blank" href="/system_advanced_sysctl.php">System: Settings: Tunables</a>, otherwise HAProxy will fail to open the specified number of connections.</div>]]></help>
     </field>
     <field>
         <id>haproxy.general.tuning.sslServerVerify</id>

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/generalTuning.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/generalTuning.xml
@@ -49,13 +49,6 @@
         <advanced>true</advanced>
     </field>
     <field>
-        <id>haproxy.general.tuning.checkBufferSize</id>
-        <label>Health check buffer size</label>
-        <type>text</type>
-        <help><![CDATA[Change the check buffer size (in bytes). Higher values may help find string or regex patterns in very large pages, though doing so may imply more memory and CPU usage. The default value is 16384.]]></help>
-        <advanced>true</advanced>
-    </field>
-    <field>
         <id>haproxy.general.tuning.luaMaxMem</id>
         <label>Maximum RAM per LUA process</label>
         <type>text</type>

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/generalTuning.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/generalTuning.xml
@@ -27,7 +27,7 @@
         <id>haproxy.general.tuning.maxConnections</id>
         <label>Maximum connections</label>
         <type>text</type>
-        <help><![CDATA[Sets the maximum number of concurrent connections per HAProxy process.<br/><div class="text-info"><b>NOTE:</b> HAProxy will not be able to allocate enough memory if you set this value too high. Consider raising the settings for kern.maxfiles and kern.maxfilesperproc if you need to specify a non-default value.</div>]]></help>
+        <help><![CDATA[Sets the maximum number of concurrent connections per HAProxy process.<br/><div class="text-info"><b>NOTE:</b> Consider raising the settings for kern.maxfiles and kern.maxfilesperproc in <a target="_blank" href="/ui/haproxy#general-settings">System: Settings: Tunables</a>, otherwise HAProxy will fail to open the specified number of connections.</div>]]></help>
     </field>
     <field>
         <id>haproxy.general.tuning.sslServerVerify</id>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -2796,9 +2796,9 @@
                     <Required>N</Required>
                     <Sorted>Y</Sorted>
                     <multiple>Y</multiple>
-                    <mask>/^((([0-9a-zA-Z._\-\*:\[\]]+:[0-9]+(-[0-9]+)?)([,]){0,1}))*/u</mask>
+                    <mask>/^((((udp@|tcp@)?[0-9a-zA-Z._\-\*:\[\]]+:[0-9]+(-[0-9]+)?)([,]){0,1}))*/u</mask>
                     <ChangeCase>lower</ChangeCase>
-                    <ValidationMessage>Please provide a valid nameserver address, i.e. 127.0.0.1:53, [::1]:53 or 192.168.1.1:53.</ValidationMessage>
+                    <ValidationMessage>Please provide a valid nameserver address, i.e. 127.0.0.1:53, [::1]:53 or tcp@192.168.1.1:53.</ValidationMessage>
                 </nameservers>
                 <parse_resolv_conf type="BooleanField">
                     <default>0</default>
@@ -2825,8 +2825,8 @@
                 </timeout_retry>
                 <accepted_payload_size type="IntegerField">
                     <MinimumValue>0</MinimumValue>
-                    <MaximumValue>8192</MaximumValue>
-                    <ValidationMessage>Should be a number between 0 and 8192</ValidationMessage>
+                    <MaximumValue>65535</MaximumValue>
+                    <ValidationMessage>Should be a number between 0 and 65535</ValidationMessage>
                     <Required>N</Required>
                 </accepted_payload_size>
                 <hold_valid type="TextField">

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -109,13 +109,6 @@
                     <ValidationMessage>Please specify a value between 1024 and 1048576.</ValidationMessage>
                     <Required>N</Required>
                 </bufferSize>
-                <checkBufferSize type="IntegerField">
-                    <default>16384</default>
-                    <MinimumValue>1024</MinimumValue>
-                    <MaximumValue>1048576</MaximumValue>
-                    <ValidationMessage>Please specify a value between 1024 and 1048576.</ValidationMessage>
-                    <Required>N</Required>
-                </checkBufferSize>
                 <spreadChecks type="IntegerField">
                     <default>2</default>
                     <MinimumValue>0</MinimumValue>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/HAProxy</mount>
-    <version>3.5.0</version>
+    <version>3.6.0</version>
     <description>the HAProxy load balancer</description>
     <items>
         <general>

--- a/net/haproxy/src/opnsense/mvc/app/views/OPNsense/HAProxy/index.volt
+++ b/net/haproxy/src/opnsense/mvc/app/views/OPNsense/HAProxy/index.volt
@@ -698,7 +698,7 @@ POSSIBILITY OF SUCH DAMAGE.
               <li>{{ lang._('Lastly, enable HAProxy using the %sService%s settings page.') | format('<b>', '</b>') }}</li>
             </ul>
             <p>{{ lang._('Please be aware that you need to %smanually%s add the required firewall rules for all configured services.') | format('<b>', '</b>') }}</p>
-            <p>{{ lang._('Further information is available in our %sHAProxy plugin documentation%s and of course in the %sofficial HAProxy documentation%s. Be sure to report bugs and request features on our %sGitHub issue page%s. Code contributions are also very welcome!') | format('<a href="https://docs.opnsense.org/manual/how-tos/haproxy.html" target="_blank">', '</a>', '<a href="http://cbonte.github.io/haproxy-dconv/2.2/configuration.html" target="_blank">', '</a>', '<a href="https://github.com/opnsense/plugins/issues/" target="_blank">', '</a>') }}</p>
+            <p>{{ lang._('Further information is available in our %sHAProxy plugin documentation%s and of course in the %sofficial HAProxy documentation%s. Be sure to report bugs and request features on our %sGitHub issue page%s. Code contributions are also very welcome!') | format('<a href="https://docs.opnsense.org/manual/how-tos/haproxy.html" target="_blank">', '</a>', '<a href="http://cbonte.github.io/haproxy-dconv/2.4/configuration.html" target="_blank">', '</a>', '<a href="https://github.com/opnsense/plugins/issues/" target="_blank">', '</a>') }}</p>
             <br/>
         </div>
     </div>
@@ -740,7 +740,7 @@ POSSIBILITY OF SUCH DAMAGE.
               <li>{{ lang._('%sConditions:%s HAProxy is capable of extracting data from requests, responses and other connection data and match it against predefined patterns. Use these powerful patterns to compose a condition that may be used in multiple Rules.') | format('<b>', '</b>') }}</li>
               <li>{{ lang._('%sRules:%s Perform a large set of actions if one or more %sConditions%s match. These Rules may be used in %sBackend Pools%s as well as %sPublic Services%s.') | format('<b>', '</b>', '<b>', '</b>', '<b>', '</b>', '<b>', '</b>') }}</li>
             </ul>
-            <p>{{ lang._("For more information on HAProxy's %sACL feature%s see the %sofficial documentation%s.") | format('<b>', '</b>', '<a href="http://cbonte.github.io/haproxy-dconv/2.2/configuration.html#7" target="_blank">', '</a>') }}</p>
+            <p>{{ lang._("For more information on HAProxy's %sACL feature%s see the %sofficial documentation%s.") | format('<b>', '</b>', '<a href="http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#7" target="_blank">', '</a>') }}</p>
             <p>{{ lang._('Note that it is possible to directly add options to the HAProxy configuration by using the "option pass-through", a setting that is available for several configuration items. It allows you to implement configurations that are currently not officially supported by this plugin. It is strongly discouraged to rely on this feature. Please report missing features on our GitHub page!') | format('<b>', '</b>') }}</p>
             <br/>
         </div>
@@ -755,7 +755,7 @@ POSSIBILITY OF SUCH DAMAGE.
               <li>{{ lang._('%sGroup:%s A optional list containing one or more users. Groups usually make it easier to manage permissions for a large number of users') | format('<b>', '</b>') }}</li>
             </ul>
             <p>{{ lang._('Note that users and groups must be selected from the Backend Pool or Public Service configuration in order to be used for authentication. In addition to this users and groups may also be used in Rules/Conditions.') }}</p>
-            <p>{{ lang._("For more information on HAProxy's %suser/group management%s see the %sofficial documentation%s.") | format('<b>', '</b>', '<a href="http://cbonte.github.io/haproxy-dconv/2.2/configuration.html#3.4" target="_blank">', '</a>') }}</p>
+            <p>{{ lang._("For more information on HAProxy's %suser/group management%s see the %sofficial documentation%s.") | format('<b>', '</b>', '<a href="http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#3.4" target="_blank">', '</a>') }}</p>
             <br/>
         </div>
     </div>
@@ -773,7 +773,7 @@ POSSIBILITY OF SUCH DAMAGE.
               <li>{{ lang._("%sCache:%s HAProxy's cache which was designed to perform cache on small objects (favicon, css, etc.). This is a minimalist low-maintenance cache which runs in RAM.") | format('<b>', '</b>', '<b>', '</b>') }}</li>
               <li>{{ lang._("%sPeers:%s Configure a communication channel between two HAProxy instances. This will propagate entries of any data-types in stick-tables between these HAProxy instances over TCP connections in a multi-master fashion. Useful when aiming for a seamless failover in a HA setup.") | format('<b>', '</b>', '<b>', '</b>') }}</li>
             </ul>
-            <p>{{ lang._("For more details visit HAProxy's official documentation regarding the %sStatistics%s, %sCache%s and %sPeers%s features.") | format('<a href="http://cbonte.github.io/haproxy-dconv/2.2/configuration.html#stats%20enable" target="_blank">', '</a>', '<a href="http://cbonte.github.io/haproxy-dconv/2.2/configuration.html#10" target="_blank">', '</a>', '<a href="http://cbonte.github.io/haproxy-dconv/2.2/configuration.html#3.5" target="_blank">', '</a>') }}</p>
+            <p>{{ lang._("For more details visit HAProxy's official documentation regarding the %sStatistics%s, %sCache%s and %sPeers%s features.") | format('<a href="http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#stats%20enable" target="_blank">', '</a>', '<a href="http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#10" target="_blank">', '</a>', '<a href="http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#3.5" target="_blank">', '</a>') }}</p>
             <br/>
         </div>
     </div>
@@ -790,7 +790,7 @@ POSSIBILITY OF SUCH DAMAGE.
               <li>{{ lang._("%sResolvers:%s This feature allows in-depth configuration of how HAProxy handles name resolution and interacts with name resolvers (DNS). Each resolver configuration can be used in %sBackend Pools%s to apply individual name resolution configurations.") | format('<b>', '</b>', '<b>', '</b>') }}</li>
               <li>{{ lang._("%sE-Mail Alerts:%s It is possible to send email alerts when the state of servers changes. Each configuration can be used in %sBackend Pools%s to send e-mail alerts to the configured recipient.") | format('<b>', '</b>', '<b>', '</b>') }}</li>
             </ul>
-            <p>{{ lang._("For more details visit HAProxy's official documentation regarding the %sError Messages%s, %sLua Script%s and the %sMap Files%s features. More information on HAProxy's CPU Affinity is also available %shere%s, %shere%s and %shere%s. A detailed explanation of the resolvers feature can be found %shere%s.") | format('<a href="http://cbonte.github.io/haproxy-dconv/2.2/configuration.html#4-errorfile" target="_blank">', '</a>', '<a href="http://cbonte.github.io/haproxy-dconv/2.2/configuration.html#lua-load" target="_blank">', '</a>', '<a href="http://cbonte.github.io/haproxy-dconv/2.2/configuration.html#map" target="_blank">', '</a>' ,'<a href="http://cbonte.github.io/haproxy-dconv/2.2/configuration.html#cpu-map" target="_blank">', '</a>' ,'<a href="http://cbonte.github.io/haproxy-dconv/2.2/configuration.html#bind-process" target="_blank">', '</a>' ,'<a href="http://cbonte.github.io/haproxy-dconv/2.2/configuration.html#process" target="_blank">', '</a>','<a href="http://cbonte.github.io/haproxy-dconv/2.2/configuration.html#5.3.2" target="_blank">', '</a>') }}</p>
+            <p>{{ lang._("For more details visit HAProxy's official documentation regarding the %sError Messages%s, %sLua Script%s and the %sMap Files%s features. More information on HAProxy's CPU Affinity is also available %shere%s, %shere%s and %shere%s. A detailed explanation of the resolvers feature can be found %shere%s.") | format('<a href="http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#4-errorfile" target="_blank">', '</a>', '<a href="http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#lua-load" target="_blank">', '</a>', '<a href="http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#map" target="_blank">', '</a>' ,'<a href="http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#cpu-map" target="_blank">', '</a>' ,'<a href="http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#bind-process" target="_blank">', '</a>' ,'<a href="http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#process" target="_blank">', '</a>','<a href="http://cbonte.github.io/haproxy-dconv/2.4/configuration.html#5.3.2" target="_blank">', '</a>') }}</p>
             <br/>
         </div>
     </div>

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -1174,7 +1174,8 @@ userlist stats_auth
 resolvers {{resolver.id}}
 {%       if resolver.nameservers|default("") != "" %}
 {%         for nameserver in resolver.nameservers.split(",") %}
-    nameserver {{nameserver}} {{nameserver}}
+{#  # special characters are not supported in server names #}
+    nameserver {{nameserver|replace('@', '_')}} {{nameserver}}
 {%         endfor %}
 {%       endif %}
 {%       if resolver.parse_resolv_conf|default("") == "1" %}

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -958,6 +958,9 @@ global
 {% if OPNsense.HAProxy.general.hardStopAfter|default('') != '' %}
     hard-stop-after             {{OPNsense.HAProxy.general.hardStopAfter}}
 {% endif %}
+{# # Disable strict-limits because a syntax check will not reveal #}
+{# # whether kern.maxfilesperproc or kern.maxfiles are too low. #}
+    no strict-limits
 {% if helpers.exists('OPNsense.HAProxy.general.tuning.maxConnections') %}
     maxconn                     {{OPNsense.HAProxy.general.tuning.maxConnections}}
 {% endif %}

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -975,9 +975,6 @@ global
 {% if OPNsense.HAProxy.general.tuning.bogusProxyEnabled|default("") == '1' %}
     pp2-never-send-local
 {% endif %}
-{% if OPNsense.HAProxy.general.tuning.checkBufferSize|default("") != "" %}
-    tune.chksize                {{OPNsense.HAProxy.general.tuning.checkBufferSize}}
-{% endif %}
 {% if OPNsense.HAProxy.general.tuning.bufferSize|default("") != "" %}
     tune.bufsize                {{OPNsense.HAProxy.general.tuning.bufferSize}}
 {% endif %}


### PR DESCRIPTION
See plugin changelog for details.

**NOTE: This release is intended for OPNsense 22.1, it should NOT be merged to previous releases due to the possibility of breaking changes.**