### PR TITLE
dns/ddclinet: Cron action for forced update

### DIFF
--- a/dns/ddclient/src/opnsense/service/conf/actions.d/actions_ddclient.conf
+++ b/dns/ddclient/src/opnsense/service/conf/actions.d/actions_ddclient.conf
@@ -23,3 +23,10 @@ description:Restart ddclient service
 command:/usr/local/etc/rc.d/ddclient reload
 type:script
 message:reload ddclient configuration
+
+[update]
+command:/usr/local/etc/rc.d/ddclient -force
+parameters:
+type:script
+message:Forcing a DNS update
+description:Force a DNS update

--- a/dns/ddclient/src/opnsense/service/conf/actions.d/actions_ddclient.conf
+++ b/dns/ddclient/src/opnsense/service/conf/actions.d/actions_ddclient.conf
@@ -25,7 +25,7 @@ type:script
 message:reload ddclient configuration
 
 [update]
-command:/usr/local/etc/rc.d/ddclient -force
+command:/usr/local/sbin/ddclient -force
 parameters:
 type:script
 message:Forcing a DNS update


### PR DESCRIPTION
Some providers like No-IP need an update every 7 days.
This is necessary even if the IP does not change.