### PR TITLE
net/frr: (BGP) Configure ipv6 next-hop on route-map

### DIFF
--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -183,7 +183,7 @@ route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
 {%             endif %}
 {%           endfor %}
 {%         endif %}
-{%         if routemap.set|default("") != '' and routemap.match|default("") != '' %}
+{%         if routemap.set|default("") != '' %}
  set {{ routemap.set }}
 {%         endif %}
 {%         if routemap.match2|default("") != "" %}


### PR DESCRIPTION
according to the FRR documentation and the ui validations, match is optional (https://docs.frrouting.org/en/latest/routemap.html#term-Matching-Conditions). Likely fixes https://github.com/opnsense/plugins/issues/2955