### PR TITLE
security/maltrail: remove MFS for /var/log/

### DIFF
--- a/security/maltrail/Makefile
+++ b/security/maltrail/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		maltrail
-PLUGIN_VERSION=		1.8
+PLUGIN_VERSION=		1.9
 PLUGIN_COMMENT=		Malicious traffic detection system
 PLUGIN_DEPENDS=		maltrail
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/security/maltrail/pkg-descr
+++ b/security/maltrail/pkg-descr
@@ -11,6 +11,10 @@ WWW: https://github.com/stamparm/maltrail
 Changelog
 ---------
 
+1.9
+
+* Remove MFS support for /var/log/
+
 1.8
 
 * Add firewall alias "BlocklistMaltrail" that points to the built-in ip block list

--- a/security/maltrail/src/opnsense/service/templates/OPNsense/Maltrail/maltrailsensor
+++ b/security/maltrail/src/opnsense/service/templates/OPNsense/Maltrail/maltrailsensor
@@ -4,4 +4,3 @@ maltrailsensor_enable="YES"
 {% else %}
 maltrailsensor_enable="NO"
 {% endif %}
-maltrailsensor_var_mfs="/var/log/maltrail"

--- a/security/maltrail/src/opnsense/service/templates/OPNsense/Maltrail/maltrailserver
+++ b/security/maltrail/src/opnsense/service/templates/OPNsense/Maltrail/maltrailserver
@@ -4,4 +4,3 @@ maltrailserver_enable="YES"
 {% else %}
 maltrailserver_enable="NO"
 {% endif %}
-maltrailserver_var_mfs="/var/log/maltrail"


### PR DESCRIPTION
As discussed in https://github.com/opnsense/plugins/issues/3002