### PR TITLE
security/stunnel: Fix connect format for IPv6 addresses

### DIFF
--- a/security/stunnel/src/opnsense/service/templates/OPNsense/Stunnel/stunnel.conf
+++ b/security/stunnel/src/opnsense/service/templates/OPNsense/Stunnel/stunnel.conf
@@ -18,7 +18,7 @@ logId = unique
 ; **************************************************************************
 [{{service['@uuid']}}]
 accept = {% if service.accept_address %}{{service.accept_address}}:{% endif %}{{service.accept_port}}
-connect = {% if service.connect_address.find(":") > -1 %}[{{service.connect_address}}]{% else %}{{service.connect_address}}{% endif %}:{{service.connect_port}}
+connect = {{service.connect_address}}:{{service.connect_port}}
 {% if service.protocol %}
 protocol = {{service.protocol}}
 {% endif %}


### PR DESCRIPTION
The current code generates conf line:
```
connect = [::1]:53
```

will end up producing the following:
```
Error resolving "[::1]": Neither nodename nor servname known (EAI_NONAME)
```

stunnel(8) states that an address parameter of an option may be either:
> ...
> A colon-separated pair of IP address (either IPv4, IPv6, or domain name)
  and port number.
> ...

which means there should not be special treatment on IPv6 addresses.