### PR TITLE
dns/ddclient - Add icanhazip.com as a checkip provider

### DIFF
--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
@@ -50,7 +50,6 @@
                         <gandi>Gandi.net</gandi>
                         <he-net>HE.net</he-net>
                         <he-net-tunnel>HE.net TunnelBroker</he-net-tunnel>
-                        <icanhazip>icanhazip</icanhazip>
                         <inwx>INWX</inwx>
                         <loopia>Loopia</loopia>
                         <namecheap>NameCheap</namecheap>

--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
@@ -111,6 +111,7 @@
                         <web_freedns>freedns</web_freedns>
                         <web_googledomains>googledomains</web_googledomains>
                         <web_he>he</web_he>
+                        <web_icanhazip value="icanhazip">icanhazip</web_icanhazip>
                         <web_ip4only_me value="web_ip4only.me">ip4only.me</web_ip4only_me>
                         <web_ip6only_me value="web_ip6only.me">ip6only.me</web_ip6only_me>
                         <web_ipify_ipv4 value="web_ipify-ipv4">ipify-ipv4</web_ipify_ipv4>

--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
@@ -50,6 +50,7 @@
                         <gandi>Gandi.net</gandi>
                         <he-net>HE.net</he-net>
                         <he-net-tunnel>HE.net TunnelBroker</he-net-tunnel>
+                        <icanhazip>icanhazip</icanhazip>
                         <inwx>INWX</inwx>
                         <loopia>Loopia</loopia>
                         <namecheap>NameCheap</namecheap>

--- a/dns/ddclient/src/opnsense/scripts/ddclient/checkip
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/checkip
@@ -35,6 +35,7 @@ service_list = {
   'freedns': '%s://freedns.afraid.org/dynamic/check.php',
   'googledomains': '%s://domains.google.com/checkip',
   'he': '%s://checkip.dns.he.net/',
+  'icanhazip': '%s://icanhazip.com/',
   'ip4only.me': '%s://ip4only.me/api/',
   'ip6only.me': '%s://ip6only.me/api/',
   'ipify-ipv4': '%s://api.ipify.org/',


### PR DESCRIPTION
icanhazip.com tends to be very fast, and only returns the actual IP address, so less processing time is needed.