### PR TITLE
net/haproxy: chrooted sockets binding

### DIFF
--- a/net/haproxy/src/opnsense/scripts/OPNsense/HAProxy/setup.sh
+++ b/net/haproxy/src/opnsense/scripts/OPNsense/HAProxy/setup.sh
@@ -5,7 +5,7 @@ if [ -f /etc/rc.conf.d/haproxy ]; then
 fi
 
 # NOTE: Keep /var/haproxy on this list, see GH issue opnsense/plugins #39.
-HAPROXY_DIRS="/var/haproxy /var/haproxy/var/run /tmp/haproxy /tmp/haproxy/ssl /tmp/haproxy/lua /tmp/haproxy/errorfiles /tmp/haproxy/mapfiles /tmp/haproxy/sockets"
+HAPROXY_DIRS="/var/haproxy /var/haproxy/sockets /var/haproxy/var/run /tmp/haproxy /tmp/haproxy/ssl /tmp/haproxy/lua /tmp/haproxy/errorfiles /tmp/haproxy/mapfiles /tmp/haproxy/sockets"
 
 for directory in ${HAPROXY_DIRS}; do
     mkdir -p ${directory}

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -1375,11 +1375,13 @@ frontend {{frontend.name}}
 {%           if unix_bind == "TRUE" %}
 {#             # extract socket name and add full path #}
 {%             set socket_name = bind | regex_replace ("^unix@","") %}
-{%             set bind_address = "unix@/tmp/haproxy/sockets/" ~ socket_name %}
+{%             set bind_address = "/var/haproxy/sockets/" ~ socket_name ~ " user www" %}
+{%             set bind_name = "unix@" ~ socket_name %}
 {%           else %}
 {%             set bind_address = bind %}
+{%             set bind_name = bind %}
 {%           endif %}
-    bind {{bind_address}} name {{bind_address}} {% if frontend.bindOptions|default("") != "" %}{{ frontend.bindOptions }} {% endif %}{% if frontend.ssl_enabled == '1' and ssl_certs|default("") != "" %}ssl {{ ssl_options|join(' ') }} {{ ssl_certs|join(' ') }} {% endif %}{% if adv_options|length > 0 %} {{ adv_options|join(' ') }} {% endif %}
+    bind {{bind_address}} name {{bind_name}} {% if frontend.bindOptions|default("") != "" %}{{ frontend.bindOptions }} {% endif %}{% if frontend.ssl_enabled == '1' and ssl_certs|default("") != "" %}ssl {{ ssl_options|join(' ') }} {{ ssl_certs|join(' ') }} {% endif %}{% if adv_options|length > 0 %} {{ adv_options|join(' ') }} {% endif %}
 
 {%         endfor %}
 {%       endif %}
@@ -1690,7 +1692,7 @@ backend {{backend.name}}
 {%                   if unix_bind == "TRUE" %}
 {#                     # extract socket name and add full path #}
 {%                     set socket_name = bind | regex_replace ("^unix@","") %}
-{%                     set socket_path = "unix@/tmp/haproxy/sockets/" ~ socket_name %}
+{%                     set socket_path = "/sockets/" ~ socket_name %}
 {%                     do server_basics.append('server ' ~ server_data.name ~ ' ' ~ socket_path) %}
 {#                     # only the first unix socket is considered #}
 {%                     break %}


### PR DESCRIPTION
Hi!
ref. https://forum.opnsense.org/index.php?topic=28007.0
looks like it require special unix sockets binding and targeting since haproxy is chrooted
pr moves sockets to `/var/haproxy/sockets` 
Thanks!