### PR TITLE
New DynDNS option to allow IPv6 updates (issue 2895)

### DIFF
--- a/dns/ddclient/pkg-descr
+++ b/dns/ddclient/pkg-descr
@@ -6,6 +6,10 @@ WWW: https://github.com/ddclient/ddclient
 Plugin Changelog
 ================
 
+1.4
+
+* Add advanced general setting to allow updates via IPv6
+
 1.3
 
 * Add checkip settings per account using selected source interface when provided

--- a/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/settings.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/settings.xml
@@ -13,6 +13,13 @@
         <help>Enable verbose logging</help>
     </field>
     <field>
+        <id>ddclient.general.allowipv6</id>
+        <label>Allow IPv6</label>
+        <type>checkbox</type>
+        <advanced>true</advanced>
+        <help>Allow IPv6 for updates</help>
+    </field>
+    <field>
         <id>ddclient.general.daemon_delay</id>
         <label>Interval</label>
         <type>text</type>

--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
@@ -14,6 +14,10 @@
                 <default>0</default>
                 <Required>Y</Required>
             </verbose>
+            <allowipv6 type="BooleanField">
+                <default>0</default>
+                <Required>Y</Required>
+            </allowipv6>
             <daemon_delay type="IntegerField">
                 <default>300</default>
                 <Required>Y</Required>

--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/DynDNS</mount>
-    <version>1.2.0</version>
+    <version>1.4.0</version>
     <description>
         Dynamic DNS client
     </description>

--- a/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
+++ b/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
@@ -5,6 +5,9 @@ pid=/var/run/ddclient.pid   # record PID in file.
 {% if not helpers.empty('OPNsense.DynDNS.general.verbose') %}
 verbose=yes
 {% endif %}
+{% if not helpers.empty('OPNsense.DynDNS.general.allowipv6') %}
+ipv6=yes
+{% endif %}
 {%  set accounts = [] %}
 {%  set force_ssl = [] %}
 {%  if helpers.exists('OPNsense.DynDNS.accounts.account') %}


### PR DESCRIPTION
This is a pull request to integrate the fix for https://github.com/opnsense/plugins/issues/2895.

There is a new advanced general option to allow updates via IPv6.

I think that the new setting is backward-compatible so that no migration needs to be done. After all, the version for the settings is still 1.2.0 despite the version is 1.3 already.
