### PR TITLE
security/acme-client: Correct TransIP API

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -1066,6 +1066,10 @@
         <style>table_dns table_dns_transip</style>
     </field>
     <field>
+        <label>NOTE: A DNS sleep time of at least 300 is recommended.</label>
+        <type>header</type>
+        <style>table_dns table_dns_transip</style>
+    <field>
         <id>validation.dns_transip_username</id>
         <label>Username</label>
         <type>text</type>
@@ -1074,7 +1078,7 @@
     <field>
         <id>validation.dns_transip_key</id>
         <label>API Key</label>
-        <type>text</type>
+        <type>textbox</type>
         <help>Requires the whole key file in a format that is compatible with TransIP.</help>
     </field>
     <field>


### PR DESCRIPTION
API key field  type of Transip corrected from "text" to "textbox". It was nog working with "text" due to linebreaks. I tested and this and now it works. Furthernore added a note that 300s sleep time is recommended.