### PR TITLE
net/frr - BGP weight option and bug fix for disable-connected-check option

### DIFF
--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/Api/BgpController.php
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/Api/BgpController.php
@@ -197,6 +197,11 @@ class BgpController extends ApiMutableModelControllerBase
         return $this->setBase('routemap', 'routemaps.routemap', $uuid);
     }
 
+    public function toggleCommunitylistAction($uuid)
+    {
+        return $this->toggleBase('communitylists.communitylist', $uuid);
+    }
+
     public function toggleNeighborAction($uuid)
     {
         return $this->toggleBase('neighbors.neighbor', $uuid);

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPNeighbor.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPNeighbor.xml
@@ -30,6 +30,13 @@
     <help>Set a password for BGP authentication.</help>
   </field>
   <field>
+    <id>neighbor.weight</id>
+    <label>Weight</label>
+    <type>text</type>
+    <advanced>true</advanced>
+    <help>Specify a default weight value for the neighbor’s routes.</help>
+  </field>
+  <field>
     <id>neighbor.localip</id>
     <label>Local Initiater IP</label>
     <type>text</type>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
@@ -60,6 +60,12 @@
                         <password type="TextField">
                                 <Required>N</Required>
                         </password>
+                        <weight type="IntegerField">
+                                <default></default>
+                                <Required>N</Required>
+                                <MinimumValue>0</MinimumValue>
+                                <MaximumValue>65535</MaximumValue>
+                        </weight>
                         <localip type="NetworkField">
                                 <Required>N</Required>
                         </localip>

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -63,7 +63,7 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%         if 'weight' in neighbor and neighbor.weight != '' %}
  neighbor {{ neighbor.address }} weight {{ neighbor.weight }}
 {%         endif %}
-{%     if 'disable_connected_check' in neighbor and neighbor.disable_connected_check == '1' %}
+{%         if 'disable_connected_check' in neighbor and neighbor.disable_connected_check == '1' %}
  neighbor {{ neighbor.address }} disable-connected-check
 {%         endif %}
 {%         if ':' not in neighbor.address and 'updatesource' in neighbor and neighbor.updatesource != '' %}

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -60,6 +60,12 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%         if 'password' in neighbor and neighbor.password != '' %}
  neighbor {{ neighbor.address }} password {{ neighbor.password }}
 {%         endif %}
+{%         if 'weight' in neighbor and neighbor.weight != '' %}
+ neighbor {{ neighbor.address }} weight {{ neighbor.weight }}
+{%         endif %}
+{%     if 'disable_connected_check' in neighbor and neighbor.disable_connected_check == '1' %}
+ neighbor {{ neighbor.address }} disable-connected-check
+{%         endif %}
 {%         if ':' not in neighbor.address and 'updatesource' in neighbor and neighbor.updatesource != '' %}
  neighbor {{ neighbor.address }} update-source {{ physical_interface(neighbor.updatesource) }}
 {%         endif %}
@@ -105,9 +111,6 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%     endif %}
 {%     if 'asoverride' in neighbor and neighbor.asoverride == '1' %}
   neighbor {{ neighbor.address }} as-override
-{%         endif %}
-{%     if 'disable_connected_check' in neighbor and neighbor.disable_connected_check == '1' %}
-  neighbor {{ neighbor.address }} disable-connected-check
 {%         endif %}
 {%     if neighbor.linkedPrefixlistIn|default("") != "" %}
 {%       for prefixlist in neighbor.linkedPrefixlistIn.split(",") %}


### PR DESCRIPTION
Add (advanced) bgp `weight` attribute and move `disable-connected-check` to the correct place (both should be set in the generic peer options). 

It looked like "community lists" missed a toggle action, added that as well.


