### PR TITLE
Add STRATO DynDNS functionality to the new ddclient-dyndns plugin.

### DIFF
--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
@@ -64,6 +64,7 @@
                         <noip>Noip</noip>
                         <nsupdatev4>nsupdate.info (IPv4)</nsupdatev4>
                         <nsupdatev6>nsupdate.info (IPv6)</nsupdatev6>
+						<strato>STRATO</strato>
                         <zoneedit1>Zoneedit</zoneedit1>
                     </OptionValues>
                 </service>

--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
@@ -64,7 +64,7 @@
                         <noip>Noip</noip>
                         <nsupdatev4>nsupdate.info (IPv4)</nsupdatev4>
                         <nsupdatev6>nsupdate.info (IPv6)</nsupdatev6>
-						<strato>STRATO</strato>
+                        <strato>STRATO</strato>
                         <zoneedit1>Zoneedit</zoneedit1>
                     </OptionValues>
                 </service>

--- a/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
+++ b/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
@@ -54,6 +54,11 @@ server=ipv4.nsupdate.info
 protocol=dyndns2
 ssl=yes
 server=ipv6.nsupdate.info
+{%            elif account.service == 'strato' %}
+use=web
+protocol=dyndns2
+ssl=yes
+server=dyndns.strato.com
 {%            else %}
 protocol={{account.service}}
 ssl=yes


### PR DESCRIPTION
I created this small tweak, so the new ddclient plugin works with STRATO. It should work, although I have not tested it yet. (not upgraded to 22.1 yet). 

EDIT:
I´m not really sure if `use=web` without a `web=address` is sufficient.

If not maybe consider https://ipinfo.io/ip for lookup as STRATO has no external IP checkup site.