### PR TITLE
dns/dnscrypt-proxy: fixed "disabled_server_names"

### DIFF
--- a/dns/dnscrypt-proxy/pkg-descr
+++ b/dns/dnscrypt-proxy/pkg-descr
@@ -8,6 +8,8 @@ Plugin Changelog
 1.11
 
 * Fix DNSBL update due to FreeBSD13 upgrade (sed syntax)
+* Fix "manual disable of specific servers" when more than one server is
+  specified (contributed by Evgeny Grin (karlson2k))
 
 1.10
 

--- a/dns/dnscrypt-proxy/src/opnsense/service/templates/OPNsense/Dnscryptproxy/dnscrypt-proxy.toml
+++ b/dns/dnscrypt-proxy/src/opnsense/service/templates/OPNsense/Dnscryptproxy/dnscrypt-proxy.toml
@@ -5,7 +5,7 @@ server_names = [{{ "'" + ("','".join(OPNsense.dnscryptproxy.general.serverlist.s
 {%   endif %}
 
 {%   if helpers.exists('OPNsense.dnscryptproxy.general.disabled_serverlist') and OPNsense.dnscryptproxy.general.disabled_serverlist != '' %}
-disabled_server_names = ['{{OPNsense.dnscryptproxy.general.disabled_serverlist}}']
+disabled_server_names = [{{ "'" + ("','".join(OPNsense.dnscryptproxy.general.disabled_serverlist.split(','))) + "'" }}]
 {%   endif %}
 
 {%   if helpers.exists('OPNsense.dnscryptproxy.general.listen_addresses') and OPNsense.dnscryptproxy.general.listen_addresses != '' %}


### PR DESCRIPTION
Fixed function of "Disabled Servers List" when more than one server specified in the list.
