### PR TITLE
Trim whitespace around public and private keys in config.

### DIFF
--- a/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/Api/ServerController.php
+++ b/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/Api/ServerController.php
@@ -59,8 +59,8 @@ class ServerController extends ApiMutableModelControllerBase
                 $backend = new Backend();
                 $keyspriv = $backend->configdpRun("wireguard genkey", 'private');
                 $keyspub = $backend->configdpRun("wireguard genkey", 'public');
-                $node->privkey = $keyspriv;
-                $node->pubkey = $keyspub;
+                $node->privkey = trim($keyspriv);
+                $node->pubkey = trim($keyspub);
             }
             return $this->validateAndSave($node, 'server');
         }
@@ -84,8 +84,8 @@ class ServerController extends ApiMutableModelControllerBase
                 $backend = new Backend();
                 $keyspriv = $backend->configdpRun("wireguard genkey", 'private');
                 $keyspub = $backend->configdpRun("wireguard genkey", 'public');
-                $node->privkey = $keyspriv;
-                $node->pubkey = $keyspub;
+                $node->privkey = trim($keyspriv);
+                $node->pubkey = trim($keyspub);
             }
             return $this->validateAndSave($node, 'server');
         }


### PR DESCRIPTION
Trim is used in many other plugins before config values are stored. Discussion here:

https://forum.opnsense.org/index.php?topic=28345.msg137607#msg137607