### PR TITLE
net/frr: Added BGP Network Import-Check

### DIFF
--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/bgp.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/bgp.xml
@@ -31,13 +31,20 @@
         <style>tokenize</style>
         <type>select_multiple</type>
         <allownew>true</allownew>
-        <help>Select the network to advertise, you have to set a Null route via System -> Routes</help>
+        <help>Defines which networks, which are connected to this router, will be advertised over BGP. To announce all defined networks, Network Import-Check can be disabled in advanced settings if required.</help>
+    </field>
+    <field>
+        <id>bgp.networkimportcheck</id>
+        <label>Network Import-Check</label>
+        <type>checkbox</type>
+        <advanced>true</advanced>
+        <help>When enabled (default), BGP only announces networks set at 'Network' if they are present in the routers routing table (alternatively, you can also set a null-route via System -> Routes). If disabled, all configured networks will be announced.</help>
     </field>
     <field>
         <id>bgp.redistribute</id>
         <label>Route Redistribution</label>
         <type>select_multiple</type>
-        <help><![CDATA[Select other routing sources, which should be redistributed to the other nodes.]]></help>
+        <help>Select other routing sources, which should be redistributed to the other nodes.></help>
         <hint>Type or select a route source.</hint>
     </field>
 </form>

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/bgp.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/bgp.xml
@@ -44,7 +44,7 @@
         <id>bgp.redistribute</id>
         <label>Route Redistribution</label>
         <type>select_multiple</type>
-        <help>Select other routing sources, which should be redistributed to the other nodes.></help>
+        <help>Select other routing sources, which should be redistributed to the other nodes.</help>
         <hint>Type or select a route source.</hint>
     </field>
 </form>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/quagga/bgp</mount>
     <description>BGP Routing configuration</description>
-    <version>1.0.6</version>
+    <version>1.0.7</version>
     <items>
         <enabled type="BooleanField">
             <default>0</default>
@@ -21,6 +21,10 @@
             <default>0</default>
             <Required>Y</Required>
         </graceful>
+        <networkimportcheck type="BooleanField">
+            <default>1</default>
+            <Required>Y</Required>
+        </networkimportcheck>
         <networks type="CSVListField">
             <default></default>
             <Required>N</Required>

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -44,6 +44,11 @@ frr defaults {{ OPNsense.quagga.general.profile }}
 {% if helpers.exists('OPNsense.quagga.bgp.asnumber') and OPNsense.quagga.bgp.asnumber != '' %}
 router bgp {{ OPNsense.quagga.bgp.asnumber }}
  no bgp ebgp-requires-policy
+{%   if helpers.exists('OPNsense.quagga.bgp.networkimportcheck') and OPNsense.quagga.bgp.networkimportcheck == '1' %}
+ bgp network import-check
+{%   else %}
+ no bgp network import-check
+{%   endif %}
 {%   if helpers.exists('OPNsense.quagga.bgp.graceful') and OPNsense.quagga.bgp.graceful == '1' %}
  bgp graceful-restart
 {%   endif %}


### PR DESCRIPTION
This adds a checkbox to enable frr's BGP Network Import-Check, as I had requirement in my own setup for this.

**Reason**
Until including frr 7.3, all defined networks were announced. Starting frr 7.4 (released [July 2020](https://github.com/FRRouting/frr/releases/tag/frr-7.4)) only routes present in the routing tables are announced. See frr documentation at: https://docs.frrouting.org/en/latest/bgp.html#networks

To not change default behavior in future frr releases again, I have added if-else to explicitly enable or disable the functionality based on the setting in OPNsense GUI.

There might be requirements - or expectations from users like myself - that all defined networks are announced. Therefore I also added a clarification with existing 'Network' help text.

**Impact**
For existing and new environments there will be no change. "Network Import-Check" is enabled in frr by default in current releases where this code is part of. The config setting will just explicitly enable the same in the config file.

**Screenshot**
Change looks like:
![image](https://user-images.githubusercontent.com/2029878/188292593-ccc27a35-2392-49f8-a225-dee07ed5ad89.png)

**Config**
Config generated when enabled:
```
root@OPNsense:~ # cat /usr/local/etc/frr/bgpd.conf
[...]
router bgp 64511
 no bgp ebgp-requires-policy
 bgp network import-check
 neighbor 10.2.2.2 remote-as 64512
```

Config generated when disabled:
```
root@OPNsense:~ # cat /usr/local/etc/frr/bgpd.conf
[...]
router bgp 64511
 no bgp ebgp-requires-policy
 no bgp network import-check
 neighbor 10.2.2.2 remote-as 64512
```