### PR TITLE
net/wireguard: Late Spring Cleaning

### DIFF
--- a/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/Api/ClientController.php
+++ b/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/Api/ClientController.php
@@ -41,23 +41,28 @@ class ClientController extends ApiMutableModelControllerBase
     {
         return $this->searchBase('clients.client', array("enabled", "name", "pubkey", "tunneladdress", "serveraddress", "serverport"));
     }
+
     public function getClientAction($uuid = null)
     {
         $this->sessionClose();
         return $this->getBase('client', 'clients.client', $uuid);
     }
+
     public function addClientAction()
     {
         return $this->addBase('client', 'clients.client');
     }
+
     public function delClientAction($uuid)
     {
         return $this->delBase('clients.client', $uuid);
     }
+
     public function setClientAction($uuid)
     {
         return $this->setBase('client', 'clients.client', $uuid);
     }
+
     public function toggleClientAction($uuid)
     {
         return $this->toggleBase('clients.client', $uuid);

--- a/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/Api/ServerController.php
+++ b/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/Api/ServerController.php
@@ -40,11 +40,13 @@ class ServerController extends ApiMutableModelControllerBase
     {
         return $this->searchBase('servers.server', array("enabled", "name", "networks", "pubkey", "port", "tunneladdress"));
     }
+
     public function getServerAction($uuid = null)
     {
         $this->sessionClose();
         return $this->getBase('server', 'servers.server', $uuid);
     }
+
     public function addServerAction($uuid = null)
     {
         if ($this->request->isPost() && $this->request->hasPost("server")) {
@@ -66,10 +68,12 @@ class ServerController extends ApiMutableModelControllerBase
         }
         return array("result" => "failed");
     }
+
     public function delServerAction($uuid)
     {
         return $this->delBase('servers.server', $uuid);
     }
+
     public function setServerAction($uuid = null)
     {
         if ($this->request->isPost() && $this->request->hasPost("server")) {
@@ -91,6 +95,7 @@ class ServerController extends ApiMutableModelControllerBase
         }
         return array("result" => "failed");
     }
+
     public function toggleServerAction($uuid)
     {
         return $this->toggleBase('servers.server', $uuid);

--- a/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/Api/ServerController.php
+++ b/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/Api/ServerController.php
@@ -38,7 +38,12 @@ class ServerController extends ApiMutableModelControllerBase
 
     public function searchServerAction()
     {
-        return $this->searchBase('servers.server', array("enabled", "name", "networks", "pubkey", "port", "tunneladdress"));
+        $search = $this->searchBase('servers.server', array("enabled", "instance", "peers", "name", "networks", "pubkey", "port", "tunneladdress"));
+        // prepend "wg" to all instance IDs to use as interface name
+        foreach ($search["rows"] as $key => $server) {
+            $search["rows"][$key]["interface"] = "wg" . $server["instance"];
+        }
+        return $search;
     }
 
     public function getServerAction($uuid = null)

--- a/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardClient.xml
+++ b/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardClient.xml
@@ -33,15 +33,15 @@
     </field>
     <field>
         <id>client.serveraddress</id>
-        <label>Endpoint Address</label>
+        <label>Peer Address</label>
         <type>text</type>
-        <help>Set public IP address the endpoint listens to.</help>
+        <help>Set public IP address the peer listens to.</help>
     </field>
     <field>
         <id>client.serverport</id>
-        <label>Endpoint Port</label>
+        <label>Peer Port</label>
         <type>text</type>
-        <help>Set port the endpoint listens to.</help>
+        <help>Set port the peer listens to.</help>
     </field>
     <field>
         <id>client.keepalive</id>

--- a/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardClient.xml
+++ b/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardClient.xml
@@ -21,7 +21,7 @@
         <id>client.psk</id>
         <label>Shared Secret</label>
         <type>text</type>
-        <help>Shared secret (PSK) for this peer.</help>
+        <help>Shared secret (PSK) for this peer. You can generate a key using "wg genpsk" on a client with WireGuard installed.</help>
     </field>
     <field>
         <id>client.tunneladdress</id>
@@ -45,8 +45,8 @@
     </field>
     <field>
         <id>client.keepalive</id>
-        <label>Keepalive</label>
+        <label>Keepalive (seconds)</label>
         <type>text</type>
-        <help>Set persistent keepalive interval.</help>
+        <help>Set persistent keepalive interval in seconds.</help>
     </field>
 </form>

--- a/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardClient.xml
+++ b/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardClient.xml
@@ -33,15 +33,15 @@
     </field>
     <field>
         <id>client.serveraddress</id>
-        <label>Peer Address</label>
+        <label>Endpoint Address</label>
         <type>text</type>
-        <help>Set public IP address the peer listens to.</help>
+        <help>Set public IP address the endpoint listens to.</help>
     </field>
     <field>
         <id>client.serverport</id>
-        <label>Peer Port</label>
+        <label>Endpoint Port</label>
         <type>text</type>
-        <help>Set port the peer listens to.</help>
+        <help>Set port the endpoint listens to.</help>
     </field>
     <field>
         <id>client.keepalive</id>

--- a/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardClient.xml
+++ b/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardClient.xml
@@ -45,7 +45,7 @@
     </field>
     <field>
         <id>client.keepalive</id>
-        <label>Keepalive (seconds)</label>
+        <label>Keepalive Interval</label>
         <type>text</type>
         <help>Set persistent keepalive interval in seconds.</help>
     </field>

--- a/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardServer.xml
+++ b/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardServer.xml
@@ -15,19 +15,19 @@
         <id>server.instance</id>
         <label>Instance</label>
         <type>info</type>
-        <help>Set the instance number needed for interface calculation. It has to be unique for each instance.</help>
+        <help>This is the instance number to give the wg interface a unique name (wgX).</help>
     </field>
     <field>
         <id>server.pubkey</id>
         <label>Public Key</label>
         <type>text</type>
-        <help>Public key of this instance. After saving you will see here your public key.</help>
+        <help>Public key of this instance. You can specify your own one, or a key will be generated after saving.</help>
     </field>
     <field>
         <id>server.privkey</id>
         <label>Private Key</label>
         <type>text</type>
-        <help>Private key of this instance. After saving you will see here your private key, please keep it safe.</help>
+        <help>Private key of this instance. You can specify your own one, or a key will be generated after saving. Please keep this key safe.</help>
     </field>
     <field>
         <id>server.port</id>

--- a/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardServer.xml
+++ b/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardServer.xml
@@ -61,10 +61,10 @@
     </field>
     <field>
         <id>server.peers</id>
-        <label>Peers</label>
+        <label>Endpoint</label>
         <type>select_multiple</type>
         <allownew>true</allownew>
-        <help>List of peers for this server.</help>
+        <help>List of endpoint for this server. (Also known as Peer)</help>
     </field>
     <field>
         <id>server.disableroutes</id>

--- a/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardServer.xml
+++ b/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardServer.xml
@@ -61,10 +61,10 @@
     </field>
     <field>
         <id>server.peers</id>
-        <label>Endpoint</label>
+        <label>Peers</label>
         <type>select_multiple</type>
         <allownew>true</allownew>
-        <help>List of endpoint for this server. (Also known as Peer)</help>
+        <help>List of peers for this server.</help>
     </field>
     <field>
         <id>server.disableroutes</id>

--- a/net/wireguard/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
+++ b/net/wireguard/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
@@ -28,8 +28,8 @@
 <!-- Navigation bar -->
 <ul class="nav nav-tabs" data-tabs="tabs" id="maintabs">
     <li class="active"><a data-toggle="tab" href="#general">{{ lang._('General') }}</a></li>
-    <li><a data-toggle="tab" href="#servers">{{ lang._('Interfaces') }}</a></li>
-    <li><a data-toggle="tab" href="#clients">{{ lang._('Peers') }}</a></li>
+    <li><a data-toggle="tab" href="#servers">{{ lang._('Local') }}</a></li>
+    <li><a data-toggle="tab" href="#clients">{{ lang._('Endpoints') }}</a></li>
     <li><a data-toggle="tab" href="#showconf">{{ lang._('Status') }}</a></li>
     <li><a data-toggle="tab" href="#showhandshake">{{ lang._('Handshakes') }}</a></li>
 </ul>
@@ -50,8 +50,8 @@
                 <tr>
                     <th data-column-id="enabled" data-type="string" data-formatter="rowtoggle">{{ lang._('Enabled') }}</th>
                     <th data-column-id="name" data-type="string" data-visible="true">{{ lang._('Name') }}</th>
-                    <th data-column-id="serveraddress" data-type="string" data-visible="true">{{ lang._('Peer Address') }}</th>
-                    <th data-column-id="serverport" data-type="string" data-visible="true">{{ lang._('Peer Port') }}</th>
+                    <th data-column-id="serveraddress" data-type="string" data-visible="true">{{ lang._('Endpoint Address') }}</th>
+                    <th data-column-id="serverport" data-type="string" data-visible="true">{{ lang._('Endpoint Port') }}</th>
                     <th data-column-id="tunneladdress" data-type="string" data-visible="true">{{ lang._('Allowed IPs') }}</th>
                     <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
                     <th data-column-id="commands" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>

--- a/net/wireguard/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
+++ b/net/wireguard/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
@@ -92,7 +92,7 @@
             </tbody>
             <tfoot>
                 <tr>
-                    <td colspan="8"></td>
+                    <td colspan="7"></td>
                     <td>
                         <button data-action="add" type="button" class="btn btn-xs btn-default"><span class="fa fa-plus"></span></button>
                     </td>

--- a/net/wireguard/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
+++ b/net/wireguard/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
@@ -28,9 +28,9 @@
 <!-- Navigation bar -->
 <ul class="nav nav-tabs" data-tabs="tabs" id="maintabs">
     <li class="active"><a data-toggle="tab" href="#general">{{ lang._('General') }}</a></li>
-    <li><a data-toggle="tab" href="#servers">{{ lang._('Local') }}</a></li>
-    <li><a data-toggle="tab" href="#clients">{{ lang._('Endpoints') }}</a></li>
-    <li><a data-toggle="tab" href="#showconf">{{ lang._('List Configuration') }}</a></li>
+    <li><a data-toggle="tab" href="#servers">{{ lang._('Interfaces') }}</a></li>
+    <li><a data-toggle="tab" href="#clients">{{ lang._('Peers') }}</a></li>
+    <li><a data-toggle="tab" href="#showconf">{{ lang._('Show Configuration') }}</a></li>
     <li><a data-toggle="tab" href="#showhandshake">{{ lang._('Handshakes') }}</a></li>
 </ul>
 
@@ -50,8 +50,8 @@
                 <tr>
                     <th data-column-id="enabled" data-type="string" data-formatter="rowtoggle">{{ lang._('Enabled') }}</th>
                     <th data-column-id="name" data-type="string" data-visible="true">{{ lang._('Name') }}</th>
-                    <th data-column-id="serveraddress" data-type="string" data-visible="true">{{ lang._('Endpoint Address') }}</th>
-                    <th data-column-id="serverport" data-type="string" data-visible="true">{{ lang._('Endpoint Port') }}</th>
+                    <th data-column-id="serveraddress" data-type="string" data-visible="true">{{ lang._('Peer Address') }}</th>
+                    <th data-column-id="serverport" data-type="string" data-visible="true">{{ lang._('Peer Port') }}</th>
                     <th data-column-id="tunneladdress" data-type="string" data-visible="true">{{ lang._('Allowed IPs') }}</th>
                     <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
                     <th data-column-id="commands" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>

--- a/net/wireguard/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
+++ b/net/wireguard/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
@@ -113,7 +113,7 @@
     </div>
 </div>
 
-{{ partial("layout_partials/base_dialog",['fields':formDialogEditWireguardClient,'id':'dialogEditWireguardClient','label':lang._('Edit Peer')])}}
+{{ partial("layout_partials/base_dialog",['fields':formDialogEditWireguardClient,'id':'dialogEditWireguardClient','label':lang._('Edit Endpoint')])}}
 {{ partial("layout_partials/base_dialog",['fields':formDialogEditWireguardServer,'id':'dialogEditWireguardServer','label':lang._('Edit Local Configuration')])}}
 
 <script>

--- a/net/wireguard/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
+++ b/net/wireguard/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
@@ -30,7 +30,7 @@
     <li class="active"><a data-toggle="tab" href="#general">{{ lang._('General') }}</a></li>
     <li><a data-toggle="tab" href="#servers">{{ lang._('Interfaces') }}</a></li>
     <li><a data-toggle="tab" href="#clients">{{ lang._('Peers') }}</a></li>
-    <li><a data-toggle="tab" href="#showconf">{{ lang._('Show Configuration') }}</a></li>
+    <li><a data-toggle="tab" href="#showconf">{{ lang._('Status') }}</a></li>
     <li><a data-toggle="tab" href="#showhandshake">{{ lang._('Handshakes') }}</a></li>
 </ul>
 
@@ -113,7 +113,7 @@
     </div>
 </div>
 
-{{ partial("layout_partials/base_dialog",['fields':formDialogEditWireguardClient,'id':'dialogEditWireguardClient','label':lang._('Edit Endpoint')])}}
+{{ partial("layout_partials/base_dialog",['fields':formDialogEditWireguardClient,'id':'dialogEditWireguardClient','label':lang._('Edit Peer')])}}
 {{ partial("layout_partials/base_dialog",['fields':formDialogEditWireguardServer,'id':'dialogEditWireguardServer','label':lang._('Edit Local Configuration')])}}
 
 <script>
@@ -159,6 +159,10 @@ $( document ).ready(function() {
             'toggle':'/api/wireguard/server/toggleServer/'
         }
     );
+
+    // Call update funcs once when page loaded
+    update_showconf();
+    update_showhandshake();
 
     // Call function update_neighbor with a auto-refresh of 5 seconds
     setInterval(update_showconf, 5000);

--- a/net/wireguard/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
+++ b/net/wireguard/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
@@ -83,7 +83,7 @@
                     <th data-column-id="interface" data-type="string" data-visible="true">{{ lang._('Interface') }}</th>
                     <th data-column-id="tunneladdress" data-type="string" data-visible="true">{{ lang._('Tunnel Address') }}</th>
                     <th data-column-id="port" data-type="string" data-visible="true">{{ lang._('Port') }}</th>
-                    <th data-column-id="peers" data-type="string" data-visible="true">{{ lang._('Peers') }}</th>
+                    <th data-column-id="peers" data-type="string" data-visible="true">{{ lang._('Endpoints') }}</th>
                     <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
                     <th data-column-id="commands" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
                 </tr>

--- a/net/wireguard/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
+++ b/net/wireguard/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
@@ -51,6 +51,7 @@
                     <th data-column-id="enabled" data-type="string" data-formatter="rowtoggle">{{ lang._('Enabled') }}</th>
                     <th data-column-id="name" data-type="string" data-visible="true">{{ lang._('Name') }}</th>
                     <th data-column-id="serveraddress" data-type="string" data-visible="true">{{ lang._('Endpoint Address') }}</th>
+                    <th data-column-id="serverport" data-type="string" data-visible="true">{{ lang._('Endpoint Port') }}</th>
                     <th data-column-id="tunneladdress" data-type="string" data-visible="true">{{ lang._('Allowed IPs') }}</th>
                     <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
                     <th data-column-id="commands" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
@@ -60,7 +61,7 @@
             </tbody>
             <tfoot>
                 <tr>
-                    <td colspan="5"></td>
+                    <td colspan="6"></td>
                     <td>
                         <button data-action="add" type="button" class="btn btn-xs btn-default"><span class="fa fa-plus"></span></button>
                     </td>

--- a/net/wireguard/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
+++ b/net/wireguard/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
@@ -79,8 +79,10 @@
                 <tr>
                     <th data-column-id="enabled" data-type="string" data-formatter="rowtoggle">{{ lang._('Enabled') }}</th>
                     <th data-column-id="name" data-type="string" data-visible="true">{{ lang._('Name') }}</th>
-                    <th data-column-id="port" data-type="string" data-visible="true">{{ lang._('Port') }}</th>
+                    <th data-column-id="interface" data-type="string" data-visible="true">{{ lang._('Interface') }}</th>
                     <th data-column-id="tunneladdress" data-type="string" data-visible="true">{{ lang._('Tunnel Address') }}</th>
+                    <th data-column-id="port" data-type="string" data-visible="true">{{ lang._('Port') }}</th>
+                    <th data-column-id="peers" data-type="string" data-visible="true">{{ lang._('Peers') }}</th>
                     <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
                     <th data-column-id="commands" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
                 </tr>
@@ -89,7 +91,7 @@
             </tbody>
             <tfoot>
                 <tr>
-                    <td colspan="5"></td>
+                    <td colspan="8"></td>
                     <td>
                         <button data-action="add" type="button" class="btn btn-xs btn-default"><span class="fa fa-plus"></span></button>
                     </td>

--- a/net/wireguard/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
+++ b/net/wireguard/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
@@ -136,7 +136,8 @@ $( document ).ready(function() {
     });
 
     $("#grid-clients").UIBootgrid(
-        {   'search':'/api/wireguard/client/searchClient',
+        {
+            'search':'/api/wireguard/client/searchClient',
             'get':'/api/wireguard/client/getClient/',
             'set':'/api/wireguard/client/setClient/',
             'add':'/api/wireguard/client/addClient/',
@@ -146,7 +147,8 @@ $( document ).ready(function() {
     );
 
     $("#grid-servers").UIBootgrid(
-        {   'search':'/api/wireguard/server/searchServer',
+        {
+            'search':'/api/wireguard/server/searchServer',
             'get':'/api/wireguard/server/getServer/',
             'set':'/api/wireguard/server/setServer/',
             'add':'/api/wireguard/server/addServer/',


### PR DESCRIPTION
Those are generally minor changes:
1. Add interface name (wgX) as a column
2. Corrected/improved/explained a few help entries better and renamed them. Also using "Peers" instead of "Endpoints", as WireGuard also refers to "Peers" in their configuration and documentation.
3. Update configuration and handshakes once page loaded, instead waiting for the 5 secs refresh interval to start.

![image](https://user-images.githubusercontent.com/2029878/189226168-5a69c681-18ef-4a23-bacb-064714a699e8.png)
