### PR TITLE
www/nginx: add support for workers and websockets in CSP directive

### DIFF
--- a/www/nginx/Makefile
+++ b/www/nginx/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		nginx
-PLUGIN_VERSION=		1.27
+PLUGIN_VERSION=		1.28
 PLUGIN_COMMENT=		Nginx HTTP server and reverse proxy
 PLUGIN_DEPENDS=		nginx
 PLUGIN_MAINTAINER=	franz.fabian.94@gmail.com

--- a/www/nginx/pkg-descr
+++ b/www/nginx/pkg-descr
@@ -10,6 +10,10 @@ WWW: https://nginx.org/
 Plugin Changelog
 ================
 
+1.28
+
+* add support for connect-src and worker-src in content security policy
+
 1.27
 
 * add support for custom configuration in stream server (contributed by Fabio Castagnino)

--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/security_headers.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/security_headers.xml
@@ -617,6 +617,97 @@
       <help>If this checkbox is checked, all other settings for this directive are ignored and everything will be forbidden.</help>
     </field>
   </tab>
+  <tab id="connect_src" description="Websockets">
+    <field>
+      <type>header</type>
+      <label>Content Security Policy: Connect Source</label>
+      <hint><![CDATA[The setting <em>Content Security Policy: Enable</em> on the <em>General</em> tab needs to be enabled to activate this header.]]></hint>
+    </field>
+    <field>
+      <id>security_header.csp_connect_src_enabled</id>
+      <label>Enable</label>
+      <type>checkbox</type>
+      <help>If checked, this part of the CSP is enabled.</help>
+    </field>
+    <field>
+      <id>security_header.csp_connect_src_http_urls</id>
+      <label>Enable HTTP(S) URLs</label>
+      <type>select_multiple</type>
+      <allownew>true</allownew>
+      <style>tokenize</style>
+      <help>Allow connecting to websockets. You can use wildcards here like wss://*.exmaple.com.</help>
+    </field>
+    <field>
+      <id>security_header.csp_connect_src_none</id>
+      <label>Forbid Explicitly</label>
+      <type>checkbox</type>
+      <help>If this checkbox is checked, all other settings for this directive are ignored and everything will be forbidden.</help>
+    </field>
+  </tab>
+  <tab id="worker_src" description="Worker">
+    <field>
+      <type>header</type>
+      <label>Content Security Policy: Worker Source</label>
+      <hint><![CDATA[The setting <em>Content Security Policy: Enable</em> on the <em>General</em> tab needs to be enabled to activate this header.]]></hint>
+    </field>
+    <field>
+      <id>security_header.csp_worker_src_enabled</id>
+      <label>Enable</label>
+      <type>checkbox</type>
+      <help>If checked, this part of the CSP is enabled.</help>
+    </field>
+    <field>
+      <id>security_header.csp_worker_src_data_urls</id>
+      <label>Enable Data URLs</label>
+      <help>Data URLs are used to embed files into HTML (for example images written directly into the src attribute).</help>
+      <type>checkbox</type>
+    </field>
+    <field>
+      <id>security_header.csp_worker_src_http_urls</id>
+      <label>Enable HTTP(S) URLs</label>
+      <type>select_multiple</type>
+      <allownew>true</allownew>
+      <style>tokenize</style>
+      <help>Allow loading files over HTTP(S) allows downloading of content over other domains or CDNs.
+        You can use wildcards here like https://*.exmaple.com.</help>
+    </field>
+    <field>
+      <id>security_header.csp_worker_src_inline</id>
+      <label>Enable Inline Scripting</label>
+      <type>checkbox</type>
+      <help>Checking this directive allows to use scripts or styles directly embedded in in the HTML content.
+        Examples are the script and the style tags.</help>
+    </field>
+    <field>
+      <id>security_header.csp_worker_src_eval</id>
+      <label>Enable Eval</label>
+      <type>checkbox</type>
+      <help>Checking this box allows functions like eval or createFunction in JS, or style attributes for CSS.</help>
+    </field>
+    <field>
+      <id>security_header.csp_worker_src_self</id>
+      <label>Enable Same Origin (recommended)</label>
+      <type>checkbox</type>
+      <help>Allows everything from the same site (path can differ, but host, protocol and port need to be the same).</help>
+    </field>
+    <field>
+      <id>security_header.csp_worker_src_blob</id>
+      <label>Enable Blobs</label>
+      <type>checkbox</type>
+      <help>Allows to use blobs as a data source. This usually is content, which is somehow generated in JavaScript.</help>
+    </field>
+    <field>
+      <id>security_header.csp_worker_src_filesystem</id>
+      <label>Enable File System URLs</label>
+      <type>checkbox</type>
+    </field>
+    <field>
+      <id>security_header.csp_worker_src_none</id>
+      <label>Forbid Explicitly</label>
+      <type>checkbox</type>
+      <help>If this checkbox is checked, all other settings for this directive are ignored and everything will be forbidden.</help>
+    </field>
+  </tab>
   <tab id="form-action" description="Form">
     <field>
       <type>header</type>

--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
@@ -1,6 +1,6 @@
 <model>
   <mount>//OPNsense/Nginx</mount>
-  <version>1.26.0</version>
+  <version>1.28.0</version>
   <description>nginx web server, reverse proxy and waf</description>
   <items>
     <general>
@@ -1512,6 +1512,52 @@
         <Required>Y</Required>
         <default>0</default>
       </csp_frame_ancestors_none>
+      <csp_connect_src_enabled type="BooleanField">
+        <Required>Y</Required>
+        <default>0</default>
+      </csp_connect_src_enabled>
+      <csp_connect_src_http_urls type="CSVListField">
+        <Required>N</Required>
+      </csp_connect_src_http_urls>
+      <csp_connect_src_none type="BooleanField">
+        <Required>Y</Required>
+        <default>0</default>
+      </csp_connect_src_none>
+      <csp_worker_src_enabled type="BooleanField">
+        <Required>Y</Required>
+        <default>0</default>
+      </csp_worker_src_enabled>
+      <csp_worker_src_data_urls type="BooleanField">
+        <Required>Y</Required>
+        <default>0</default>
+      </csp_worker_src_data_urls>
+      <csp_worker_src_http_urls type="CSVListField">
+        <Required>N</Required>
+      </csp_worker_src_http_urls>
+      <csp_worker_src_inline type="BooleanField">
+        <Required>Y</Required>
+        <default>0</default>
+      </csp_worker_src_inline>
+      <csp_worker_src_eval type="BooleanField">
+        <Required>Y</Required>
+        <default>0</default>
+      </csp_worker_src_eval>
+      <csp_worker_src_self type="BooleanField">
+        <Required>Y</Required>
+        <default>0</default>
+      </csp_worker_src_self>
+      <csp_worker_src_blob type="BooleanField">
+        <Required>Y</Required>
+        <default>0</default>
+      </csp_worker_src_blob>
+      <csp_worker_src_filesystem type="BooleanField">
+        <Required>Y</Required>
+        <default>0</default>
+      </csp_worker_src_filesystem>
+      <csp_worker_src_none type="BooleanField">
+        <Required>Y</Required>
+        <default>0</default>
+      </csp_worker_src_none>
       <csp_form_action_enabled type="BooleanField">
         <Required>Y</Required>
         <default>0</default>

--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/security_rule.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/security_rule.conf
@@ -19,7 +19,7 @@
 {% endif %}
 {% if security_rule.enable_csp is defined and security_rule.enable_csp == '1' %}
 {% set hash_csp = {} %}
-{%   for csp_category in ['default-src', 'script-src', 'img-src', 'style-src', 'media-src', 'font-src', 'frame-src', 'frame-ancestors', 'form-action'] %}
+{%   for csp_category in ['default-src', 'script-src', 'img-src', 'style-src', 'media-src', 'font-src', 'frame-src', 'frame-ancestors', 'form-action', 'connect-src', 'worker-src'] %}
 {%     set prefix = 'csp_' + csp_category.replace('-', '_') + '_' %}
 {%     if security_rule[prefix + 'enabled'] == '1' %}
 {%       set current_list = [] %}


### PR DESCRIPTION
Add support for

* Web Workers
* Websockets

in Content Security Policy.

Closes #1396