### PR TITLE
update ACME Client KAS by all-inkl.com

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -1395,7 +1395,7 @@
     <field>
         <id>validation.dns_kas_authdata</id>
         <label>KAS Authdata</label>
-        <type>text</type>
+        <type>password</type>
     </field>
     <field>
         <id>validation.dns_kas_authtype</id>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -1073,9 +1073,10 @@
                 </dns_kas_authdata>
                 <dns_kas_authtype type="OptionField">
                     <Required>N</Required>
-                    <default>sha1</default>
+                    <default>plain</default>
                     <OptionValues>
-                        <sha1>SHA1</sha1>
+                        <plain>plain</plain>
+                        <sha1>SHA1 (deprecated in December 2022)</sha1>
                     </OptionValues>
                 </dns_kas_authtype>
                 <dns_desec_token type="TextField">


### PR DESCRIPTION
Hi there,

all-inkl.com updated its KASAPI and is removing SHA1 as Authtype at around December 2022. Unfortunately, they will just have plain as option. Even if one would like to use the alternate "session", the login will need "plain". In regards of the task (ACME client), the documentation and staff state (not directly advise, but you can avoid the session) to just use plain instead of session.