### PR TITLE
Avoid errors with repeated primary servers and keys

### DIFF
--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindDomain.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindDomain.xml
@@ -46,13 +46,19 @@
         <id>domain.transferkeyalgo</id>
         <label>Transfer Key Algorithm</label>
         <type>dropdown</type>
-        <help>Set the authentication algorithm for the TSIG key.</help>
+        <help>Set the authentication algorithm for the TSIG key used to transfer domain data from the master server.</help>
+    </field>
+    <field>
+        <id>domain.transferkeyname</id>
+        <label>Transfer Key Name</label>
+        <type>text</type>
+        <help>The name of the TSIG key, which must match the value on the master server.</help>
     </field>
     <field>
         <id>domain.transferkey</id>
         <label>Transfer Key</label>
         <type>text</type>
-        <help>The TSIG key used to transfer domain data from the master server.</help>
+        <help>The base64-encoded TSIG key.</help>
     </field>
     <field>
         <id>domain.allownotifyslave</id>

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Domain.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Domain.xml
@@ -33,6 +33,10 @@
                         <hmac-md5>HMAC-MD5</hmac-md5>
                     </OptionValues>
                 </transferkeyalgo>
+                <transferkeyname type="TextField">
+                    <Required>N</Required>
+                    <default></default>
+                </transferkeyname>
                 <transferkey type="TextField">
                     <Required>N</Required>
                     <default></default>

--- a/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/general.volt
+++ b/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/general.volt
@@ -277,9 +277,9 @@ $( document ).ready(function() {
 
     $('#domain\\.transferkeyalgo').on('change', function(e) {
         if (e.target.selectedIndex === 0) {
-            $('#domain\\.transferkey').val('').attr('readonly', true);
+            $('#domain\\.transferkey,#domain\\.transferkeyname').val('').attr('readonly', true);
         } else {
-            $('#domain\\.transferkey').attr('readonly', false);
+            $('#domain\\.transferkey,#domain\\.transferkeyname').attr('readonly', false);
         }
     });
 

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
@@ -131,6 +131,7 @@ zone "rpzbing" { type master; file "/usr/local/etc/namedb/master/bing.db"; notif
 {% endif %}
 
 {% if helpers.exists('OPNsense.bind.domain.domains.domain') %}
+{%   set usedkeys = [] %}
 {%   for domain in helpers.toList('OPNsense.bind.domain.domains.domain') %}
 {%     if domain.enabled == '1' %}
 {%     set allow_transfer = helpers.getUUID(domain.allowtransfer) %}
@@ -138,7 +139,11 @@ zone "rpzbing" { type master; file "/usr/local/etc/namedb/master/bing.db"; notif
 zone "{{ domain.domainname }}" {
         type {{ domain.type }};
 {%       if domain.type == 'slave' %}
+{%         if domain.transferkey is defined %}
+        masters { {{ domain.masterip.replace(',', ' key "' ~ domain.transferkeyname ~ '"; ') }} key "{{ domain.transferkeyname }}"; };
+{%         else %}
         masters { {{ domain.masterip.replace(',', '; ') }}; };
+{%         endif %}
 {%         if domain.allownotifyslave is defined %}
         allow-notify { {{ domain.allownotifyslave.replace(',', '; ') }}; };
 {%         endif %}
@@ -153,14 +158,11 @@ zone "{{ domain.domainname }}" {
         allow-query { {{ allow_query.name }}; };
 {%       endif %}
 };
-{%       if domain.type == 'slave' and domain.transferkey is defined %}
-{%         set key_name = 'tsig-transferkey-' ~ domain.domainname.replace('.', '-') %}
-key "{{ key_name }}" {
+{%       if domain.type == 'slave' and domain.transferkey is defined and not(domain.transferkeyname in usedkeys) %}
+{%         do usedkeys.append(domain.transferkeyname) %}
+key "{{ domain.transferkeyname }}" {
         algorithm "{{ domain.transferkeyalgo }}";
         secret "{{ domain.transferkey }}";
-};
-server {{ domain.masterip }} {
-        keys { "{{ key_name }}" };
 };
 {%       endif %}
 {%     endif %}


### PR DESCRIPTION
This resolves #2873 by getting a key name from the user. The key is also specified in the `masters` section, so a separate `server` block is not needed (incidentally this also allows different keys on the same server.)

Not sure how one would handle keys with the same name on different servers. Seems like an edge case not worth worrying about ATM.