### PR TITLE
net/frr: Added attribute-unchanged option

### DIFF
--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPNeighbor.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPNeighbor.xml
@@ -133,6 +133,13 @@
     <help>Allow peerings between directly connected eBGP peers using loopback addresses.</help>
   </field>
   <field>
+    <id>neighbor.attributeunchanged</id>
+    <label>Attribute Unchanged</label>
+    <type>dropdown</type>
+    <advanced>true</advanced>
+    <help><![CDATA[This specifies attributes to be left unchanged when sending advertisements to a peer. Read more at <a href="https://docs.frrouting.org/en/latest/bgp.html#clicmd-neighbor-PEER-attribute-unchanged-as-path-next-hop-med">FRR documentation</a>.]]></help>
+  </field>
+  <field>
     <id>neighbor.linkedPrefixlistIn</id>
     <label>Prefix-List In</label>
     <type>dropdown</type>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
@@ -138,6 +138,15 @@
                                 <default>0</default>
                                 <Required>N</Required>
                         </disable_connected_check>
+                        <attributeunchanged type="OptionField">
+                                <default></default>
+                                <Required>N</Required>
+                                <OptionValues>
+                                        <as-path>as-path</as-path>
+                                        <next-hop>next-hop</next-hop>
+                                        <med>med</med>
+                                </OptionValues>
+                        </attributeunchanged>
                         <linkedPrefixlistIn type="ModelRelationField">
                                 <Model>
                                         <template>

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -83,6 +83,9 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%         if 'connecttimer' in neighbor and neighbor.connecttimer != '' %}
  neighbor {{ neighbor.address }} timers connect {{ neighbor.connecttimer }}
 {%         endif %}
+{%         if 'attributeunchanged' in neighbor and neighbor.attributeunchanged != '' %}
+ neighbor {{ neighbor.address }} attribute-unchanged {{ neighbor.attributeunchanged }}
+{%         endif %}
 {%       endif %}
 {%     endfor %}
 {%   endif %}


### PR DESCRIPTION
Closes #3084

This adds the attribute-unchanged option as discussed in above issue.

![image](https://user-images.githubusercontent.com/2029878/188295006-142d4fc4-9b48-4482-a5d1-22b5a6401e78.png)

![image](https://user-images.githubusercontent.com/2029878/188295010-720a6b92-4ce1-4078-aadc-76a6cfd9cf00.png)

The config generated when enabling looks like:
```
root@OPNsense:~ # cat /usr/local/etc/frr/bgpd.conf
[...]
router bgp 64511
 no bgp ebgp-requires-policy
 neighbor 10.2.2.2 remote-as 64512
 neighbor 10.2.2.2 update-source em0
 neighbor 10.2.2.2 attribute-unchanged med

 address-family ipv4 unicast
```

