### PR TITLE
dns/ddclient Add support for ddclient 3.10.0 dns provider

### DIFF
--- a/dns/ddclient/pkg-descr
+++ b/dns/ddclient/pkg-descr
@@ -5,6 +5,7 @@ WWW: https://github.com/ddclient/ddclient
 
 Plugin Changelog
 ================
+
 2.0
 
 * Update to ddclient 3.10.0

--- a/dns/ddclient/pkg-descr
+++ b/dns/ddclient/pkg-descr
@@ -6,7 +6,7 @@ WWW: https://github.com/ddclient/ddclient
 Plugin Changelog
 ================
 
-2.0
+1.10
 
 * Update to ddclient 3.10.0
 * Add 1984 support (contributed by Luca Schoeneberg)

--- a/dns/ddclient/pkg-descr
+++ b/dns/ddclient/pkg-descr
@@ -5,6 +5,23 @@ WWW: https://github.com/ddclient/ddclient
 
 Plugin Changelog
 ================
+2.0
+
+* Update to ddclient 3.10.0
+* Add 1984 support (contributed by Luca Schoeneberg)
+* Add ClouDNS support (contributed by Luca Schoeneberg)
+* Add Dinahosting support (contributed by Luca Schoeneberg)
+* Add DNSExit support (contributed by Luca Schoeneberg)
+* Add DonDominio support (contributed by Luca Schoeneberg)
+* Add Freemyip support (contributed by Luca Schoeneberg)
+* Add godaddy support (contributed by Luca Schoeneberg)
+* Add Hetzner support (contributed by Luca Schoeneberg)
+* Add Key-Systems support (contributed by Luca Schoeneberg)
+* Add NearlyFreeSpeech.NET support (contributed by Luca Schoeneberg)
+* Add Njal.la support (contributed by satrapes)
+* Add sitelutions support (contributed by Luca Schoeneberg)
+* Add woima support (contributed by Luca Schoeneberg)
+* Add Yandex support (contributed by Luca Schoeneberg)
 
 1.9
 

--- a/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/dialogAccount.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/dialogAccount.xml
@@ -41,14 +41,14 @@
         <id>account.wildcard</id>
         <label>Wildcard</label>
         <type>checkbox</type>
-        <style>optional_setting service_dyndns2 service_easydns service_custom</style>
+        <style>optional_setting service_dyndns2 service_woima service_cloudflare service_easydns service_custom</style>
         <help>add a DNS wildcard CNAME record that points to the configured host.</help>
     </field>
     <field>
         <id>account.zone</id>
         <label>Zone</label>
         <type>text</type>
-        <style>optional_setting service_cloudflare</style>
+        <style>optional_setting service_zoneedit1 service_cloudflare service_nsupdate service_gandi service_godaddy service_nfsn service_hetzner</style>
         <help>Zone containing the host entry.</help>
     </field>
     <field>

--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
@@ -35,32 +35,46 @@
                     <Required>Y</Required>
                     <ValidationMessage>A service type is required.</ValidationMessage>
                     <OptionValues>
+                        <hosting1984>1984</hosting1984>
                         <changeip>Changeip</changeip>
                         <cloudflare>Cloudflare</cloudflare>
+                        <cloudns>Cloudns</cloudns>
+                        <dinahosting>Dinahosting</dinahosting>
                         <dnsmadeeasy>DNS Made Easy</dnsmadeeasy>
                         <dns-o-matic>DNS-O-Matic</dns-o-matic>
+                        <dnsexit>DNSExit</dnsexit>
                         <dyndns2>DynDNS.com</dyndns2>
                         <dnspark>DnsPark</dnspark>
                         <dslreports1>DslReports</dslreports1>
+                        <donDominio>DonDominio</donDominio>
                         <duckdns>DuckDNS</duckdns>
                         <dynu>Dynu</dynu>
                         <easydns>EasyDNS</easydns>
                         <freedns>FreeDNS</freedns>
-                        <googledomains>Google</googledomains>
+                        <freemyip>FreeMyIP</freemyip>
                         <gandi>Gandi.net</gandi>
+                        <godaddy>GoDaddy</godaddy>
+                        <googledomains>Google</googledomains>
                         <he-net>HE.net</he-net>
                         <he-net-tunnel>HE.net TunnelBroker</he-net-tunnel>
+                        <hetzner>Hetzner</hetzner>
                         <inwx>INWX</inwx>
+                        <keysystems>Key-Systems</keysystems>
                         <loopia>Loopia</loopia>
                         <namecheap>NameCheap</namecheap>
+                        <nfsn>NearlyFreeSpeech.net</nfsn>
+                        <njalla>Njalla</njalla>
                         <noip>Noip</noip>
                         <nsupdatev4>nsupdate.info (IPv4)</nsupdatev4>
                         <nsupdatev6>nsupdate.info (IPv6)</nsupdatev6>
+                        <ovh>OVH DynHost</ovh>
                         <servercow>Servercow</servercow>
+                        <sitelutions>Sitelutions</sitelutions>
                         <spdyn>spDYN</spdyn>
                         <strato>STRATO</strato>
+                        <woima>Woima</woima>
+                        <yandex>Yandex</yandex>
                         <zoneedit1>Zoneedit</zoneedit1>
-                        <ovh>OVH DynHost</ovh>
                         <custom>Custom</custom>
                     </OptionValues>
                 </service>

--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
@@ -38,36 +38,36 @@
                         <hosting1984>1984</hosting1984>
                         <changeip>Changeip</changeip>
                         <cloudflare>Cloudflare</cloudflare>
-                        <cloudns>Cloudns</cloudns>
-                        <dinahosting>Dinahosting</dinahosting>
-                        <dnsmadeeasy>DNS Made Easy</dnsmadeeasy>
+                        <cloudns>ClouDNS</cloudns>
+                        <dinahosting>dinahosting</dinahosting>
+                        <dnsmadeeasy>DNS Made Easy (digicert)</dnsmadeeasy>
                         <dns-o-matic>DNS-O-Matic</dns-o-matic>
                         <dnsexit>DNSExit</dnsexit>
                         <dyndns2>DynDNS.com</dyndns2>
                         <dnspark>DnsPark</dnspark>
-                        <dslreports1>DslReports</dslreports1>
-                        <donDominio>DonDominio</donDominio>
-                        <duckdns>DuckDNS</duckdns>
+                        <dslreports1>DSLReports</dslreports1>
+                        <dondominio>DonDominio</dondominio>
+                        <duckdns>Duck DNS</duckdns>
                         <dynu>Dynu</dynu>
-                        <easydns>EasyDNS</easydns>
+                        <easydns>easyDNS</easydns>
                         <freedns>FreeDNS</freedns>
-                        <freemyip>FreeMyIP</freemyip>
-                        <gandi>Gandi.net</gandi>
+                        <freemyip>freeMyIP</freemyip>
+                        <gandi>gandi.net</gandi>
                         <godaddy>GoDaddy</godaddy>
                         <googledomains>Google</googledomains>
                         <he-net>HE.net</he-net>
                         <he-net-tunnel>HE.net TunnelBroker</he-net-tunnel>
-                        <hetzner>Hetzner</hetzner>
+                        <hetzner>Hetzner DNS Console</hetzner>
                         <inwx>INWX</inwx>
                         <keysystems>Key-Systems</keysystems>
                         <loopia>Loopia</loopia>
                         <namecheap>NameCheap</namecheap>
                         <nfsn>NearlyFreeSpeech.net</nfsn>
                         <njalla>Njalla</njalla>
-                        <noip>Noip</noip>
+                        <noip>no-ip</noip>
                         <nsupdatev4>nsupdate.info (IPv4)</nsupdatev4>
                         <nsupdatev6>nsupdate.info (IPv6)</nsupdatev6>
-                        <ovh>OVH DynHost</ovh>
+                        <ovh>OVHcloud DynHost</ovh>
                         <servercow>Servercow</servercow>
                         <sitelutions>Sitelutions</sitelutions>
                         <spdyn>spDYN</spdyn>

--- a/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
+++ b/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
@@ -40,6 +40,14 @@ server={{account.server}}, \
 {%      elif account.service == 'cloudflare' %}
 protocol=cloudflare, \
 zone={{account.zone}}, \
+{%      elif account.service == 'hosting1984' %}
+protocol=1984, \
+{%      elif account.service == 'godaddy' %}
+protocol=godaddy, \
+zone={{account.zone}}, \
+{%      elif account.service == 'hetzner' %}
+protocol=hetzner, \
+zone={{account.zone}}, \
 {%      elif account.service == 'dnsmadeeasy' %}
 protocol=dnsmadeeasy, \
 {%      elif account.service == 'dns-o-matic' %}


### PR DESCRIPTION
Add 1984, ClouDNS, Dinahosting, DNSExit, DonDominio, Freemyip, godaddy, Hetzner, Key-Systems, NearlyFreeSpeech.NET, Njal.la(thanks to satrapes), sitelutions, woima and Yandex for ddclient 3.10.0.

I hope that is okay that I have taken the changes from https://github.com/opnsense/plugins/pull/3129.