### PR TITLE
make multimap Whitelist work

### DIFF
--- a/mail/rspamd/Makefile
+++ b/mail/rspamd/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		rspamd
-PLUGIN_VERSION=		1.11
+PLUGIN_VERSION=		1.12
 PLUGIN_COMMENT=		Protect your network from spam
 PLUGIN_DEPENDS=		rspamd
 PLUGIN_MAINTAINER=	franz.fabian.94@gmail.com

--- a/mail/rspamd/pkg-descr
+++ b/mail/rspamd/pkg-descr
@@ -5,6 +5,11 @@ lua.
 Plugin Changelog
 ----------------
 
+1.12
+
+* Adjusting the multimap setting to make the multimap whitelist work
+
+
 1.11
 
 * Fix Milter Protocol by binding to Unix Sockets

--- a/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/multimap.conf
+++ b/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/multimap.conf
@@ -8,13 +8,13 @@ extension_blacklist {
   filter = "extension";
   map = "/${LOCAL_CONFDIR}/local.d/bad_file_extensions.map";
   symbol = "FILENAME_BLACKLISTED";
-  action = "reject";
+  score 1000;
 }
 
 WHITELIST_SENDER_DOMAIN {
   type = "from";
   filter = "email:domain";
   map = "/${LOCAL_CONFDIR}/local.d/whitelist_sender_domains.map";
-  score = -50.0
+  score = -1000
   }
 {% endif %}


### PR DESCRIPTION
If it says "reject", the multimap whitelist is ignored and whitelisted domains are still getting blocked.

If you give it a Score of 1000 blocking still works.

Whitelisted senders are getting -1000 so that they can pass,

Destroyed the old one:
https://github.com/opnsense/plugins/pull/2819