### PR TITLE
security/acme-client: ACMEDNS_UPDATE_URL to ACMEDNS_BASE_URL

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -1187,10 +1187,10 @@
         <type>text</type>
     </field>
     <field>
-        <id>validation.dns_acmedns_updateurl</id>
-        <label>Update URL</label>
+        <id>validation.dns_acmedns_baseurl</id>
+        <label>ACME DNS URL</label>
         <type>text</type>
-        <help>Specify the custom ACME DNS Update URL, i.e. https://auth.acme-dns.io/update (optional)</help>
+        <help>Specify the custom ACME DNS URL, i.e. https://auth.acme-dns.io:443 (optional)</help>
     </field>
     <field>
         <label>Acmeproxy</label>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsAcmedns.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsAcmedns.php
@@ -42,6 +42,6 @@ class DnsAcmedns extends Base implements LeValidationInterface
         $this->acme_env['ACMEDNS_USERNAME'] = (string)$this->config->dns_acmedns_user;
         $this->acme_env['ACMEDNS_PASSWORD'] = (string)$this->config->dns_acmedns_password;
         $this->acme_env['ACMEDNS_SUBDOMAIN'] = (string)$this->config->dns_acmedns_subdomain;
-        $this->acme_env['ACMEDNS_UPDATE_URL'] = (string)$this->config->dns_acmedns_updateurl;
+        $this->acme_env['ACMEDNS_BASE_URL'] = (string)$this->config->dns_acmedns_baseurl;
     }
 }

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/AcmeClient</mount>
-    <version>3.2.0</version>
+    <version>3.3.0</version>
     <description>A secure ACME Client plugin</description>
     <items>
         <settings>
@@ -978,9 +978,13 @@
                 <dns_acmedns_subdomain type="TextField">
                     <Required>N</Required>
                 </dns_acmedns_subdomain>
+                <!-- old value, should be removed in next major release -->
                 <dns_acmedns_updateurl type="TextField">
                     <Required>N</Required>
                 </dns_acmedns_updateurl>
+                <dns_acmedns_baseurl type="TextField">
+                    <Required>N</Required>
+                </dns_acmedns_baseurl>
                 <dns_acmeproxy_endpoint type="TextField">
                     <Required>N</Required>
                 </dns_acmeproxy_endpoint>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/Migrations/M3_3_0.php
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/Migrations/M3_3_0.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ *    Copyright (C) 2021 Frank Wall
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+namespace OPNsense\AcmeClient\Migrations;
+
+use OPNsense\Base\BaseModelMigration;
+
+class M3_3_0 extends BaseModelMigration
+{
+    public function run($model)
+    {
+        // Migrate validations
+        foreach ($model->getNodeByReference('validations.validation')->iterateItems() as $validation) {
+            $updateUrl = trim(strval($validation->dns_acmedns_updateurl ?? ''));
+            $baseUrl = trim(strval($validation->dns_acmedns_baseurl ?? ''));
+
+            if (!empty($updateUrl) && empty($baseUrl)) {
+                // Translate "https://auth.acme-dns.io/update" to "https://auth.acme-dns.io"
+                $baseUrl = preg_replace('/\/update$/', '', $updateUrl);
+                $validation->dns_acmedns_baseurl = $baseUrl;
+                $validation->dns_acmedns_updateurl = null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes the use of a self hosted ACME-DNS service after the following change https://github.com/acmesh-official/acme.sh/commit/2ce145f359deaaaff9bea06312984c70a04ef87c.

The env var `ACMEDNS_UPDATE_URL` is no longer accepted. `acme.sh` requires `ACMEDNS_BASE_URL` now, since it can also auto-register with the service.