### PR TITLE
Add Enable Remote Commands to Zabbix Proxy

### DIFF
--- a/net-mgmt/zabbix-proxy/pkg-descr
+++ b/net-mgmt/zabbix-proxy/pkg-descr
@@ -11,6 +11,8 @@ WWW: https://www.zabbix.com/
 
 Plugin Changelog
 ----------------
+1.8
+* Add EnableRemoteCommands
 
 1.7
 

--- a/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/controllers/OPNsense/Zabbixproxy/forms/general.xml
+++ b/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/controllers/OPNsense/Zabbixproxy/forms/general.xml
@@ -12,6 +12,12 @@
         <help>Active (default) or passive mode, only switch to passive if you know what you are doing.</help>
     </field>
     <field>
+        <id>general.remotecommands</id>
+        <label>Enable Remote Commands</label>
+        <type>checkbox</type>
+        <help>Enable Remote Commands on Proxy.</help>
+    </field>
+    <field>
         <id>general.server</id>
         <label>Server</label>
         <type>text</type>

--- a/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/models/OPNsense/Zabbixproxy/General.xml
+++ b/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/models/OPNsense/Zabbixproxy/General.xml
@@ -11,6 +11,10 @@
             <default>0</default>
             <Required>Y</Required>
         </proxymode>
+        <remotecommands type="BooleanField">
+            <default>0</default>
+            <Required>Y</Required>
+        </remotecommands>
         <server type="TextField">
             <default></default>
             <Required>N</Required>

--- a/net-mgmt/zabbix-proxy/src/opnsense/service/templates/OPNsense/Zabbixproxy/zabbix_proxy.conf.in
+++ b/net-mgmt/zabbix-proxy/src/opnsense/service/templates/OPNsense/Zabbixproxy/zabbix_proxy.conf.in
@@ -3,6 +3,9 @@
 {% if helpers.exists('OPNsense.zabbixproxy.general.proxymode') and OPNsense.zabbixproxy.general.proxymode == '1' %}
 ProxyMode=1
 {% else %}
+{% if helpers.exists('OPNsense.zabbixproxy.general.remotecommands') and OPNsense.zabbixproxy.general.remotecommands == '1' %}
+EnableRemoteCommands=1
+{% else %}
 ProxyMode=0
 {% endif %}
 {% if helpers.exists('OPNsense.zabbixproxy.general.server') and OPNsense.zabbixproxy.general.server != '' %}


### PR DESCRIPTION
This to add Enable Remote Commands to Zabbix Proxy on GUI.
Instead of agent that EnableRemoteCommands is deprecated, on Proxy configuration EnableRemoteCommands is alway valid.