### PR TITLE
net/frr add disable-connected-check option

### DIFF
--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPNeighbor.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPNeighbor.xml
@@ -63,6 +63,10 @@
   <field>
     <id>neighbor.multihop</id>
     <label>Multi-Hop</label>
+    <help>
+      Specifying ebgp-multihop allows sessions with eBGP neighbors to establish when they are multiple hops away.
+      When the neighbor is not directly connected and this knob is not enabled, the session will not establish.
+    </help>
     <type>checkbox</type>
   </field>
   <field>
@@ -113,7 +117,13 @@
     <id>neighbor.asoverride</id>
     <label>Enable AS-Override</label>
     <type>checkbox</type>
-	<help>Override AS number of the originating router with the local AS number. This command is only allowed for eBGP peers.</help>
+    <help>Override AS number of the originating router with the local AS number. This command is only allowed for eBGP peers.</help>
+  </field>
+  <field>
+    <id>neighbor.disable_connected_check</id>
+    <label>Disable Connected Check</label>
+    <type>checkbox</type>
+    <help>Allow peerings between directly connected eBGP peers using loopback addresses.</help>
   </field>
   <field>
     <id>neighbor.linkedPrefixlistIn</id>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
@@ -128,6 +128,10 @@
                                 <default>0</default>
                                 <Required>N</Required>
                         </asoverride>
+                        <disable_connected_check type="BooleanField">
+                                <default>0</default>
+                                <Required>N</Required>
+                        </disable_connected_check>
                         <linkedPrefixlistIn type="ModelRelationField">
                                 <Model>
                                         <template>

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -106,6 +106,9 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%     if 'asoverride' in neighbor and neighbor.asoverride == '1' %}
   neighbor {{ neighbor.address }} as-override
 {%         endif %}
+{%     if 'disable_connected_check' in neighbor and neighbor.disable_connected_check == '1' %}
+  neighbor {{ neighbor.address }} disable-connected-check
+{%         endif %}
 {%     if neighbor.linkedPrefixlistIn|default("") != "" %}
 {%       for prefixlist in neighbor.linkedPrefixlistIn.split(",") %}
 {%         set prefixlist2_data = helpers.getUUID(prefixlist) %}


### PR DESCRIPTION
While working on an Azure setup where the neighbor isn't within visible range, we stumbled upon the "disable-connected-check" option to allow loopback addresses.
Reading a bit further there seem to be different ways of dealing with similar kind of situations.

Either by setting an ebgp-multihop ttl value or to enable the disable-connected-check option. Since the multihop didn't come with a help text, it seemed like a good idea to add at least the upstream frr one. Knowning that the current multihop fieldtype currently is wrong ("enabling" will set a ttl of 255, where it should have been a number)

Used the following resources:

- https://nexp.com.ua/technologies/rns/bgp-loopbacks/
- https://docs.frrouting.org/en/latest/bgp.html
- https://github.com/FRRouting/frr/issues/2713

Ideally one should change the ebgp-multihop to an int some day as the current option always seems to enforce the maximum ttl when set, but this will need a migration as well.