### PR TITLE
dns/ddclient - Increase default timeout from 10 seconds to 30 seconds. Closes #3051 and Possibly #3017

### DIFF
--- a/dns/ddclient/src/opnsense/scripts/ddclient/checkip
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/checkip
@@ -72,7 +72,7 @@ if __name__ == '__main__':
     inputargs = parser.parse_args()
 
     # use curl to fetch data, so we can optionally use "--interface"
-    params = ['/usr/local/bin/curl', '-m', '10']
+    params = ['/usr/local/bin/curl', '-m', '30']
     if inputargs.interface.strip() != "":
         params.append("--interface")
         params.append(inputargs.interface)


### PR DESCRIPTION
This simple change bumps the timeout for fetching our own IP address to 30 seconds instead of 10, as updating the Dynamic IP is not super time sensitive when it comes to this minor adjustment.

In my testing, and in others in #3051 we have determined the timeout to be a major cause of issues for those of us with higher latency than some connections.