### PR TITLE
os-wireguard: add script to enable cron renewal of DNS for stale connections

### DIFF
--- a/net/wireguard/Makefile
+++ b/net/wireguard/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		wireguard
-PLUGIN_VERSION=		1.10
+PLUGIN_VERSION=		1.11
 PLUGIN_COMMENT=		WireGuard VPN service
 PLUGIN_DEPENDS=		wireguard-go wireguard-tools
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net/wireguard/pkg-descr
+++ b/net/wireguard/pkg-descr
@@ -16,6 +16,10 @@ WWW: https://www.wireguard.com/
 Changelog
 ---------
 
+1.11
+
+* Add script for renewal of Wireguard DNS-based entries for stale connections
+
 1.10
 
 * Remove instance limit

--- a/net/wireguard/src/opnsense/scripts/OPNsense/Wireguard/resolve-dns.sh
+++ b/net/wireguard/src/opnsense/scripts/OPNsense/Wireguard/resolve-dns.sh
@@ -1,0 +1,49 @@
+#!/usr/local/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (C) 2015-2020 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
+
+set -e
+shopt -s nocasematch
+shopt -s extglob
+export LC_ALL=C
+
+for CONFIG_FILE in /usr/local/etc/wireguard/*.conf
+do
+
+[[ $CONFIG_FILE =~ /?([a-zA-Z0-9_=+.-]{1,15})\.conf$ ]]
+INTERFACE="${BASH_REMATCH[1]}"
+
+process_peer() {
+        [[ $PEER_SECTION -ne 1 || -z $PUBLIC_KEY || -z $ENDPOINT ]] && return 0
+        [[ $(wg show "$INTERFACE" latest-handshakes) =~ ${PUBLIC_KEY//+/\\+}\   ([0-9]+) ]
+] || return 0
+        (( ($EPOCHSECONDS - ${BASH_REMATCH[1]}) > 135 )) || return 0
+        wg set "$INTERFACE" peer "$PUBLIC_KEY" endpoint "$ENDPOINT"
+        reset_peer_section
+}
+
+reset_peer_section() {
+        PEER_SECTION=0
+        PUBLIC_KEY=""
+        ENDPOINT=""
+}
+
+reset_peer_section
+while read -r line || [[ -n $line ]]; do
+        stripped="${line%%\#*}"
+        key="${stripped%%=*}"; key="${key##*([[:space:]])}"; key="${key%%*([[:space:]])}"
+        value="${stripped#*=}"; value="${value##*([[:space:]])}"; value="${value%%*([[:spa
+ce:]])}"
+        [[ $key == "["* ]] && { process_peer; reset_peer_section; }
+        [[ $key == "[Peer]" ]] && PEER_SECTION=1
+        if [[ $PEER_SECTION -eq 1 ]]; then
+                case "$key" in
+                PublicKey) PUBLIC_KEY="$value"; continue ;;
+                Endpoint) ENDPOINT="$value"; continue ;;
+                esac
+        fi
+done < "$CONFIG_FILE"
+process_peer
+
+done

--- a/net/wireguard/src/opnsense/service/conf/actions.d/actions_wireguard.conf
+++ b/net/wireguard/src/opnsense/service/conf/actions.d/actions_wireguard.conf
@@ -23,6 +23,14 @@ type:script
 message:Restarting WireGuard
 description: Restart WireGuard
 
+[renew]
+command:
+    /usr/local/opnsense/scripts/OPNsense/Wireguard/resolve-dns.sh
+parameters:
+type:script
+message:Renew DNS for Wireguard
+description:Renew DNS for Wireguard on stale connections
+
 [genkey]
 command:/usr/local/opnsense/scripts/OPNsense/Wireguard/genkey.sh
 parameters: %s

--- a/net/wireguard/src/opnsense/service/conf/actions.d/actions_wireguard.conf
+++ b/net/wireguard/src/opnsense/service/conf/actions.d/actions_wireguard.conf
@@ -24,8 +24,7 @@ message:Restarting WireGuard
 description: Restart WireGuard
 
 [renew]
-command:
-    /usr/local/opnsense/scripts/OPNsense/Wireguard/resolve-dns.sh
+command:/usr/local/opnsense/scripts/OPNsense/Wireguard/resolve-dns.sh
 parameters:
 type:script
 message:Renew DNS for Wireguard


### PR DESCRIPTION
Wireguard does DNS resolution of endpoints only on startup. Even when a keepalive is in place, a stale connection does not lead to a renewal of DNS entries in case the other side's IP has changed.

This adds a script that can be called from cron every now and then and then triggers a DNS renewal for all stale connections.
