### PR TITLE
net/wireguard: Reworked widget

### DIFF
--- a/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/Api/GeneralController.php
+++ b/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/Api/GeneralController.php
@@ -56,7 +56,6 @@ class GeneralController extends ApiMutableModelControllerBase
             $peers[$peerUuid] = [
                 "name"      => (string)  $client->name,
                 "enabled"   => (integer) $client->enabled,
-                "keepalive" => (integer) $client->keepalive,
             ];
         }
 

--- a/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/Api/GeneralController.php
+++ b/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/Api/GeneralController.php
@@ -56,6 +56,7 @@ class GeneralController extends ApiMutableModelControllerBase
             $peers[$peerUuid] = [
                 "name"      => (string)  $client->name,
                 "enabled"   => (integer) $client->enabled,
+                "publicKey" => (string)  $client->pubkey,
             ];
         }
 

--- a/net/wireguard/src/www/widgets/widgets/wireguard.widget.php
+++ b/net/wireguard/src/www/widgets/widgets/wireguard.widget.php
@@ -59,6 +59,12 @@ $enabled = ($config["OPNsense"]["wireguard"]["general"]["enabled"] === "1" ? tru
 $(window).on("load", function() {
     function wgGenerateRow(name, interface, peerName, latestHandshake, status)
     {
+
+        // More user friendly naming
+        if (latestHandshake === "0000-00-00 00:00:00+00:00") {
+            latestHandshake = "<?= gettext("Never connected") ?>";
+        }
+
         var tr = ''
         +'<tr>'
         +'    <td>' + name + '</td>'

--- a/net/wireguard/src/www/widgets/widgets/wireguard.widget.php
+++ b/net/wireguard/src/www/widgets/widgets/wireguard.widget.php
@@ -60,12 +60,14 @@ $enabled = ($config["OPNsense"]["wireguard"]["general"]["enabled"] === "1" ? tru
 $(window).on("load", function() {
     function wgGenerateRow(name, interface, peerName, publicKey, latestHandshake, status)
     {
+        publicKeyShort = publicKey.slice(0, 19) + '...';
+
         var tr = ''
         +'<tr>'
         +'    <td>' + name + '</td>'
         +'    <td>' + interface + '</td>'
         +'    <td>' + peerName  + '</td>'
-        +'    <td>' + publicKey  + '</td>'
+        +'    <td title="' + publicKey + '">' + publicKeyShort  + '</td>'
         +'    <td>' + latestHandshake + '</td>'
         +'</tr>';
 

--- a/net/wireguard/src/www/widgets/widgets/wireguard.widget.php
+++ b/net/wireguard/src/www/widgets/widgets/wireguard.widget.php
@@ -3,6 +3,7 @@
 /*
  * Copyright (C) 2020 Deciso B.V.
  * Copyright (C) 2020 D. Domig
+ * Copyright (C) 2022 Patrik Kernstock <patrik@kernstock.net>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,50 +31,87 @@
 require_once("guiconfig.inc");
 require_once("widgets/include/wireguard.inc");
 
-$data = trim(configd_run('wireguard showhandshake'));
+$enabled = ($config["OPNsense"]["wireguard"]["general"]["enabled"] === "1" ? true : false);
 
-$empty = strlen($data) == 0;
 ?>
 
 <table class="table table-striped table-condensed">
     <thead>
         <tr>
+            <th><?= gettext("Name") ?></th>
             <th><?= gettext("Interface") ?></th>
-            <th><?= gettext("Endpoint") ?></th>
+            <th><?= gettext("Peer") ?></th>
             <th><?= gettext("Latest Handshake") ?></th>
         </tr>
     </thead>
-    <tbody>
+    <tbody id="wg-table-tbody">
 
-<?php if (!$empty):
-    $handshakes = explode("\n", $data);
-
-    foreach ($handshakes as $handshake):
-        $item = explode("\t", $handshake);
-
-        $epoch = $item[2];
-        $latest = "-";
-        if ($epoch > 0):
-            $dt = new DateTime("@$epoch");
-            $dt->setTimezone(new DateTimeZone(date_default_timezone_get()));
-            $latest = $dt->format(gettext("Y-m-d H:i:sP"));
-        endif; ?>
-
+    <?php if (!$enabled): ?>
     <tr>
-        <td><?= $item[0] ?></td>
-        <td><?= gettext(substr($item[1], 0, 10)) ?>...</td>
-        <td><?= $latest ?></td>
+        <td colspan="4"><?= gettext("No WireGuard instance defined or enabled.") ?></td>
     </tr>
-
-    <?php endforeach; ?>
-
-<?php else: ?>
-
-    <tr>
-        <td colspan="3"><?= gettext("No WireGuard instance defined or enabled.") ?></td>
-    </tr>
-
-<?php endif; ?>
+    <?php endif; ?>
 
     </tbody>
 </table>
+
+<script>
+$(window).on("load", function() {
+    function wgGenerateRow(name, interface, peerName, latestHandshake, status)
+    {
+        var tr = ''
+        +'<tr>'
+        +'    <td>' + name + '</td>'
+        +'    <td>' + interface + '</td>'
+        +'    <td>' + peerName  + '</td>'
+        +'    <td>' + latestHandshake + '</td>'
+        +'</tr>';
+
+        return tr;
+    }
+
+    function wgUpdateStatusIf(obj)
+    {
+        // check if at least one peer is set. If not, ignore it.
+        if (Object.keys(obj.peers).length == 0) {
+            return '';
+        }
+
+        // generate row based on data
+        row = '';
+        for (var peerId in obj.peers) {
+            var peer = obj.peers[peerId];
+
+            // generate table row
+            row += wgGenerateRow(
+                obj.name,
+                obj.interface,
+                peer.name,
+                peer.lastHandshake,
+                status
+            );
+        }
+
+        return row;
+    }
+
+    function wgUpdateStatus()
+    {
+        var table = '';
+        ajaxGet("/api/wireguard/general/getStatus", {}, function(data, status) {
+            if (status === 'success') {
+                for (var interface in data.items) {
+                    table += wgUpdateStatusIf(data.items[interface]);
+                }
+            }
+            // update table accordingly
+            document.getElementById("wg-table-tbody").innerHTML = table;
+            setTimeout(wgUpdateStatus, 10000);
+        });
+    };
+
+    <?php if ($enabled): ?>
+    wgUpdateStatus();
+    <?php endif; ?>
+});
+</script>

--- a/net/wireguard/src/www/widgets/widgets/wireguard.widget.php
+++ b/net/wireguard/src/www/widgets/widgets/wireguard.widget.php
@@ -40,7 +40,7 @@ $enabled = ($config["OPNsense"]["wireguard"]["general"]["enabled"] === "1" ? tru
         <tr>
             <th><?= gettext("Name") ?></th>
             <th><?= gettext("Interface") ?></th>
-            <th><?= gettext("Peer") ?></th>
+            <th><?= gettext("Endpoint") ?></th>
             <th><?= gettext("Latest Handshake") ?></th>
         </tr>
     </thead>

--- a/net/wireguard/src/www/widgets/widgets/wireguard.widget.php
+++ b/net/wireguard/src/www/widgets/widgets/wireguard.widget.php
@@ -59,12 +59,6 @@ $enabled = ($config["OPNsense"]["wireguard"]["general"]["enabled"] === "1" ? tru
 $(window).on("load", function() {
     function wgGenerateRow(name, interface, peerName, latestHandshake, status)
     {
-
-        // More user friendly naming
-        if (latestHandshake === "0000-00-00 00:00:00+00:00") {
-            latestHandshake = "<?= gettext("Never connected") ?>";
-        }
-
         var tr = ''
         +'<tr>'
         +'    <td>' + name + '</td>'

--- a/net/wireguard/src/www/widgets/widgets/wireguard.widget.php
+++ b/net/wireguard/src/www/widgets/widgets/wireguard.widget.php
@@ -41,6 +41,7 @@ $enabled = ($config["OPNsense"]["wireguard"]["general"]["enabled"] === "1" ? tru
             <th><?= gettext("Name") ?></th>
             <th><?= gettext("Interface") ?></th>
             <th><?= gettext("Endpoint") ?></th>
+            <th><?= gettext("Public Key") ?></th>
             <th><?= gettext("Latest Handshake") ?></th>
         </tr>
     </thead>
@@ -48,7 +49,7 @@ $enabled = ($config["OPNsense"]["wireguard"]["general"]["enabled"] === "1" ? tru
 
     <?php if (!$enabled): ?>
     <tr>
-        <td colspan="4"><?= gettext("No WireGuard instance defined or enabled.") ?></td>
+        <td colspan="5"><?= gettext("No WireGuard instance defined or enabled.") ?></td>
     </tr>
     <?php endif; ?>
 
@@ -57,13 +58,14 @@ $enabled = ($config["OPNsense"]["wireguard"]["general"]["enabled"] === "1" ? tru
 
 <script>
 $(window).on("load", function() {
-    function wgGenerateRow(name, interface, peerName, latestHandshake, status)
+    function wgGenerateRow(name, interface, peerName, publicKey, latestHandshake, status)
     {
         var tr = ''
         +'<tr>'
         +'    <td>' + name + '</td>'
         +'    <td>' + interface + '</td>'
         +'    <td>' + peerName  + '</td>'
+        +'    <td>' + publicKey  + '</td>'
         +'    <td>' + latestHandshake + '</td>'
         +'</tr>';
 
@@ -87,6 +89,7 @@ $(window).on("load", function() {
                 obj.name,
                 obj.interface,
                 peer.name,
+                peer.publicKey,
                 peer.lastHandshake,
                 status
             );


### PR DESCRIPTION
The old WireGuard widget was there, but honestly wasn't providing much information:
![image](https://user-images.githubusercontent.com/2029878/189228492-27345cf3-ffc2-425a-92da-1d58feb3ade5.png)

So I decided to rework it. It now looks like this:
![image](https://user-images.githubusercontent.com/2029878/189228439-08f97cf7-b23a-4b9a-8147-542db8b5ee0c.png)

Following to note:
1. When WireGuard is disabled, nothing will appear.
2. Disabled Locals or Peers are not shown. If they are disabled, they will disappear on the next refresh cycle.
3. The data is refreshed via AJAX every 10 seconds.
4. When there is one Interface with 2 Peers, there're 2 entries in the table (see 2x wg4 and end4 and end5 entries)
5. The code sometimes looks a bit complicated - but the handshakes are retrieved from the CLI with only 1) the interface name, 2) the public key of the peer. So to get more details from the WireGuard configuration, I had to do some matching. The matching is based on 1) searching the same interface, 2) and then matching the public key. Works fine.

It also works just fine on my production firewall:
![image](https://user-images.githubusercontent.com/2029878/189228928-81ce6cfb-d948-4f24-be93-9edb906ca95f.png)
