### PR TITLE
Enable hardware acceleration in TOR

### DIFF
--- a/security/tor/src/opnsense/service/templates/OPNsense/Tor/torrc
+++ b/security/tor/src/opnsense/service/templates/OPNsense/Tor/torrc
@@ -117,6 +117,8 @@ HidServAuth {{ service.onion_service }} {{ service.auth_cookie }}
 MaxMemInQueues {{ OPNsense.tor.general.max_memory_in_queues }} MB
 {% endif %}
 
+HardwareAccel 1
+
 {% if helpers.exists('OPNsense.tor.hiddenservice') and helpers.exists('OPNsense.tor.hiddenserviceacl') and helpers.exists('OPNsense.tor.hiddenserviceacl.hiddenserviceacl') %}
 
 ############### This section is just for location-hidden services ###


### PR DESCRIPTION
On suitable hardware platforms, FreeBSD/OPNsense supports hardware acceleration for crypto. Verified with https://stackoverflow.com/a/28614159/5424487

TOR however is not set up to make use of this. This change should enable it. Especially useful on those weak CPUs commonly used in router boxes. From https://www.freebsd.org/cgi/man.cgi?tor(1):

```
       HardwareAccel 0|1
	   If non-zero,	try to use built-in (static) crypto hardware
	   acceleration	when available.	Can not	be changed while tor is
	   running. (Default: 0)
```

Because TOR (or rather OpenSSL) will fall back to software crypto when hardware crypto is not available, I see no need to make this flag configurable in the web UI, making this a very trivial PR :)