### PR TITLE
net/frr: set no bgp default ipv4-unicast in bgpd.conf

### DIFF
--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -43,6 +43,7 @@ frr defaults {{ OPNsense.quagga.general.profile }}
 !
 {% if helpers.exists('OPNsense.quagga.bgp.asnumber') and OPNsense.quagga.bgp.asnumber != '' %}
 router bgp {{ OPNsense.quagga.bgp.asnumber }}
+ no bgp default ipv4-unicast
  no bgp ebgp-requires-policy
 {%   if helpers.exists('OPNsense.quagga.bgp.graceful') and OPNsense.quagga.bgp.graceful == '1' %}
  bgp graceful-restart


### PR DESCRIPTION
By default any BGP neighbor has IPv4-unicast address family enabled. This leads to a number of IPv6 neighbors listed under the IPv4-unicast summary in Routing -> Diagnostics -> BGP ->Summary with NoNeg status (unless it is OpnSense on the other side as well). With _no bgp default ipv4-unicast_ option we will have only IPv4 neighbors under the IPv4-unicast address family summary and only IPv6 neighbors under the IPv6-unicast address family summary.

Please, refer to the [docs](http://docs.frrouting.org/en/stable-7.5/bgp.html#clicmd-[no]bgpdefaultipv4-unicast) for details.