### PR TITLE
net-mgmt/telegraf: Add Influxv2 timeout

### DIFF
--- a/net-mgmt/telegraf/Makefile
+++ b/net-mgmt/telegraf/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		telegraf
-PLUGIN_VERSION=		1.12.5
+PLUGIN_VERSION=		1.12.6
 PLUGIN_COMMENT=		Agent for collecting metrics and data
 PLUGIN_DEPENDS=		telegraf
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net-mgmt/telegraf/pkg-descr
+++ b/net-mgmt/telegraf/pkg-descr
@@ -11,6 +11,9 @@ WWW: https://www.influxdata.com/time-series-platform/telegraf/
 
 Plugin Changelog
 ================
+1.12.6
+
+* Add Influx v2 flush timeout
 
 1.12.5
 

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/output.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/output.xml
@@ -81,7 +81,7 @@
         <id>output.influx_v2_timeout</id>
         <label>Timeout</label>
         <type>text</type>
-        <help>Flush timeout for the v2 Telegraf output, formatted as a string. If not provided, will default to 5s. 0s means no timeout (not recommended). Increase if you get timeout errors.</help>
+        <help>Flush timeout for the v2 Telegraf output (in seconds), formatted as a string. If not provided, will default to 5. 0 means no timeout (not recommended). Increase if you get timeout errors.</help>
     </field>
     <field>
         <id>output.graphite_enable</id>

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/output.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/output.xml
@@ -78,6 +78,12 @@
         <help>This will skip chain and host verification.</help>
     </field>
     <field>
+        <id>output.influx_v2_timeout</id>
+        <label>Timeout</label>
+        <type>text</type>
+        <help>Flush timeout for the v2 Telegraf output, formatted as a string. If not provided, will default to 5s. 0s means no timeout (not recommended). Increase if you get timeout errors.</help>
+    </field>
+    <field>
         <id>output.graphite_enable</id>
         <label>Enable Graphite Output</label>
         <type>checkbox</type>

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/output.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/output.xml
@@ -81,7 +81,7 @@
         <id>output.influx_v2_timeout</id>
         <label>Timeout</label>
         <type>text</type>
-        <help>Flush timeout for the v2 Telegraf output (in seconds), formatted as a string. If not provided, will default to 5. 0 means no timeout (not recommended). Increase if you get timeout errors.</help>
+        <help>Flush timeout for the v2 Telegraf output in seconds, formatted as a string. If not provided, will default to 5. 0 means no timeout, but is not recommended. Increase if you get timeout errors.</help>
     </field>
     <field>
         <id>output.graphite_enable</id>

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Output.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Output.xml
@@ -123,6 +123,10 @@
             <default>0</default>
             <Required>N</Required>
         </influx_v2_insecure_skip_verify>
+        <influx_v2_timeout type="IntegerField">
+            <default>5</default>
+            <Required>N</Required>
+        </influx_v2_timeout>
         <datadog_enable type="BooleanField">
             <default>0</default>
             <Required>N</Required>

--- a/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
+++ b/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
@@ -176,6 +176,9 @@
   insecure_skip_verify = false
 {%   endif %}
 {% endif %}
+{%   if helpers.exists('OPNsense.telegraf.output.influx_v2_timeout') and OPNsense.telegraf.output.influx_v2_timeout != '' %}
+  timeout = "{{ OPNsense.telegraf.output.influx_v2_timeout }}s"
+{%   endif %}
 
 {% if helpers.exists('OPNsense.telegraf.input.cpu') and OPNsense.telegraf.input.cpu == '1' %}
 [[inputs.cpu]]


### PR DESCRIPTION
Adding the ability to configure a timeout for InfluxV2. Without this issues can arise when the Telegraf is trying to flush metrics.