### PR TITLE
FRR: OSPF ipv6 influence interface cost via carp

### DIFF
--- a/net/frr/pkg-descr
+++ b/net/frr/pkg-descr
@@ -11,6 +11,13 @@ switching and routing, Internet access routers, and Internet peering.
 Plugin Changelog
 ================
 
+1.28
+
+* OSPF6 Interface change networktype and interfacename to dropdown in stead of multi select
+* Diagnostics / BGP - fix search in grid, should only use a formatter for presentation purposes.
+* Add ospf6 carp demotion event handler
+
+
 1.27
 
 * Add BGP password authentication

--- a/net/frr/src/etc/rc.carp_service_status.d/carp_frr_ospf6
+++ b/net/frr/src/etc/rc.carp_service_status.d/carp_frr_ospf6
@@ -6,7 +6,7 @@ fi
 if [ "$frr_enable" == "YES" ] && (`echo "$frr_daemons" | /usr/bin/grep -F -q -w "ospf6d"`) &&
         (`echo "$frr_carp_demote" | /usr/bin/grep -F -q -w "ospf6d"`)  ; then
     # OSPF enabled
-    OSPF_NEIGHBOR=`echo "show ipv6 ospf6 neighbor" | /usr/local/bin/vtysh 2>&1`
+    OSPF_NEIGHBOR=`echo "show ipv6 ospf6 neighbor" | /usr/local/bin/vtysh 2>&1` IFS=
     if [ "$?" -eq 0 ]; then
         # running, check if we can find any neighbors
         IFS=

--- a/net/frr/src/etc/rc.carp_service_status.d/carp_frr_ospf6
+++ b/net/frr/src/etc/rc.carp_service_status.d/carp_frr_ospf6
@@ -1,0 +1,25 @@
+#!/bin/sh
+if [ -f /etc/rc.conf.d/frr ]; then
+    . /etc/rc.conf.d/frr
+fi
+
+if [ "$frr_enable" == "YES" ] && (`echo "$frr_daemons" | /usr/bin/grep -F -q -w "ospf6d"`) &&
+        (`echo "$frr_carp_demote" | /usr/bin/grep -F -q -w "ospf6d"`)  ; then
+    # OSPF enabled
+    OSPF_NEIGHBOR=`echo "show ipv6 ospf6 neighbor" | /usr/local/bin/vtysh 2>&1`
+    if [ "$?" -eq 0 ]; then
+        # running, check if we can find any neighbors
+        IFS=
+        neighbors_count=`echo $OSPF_NEIGHBOR |  grep "Full/" | wc -l`
+        unset IFS
+        if [ "$neighbors_count" -eq 0 ]; then
+            # no neighbors in state Full/* found
+            exit 2
+        else
+            exit 0
+        fi
+    else
+        # not running
+        exit 1
+    fi
+fi

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditOSPF6Interface.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditOSPF6Interface.xml
@@ -7,7 +7,7 @@
   <field>
     <id>interface.interfacename</id>
     <label>Interface</label>
-    <type>select_multiple</type>
+    <type>dropdown</type>
     <help>Select an interface where this settings apply to.</help>
   </field>
   <field>
@@ -25,6 +25,18 @@
     <id>interface.cost</id>
     <label>Cost</label>
     <type>text</type>
+  </field>
+  <field>
+    <id>interface.cost_demoted</id>
+    <label>Cost (when demoted)</label>
+    <type>text</type>
+  </field>
+  <field>
+    <id>interface.carp_depend_on</id>
+    <label>Depend on (carp)</label>
+    <type>dropdown</type>
+    <help>The carp VHID to depend on, when this virtual address is not in master state,
+      the interface cost will be set to the demoted cost (specified above).</help>
   </field>
   <field>
     <id>interface.hellointerval</id>
@@ -54,6 +66,6 @@
   <field>
     <id>interface.networktype</id>
     <label>Network Type</label>
-    <type>select_multiple</type>
+    <type>dropdown</type>
   </field>
 </form>

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/ospf6.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/ospf6.xml
@@ -6,6 +6,16 @@
         <help>This will activate the OSPFv3 service if routing protocols are enabled in "General".</help>
     </field>
     <field>
+      <id>ospf6.carp_demote</id>
+      <label>CARP demote</label>
+      <type>checkbox</type>
+      <help>
+            Register CARP status monitor, when no neighbors are found, consider this node less attractive.
+            This feature needs syslog enabled using "Debugging" logging to catch all relevant status events.
+            This option is not compatible with "Enable CARP Failover".
+      </help>
+    </field>
+    <field>
         <id>ospf6.redistribute</id>
         <label>Route Redistribution</label>
         <type>select_multiple</type>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF6.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF6.xml
@@ -52,6 +52,17 @@
                                 <MaximumValue>4294967295</MaximumValue>
                                 <ValidationMessage>Cost must be between 0 and 4294967295.</ValidationMessage>
                         </cost>
+                        <cost_demoted type="IntegerField">
+                                <default>65535</default>
+                                <MinimumValue>1</MinimumValue>
+                                <Required>N</Required>
+                                <MaximumValue>65535</MaximumValue>
+                                <ValidationMessage>Cost must be between 1 and 65535.</ValidationMessage>
+                        </cost_demoted>
+                        <carp_depend_on type="VirtualIPField">
+                            <type>carp</type>
+                            <Required>N</Required>
+                        </carp_depend_on>
                         <hellointerval type="IntegerField">
                                 <default></default>
                                 <MinimumValue>0</MinimumValue>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF6.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF6.xml
@@ -7,6 +7,10 @@
             <default>0</default>
             <Required>Y</Required>
         </enabled>
+        <carp_demote type="BooleanField">
+            <default>0</default>
+            <Required>Y</Required>
+        </carp_demote>
         <redistribute type="OptionField">
                 <Required>N</Required>
                 <multiple>Y</multiple>

--- a/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/diagnosticsbgp.volt
+++ b/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/diagnosticsbgp.volt
@@ -101,7 +101,6 @@ $(document).ready(function() {
     content = _.template($('#routestpl').html())(data['response']);
     $('#routing').html(content);
     $('#routing table').bootgrid({
-      converters: dataconverters,
       formatters: dataformatters
     });
   });
@@ -110,7 +109,6 @@ $(document).ready(function() {
     content = _.template($('#routestpl').html())(data['response']);
     $('#routing6').html(content);
     $('#routing6 table').bootgrid({
-      converters: dataconverters,
       formatters: dataformatters
     });
   });

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/+TARGETS
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/+TARGETS
@@ -3,6 +3,7 @@ bgpd.conf:/usr/local/etc/frr/bgpd.conf
 ospfd.conf:/usr/local/etc/frr/ospfd.conf
 ospfd_carp.conf:/usr/local/etc/frr/ospfd_carp.conf
 ospf6d.conf:/usr/local/etc/frr/ospf6d.conf
+ospf6d_carp.conf:/usr/local/etc/frr/ospf6d_carp.conf
 ripd.conf:/usr/local/etc/frr/ripd.conf
 sa_policies.conf:/usr/local/etc/frr/sa_policies.conf
 frr:/etc/rc.conf.d/frr

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/frr
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/frr
@@ -12,7 +12,10 @@ if helpers.exists('OPNsense.quagga.bgp.enabled') and OPNsense.quagga.bgp.enabled
 if helpers.exists('OPNsense.quagga.ospf6.enabled') and OPNsense.quagga.ospf6.enabled == '1' %} ospf6d{% endif %}{%
 if helpers.exists('OPNsense.quagga.ripng.enabled') and OPNsense.quagga.ripng.enabled == '1' %} ripngd{% endif %}{%
 if helpers.exists('OPNsense.quagga.isis.enabled') and OPNsense.quagga.isis.enabled == '1' %} isisd{% endif %}"
-frr_carp_demote="{% if not helpers.empty('OPNsense.quagga.ospf.carp_demote') %} ospfd{% endif %}"
+frr_carp_demote="{%
+    if not helpers.empty('OPNsense.quagga.ospf.carp_demote') %} ospfd{% endif %}{%
+    if not helpers.empty('OPNsense.quagga.ospf6.carp_demote') %} ospf6d{% endif
+%}"
 start_postcmd="/usr/local/opnsense/scripts/frr/carp_event_handler"
 {% else %}
 frr_enable="NO"

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospf6d_carp.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospf6d_carp.conf
@@ -1,0 +1,13 @@
+{% from 'OPNsense/Macros/interface.macro' import physical_interface %}
+{% if helpers.exists('OPNsense.quagga.ospf6.interfaces.interface') %}
+{%   for interface in helpers.toList('OPNsense.quagga.ospf6.interfaces.interface') %}
+{%     if interface.enabled == '1' %}
+[{{ interface['@uuid'] }}]
+enabled={{interface.enabled|default('0')}}
+interface={{physical_interface(interface.interfacename)}}
+default_cost={{interface.cost|default('')}}
+demoted_cost={{interface.cost_demoted|default('')}}
+carp_depend_on={{interface.carp_depend_on|default('')}}
+{%     endif %}
+{%   endfor %}
+{% endif %}

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/syslog-ng-frr-events.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/syslog-ng-frr-events.conf
@@ -6,7 +6,8 @@ destination d_frr_event {
 };
 
 filter f_frr_ospf {
-    program("ospfd") and (
+    (program("ospfd") or program("ospf6d"))
+    and (
         (
                 level("info") or level("notice")
         ) or (


### PR DESCRIPTION
Implements https://github.com/opnsense/plugins/issues/2923 

Add event handler for ospf6 carp demotion including required interface fields (carp_depend_on and cost_demoted) and implement "CARP demote" for IPv6 as well to bring HA features on par with OSPF.   

While here polish some small usability issues, knowing:
    
o Interface networktype and interfacename should be single dropdown boxes
o diagnostics / bgp - fix search in grid, should only use a formatter for presentation purposes.
