### PR TITLE
security/acme-client: Update selfhost (breaking change)

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -1065,16 +1065,10 @@
         <type>password</type>
     </field>
     <field>
-        <id>validation.dns_selfhost_rid</id>
-        <label>rid</label>
-        <type>text</type>
-        <help>Please create the TXT Record with Subdomain _acme-challenge first, than you can get the ID from the edit page.</help>
-    </field>
-    <field>
-        <id>validation.dns_selfhost_rid2</id>
-        <label>rid2</label>
-        <type>text</type>
-        <help>Please create a second TXT Record with Subdomain _acme-challenge (needed to support ACME v2).</help>
+        <id>validation.dns_selfhost_map</id>
+        <label>RID Mapping</label>
+        <type>textbox</type>
+        <help>Please create the TXT Record with Subdomain _acme-challenge first, than you can get the ID from the edit page. Up to two RIDs per fulldomain are supported but at least one must be set, e.g. _acme-challenge.domain.net:RID:RI>
     </field>
     <field>
         <label>Servercow</label>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsSelfhost.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsSelfhost.php
@@ -41,7 +41,6 @@ class DnsSelfhost extends Base implements LeValidationInterface
     {
         $this->acme_env['SELFHOSTDNS_USERNAME'] = (string)$this->config->dns_selfhost_user;
         $this->acme_env['SELFHOSTDNS_PASSWORD'] = (string)$this->config->dns_selfhost_password;
-        $this->acme_env['SELFHOSTDNS_RID'] = (string)$this->config->dns_selfhost_rid;
-        $this->acme_env['SELFHOSTDNS_RID2'] = (string)$this->config->dns_selfhost_rid2;
+        $this->acme_env['SELFHOSTDNS_MAP'] = (string)$this->config->dns_selfhost_map;
     }
 }

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -948,12 +948,9 @@
                 <dns_selfhost_password type="TextField">
                     <Required>N</Required>
                 </dns_selfhost_password>
-                <dns_selfhost_rid type="TextField">
+                <dns_selfhost_map type="TextField">
                     <Required>N</Required>
-                </dns_selfhost_rid>
-                <dns_selfhost_rid2 type="TextField">
-                    <Required>N</Required>
-                </dns_selfhost_rid2>
+                </dns_selfhost_map>
                 <dns_servercow_username type="TextField">
                     <Required>N</Required>
                 </dns_servercow_username>


### PR DESCRIPTION
Hello,

now we got the selfhost dns in the acme.sh master.
We had to remove rid and rid2 and have replaced it with a mapping field.

Usage: https://github.com/acmesh-official/acme.sh/wiki/dnsapi2#151-use-selfhost-dns-api

