### PR TITLE
net-mgmt/zabbix-proxy/agent: Added preliminar support for 6.0

### DIFF
--- a/net-mgmt/zabbix-agent/Makefile
+++ b/net-mgmt/zabbix-agent/Makefile
@@ -2,7 +2,10 @@ PLUGIN_NAME=		zabbix-agent
 PLUGIN_VERSION=		1.11
 PLUGIN_COMMENT=		Zabbix monitoring agent
 PLUGIN_MAINTAINER=	opnsense@moov.de
-PLUGIN_VARIANTS=	zabbix5 zabbix54
+PLUGIN_VARIANTS=	zabbix6 zabbix5 zabbix54
+
+zabbix6_NAME=		zabbix6-agent
+zabbix6_DEPENDS=	zabbix6-agent
 
 zabbix5_NAME=		zabbix-agent
 zabbix5_DEPENDS=	zabbix5-agent

--- a/net-mgmt/zabbix-agent/pkg-descr
+++ b/net-mgmt/zabbix-agent/pkg-descr
@@ -11,6 +11,9 @@ WWW: https://www.zabbix.com/
 
 Plugin Changelog
 ----------------
+1.12
+
+* Plugin variant for Zabbix Agent 6.0
 
 1.11
 

--- a/net-mgmt/zabbix-proxy/Makefile
+++ b/net-mgmt/zabbix-proxy/Makefile
@@ -2,7 +2,10 @@ PLUGIN_NAME=		zabbix-proxy
 PLUGIN_VERSION=		1.8
 PLUGIN_COMMENT=		Zabbix monitoring proxy
 PLUGIN_MAINTAINER=	m.muenz@gmail.com
-PLUGIN_VARIANTS=	zabbix5 zabbix54 zabbix4
+PLUGIN_VARIANTS=	zabbix6 zabbix5 zabbix54 zabbix4
+
+zabbix6_NAME=		zabbix6-proxy
+zabbix6_DEPENDS=	zabbix6-proxy
 
 zabbix5_NAME=		zabbix5-proxy
 zabbix5_DEPENDS=	zabbix5-proxy

--- a/net-mgmt/zabbix-proxy/pkg-descr
+++ b/net-mgmt/zabbix-proxy/pkg-descr
@@ -12,6 +12,10 @@ WWW: https://www.zabbix.com/
 Plugin Changelog
 ----------------
 
+1.9
+
+* Add plugin variant for Zabbix Proxy 6.0
+
 1.8
 
 * Add EnableRemoteCommands (#2948)


### PR DESCRIPTION
Hey guys, I'm trying to add zabbix proxy and agent 6.0 into the main plugin as the port already exists.

I'm stuck with two issues (maybe is my test setup):

- No log text shows in the *Log File* tab (although file permissions are ok, there's content inside)
- Zabbix Proxy 6.0 deprecated the ServerPort parameter. Now it must be specified with the host adress separated by ':' instead