### PR TITLE
net/wireguard: Fixed array_merge error for removed peers

### DIFF
--- a/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/Api/GeneralController.php
+++ b/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/Api/GeneralController.php
@@ -84,6 +84,10 @@ class GeneralController extends ApiMutableModelControllerBase
                 $serverPeers = explode(",", (string) $server->peers);
                 // iteriate over each peer uuid
                 foreach ($serverPeers as $peerUuid) {
+                    // skipping removed peer that is still referenced in server
+                    if (!isset($peers[$peerUuid])) {
+                        continue;
+                    }
                     // remember interface and pubkey <> peer-uuid reference for referencing handshake logic below
                     $peer_pubkey_reference[$interface][$peers_uuid_pubkey[$peerUuid]] = $peerUuid;
                     // merge peer info and initial values for handshake data


### PR DESCRIPTION
This PR fixes the following error, triggered when opening the dashboard (with the Wireguard widget and a configuration with dead peers in servers): 

```

[04-Nov-2022 13:53:07 Europe/Berlin] TypeError: array_merge(): Argument #1 must be of type array, null given in /usr/local/opnsense/mvc/app/controllers/OPNsense/Wireguard/Api/GeneralController.php:93
Stack trace:
#0 /usr/local/opnsense/mvc/app/controllers/OPNsense/Wireguard/Api/GeneralController.php(93): array_merge(NULL, Array)
#1 [internal function]: OPNsense\Wireguard\Api\GeneralController->getStatusAction()
#2 [internal function]: Phalcon\Dispatcher\AbstractDispatcher->callActionMethod(Object(OPNsense\Wireguard\Api\GeneralController), 'getStatusAction', Array)
#3 [internal function]: Phalcon\Dispatcher\AbstractDispatcher->dispatch()
#4 /usr/local/opnsense/www/api.php(24): Phalcon\Mvc\Application->handle('/api/wireguard/...')
#5 {main}
```

(Caused by the fact that `$server->peers` may contain peers that no longer exist)