### PR TITLE
Re-order function parameters due to PHP8 deprecation notice

### DIFF
--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.php
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.php
@@ -138,19 +138,19 @@ class HAProxy extends BaseModel
     /**
      * create a new ACL
      * @param string $name
-     * @param string $description
      * @param string $expression
+     * @param string $description
      * @param string $negate
      * @param hash $parameters
      * @return string
      */
-    public function newAcl($name, $description = "", $expression, $negate = "0", $parameters = array())
+    public function newAcl($name, $expression, $description = "", $negate = "0", $parameters = array())
     {
         $acl = $this->acls->acl->Add();
         $uuid = $acl->getAttributes()['uuid'];
         $acl->name = $name;
-        $acl->description = $description;
         $acl->expression = $expression;
+        $acl->description = $description;
         $acl->negate = $negate;
         foreach ($parameters as $key => $value) {
             $acl->$key = $value;
@@ -161,11 +161,11 @@ class HAProxy extends BaseModel
     /**
      * create a new action
      * @param string $name
-     * @param string $description
      * @param string $testType
+     * @param string $type
+     * @param string $description
      * @param string $linkedAcls
      * @param string $operator
-     * @param string $type
      * @param string $useBackend
      * @param string $useServer
      * @param string $actionName
@@ -173,16 +173,16 @@ class HAProxy extends BaseModel
      * @param string $actionValue
      * @return string
      */
-    public function newAction($name, $description = "", $testType, $linkedAcls = "", $operator = "and", $type, $parameters = array())
+    public function newAction($name, $testType, $type, $description = "", $linkedAcls = "", $operator = "and", $parameters = array())
     {
         $action = $this->actions->action->Add();
         $uuid = $action->getAttributes()['uuid'];
         $action->name = $name;
-        $action->description = $description;
         $action->testType = $testType;
+        $action->type = $type;
+        $action->description = $description;
         $action->linkedAcls = $linkedAcls;
         $action->operator = $operator;
-        $action->type = $type;
         foreach ($parameters as $key => $value) {
             $action->$key = $value;
         }
@@ -192,24 +192,24 @@ class HAProxy extends BaseModel
     /**
      * create a new server
      * @param string $name
-     * @param string $description
      * @param string $address
      * @param string $port
      * @param string $mode
+     * @param string $description
      * @param string $ssl
      * @param string $sslVerify
      * @param string $weight
      * @return string
      */
-    public function newServer($name, $description = "", $address, $port, $mode, $ssl = "0", $sslVerify = "1", $weight = "")
+    public function newServer($name, $address, $port, $mode, $description = "", $ssl = "0", $sslVerify = "1", $weight = "")
     {
         $srv = $this->servers->server->Add();
         $uuid = $srv->getAttributes()['uuid'];
         $srv->name = $name;
-        $srv->description = $description;
         $srv->address = $address;
         $srv->port = $port;
         $srv->mode = $mode;
+        $srv->description = $description;
         $srv->ssl = $ssl;
         $srv->sslVerify = $sslVerify;
         $srv->weight = $weight;
@@ -220,22 +220,22 @@ class HAProxy extends BaseModel
      * create a new backend
      * @param string $enabled
      * @param string $name
-     * @param string $description
      * @param string $mode
      * @param string $algorithm
+     * @param string $description
      * @param string $linkedServers
      * @param string $linkedActions
      * @return string
      */
-    public function newBackend($enabled = "0", $name, $description = "", $mode, $algorithm, $linkedServers = "", $linkedActions = "")
+    public function newBackend($enabled = "0", $name, $mode, $algorithm, $description = "", $linkedServers = "", $linkedActions = "")
     {
         $backend = $this->backends->backend->Add();
         $uuid = $backend->getAttributes()['uuid'];
         $backend->enabled = $enabled;
         $backend->name = $name;
-        $backend->description = $description;
         $backend->mode = $mode;
         $backend->algorithm = $algorithm;
+        $backend->description = $description;
         $backend->linkedServers = $linkedServers;
         $backend->linkedActions = $linkedActions;
         return $uuid;

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.php
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.php
@@ -218,23 +218,23 @@ class HAProxy extends BaseModel
 
     /**
      * create a new backend
-     * @param string $enabled
      * @param string $name
      * @param string $mode
      * @param string $algorithm
+     * @param string $enabled
      * @param string $description
      * @param string $linkedServers
      * @param string $linkedActions
      * @return string
      */
-    public function newBackend($enabled = "0", $name, $mode, $algorithm, $description = "", $linkedServers = "", $linkedActions = "")
+    public function newBackend($name, $mode, $algorithm, $enabled = "0", $description = "", $linkedServers = "", $linkedActions = "")
     {
         $backend = $this->backends->backend->Add();
         $uuid = $backend->getAttributes()['uuid'];
-        $backend->enabled = $enabled;
         $backend->name = $name;
         $backend->mode = $mode;
         $backend->algorithm = $algorithm;
+        $backend->enabled = $enabled;
         $backend->description = $description;
         $backend->linkedServers = $linkedServers;
         $backend->linkedActions = $linkedActions;

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/Api/SettingsController.php
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/Api/SettingsController.php
@@ -263,8 +263,8 @@ class SettingsController extends ApiMutableModelControllerBase
                     // Add a new HAProxy ACL
                     $acl_uuid = $mdlHAProxy->newAcl(
                         "find_acme_challenge",
-                        "Added by ACME Client plugin",
                         "path_beg",
+                        "Added by ACME Client plugin",
                         "0",
                         array("path_beg" => "/.well-known/acme-challenge/")
                     );
@@ -273,9 +273,9 @@ class SettingsController extends ApiMutableModelControllerBase
                     $backend_uuid = $mdlHAProxy->newBackend(
                         "1",
                         "acme_challenge_backend",
-                        "Added by ACME Client plugin",
                         "http",
                         "source",
+                        "Added by ACME Client plugin",
                         "",
                         ""
                     );
@@ -283,11 +283,11 @@ class SettingsController extends ApiMutableModelControllerBase
                     // Add a new HAProxy action
                     $action_uuid = $mdlHAProxy->newAction(
                         "redirect_acme_challenges",
-                        "Added by ACME Client plugin",
                         "if",
+                        "use_backend",
+                        "Added by ACME Client plugin",
                         "",
                         "and",
-                        "use_backend",
                         // Use the new backend uuid in field "useBackend"
                         array("use_backend" => $backend_uuid)
                     );
@@ -298,10 +298,10 @@ class SettingsController extends ApiMutableModelControllerBase
                     // Add a new HAProxy server
                     $server_uuid = $mdlHAProxy->newServer(
                         "acme_challenge_host",
-                        "Added by ACME Client plugin",
                         "127.0.0.1",
                         $acme_port,
                         "active",
+                        "Added by ACME Client plugin",
                         "0",
                         "0",
                         ""

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/Api/SettingsController.php
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/Api/SettingsController.php
@@ -271,10 +271,10 @@ class SettingsController extends ApiMutableModelControllerBase
 
                     // Add a new HAProxy backend
                     $backend_uuid = $mdlHAProxy->newBackend(
-                        "1",
                         "acme_challenge_backend",
                         "http",
                         "source",
+                        "1",
                         "Added by ACME Client plugin",
                         "",
                         ""


### PR DESCRIPTION
This changes the parameters for four functions in HAProxy.php.

The ACME Client appears to call these functions with positional rather than named params so also switch the order of the parameters in these function calls

Fixes: #3042 