### PR TITLE
Text validation error when creating a Freeradius user with a password containing special characters

### DIFF
--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/User.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/User.xml
@@ -15,7 +15,7 @@
                 </username>
                 <password type="TextField">
                     <Required>Y</Required>
-                    <mask>/^([0-9a-zA-Z._\-\,\£\$\%\^\&amp;\*\(\)\}\{\@\:\'\-\=\-\_\+\-\¬\`\#\~\?\>\,\;\@\!\$\%\/\(\)\+\#\=\{\}]){1,128}$/u</mask>
+                    <mask>/^([0-9a-zA-Z._\-\,\£\$\%\^\&amp;\*\(\)\}\{\@\:\'\-\=\-\_\+\-\¬\`\#\~\?\&#60;\>\,\;\@\!\$\%\/\(\)\+\#\=\{\}]){1,128}$/u</mask>
                 </password>
                 <description type="TextField">
                     <Required>N</Required>

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/User.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/User.xml
@@ -15,7 +15,7 @@
                 </username>
                 <password type="TextField">
                     <Required>Y</Required>
-                    <mask>/^([0-9a-zA-Z._\-\,\!\$\%\/\(\)\+\#\=\{\}]){1,128}$/u</mask>
+                    <mask>/^([0-9a-zA-Z._\-\,\£\$\%\^\&amp;\*\(\)\}\{\@\:\'\-\=\-\_\+\-\¬\`\#\~\?\>\,\;\@\!\$\%\/\(\)\+\#\=\{\}]){1,128}$/u</mask>
                 </password>
                 <description type="TextField">
                     <Required>N</Required>

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/User.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/User.xml
@@ -15,7 +15,7 @@
                 </username>
                 <password type="TextField">
                     <Required>Y</Required>
-                    <mask>/^([0-9a-zA-Z._\-\!\$\%\/\(\)\+\#\=\{\}]){1,128}$/u</mask>
+                    <mask>/^([0-9a-zA-Z._\-\,\!\$\%\/\(\)\+\#\=\{\}]){1,128}$/u</mask>
                 </password>
                 <description type="TextField">
                     <Required>N</Required>


### PR DESCRIPTION
Initially I realized I could not not create Freeradius user with password containing special characters such as,>,<,?(This was noticed on the latest branch of Freeradius.

I made the a few modifications in the user.xml file and tested it and was able to add users with passwords containing special characters