### PR TITLE
net/upnp: add missing firewall anchors

### DIFF
--- a/net/upnp/src/etc/inc/plugins.inc.d/miniupnpd.inc
+++ b/net/upnp/src/etc/inc/plugins.inc.d/miniupnpd.inc
@@ -41,7 +41,7 @@ function miniupnpd_firewall($fw)
 
     $fw->registerAnchor('miniupnpd', 'rdr');
     $fw->registerAnchor('miniupnpd', 'fw');
-    $fw->registerAnchor('miniupnpd', 'nat');
+    $fw->registerAnchor('miniupnpd', 'nat', '', 'head');
     $fw->registerAnchor('miniupnpd', 'binat');
 }
 

--- a/net/upnp/src/etc/inc/plugins.inc.d/miniupnpd.inc
+++ b/net/upnp/src/etc/inc/plugins.inc.d/miniupnpd.inc
@@ -41,7 +41,7 @@ function miniupnpd_firewall($fw)
 
     $fw->registerAnchor('miniupnpd', 'rdr');
     $fw->registerAnchor('miniupnpd', 'fw');
-    $fw->registerAnchor('miniupnpd', 'nat', '', 'head');
+    $fw->registerAnchor('miniupnpd', 'nat', 0, 'head');
     $fw->registerAnchor('miniupnpd', 'binat');
 }
 

--- a/net/upnp/src/etc/inc/plugins.inc.d/miniupnpd.inc
+++ b/net/upnp/src/etc/inc/plugins.inc.d/miniupnpd.inc
@@ -41,6 +41,8 @@ function miniupnpd_firewall($fw)
 
     $fw->registerAnchor('miniupnpd', 'rdr');
     $fw->registerAnchor('miniupnpd', 'fw');
+    $fw->registerAnchor('miniupnpd', 'nat');
+    $fw->registerAnchor('miniupnpd', 'binat');
 }
 
 function miniupnpd_services()


### PR DESCRIPTION
Later releases of miniupnpd require additional firewall anchors to function properly. This commit adds those.