### PR TITLE
security/clamav: migrate to syslog-ng

### DIFF
--- a/security/clamav/Makefile
+++ b/security/clamav/Makefile
@@ -1,6 +1,5 @@
 PLUGIN_NAME=		clamav
-PLUGIN_VERSION=		1.7
-PLUGIN_REVISION=	2
+PLUGIN_VERSION=		1.8
 PLUGIN_COMMENT=		Antivirus engine for detecting malicious threats
 PLUGIN_DEPENDS=		clamav
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/security/clamav/pkg-descr
+++ b/security/clamav/pkg-descr
@@ -9,6 +9,11 @@ database updates.
 Plugin Changelog
 ================
 
+1.8
+
+* Use syslog for logging
+* ClamAV verbose logging option added
+
 1.7
 
 * Allow addition of external signatures

--- a/security/clamav/src/opnsense/mvc/app/controllers/OPNsense/ClamAV/forms/general.xml
+++ b/security/clamav/src/opnsense/mvc/app/controllers/OPNsense/ClamAV/forms/general.xml
@@ -160,10 +160,16 @@
         <help>Number of files to be scanned within an archive, a document, or any other container file.</help>
     </field>
     <field>
+        <id>general.logverbose</id>
+        <label>ClamAV log verbose</label>
+        <type>checkbox</type>
+        <help>Enable ClamAV verbose logging.</help>
+    </field>
+    <field>
         <id>general.fc_logverbose</id>
         <label>Freshclam log verbose</label>
         <type>checkbox</type>
-        <help>Enable verbose logging.</help>
+        <help>Enable Freshclam verbose logging.</help>
     </field>
     <field>
         <id>general.fc_databasemirror</id>

--- a/security/clamav/src/opnsense/mvc/app/models/OPNsense/ClamAV/ACL/ACL.xml
+++ b/security/clamav/src/opnsense/mvc/app/models/OPNsense/ClamAV/ACL/ACL.xml
@@ -4,10 +4,8 @@
       <patterns>
          <pattern>ui/clamav/*</pattern>
          <pattern>api/clamav/*</pattern>
-         <pattern>ui/diagnostics/log/clamav/clamd/*</pattern>
-         <pattern>api/diagnostics/log/clamav/clamd/*</pattern>
-         <pattern>ui/diagnostics/log/clamav/freshclam/*</pattern>
-         <pattern>api/diagnostics/log/clamav/freshclam/*</pattern>
+         <pattern>ui/diagnostics/log/core/clamd/*</pattern>
+         <pattern>api/diagnostics/log/core/clamd/*</pattern>
       </patterns>
    </page-services-clamav>
 </acl>

--- a/security/clamav/src/opnsense/mvc/app/models/OPNsense/ClamAV/General.xml
+++ b/security/clamav/src/opnsense/mvc/app/models/OPNsense/ClamAV/General.xml
@@ -111,6 +111,10 @@
             <default>10000</default>
             <Required>N</Required>
 	</maxfiles>
+        <logverbose type="BooleanField">
+            <default>0</default>
+            <Required>N</Required>
+        </logverbose>
         <fc_logverbose type="BooleanField">
             <default>0</default>
             <Required>N</Required>

--- a/security/clamav/src/opnsense/mvc/app/models/OPNsense/ClamAV/Menu/Menu.xml
+++ b/security/clamav/src/opnsense/mvc/app/models/OPNsense/ClamAV/Menu/Menu.xml
@@ -2,8 +2,7 @@
     <Services>
         <ClamAV cssClass="fa fa-stethoscope">
             <Configuration order="10" url="/ui/clamav/general/index"/>
-            <LogFile VisibleName="Log / Clamd" order="20" url="/ui/diagnostics/log/clamav/clamd"/>
-            <LogFile VisibleName="Log / Freshclam" order="30" url="/ui/diagnostics/log/clamav/freshclam"/>
+            <LogFile VisibleName="Log" order="20" url="/ui/diagnostics/log/core/clamd"/>
         </ClamAV>
     </Services>
 </menu>

--- a/security/clamav/src/opnsense/service/templates/OPNsense/ClamAV/clamd.conf
+++ b/security/clamav/src/opnsense/service/templates/OPNsense/ClamAV/clamd.conf
@@ -1,6 +1,9 @@
 {% if helpers.exists('OPNsense.clamav.general.enabled') and OPNsense.clamav.general.enabled == '1' %}
-LogFile /var/log/clamav/clamd.log
 LogTime yes
+LogSyslog yes
+{%   if helpers.exists('OPNsense.clamav.general.logverbose') and OPNsense.clamav.general.logverbose == '1' %}
+LogVerbose yes
+{%   endif %}
 PidFile /var/run/clamav/clamd.pid
 DatabaseDirectory /var/db/clamav
 LocalSocket /var/run/clamav/clamd.sock

--- a/security/clamav/src/opnsense/service/templates/OPNsense/ClamAV/freshclam.conf
+++ b/security/clamav/src/opnsense/service/templates/OPNsense/ClamAV/freshclam.conf
@@ -2,7 +2,7 @@
 
 
 DatabaseDirectory /var/db/clamav
-UpdateLogFile /var/log/clamav/freshclam.log
+LogSyslog yes
 
 LogTime yes
 {% if helpers.exists('OPNsense.clamav.general.fc_logverbose') and OPNsense.clamav.general.fc_logverbose == '1' %}

--- a/security/clamav/src/opnsense/service/templates/OPNsense/Syslog/local/clamd.conf
+++ b/security/clamav/src/opnsense/service/templates/OPNsense/Syslog/local/clamd.conf
@@ -1,0 +1,6 @@
+###################################################################
+# Local syslog-ng configuration filter definition [clamd].
+###################################################################
+filter f_local_clamd {
+    program("clamd") or program("freshclam");
+};


### PR DESCRIPTION
Hi
ref. https://forum.opnsense.org/index.php?topic=31198.0
maybe it makes sense to switch to using syslog? )
from
![clamav](https://user-images.githubusercontent.com/36099472/205371490-4cfc1e26-e906-4b80-89fe-d68279a4d725.PNG)
to
![clamav2](https://user-images.githubusercontent.com/36099472/205371580-d741b6fc-b2a4-4aa9-bee9-796027b7d63c.PNG)
verbose logging option added, just in case
thanks!