### PR TITLE
net/frr: Dont set empty defaults on required fields

### DIFF
--- a/net/frr/Makefile
+++ b/net/frr/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		frr
-PLUGIN_VERSION=		1.25
+PLUGIN_VERSION=		1.26
 PLUGIN_COMMENT=		The FRRouting Protocol Suite
 PLUGIN_DEPENDS=		frr7
 PLUGIN_MAINTAINER=	franz.fabian.94@gmail.com

--- a/net/frr/pkg-descr
+++ b/net/frr/pkg-descr
@@ -11,6 +11,10 @@ switching and routing, Internet access routers, and Internet peering.
 Plugin Changelog
 ================
 
+1.26
+
+* Fix Model migration errors
+
 1.25
 
 * Add "All" option to next-hop-self command (#2673)

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF6.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF6.xml
@@ -18,7 +18,6 @@
                 </OptionValues>
         </redistribute>
         <routerid type="TextField">
-                <default></default>
                 <Required>N</Required>
                 <mask>/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/</mask>
         </routerid>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF6.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF6.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/quagga/ospf6</mount>
     <description>OSPFv3 Routing configuration</description>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <items>
         <enabled type="BooleanField">
             <default>0</default>
@@ -19,7 +19,7 @@
         </redistribute>
         <routerid type="TextField">
                 <default></default>
-                <Required>Y</Required>
+                <Required>N</Required>
                 <mask>/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/</mask>
         </routerid>
         <interfaces>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/RIP.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/RIP.xml
@@ -14,7 +14,6 @@
             <Required>Y</Required>
         </version>
         <networks type="CSVListField">
-            <default></default>
             <Required>N</Required>
             <mask>/^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\/\d{1,2},)*(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\/\d{1,2})$/</mask>
         </networks>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/RIP.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/RIP.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/quagga/rip</mount>
     <description>RIP Routing configuration</description>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <items>
         <enabled type="BooleanField">
             <default>0</default>
@@ -15,7 +15,7 @@
         </version>
         <networks type="CSVListField">
             <default></default>
-            <Required>Y</Required>
+            <Required>N</Required>
             <mask>/^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\/\d{1,2},)*(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\/\d{1,2})$/</mask>
         </networks>
         <passiveinterfaces type="InterfaceField">


### PR DESCRIPTION
Migration errors on every update ... 

```
Starting configd.
>>> Invoking update script 'refresh'
*** OPNsense\Quagga\OSPF6 Migration failed, check log for details
*** OPNsense\Quagga\RIP Migration failed, check log for details
```

Router ID on OSPF6 is not a requirement and RIP would need a network to run, but I'd guess noone uses it anymore and ppl using it have a network in there, otherwise it wont work :)