### PR TITLE
dns/ddclient: Add Multi-Wan (NAT) support

### DIFF
--- a/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/Api/AccountsController.php
+++ b/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/Api/AccountsController.php
@@ -39,11 +39,18 @@ class AccountsController extends ApiMutableModelControllerBase
 
     public function searchItemAction()
     {
-        return $this->searchBase(
+        $result = $this->searchBase(
             "accounts.account",
-            ['enabled', 'service', 'description', 'username', 'hostnames','use_interface','interface'],
+            ['enabled', 'service', 'description', 'username', 'hostnames', 'use_interface', 'interface'],
             "description"
         );
+        foreach ($result['rows'] as &$row) {
+            if ($row['use_interface'] == "0") {
+                $row['interface'] = "";
+            }
+            unset($row['use_interface']);
+        }
+        return $result;
     }
 
     public function setItemAction($uuid)

--- a/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/Api/AccountsController.php
+++ b/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/Api/AccountsController.php
@@ -41,7 +41,7 @@ class AccountsController extends ApiMutableModelControllerBase
     {
         $result = $this->searchBase(
             "accounts.account",
-            ['enabled', 'service', 'description', 'username', 'hostnames', 'use_interface', 'interface'],
+            ['enabled', 'service', 'description', 'username', 'hostnames', 'use_interface', 'interface', 'protocol'],
             "description"
         );
         foreach ($result['rows'] as &$row) {
@@ -49,6 +49,10 @@ class AccountsController extends ApiMutableModelControllerBase
                 $row['interface'] = "";
             }
             unset($row['use_interface']);
+            if ($row['service'] == 'Custom') {
+                $row['service'] = 'Custom ('.$row['protocol'].')';
+            }
+            unset($row['protocol']);
         }
         return $result;
     }

--- a/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/Api/AccountsController.php
+++ b/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/Api/AccountsController.php
@@ -41,7 +41,7 @@ class AccountsController extends ApiMutableModelControllerBase
     {
         return $this->searchBase(
             "accounts.account",
-            ['enabled', 'service', 'description', 'username', 'hostnames'],
+            ['enabled', 'service', 'description', 'username', 'hostnames','use_interface','interface'],
             "description"
         );
     }

--- a/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/dialogAccount.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/dialogAccount.xml
@@ -46,6 +46,17 @@
         <help>Hostname to update</help>
     </field>
     <field>
+        <id>account.use_interface</id>
+        <label>Use interface IP</label>
+        <type>checkbox</type>
+        <help>Use the IP of a specified interface for the update</help>
+    </field>
+    <field>
+        <id>account.interface</id>
+        <label>Interface</label>
+        <type>dropdown</type>
+    </field>
+    <field>
         <id>account.description</id>
         <label>Description</label>
         <type>text</type>

--- a/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/dialogAccount.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/dialogAccount.xml
@@ -12,6 +12,20 @@
         <help>Select the service to use.</help>
     </field>
     <field>
+        <id>account.protocol</id>
+        <label>Protocol</label>
+        <type>dropdown</type>
+        <help>Select the protocol to use.</help>
+        <style>optional_setting service_custom</style>
+    </field>
+    <field>
+        <id>account.server</id>
+        <label>Server</label>
+        <type>text</type>
+        <help>DynDNS Server</help>
+        <style>optional_setting service_custom</style>
+    </field>
+    <field>
         <id>account.username</id>
         <label>Username</label>
         <type>text</type>
@@ -27,7 +41,7 @@
         <id>account.wildcard</id>
         <label>Wildcard</label>
         <type>checkbox</type>
-        <style>optional_setting service_dyndns2 service_easydns</style>
+        <style>optional_setting service_dyndns2 service_easydns service_custom</style>
         <help>add a DNS wildcard CNAME record that points to the configured host.</help>
     </field>
     <field>

--- a/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/settings.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/settings.xml
@@ -24,4 +24,10 @@
         <type>dropdown</type>
         <help>How to determine the address to use for this host</help>
     </field>
+    <field>
+        <id>ddclient.general.interface</id>
+        <label>Interface</label>
+        <type>dropdown</type>
+        <style>optional_setting checkip_if</style>
+    </field>
 </form>

--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
@@ -75,8 +75,21 @@
                         <nsupdatev6>nsupdate.info (IPv6)</nsupdatev6>
                         <strato>STRATO</strato>
                         <zoneedit1>Zoneedit</zoneedit1>
+                        <custom>Custom</custom>
                     </OptionValues>
                 </service>
+                <protocol type="OptionField">
+                    <Required>N</Required>
+                    <ValidationMessage>A protocol type is required.</ValidationMessage>
+                    <OptionValues>
+                        <dyndns1>DynDns1</dyndns1>
+                        <dyndns2>DynDns2</dyndns2>
+                    </OptionValues>
+                </protocol>
+                <server type="HostnameField">
+                    <Required>N</Required>
+                    <IpAllowed>N</IpAllowed>
+                </server>
                 <username type="TextField">
                     <Required>N</Required>
                     <mask>/^([a-zA-Z0-9\-.@_:+])*$/u</mask>

--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
@@ -40,8 +40,14 @@
                     <web_nsupdate_info_ipv4 value="web_nsupdate.info-ipv4">nsupdate.info-ipv4</web_nsupdate_info_ipv4>
                     <web_nsupdate_info_ipv6 value="web_nsupdate.info-ipv6">nsupdate.info-ipv6</web_nsupdate_info_ipv6>
                     <web_zoneedit>zoneedit</web_zoneedit>
+                    <if>Interface</if>
                 </OptionValues>
             </checkip>
+            <interface type="InterfaceField">
+                <Required>N</Required>
+                <multiple>N</multiple>
+                <default>wan</default>
+            </interface>
         </general>
         <accounts>
             <account type="ArrayField">

--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
@@ -100,6 +100,15 @@
                     <Required>N</Required>
                     <IpAllowed>N</IpAllowed>
                 </zone>
+                <use_interface type="BooleanField">
+                    <default>0</default>
+                    <Required>Y</Required>
+                </use_interface>
+                <interface type="InterfaceField">
+                    <Required>N</Required>
+                    <multiple>N</multiple>
+                    <default>wan</default>
+                </interface>
                 <description type="TextField">
                     <Required>N</Required>
                     <mask>/^([\t\n\v\f\r 0-9a-zA-Z.,_\x{00A0}-\x{FFFF}]){1,255}$/u</mask>

--- a/dns/ddclient/src/opnsense/mvc/app/views/OPNsense/DynDNS/index.volt
+++ b/dns/ddclient/src/opnsense/mvc/app/views/OPNsense/DynDNS/index.volt
@@ -70,6 +70,21 @@ POSSIBILITY OF SUCH DAMAGE.
             });
             $("#account\\.service").change();
         });
+
+        $("#ddclient\\.general\\.checkip").change(function(){
+            let checkip = $(this).val();
+            $(".optional_setting").each(function(){
+                let this_item = $(this);
+                if (this_item.hasClass("checkip_"+checkip)) {
+                    this_item.prop( "disabled", false );
+                    this_item.closest("tr").show();
+                } else {
+                    this_item.closest("tr").hide();
+                    this_item.prop( "disabled", true );
+                }
+            });
+        });
+        $("#ddclient\\.general\\.checkip").change();
     });
 
 </script>

--- a/dns/ddclient/src/opnsense/mvc/app/views/OPNsense/DynDNS/index.volt
+++ b/dns/ddclient/src/opnsense/mvc/app/views/OPNsense/DynDNS/index.volt
@@ -57,7 +57,7 @@ POSSIBILITY OF SUCH DAMAGE.
         $('#DialogAccount').on('shown.bs.modal', function (e) {
             $("#account\\.service").change(function(){
                 let service = $(this).val();
-                $(".optional_setting").each(function(){
+                $("#frm_DialogAccount .optional_setting").each(function(){
                     let this_item = $(this);
                     if (this_item.hasClass("service_"+service)) {
                         this_item.prop( "disabled", false );
@@ -69,11 +69,23 @@ POSSIBILITY OF SUCH DAMAGE.
                 });
             });
             $("#account\\.service").change();
+
+            $("#account\\.use_interface").change(function(){
+                if ($(this).is(':checked')) {
+                    $("#account\\.interface").prop( "disabled", false );
+                    $("#account\\.interface").closest("tr").show();
+                } else {
+                    $("#account\\.interface").closest("tr").hide();
+                    $("#account\\.interface").prop( "disabled", true );
+                }
+            });
+            $("#account\\.use_interface").change();
+
         });
 
         $("#ddclient\\.general\\.checkip").change(function(){
             let checkip = $(this).val();
-            $(".optional_setting").each(function(){
+            $("#frm_settings .optional_setting").each(function(){
                 let this_item = $(this);
                 if (this_item.hasClass("checkip_"+checkip)) {
                     this_item.prop( "disabled", false );
@@ -103,6 +115,8 @@ POSSIBILITY OF SUCH DAMAGE.
                 <th data-column-id="enabled" data-width="6em" data-type="string" data-formatter="rowtoggle">{{ lang._('Enabled') }}</th>
                 <th data-column-id="service" data-type="string">{{ lang._('Service') }}</th>
                 <th data-column-id="username" data-type="string">{{ lang._('Username') }}</th>
+                <th data-column-id="use_interface" data-type="string">{{ lang._('Use Interface') }}</th>
+                <th data-column-id="interface" data-type="string">{{ lang._('Interface') }}</th>
                 <th data-column-id="description" data-type="string">{{ lang._('Description') }}</th>
                 <th data-column-id="commands" data-width="7em" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
             </tr>

--- a/dns/ddclient/src/opnsense/mvc/app/views/OPNsense/DynDNS/index.volt
+++ b/dns/ddclient/src/opnsense/mvc/app/views/OPNsense/DynDNS/index.volt
@@ -54,33 +54,32 @@ POSSIBILITY OF SUCH DAMAGE.
               return dfObj;
           }
         });
-        $('#DialogAccount').on('shown.bs.modal', function (e) {
-            $("#account\\.service").change(function(){
-                let service = $(this).val();
-                $("#frm_DialogAccount .optional_setting").each(function(){
-                    let this_item = $(this);
-                    if (this_item.hasClass("service_"+service)) {
-                        this_item.prop( "disabled", false );
-                        this_item.closest("tr").show();
-                    } else {
-                        this_item.closest("tr").hide();
-                        this_item.prop( "disabled", true );
-                    }
-                });
-            });
-            $("#account\\.service").change();
-
-            $("#account\\.use_interface").change(function(){
-                if ($(this).is(':checked')) {
-                    $("#account\\.interface").prop( "disabled", false );
-                    $("#account\\.interface").closest("tr").show();
+        $("#account\\.service").change(function(){
+            let service = $(this).val();
+            $("#frm_DialogAccount .optional_setting").each(function(){
+                let this_item = $(this);
+                if (this_item.hasClass("service_"+service)) {
+                    this_item.prop( "disabled", false );
+                    this_item.closest("tr").show();
                 } else {
-                    $("#account\\.interface").closest("tr").hide();
-                    $("#account\\.interface").prop( "disabled", true );
+                    this_item.closest("tr").hide();
+                    this_item.prop( "disabled", true );
                 }
             });
+        });
+        $("#account\\.use_interface").change(function(){
+            if ($(this).is(':checked')) {
+                $("#account\\.interface").prop( "disabled", false );
+                $("#account\\.interface").closest("tr").show();
+            } else {
+                $("#account\\.interface").closest("tr").hide();
+                $("#account\\.interface").prop( "disabled", true );
+            }
+            $('#account\\.interface').selectpicker('refresh');
+        });
+        $('#DialogAccount').on('shown.bs.modal', function (e) {
+            $("#account\\.service").change();
             $("#account\\.use_interface").change();
-
         });
 
         $("#ddclient\\.general\\.checkip").change(function(){
@@ -115,7 +114,6 @@ POSSIBILITY OF SUCH DAMAGE.
                 <th data-column-id="enabled" data-width="6em" data-type="string" data-formatter="rowtoggle">{{ lang._('Enabled') }}</th>
                 <th data-column-id="service" data-type="string">{{ lang._('Service') }}</th>
                 <th data-column-id="username" data-type="string">{{ lang._('Username') }}</th>
-                <th data-column-id="use_interface" data-type="string">{{ lang._('Use Interface') }}</th>
                 <th data-column-id="interface" data-type="string">{{ lang._('Interface') }}</th>
                 <th data-column-id="description" data-type="string">{{ lang._('Description') }}</th>
                 <th data-column-id="commands" data-width="7em" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>

--- a/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
+++ b/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
@@ -52,7 +52,11 @@ use=web, web=http://dynamic.zoneedit.com/checkip.html
 {%            if account.use_interface|default('0') == '1' %}
 use=if, if={{physical_interface(account.interface)}}, \
 {%            endif %}
-{%            if account.service == 'cloudflare' %}
+{%            if account.service == 'custom' %}
+protocol={{account.protocol}}, \
+ssl=yes, \
+server={{account.server}}, \
+{%            elif account.service == 'cloudflare' %}
 protocol=cloudflare, \
 zone={{account.zone}}, \
 {%            elif account.service == 'he-net' %}
@@ -62,7 +66,7 @@ server=dyn.dns.he.net, \
 {%            elif account.service == 'he-net-tunnel' %}
 protocol=dyndns2, \
 ssl=yes, \
-server=ipv4.tunnelbroker.net
+server=ipv4.tunnelbroker.net, \
 {%            elif account.service == 'nsupdatev4' %}
 protocol=dyndns2, \
 ssl=yes, \

--- a/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
+++ b/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
@@ -5,13 +5,14 @@ pid=/var/run/ddclient.pid   # record PID in file.
 verbose=yes
 {% endif %}
 
+{% from 'OPNsense/Macros/interface.macro' import physical_interface %}
+
 #
 # setup how we expect to retrieve an IP address
 #
 {%  if not helpers.empty('OPNsense.DynDNS.general.checkip') %}
 {%    set checkip = OPNsense.DynDNS.general.checkip %}
 {%    if checkip == 'if' %}
-{%      from 'OPNsense/Macros/interface.macro' import physical_interface %}
 use=if, if={{physical_interface(OPNsense.DynDNS.general.interface)}}
 {%    elif checkip == 'web_dyndns' %}
 use=web, web=http://checkip.dyndns.org/, web-skip="Current IP Address:"
@@ -49,6 +50,9 @@ use=web, web=http://dynamic.zoneedit.com/checkip.html
 {%  if helpers.exists('OPNsense.DynDNS.accounts.account') %}
 {%    for account in helpers.toList('OPNsense.DynDNS.accounts.account') %}
 {%        if account.enabled|default('0') == '1' %}
+{%            if account.use_interface|default('0') == '1' %}
+use=if, if={{physical_interface(account.interface)}}
+{%            endif %}
 {%            if account.service == 'cloudflare' %}
 protocol=cloudflare
 zone={{account.zone}}
@@ -69,7 +73,6 @@ protocol=dyndns2
 ssl=yes
 server=ipv6.nsupdate.info
 {%            elif account.service == 'strato' %}
-use=web
 protocol=dyndns2
 ssl=yes
 server=dyndns.strato.com

--- a/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
+++ b/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
@@ -1,3 +1,4 @@
+{% from 'OPNsense/Macros/interface.macro' import physical_interface %}
 daemon={{OPNsense.DynDNS.general.daemon_delay|default('300')}}
 syslog=yes                  # log update msgs to syslog
 pid=/var/run/ddclient.pid   # record PID in file.
@@ -5,14 +6,12 @@ pid=/var/run/ddclient.pid   # record PID in file.
 verbose=yes
 {% endif %}
 
-{% from 'OPNsense/Macros/interface.macro' import physical_interface %}
-
 #
 # setup how we expect to retrieve an IP address
 #
 {%  if not helpers.empty('OPNsense.DynDNS.general.checkip') %}
 {%    set checkip = OPNsense.DynDNS.general.checkip %}
-{%    if checkip == 'if' %}
+{%    if checkip == 'if' and OPNsense.DynDNS.general.interface|default('') != '' %}
 use=if, if={{physical_interface(OPNsense.DynDNS.general.interface)}}
 {%    elif checkip == 'web_dyndns' %}
 use=web, web=http://checkip.dyndns.org/, web-skip="Current IP Address:"
@@ -51,42 +50,42 @@ use=web, web=http://dynamic.zoneedit.com/checkip.html
 {%    for account in helpers.toList('OPNsense.DynDNS.accounts.account') %}
 {%        if account.enabled|default('0') == '1' %}
 {%            if account.use_interface|default('0') == '1' %}
-use=if, if={{physical_interface(account.interface)}}
+use=if, if={{physical_interface(account.interface)}}, \
 {%            endif %}
 {%            if account.service == 'cloudflare' %}
-protocol=cloudflare
-zone={{account.zone}}
+protocol=cloudflare, \
+zone={{account.zone}}, \
 {%            elif account.service == 'he-net' %}
-protocol=dyndns2
-ssl=yes
-server=dyn.dns.he.net
+protocol=dyndns2, \
+ssl=yes, \
+server=dyn.dns.he.net, \
 {%            elif account.service == 'he-net-tunnel' %}
-protocol=dyndns2
-ssl=yes
+protocol=dyndns2, \
+ssl=yes, \
 server=ipv4.tunnelbroker.net
 {%            elif account.service == 'nsupdatev4' %}
-protocol=dyndns2
-ssl=yes
-server=ipv4.nsupdate.info
+protocol=dyndns2, \
+ssl=yes, \
+server=ipv4.nsupdate.info, \
 {%            elif account.service == 'nsupdatev6' %}
-protocol=dyndns2
-ssl=yes
-server=ipv6.nsupdate.info
+protocol=dyndns2, \
+ssl=yes, \
+server=ipv6.nsupdate.info, \
 {%            elif account.service == 'strato' %}
-protocol=dyndns2
-ssl=yes
-server=dyndns.strato.com
+protocol=dyndns2, \
+ssl=yes, \
+server=dyndns.strato.com, \
 {%            else %}
-protocol={{account.service}}
-ssl=yes
+protocol={{account.service}}, \
+ssl=yes, \
 {%            endif %}
 {%            if account.wildcard|default('0') == '1' %}
-wildcard=yes
+wildcard=yes, \
 {%            endif %}
 {%            if account.username %}
-login={{account.username}}
+login={{account.username}}, \
 {%            endif %}
-password={{account.password}}
+password={{account.password}} \
 {{account.hostnames}}
 
 {%        endif %}

--- a/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
+++ b/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
@@ -8,39 +8,42 @@ verbose=yes
 #
 # setup how we expect to retrieve an IP address
 #
-{%  if not helpers.empty('OPNsense.DynDNS.general.checkip') and OPNsense.DynDNS.general.checkip.startswith('web_')  %}
-{%      set checkip = OPNsense.DynDNS.general.checkip.lstrip('web_') %}
-{%      if checkip == 'dyndns' %}
+{%  if not helpers.empty('OPNsense.DynDNS.general.checkip') %}
+{%    set checkip = OPNsense.DynDNS.general.checkip %}
+{%    if checkip == 'if' %}
+{%      from 'OPNsense/Macros/interface.macro' import physical_interface %}
+use=if, if={{physical_interface(OPNsense.DynDNS.general.interface)}}
+{%    elif checkip == 'web_dyndns' %}
 use=web, web=http://checkip.dyndns.org/, web-skip="Current IP Address:"
-{%      elif checkip == 'freedns' %}
+{%    elif checkip == 'web_freedns' %}
 use=web, web=https://freedns.afraid.org/dynamic/check.php
-{%      elif checkip == 'googledomains' %}
+{%    elif checkip == 'web_googledomains' %}
 use=web, web=https://domains.google.com/checkip
-{%      elif checkip == 'he' %}
+{%    elif checkip == 'web_he' %}
 use=web, web=http://checkip.dns.he.net/
-{%      elif checkip == 'ip4only.me' %}
+{%    elif checkip == 'web_ip4only.me' %}
 use=web, web=http://ip4only.me/api/
-{%      elif checkip == 'ip6only.me' %}
+{%    elif checkip == 'web_ip6only.me' %}
 use=web, web=http://ip6only.me/api/
-{%      elif checkip == 'ipify-ipv4' %}
+{%    elif checkip == 'web_ipify-ipv4' %}
 use=web, web=https://api.ipify.org/
-{%      elif checkip == 'ipify-ipv6' %}
+{%    elif checkip == 'web_ipify-ipv6' %}
 use=web, web=https://api6.ipify.org/
-{%      elif checkip == 'loopia' %}
+{%    elif checkip == 'web_loopia' %}
 use=web, web=http://dns.loopia.se/checkip/checkip.php, web-skip="Current IP Address:"
-{%      elif checkip == 'myonlineportal' %}
+{%    elif checkip == 'web_myonlineportal' %}
 use=web, web=https://myonlineportal.net/checkip
-{%      elif checkip == 'noip-ipv4' %}
+{%    elif checkip == 'web_noip-ipv4' %}
 use=web, web=http://ip1.dynupdate.no-ip.com/
-{%      elif checkip == 'noip-ipv6' %}
+{%    elif checkip == 'web_noip-ipv6' %}
 use=web, web=http://ip1.dynupdate6.no-ip.com/
-{%      elif checkip == 'nsupdate.info-ipv4' %}
+{%    elif checkip == 'web_nsupdate.info-ipv4' %}
 use=web, web=https://ipv4.nsupdate.info/myip
-{%      elif checkip == 'nsupdate.info-ipv6' %}
+{%    elif checkip == 'web_nsupdate.info-ipv6' %}
 use=web, web=https://ipv6.nsupdate.info/myip
-{%      elif checkip == 'zoneedit' %}
+{%    elif checkip == 'web_zoneedit' %}
 use=web, web=http://dynamic.zoneedit.com/checkip.html
-{%      endif %}
+{%    endif %}
 {%  endif %}
 
 {%  if helpers.exists('OPNsense.DynDNS.accounts.account') %}


### PR DESCRIPTION
I have 2 WAN behind NAT which must register 2 dynamic DNS on the same host. Can you add the ability to choose which interface to initiate the request from without use its (private) IP address?
Example:
**WAN 0**: 192.168.200.1/24     Public IP: x.x.x.x
**WAN 1**: 192.168.201.1/24     Public IP: y.y.y.y

Thanks