### PR TITLE
dsn/ddclient option to force ssl

### DIFF
--- a/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/settings.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/settings.xml
@@ -13,6 +13,13 @@
         <help>Enable verbose logging</help>
     </field>
     <field>
+        <id>ddclient.general.force_ssl</id>
+        <label>Force SSL</label>
+        <type>checkbox</type>
+        <advanced>true</advanced>
+        <help>Force update using HTTPS</help>
+    </field>
+    <field>
         <id>ddclient.general.daemon_delay</id>
         <label>Interval</label>
         <type>text</type>

--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/DynDNS</mount>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <description>
         Dynamic DNS client
     </description>
@@ -15,7 +15,7 @@
                 <Required>Y</Required>
             </verbose>
             <force_ssl type="BooleanField">
-                <default>0</default>
+                <default>1</default>
                 <Required>Y</Required>
             </force_ssl>
             <daemon_delay type="IntegerField">

--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
@@ -14,6 +14,10 @@
                 <default>0</default>
                 <Required>Y</Required>
             </verbose>
+            <force_ssl type="BooleanField">
+                <default>0</default>
+                <Required>Y</Required>
+            </force_ssl>
             <daemon_delay type="IntegerField">
                 <default>300</default>
                 <Required>Y</Required>

--- a/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
+++ b/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
@@ -2,6 +2,9 @@
 daemon={{OPNsense.DynDNS.general.daemon_delay|default('300')}}
 syslog=yes                  # log update msgs to syslog
 pid=/var/run/ddclient.pid   # record PID in file.
+{% if not helpers.empty('OPNsense.DynDNS.general.force_ssl') %}
+ssl=yes
+{% endif %}
 {% if not helpers.empty('OPNsense.DynDNS.general.verbose') %}
 verbose=yes
 {% endif %}
@@ -54,34 +57,27 @@ use=if, if={{physical_interface(account.interface)}}, \
 {%            endif %}
 {%            if account.service == 'custom' %}
 protocol={{account.protocol}}, \
-ssl=yes, \
 server={{account.server}}, \
 {%            elif account.service == 'cloudflare' %}
 protocol=cloudflare, \
 zone={{account.zone}}, \
 {%            elif account.service == 'he-net' %}
 protocol=dyndns2, \
-ssl=yes, \
 server=dyn.dns.he.net, \
 {%            elif account.service == 'he-net-tunnel' %}
 protocol=dyndns2, \
-ssl=yes, \
 server=ipv4.tunnelbroker.net, \
 {%            elif account.service == 'nsupdatev4' %}
 protocol=dyndns2, \
-ssl=yes, \
 server=ipv4.nsupdate.info, \
 {%            elif account.service == 'nsupdatev6' %}
 protocol=dyndns2, \
-ssl=yes, \
 server=ipv6.nsupdate.info, \
 {%            elif account.service == 'strato' %}
 protocol=dyndns2, \
-ssl=yes, \
 server=dyndns.strato.com, \
 {%            else %}
 protocol={{account.service}}, \
-ssl=yes, \
 {%            endif %}
 {%            if account.wildcard|default('0') == '1' %}
 wildcard=yes, \


### PR DESCRIPTION
The option to use SSL per entry is not possible in ddclient version 3.9.1. You can only use a global option to force SSL. This is needed by some providers like dynv6.com.

https://github.com/ddclient/ddclient/blob/v3.9.1/ddclient#L2715-L2726
```
Configuration variables applicable to the 'dyndns2' protocol are:
  protocol=dyndns2             ## 
  server=fqdn.of.service       ## defaults to members.dyndns.org
  script=/path/to/script       ## defaults to /nic/update
  backupmx=no|yes              ## indicates that this host is the primary MX for the domain.
  static=no|yes                ## indicates that this host has a static IP address.
  custom=no|yes                ## indicates that this host is a 'custom' top-level domain name.
  mx=any.host.domain           ## a host MX'ing for this host definition.
  wildcard=no|yes              ## add a DNS wildcard CNAME record that points to {host}
  login=service-login          ## login name and password  registered with the service
  password=service-password    ##
  fully.qualified.host         ## the host registered with the service.
```

That should be the last step to make the plugin usable by many. 😃 