### PR TITLE
dns/ddclient Add Gandi and Zone Support 

### DIFF
--- a/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/dialogAccount.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/dialogAccount.xml
@@ -34,7 +34,7 @@
         <id>account.zone</id>
         <label>Zone</label>
         <type>text</type>
-        <style>optional_setting service_cloudflare service_gandi</style>
+        <style>optional_setting service_cloudflare service_gandi service_nfsn service_nsupdate service_zoneedit1</style>
         <help>Zone containing the host entry.</help>
     </field>
     <field>

--- a/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/dialogAccount.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/dialogAccount.xml
@@ -34,7 +34,7 @@
         <id>account.zone</id>
         <label>Zone</label>
         <type>text</type>
-        <style>optional_setting service_cloudflare</style>
+        <style>optional_setting service_cloudflare service_gandi</style>
         <help>Zone containing the host entry.</help>
     </field>
     <field>

--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
@@ -63,7 +63,9 @@
                         <gandi>Gandi.net</gandi>
                         <googledomains>Google</googledomains>
                         <namecheap>NameCheap</namecheap>
+                        <nfsn>NFSN</nfsn>
                         <noip>Noip</noip>
+                        <nsupdate>NSUpdate</nsupdate>
                         <nsupdatev4>nsupdate.info (IPv4)</nsupdatev4>
                         <nsupdatev6>nsupdate.info (IPv6)</nsupdatev6>
                         <strato>STRATO</strato>

--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
@@ -60,6 +60,7 @@
                         <dslreports1>DslReports</dslreports1>
                         <duckdns>DuckDNS</duckdns>
                         <easydns>EasyDNS</easydns>
+                        <gandi>Gandi.net</gandi>
                         <googledomains>Google</googledomains>
                         <namecheap>NameCheap</namecheap>
                         <noip>Noip</noip>

--- a/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
+++ b/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
@@ -46,10 +46,7 @@ use=web, web=http://dynamic.zoneedit.com/checkip.html
 {%  if helpers.exists('OPNsense.DynDNS.accounts.account') %}
 {%    for account in helpers.toList('OPNsense.DynDNS.accounts.account') %}
 {%        if account.enabled|default('0') == '1' %}
-{%            if account.service == 'cloudflare' %}
-protocol=cloudflare
-zone={{account.zone}}
-{%            elif account.service == 'nsupdatev4' %}
+{%            if account.service == 'nsupdatev4' %}
 protocol=dyndns2
 ssl=yes
 server=ipv4.nsupdate.info
@@ -68,6 +65,9 @@ ssl=yes
 {%            endif %}
 {%            if account.wildcard|default('0') == '1' %}
 wildcard=yes
+{%            endif %}
+{%            if account.zone %}
+zone={{account.zone}}
 {%            endif %}
 {%            if account.username %}
 login={{account.username}}

--- a/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
+++ b/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
@@ -46,7 +46,19 @@ use=web, web=http://dynamic.zoneedit.com/checkip.html
 {%  if helpers.exists('OPNsense.DynDNS.accounts.account') %}
 {%    for account in helpers.toList('OPNsense.DynDNS.accounts.account') %}
 {%        if account.enabled|default('0') == '1' %}
-{%            if account.service == 'nsupdatev4' %}
+{%            if account.service == 'cloudflare' %}
+protocol=cloudflare
+zone={{account.zone}}
+{%            elif account.service == 'gandi' %}
+protocol=gandi
+zone={{account.zone}}
+{%            elif account.service == 'nfsn' %}
+protocol=nfsn
+zone={{account.zone}}
+{%            elif account.service == 'nsupdate' %}
+protocol=nsupdate
+zone={{account.zone}}
+{%            elif account.service == 'nsupdatev4' %}
 protocol=dyndns2
 ssl=yes
 server=ipv4.nsupdate.info
@@ -59,15 +71,15 @@ use=web
 protocol=dyndns2
 ssl=yes
 server=dyndns.strato.com
+{%            elif account.service == 'zoneedit1' %}
+protocol=zoneedit1
+zone={{account.zone}}
 {%            else %}
 protocol={{account.service}}
 ssl=yes
 {%            endif %}
 {%            if account.wildcard|default('0') == '1' %}
 wildcard=yes
-{%            endif %}
-{%            if account.zone %}
-zone={{account.zone}}
 {%            endif %}
 {%            if account.username %}
 login={{account.username}}


### PR DESCRIPTION
Add Gandi, remove zone support for Cloudflare only, and add zone support for each provider that has the zone field.
Anyone know when opnsense will use the 3.10 version of this plugin ?