### PR TITLE
Update the generation of /etc/rc.conf.d/telegraf

### DIFF
--- a/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf
+++ b/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf
@@ -6,6 +6,7 @@ telegraf_group="wheel"
 telegraf_var_script="/usr/local/opnsense/scripts/OPNsense/Telegraf/setup.sh"
 telegraf_enable="YES"
 telegraf_confdir="/usr/local/etc/telegraf.d"
+telegraf_flags=""
 {% else %}
 telegraf_enable="NO"
 {% endif %}


### PR DESCRIPTION
When writing this file, empty the `telegraf_flags` field in order to allow the UI settings for `quiet`/`debug` logging to be effective

Fixes: opnsense/plugins#3137