### PR TITLE
net/freeradius: Fix template for sites-enabled-inner-tunnel

### DIFF
--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/sites-enabled-inner-tunnel
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/sites-enabled-inner-tunnel
@@ -155,7 +155,7 @@ authorize {
 
         #
         #  The ldap module reads passwords from the LDAP database.
-{%   if helpers.exists('OPNsense.freeradius.ldap.innertunnel') and OPNsense.freeradius.general.ldap.innertunnel == '1' %}
+{%   if helpers.exists('OPNsense.freeradius.ldap.innertunnel') and OPNsense.freeradius.ldap.innertunnel == '1' %}
         ldap
           if ((ok || updated) && User-Password) {
               update control {
@@ -251,7 +251,7 @@ authenticate {
         #  authentication server, and knows what to do with authentication.
         #  LDAP servers do not.
         #
-{%   if helpers.exists('OPNsense.freeradius.ldap.innertunnel') and OPNsense.freeradius.general.ldap.innertunnel == '1' %}
+{%   if helpers.exists('OPNsense.freeradius.ldap.innertunnel') and OPNsense.freeradius.ldap.innertunnel == '1' %}
         Auth-Type LDAP {
                 ldap
         }


### PR DESCRIPTION
Not sure if it's correct but I could make the plugin work for me with this change.

Error in backend log was


> Inline action failed with OPNsense/Freeradius OPNsense/Freeradius/sites-enabled-inner-tunnel 'collections.OrderedDict object' has no attribute 'ldap' at Traceback (most recent call last): File "/usr/local/opnsense/service/modules/template.py", line 267, in _generate content = j2_page.render(cnf_data) File "/usr/local/lib/python3.8/site-packages/jinja2/environment.py", line 1304, in render self.environment.handle_exception() File "/usr/local/lib/python3.8/site-packages/jinja2/environment.py", line 925, in handle_exception raise rewrite_traceback_stack(source=source) File "/usr/local/opnsense/service/modules/../templates/OPNsense/Freeradius/sites-enabled-inner-tunnel", line 159, in top-level template code {% if helpers.exists('OPNsense.freeradius.ldap.innertunnel') and OPNsense.freeradius.general.ldap.innertunnel == '1' %} File "/usr/local/lib/python3.8/site-packages/jinja2/environment.py", line 474, in getattr return getattr(obj, attribute) jinja2.exceptions.UndefinedError: 'collections.OrderedDict object' has no attribute 'ldap' During handling of the above exception, another exception occurred: Traceback (most recent call last): File "/usr/local/opnsense/service/modules/processhandler.py", line 506, in execute return ph_inline_actions.execute(self, inline_act_parameters) File "/usr/local/opnsense/service/modules/ph_inline_actions.py", line 51, in execute filenames = tmpl.generate(parameters) File "/usr/local/opnsense/service/modules/template.py", line 344, in generate raise render_exception File "/usr/local/opnsense/service/modules/template.py", line 335, in generate for filename in self._generate(template_name, create_directory): File "/usr/local/opnsense/service/modules/template.py", line 270, in _generate raise Exception("%s %s %s" % (module_name, template_filename, render_exception)) Exception: OPNsense/Freeradius OPNsense/Freeradius/sites-enabled-inner-tunnel 'collections.OrderedDict object' has no attribute 'ldap'
