### PR TITLE
ddclient configurable checkip timeout

### DIFF
--- a/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/dialogAccount.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/dialogAccount.xml
@@ -66,6 +66,12 @@
         <help>How to determine the address to use for this host</help>
     </field>
     <field>
+        <id>account.checkip_timeout</id>
+        <label>Check ip timeout</label>
+        <type>text</type>
+        <help>How long to wait before the checkip process times out</help>
+    </field>
+    <field>
         <id>account.force_ssl</id>
         <label>Force SSL</label>
         <type>checkbox</type>

--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
@@ -126,6 +126,12 @@
                         <if>Interface</if>
                     </OptionValues>
                 </checkip>
+                <checkip_timeout type="IntegerField">
+                    <default>10</default>
+                    <Required>Y</Required>
+                    <MinimumValue>10</MinimumValue>
+                    <MaximumValue>60</MaximumValue>
+                </checkip_timeout>
                 <force_ssl type="BooleanField">
                     <default>1</default>
                     <Required>Y</Required>

--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/DynDNS</mount>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <description>
         Dynamic DNS client
     </description>

--- a/dns/ddclient/src/opnsense/scripts/ddclient/checkip
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/checkip
@@ -70,10 +70,11 @@ if __name__ == '__main__':
     parser.add_argument('-s', '--service', help='service name', choices=service_list.keys(), required=True)
     parser.add_argument('-i', '--interface', help='interface', type=str, default='')
     parser.add_argument('-t', '--tls', help='enforce tls', choices=['0', '1'], default='0')
+    parser.add_argument('--timeout', help='timeout', type=str, default='10')
     inputargs = parser.parse_args()
 
     # use curl to fetch data, so we can optionally use "--interface"
-    params = ['/usr/local/bin/curl', '-m', '10']
+    params = ['/usr/local/bin/curl', '-m', inputargs.timeout]
     if inputargs.interface.strip() != "":
         params.append("--interface")
         params.append(inputargs.interface)

--- a/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
+++ b/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
@@ -29,9 +29,9 @@ ssl=yes
 use=if, if={{physical_interface(account.interface)}}, \
 {%      elif account.checkip.startswith('web_') %}
 {%          if account.interface %}
-use=cmd, cmd="/usr/local/opnsense/scripts/ddclient/checkip -i {{physical_interface(account.interface)}} -t {{account.force_ssl}} -s {{account.checkip[4:]}} --timeout {{account.checkip_timeout}}",
+use=cmd, cmd="/usr/local/opnsense/scripts/ddclient/checkip -i {{physical_interface(account.interface)}} -t {{account.force_ssl}} -s {{account.checkip[4:]}} --timeout {{account.checkip_timeout|default('10')}}",
 {%          else %}
-use=cmd, cmd="/usr/local/opnsense/scripts/ddclient/checkip -t {{account.force_ssl}} -s {{account.checkip[4:]}} --timeout {{account.checkip_timeout}}",
+use=cmd, cmd="/usr/local/opnsense/scripts/ddclient/checkip -t {{account.force_ssl}} -s {{account.checkip[4:]}} --timeout {{account.checkip_timeout|default('10')}}",
 {%            endif %}
 {%      endif %}
 {%      if account.service == 'custom' %}

--- a/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
+++ b/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
@@ -29,9 +29,9 @@ ssl=yes
 use=if, if={{physical_interface(account.interface)}}, \
 {%      elif account.checkip.startswith('web_') %}
 {%          if account.interface %}
-use=cmd, cmd="/usr/local/opnsense/scripts/ddclient/checkip -i {{physical_interface(account.interface)}} -t {{account.force_ssl}} -s {{account.checkip[4:]}}",
+use=cmd, cmd="/usr/local/opnsense/scripts/ddclient/checkip -i {{physical_interface(account.interface)}} -t {{account.force_ssl}} -s {{account.checkip[4:]}} --timeout {{account.checkip_timeout}}",
 {%          else %}
-use=cmd, cmd="/usr/local/opnsense/scripts/ddclient/checkip -t {{account.force_ssl}} -s {{account.checkip[4:]}}",
+use=cmd, cmd="/usr/local/opnsense/scripts/ddclient/checkip -t {{account.force_ssl}} -s {{account.checkip[4:]}} --timeout {{account.checkip_timeout}}",
 {%            endif %}
 {%      endif %}
 {%      if account.service == 'custom' %}


### PR DESCRIPTION
For ddclient plugin, add a configurable checkip timeout which defaults to 10 seconds. This is to cover high latency corner cases which some users have been reporting.

See #3133 and #3051 for details.

cc @AdSchellevis 