### PR TITLE
dns/ddclient Add Cloudflare

### DIFF
--- a/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/dialogAccount.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/dialogAccount.xml
@@ -31,6 +31,13 @@
         <help>add a DNS wildcard CNAME record that points to the configured host.</help>
     </field>
     <field>
+        <id>account.zone</id>
+        <label>Zone</label>
+        <type>text</type>
+        <style>optional_setting service_cloudflare</style>
+        <help>Zone containing the host entry.</help>
+    </field>
+    <field>
         <id>account.hostnames</id>
         <label>Hostname(s)</label>
         <type>select_multiple</type>

--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
@@ -89,7 +89,7 @@
                     <Required>Y</Required>
                 </wildcard>
                 <zone type="HostnameField">
-                    <Required>Y</Required>
+                    <Required>N</Required>
                     <IpAllowed>N</IpAllowed>
                 </zone>
                 <description type="TextField">

--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
@@ -54,6 +54,7 @@
                     <ValidationMessage>A service type is required.</ValidationMessage>
                     <OptionValues>
                         <changeip>Changeip</changeip>
+                        <cloudflare>Cloudflare</cloudflare>
                         <dyndns2>DynDNS.com</dyndns2>
                         <dnspark>DnsPark</dnspark>
                         <dslreports1>DslReports</dslreports1>
@@ -87,6 +88,10 @@
                     <default>0</default>
                     <Required>Y</Required>
                 </wildcard>
+                <zone type="HostnameField">
+                    <Required>Y</Required>
+                    <IpAllowed>N</IpAllowed>
+                </zone>
                 <description type="TextField">
                     <Required>N</Required>
                     <mask>/^([\t\n\v\f\r 0-9a-zA-Z.,_\x{00A0}-\x{FFFF}]){1,255}$/u</mask>

--- a/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
+++ b/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
@@ -46,7 +46,10 @@ use=web, web=http://dynamic.zoneedit.com/checkip.html
 {%  if helpers.exists('OPNsense.DynDNS.accounts.account') %}
 {%    for account in helpers.toList('OPNsense.DynDNS.accounts.account') %}
 {%        if account.enabled|default('0') == '1' %}
-{%            if account.service == 'nsupdatev4' %}
+{%            if account.service == 'cloudflare' %}
+protocol=cloudflare
+zone={{account.zone}}
+{%            elif account.service == 'nsupdatev4' %}
 protocol=dyndns2
 ssl=yes
 server=ipv4.nsupdate.info


### PR DESCRIPTION
Added Cloudflare

had to add an additional config option for the zone. I hope that's the right way. Is it possible to make that field required only for cloudflare?

fixes #2772  