### PR TITLE
dns/ddclient: Fix IPv6 address parsing from external service

### DIFF
--- a/dns/ddclient/pkg-descr
+++ b/dns/ddclient/pkg-descr
@@ -23,6 +23,7 @@ Plugin Changelog
 * Add sitelutions support (contributed by Luca Schoeneberg)
 * Add woima support (contributed by Luca Schoeneberg)
 * Add Yandex support (contributed by Luca Schoeneberg)
+* Fix parsing short IPv6 addresses from external service (contributed by Patrick Grupp)
 
 1.9
 

--- a/dns/ddclient/src/opnsense/scripts/ddclient/checkip
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/checkip
@@ -57,7 +57,7 @@ def extract_address(txt):
     """
     for regexp in [r'[^a-fA-F0-9\:]', r'[^F0-9\.]']:
         for line in re.sub(regexp, ' ', txt).split():
-            if line.count('.') == 3 or line.count(':') > 4:
+            if line.count('.') == 3 or line.count(':') >= 2:
                 try:
                     ipaddress.ip_address(line)
                     return line


### PR DESCRIPTION
When using external services to determine the public IPv6 address of an interface, the bounds are too limited for short (but valid) IPv6 addresses. Reducing the necessary amount of colon characters in the resolved IPv6 address for the `checkip` script to accept them fixes this issue.

For example an IPv6 address of this format `aaaa:bbbb:cccc::dddd` would be incorrectly deemed invalid because it has only 4 `:` colon characters but the `checkip` script requires *more* than 4.
I've reduced the amount of necessary colon characters to two, which is the least necessary amount for a valid IPv6 address according to [RFC-4291 Section 2.2](https://www.rfc-editor.org/rfc/rfc4291.html#section-2.2), even though it's unlikely many of those short IPv6 addresses are actually publicly routed/delegated.

Let me know if there's any error in my thinking or if I should not be bumping the version of the plugin, I wasn't sure if 1.10 was already released so I added a new version, hope this is fine. :)