### PR TITLE
security/acme-client: Add missing <style> field

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -1068,6 +1068,7 @@
     <field>
         <label>NOTE: A DNS sleep time of at least 300 is recommended.</label>
         <type>header</type>
+        <style>table_dns table_dns_transip</style>
     </field>
     <field>
         <id>validation.dns_transip_username</id>


### PR DESCRIPTION
The missing <style> field at TransIP was causing the fields below it to show up in ALL dialogs.