### PR TITLE
net-mgmt/telegraf: Add apcupsd input

### DIFF
--- a/net-mgmt/telegraf/Makefile
+++ b/net-mgmt/telegraf/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		telegraf
-PLUGIN_VERSION=		1.12.5
+PLUGIN_VERSION=		1.12.6
 PLUGIN_COMMENT=		Agent for collecting metrics and data
 PLUGIN_DEPENDS=		telegraf
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net-mgmt/telegraf/pkg-descr
+++ b/net-mgmt/telegraf/pkg-descr
@@ -12,6 +12,10 @@ WWW: https://www.influxdata.com/time-series-platform/telegraf/
 Plugin Changelog
 ================
 
+1.12.6
+
+* Add apcupsd input
+
 1.12.5
 
 * Add support for basic HTTP Authentication agains Elasticsearch (contributed by psychogun)

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/input.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/input.xml
@@ -189,6 +189,6 @@
         <id>input.apcupsd_server</id>
         <label>Apcupsd Netserver IP Address</label>
         <type>text</type>
-        <help>IP address or hostname of the apcupsd net information server.</help>
+        <help>IP address or hostname of the apcupsd net information server. Default address is 127.0.0.1</help>
     </field>
 </form>

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/input.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/input.xml
@@ -179,4 +179,16 @@
         <type>checkbox</type>
         <help>Enable the collection of Unbound metrics.</help>
     </field>
+    <field>
+        <id>input.apcupsd</id>
+        <label>Apcupsd</label>
+        <type>checkbox</type>
+        <help>Enable the collection of apcupsd metrics.</help>
+    </field>
+    <field>
+        <id>input.apcupsd_server</id>
+        <label>Apcupsd Netserver IP Address</label>
+        <type>text</type>
+        <help>IP address or hostname of the apcupsd net information server.</help>
+    </field>
 </form>

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Input.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Input.xml
@@ -118,7 +118,6 @@
             <Required>N</Required>
         </apcupsd>
         <apcupsd_server type="TextField">
-            <default>127.0.0.1</default>
             <Required>N</Required>
         </apcupsd_server>
     </items>

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Input.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Input.xml
@@ -114,5 +114,12 @@
         <unbound type="BooleanField">
             <Required>N</Required>
         </unbound>
+        <apcupsd type="BooleanField">
+            <Required>N</Required>
+        </apcupsd>
+        <apcupsd_server type="TextField">
+            <default>127.0.0.1</default>
+            <Required>N</Required>
+        </apcupsd_server>
     </items>
 </model>

--- a/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
+++ b/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
@@ -303,4 +303,10 @@
    timeout = "5s"
 {% endif %}
 
+{% if helpers.exists('OPNsense.telegraf.input.apcupsd') and OPNsense.telegraf.input.apcupsd == '1' %}
+[[inputs.apcupsd]]
+  servers = ["tcp://{{ OPNsense.telegraf.input.apcupsd_server }}:3551"]
+  timeout = "5s"
+{% endif %}
+
 {% endif %}

--- a/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
+++ b/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
@@ -305,7 +305,7 @@
 
 {% if helpers.exists('OPNsense.telegraf.input.apcupsd') and OPNsense.telegraf.input.apcupsd == '1' %}
 [[inputs.apcupsd]]
-  servers = ["tcp://{{ OPNsense.telegraf.input.apcupsd_server }}:3551"]
+  servers = ["tcp://{{ OPNsense.telegraf.input.apcupsd_server|default('127.0.0.1') }}:3551"]
   timeout = "5s"
 {% endif %}
 


### PR DESCRIPTION
Add the [apcupsd input](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/apcupsd/README.md) to telegraf.

Tested on multiple OPNsense running 22.7.6.