### PR TITLE
sysutils/apcupsd: change minimum value for battery level and minutes settings

### DIFF
--- a/sysutils/apcupsd/src/opnsense/mvc/app/controllers/OPNsense/Apcupsd/forms/general.xml
+++ b/sysutils/apcupsd/src/opnsense/mvc/app/controllers/OPNsense/Apcupsd/forms/general.xml
@@ -62,8 +62,10 @@
         <id>apcupsd.general.BatteryLevel</id>
         <label>Battery Level Shutdown (%)</label>
         <type>text</type>
-        <help>Apcupsd will shutdown the system during a power failure when the remaining battery charge falls below the
-            specified percentage. (Default is 5).</help>
+        <help>
+            Apcupsd will shutdown the system during a power failure when the remaining battery charge falls below the
+            specified percentage. Set to -1 to disable. (Default is 5).
+        </help>
     </field>
     <field>
         <id>apcupsd.general.Minutes</id>
@@ -71,7 +73,7 @@
         <type>text</type>
         <help>
             Apcupsd will shutdown the system during a power failure when the remaining runtime on batteries as
-            internally calculated by the UPS falls below the specified minutes. (Default is 3)
+            internally calculated by the UPS falls below the specified minutes. Set to -1 to disable. (Default is 3)
         </help>
     </field>
     <field>

--- a/sysutils/apcupsd/src/opnsense/mvc/app/models/OPNsense/Apcupsd/Apcupsd.xml
+++ b/sysutils/apcupsd/src/opnsense/mvc/app/models/OPNsense/Apcupsd/Apcupsd.xml
@@ -103,7 +103,7 @@
                 <Required>Y</Required>
                 <MinimumValue>0</MinimumValue>
                 <MaximumValue>360</MaximumValue>
-                <ValidationMessage>Timeout must be between 1 and 360 seconds.</ValidationMessage>
+                <ValidationMessage>Timeout must be between 0 and 360 seconds.</ValidationMessage>
             </Timeout>
             <Annoy type="IntegerField">
                 <default>300</default>

--- a/sysutils/apcupsd/src/opnsense/mvc/app/models/OPNsense/Apcupsd/Apcupsd.xml
+++ b/sysutils/apcupsd/src/opnsense/mvc/app/models/OPNsense/Apcupsd/Apcupsd.xml
@@ -87,16 +87,16 @@
             <BatteryLevel type="IntegerField">
                 <default>5</default>
                 <Required>Y</Required>
-                <MinimumValue>1</MinimumValue>
+                <MinimumValue>-1</MinimumValue>
                 <MaximumValue>99</MaximumValue>
-                <ValidationMessage>Battery level must be between 1 and 99 percent.</ValidationMessage>
+                <ValidationMessage>Battery level must be between -1 and 99 percent.</ValidationMessage>
             </BatteryLevel>
             <Minutes type="IntegerField">
                 <default>3</default>
                 <Required>Y</Required>
-                <MinimumValue>1</MinimumValue>
+                <MinimumValue>-1</MinimumValue>
                 <MaximumValue>60</MaximumValue>
-                <ValidationMessage>Remaining battery minutes must be between 1 and 60 minutes.</ValidationMessage>
+                <ValidationMessage>Remaining battery minutes must be between -1 and 60 minutes.</ValidationMessage>
             </Minutes>
             <Timeout type="IntegerField">
                 <default>0</default>


### PR DESCRIPTION
From the manual apcupsd will react to the first valid test of timeout expired, battery level remaining, minutes remaining setting.

Setting the minimum value to `-1` for battery level and minutes will allow to disable those checks.

