### PR TITLE
dns/ddclient - Add Hurricane Electric provider

### DIFF
--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
@@ -61,6 +61,8 @@
                         <duckdns>DuckDNS</duckdns>
                         <easydns>EasyDNS</easydns>
                         <googledomains>Google</googledomains>
+                        <he-net>HE.net</he-net>
+                        <he-net-tunnel>HE.net TunnelBroker</he-net-tunnel>
                         <namecheap>NameCheap</namecheap>
                         <noip>Noip</noip>
                         <nsupdatev4>nsupdate.info (IPv4)</nsupdatev4>

--- a/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
+++ b/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
@@ -49,6 +49,14 @@ use=web, web=http://dynamic.zoneedit.com/checkip.html
 {%            if account.service == 'cloudflare' %}
 protocol=cloudflare
 zone={{account.zone}}
+{%            elif account.service == 'he-net' %}
+protocol=dyndns2
+ssl=yes
+server=dyn.dns.he.net
+{%            elif account.service == 'he-net-tunnel' %}
+protocol=dyndns2
+ssl=yes
+server=ipv4.tunnelbroker.net
 {%            elif account.service == 'nsupdatev4' %}
 protocol=dyndns2
 ssl=yes


### PR DESCRIPTION
HE is using the dyndns2 protocol for both dynamic DNS and IPv6 TunnelBroker services. Add both services to the service.
Added provider was tested to verify that both services are updating successfully.