### PR TITLE
net/frr: Allow specifying multiple PrefixLists and CommunityLists

### DIFF
--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
@@ -353,8 +353,8 @@
                                                 <display>name</display>
                                         </template>
                                 </Model>
-                                <ValidationMessage>Related item not found</ValidationMessage>
-                                <Multiple>N</Multiple>
+                                <ValidationMessage>Related item PrefixList not found</ValidationMessage>
+                                <Multiple>Y</Multiple>
                                 <Required>N</Required>
                         </match2>
                         <match3 type="ModelRelationField">
@@ -365,8 +365,8 @@
                                                 <display>number</display>
                                         </template>
                                 </Model>
-                                <ValidationMessage>Related item not found</ValidationMessage>
-                                <Multiple>N</Multiple>
+                                <ValidationMessage>Related item CommunityList not found</ValidationMessage>
+                                <Multiple>Y</Multiple>
                                 <Required>N</Required>
                         </match3>
                         <set type="TextField">


### PR DESCRIPTION
Fixes #3074

For me unclear reasons PrefixLists and CommunityLists did not allow to specify multiple lists. Saving them failed with a very unclear error `Related item not found` in the UI, as pointed out in above issue.

![image](https://user-images.githubusercontent.com/2029878/184559760-0bef45e0-2d23-4a40-aa20-a9ddd01f14aa.png)

The bgpd.conf does include support specifying multiple lists, but the UI blocked the same:
https://github.com/opnsense/plugins/blob/4546aeb47d62010ea4f8d3e4204b26285be864fe/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf#L180-L218

After this change, multiple lists can be selected and saved:
![image](https://user-images.githubusercontent.com/2029878/184559817-4ce25f47-2554-4c13-95da-e2e7b188c667.png)

And:
![image](https://user-images.githubusercontent.com/2029878/184559825-ce7863fd-e108-41e3-ac36-31290d88bda9.png)

After reloading the service, the config at `/usr/local/etc/frr/bgpd.conf` reflects the change:
```text
ip prefix-list AllowAll seq 99 permit any
!
ip prefix-list DenyWAN seq 20 deny SOME_IP/24
!
!
!
!
route-map DefaultRouteMap permit 20
 match ip address prefix-list AllowAll
 match ip address prefix-list DenyWAN
```