### PR TITLE
dns/bind: cleanup master/slave zone UI

### DIFF
--- a/dns/bind/pkg-descr
+++ b/dns/bind/pkg-descr
@@ -11,6 +11,7 @@ Plugin Changelog
 
 1.25
 
+* Cleanup/Fix the Master/Slave domain dialogs (contributed by Robbert Rijkse and Michael Newton)
 * Revamp the logging page with proper columns (contributed by Robbert Rijkse)
 * Update base to BIND 9.18
 

--- a/dns/bind/pkg-descr
+++ b/dns/bind/pkg-descr
@@ -11,7 +11,7 @@ Plugin Changelog
 
 1.25
 
-* Cleanup/Fix the Master/Slave domain dialogs (contributed by Robbert Rijkse and Michael Newton)
+* Cleanup/Fix the Master/Slave domain dialogs (contributed by Robbert Rijkse)
 * Revamp the logging page with proper columns (contributed by Robbert Rijkse)
 * Update base to BIND 9.18
 

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindMasterDomain.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindMasterDomain.xml
@@ -24,56 +24,6 @@
         <help>Define an ACL where you allow which client are allowed to query this zone.</help>
     </field>
     <field>
-        <id>domain.type</id>
-        <label>Type</label>
-        <type>dropdown</type>
-        <help>Set the type for this zone.</help>
-    </field>
-    <field>
-        <label>Slave Zone</label>
-        <type>header</type>
-        <style>zone_type zone_type_slave</style>
-    </field>
-    <field>
-        <id>domain.masterip</id>
-        <label>Master IP</label>
-        <style>tokenize</style>
-        <type>select_multiple</type>
-        <allownew>true</allownew>
-        <help>Set the IP address of master server when using slave mode.</help>
-    </field>
-    <field>
-        <id>domain.transferkeyalgo</id>
-        <label>Transfer Key Algorithm</label>
-        <type>dropdown</type>
-        <help>Set the authentication algorithm for the TSIG key used to transfer domain data from the master server.</help>
-    </field>
-    <field>
-        <id>domain.transferkeyname</id>
-        <label>Transfer Key Name</label>
-        <type>text</type>
-        <help>The name of the TSIG key, which must match the value on the master server.</help>
-    </field>
-    <field>
-        <id>domain.transferkey</id>
-        <label>Transfer Key</label>
-        <type>text</type>
-        <help>The base64-encoded TSIG key.</help>
-    </field>
-    <field>
-        <id>domain.allownotifyslave</id>
-        <label>Allow Notfiy</label>
-        <style>tokenize</style>
-        <type>select_multiple</type>
-        <allownew>true</allownew>
-        <help>A list of allowed IP addresses to receive notifies from.</help>
-    </field>
-    <field>
-        <label>Master Zone</label>
-        <type>header</type>
-        <style>zone_type zone_type_master</style>
-    </field>
-    <field>
         <id>domain.ttl</id>
         <label>TTL</label>
         <type>text</type>

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindSlaveDomain.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindSlaveDomain.xml
@@ -47,7 +47,7 @@
         <id>domain.transferkey</id>
         <label>Transfer Key</label>
         <type>text</type>
-        <help>The base64 encoded TSIG key used to transfer domain data from the master server.</help>
+        <help>The TSIG key used to transfer domain data from the master server in Base64 encoding .</help>
     </field>
     <field>
         <id>domain.allownotifyslave</id>

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindSlaveDomain.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindSlaveDomain.xml
@@ -29,19 +29,25 @@
         <style>tokenize</style>
         <type>select_multiple</type>
         <allownew>true</allownew>
-        <help>Set the IP address of master server when using slave mode.</help>
+        <help>Set the IP address of master server.</help>
+    </field>
+     <field>
+        <id>domain.transferkeyname</id>
+        <label>Transfer Key Name</label>
+        <type>text</type>
+        <help>The name of the TSIG key, which must match the value on the master server.</help>
     </field>
     <field>
         <id>domain.transferkeyalgo</id>
         <label>Transfer Key Algorithm</label>
         <type>dropdown</type>
-        <help>Set the authentication algorithm for the TSIG key.</help>
+        <help>Set the authentication algorithm for the TSIG key used to transfer domain data from the master server.</help>
     </field>
     <field>
         <id>domain.transferkey</id>
         <label>Transfer Key</label>
         <type>text</type>
-        <help>The TSIG key used to transfer domain data from the master server.</help>
+        <help>The base64 encoded TSIG key used to transfer domain data from the master server.</help>
     </field>
     <field>
         <id>domain.allownotifyslave</id>
@@ -49,6 +55,6 @@
         <style>tokenize</style>
         <type>select_multiple</type>
         <allownew>true</allownew>
-        <help>A list of allowed IP addresses to receive notifies from.</help>
+        <help>A list of allowed IP addresses to receive notifies from (in addition to the master server).</help>
     </field>
 </form>

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindSlaveDomain.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindSlaveDomain.xml
@@ -31,17 +31,17 @@
         <allownew>true</allownew>
         <help>Set the IP address of master server.</help>
     </field>
-     <field>
-        <id>domain.transferkeyname</id>
-        <label>Transfer Key Name</label>
-        <type>text</type>
-        <help>The name of the TSIG key, which must match the value on the master server.</help>
-    </field>
     <field>
         <id>domain.transferkeyalgo</id>
         <label>Transfer Key Algorithm</label>
         <type>dropdown</type>
         <help>Set the authentication algorithm for the TSIG key used to transfer domain data from the master server.</help>
+    </field>
+    <field>
+        <id>domain.transferkeyname</id>
+        <label>Transfer Key Name</label>
+        <type>text</type>
+        <help>The name of the TSIG key, which must match the value on the master server.</help>
     </field>
     <field>
         <id>domain.transferkey</id>

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindSlaveDomain.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindSlaveDomain.xml
@@ -47,7 +47,7 @@
         <id>domain.transferkey</id>
         <label>Transfer Key</label>
         <type>text</type>
-        <help>The TSIG key used to transfer domain data from the master server in Base64 encoding .</help>
+        <help>The TSIG key used to transfer domain data from the master server in Base64 encoding.</help>
     </field>
     <field>
         <id>domain.allownotifyslave</id>

--- a/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/general.volt
+++ b/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/general.volt
@@ -92,7 +92,6 @@ POSSIBILITY OF SUCH DAMAGE.
             <thead>
                 <tr>
                     <th data-column-id="enabled" data-type="string" data-formatter="rowtoggle">{{ lang._('Enabled') }}</th>
-                    <th data-column-id="type" data-type="string" data-visible="true">{{ lang._('Type') }}</th>
                     <th data-column-id="domainname" data-type="string" data-visible="true">{{ lang._('Zone') }}</th>
                     <th data-column-id="ttl" data-type="string" data-visible="true">{{ lang._('TTL') }}</th>
                     <th data-column-id="refresh" data-type="string" data-visible="true">{{ lang._('Refresh') }}</th>
@@ -161,7 +160,6 @@ POSSIBILITY OF SUCH DAMAGE.
             <thead>
                 <tr>
                     <th data-column-id="enabled" data-type="string" data-formatter="rowtoggle">{{ lang._('Enabled') }}</th>
-                    <th data-column-id="type" data-type="string" data-visible="true">{{ lang._('Type') }}</th>
                     <th data-column-id="domainname" data-type="string" data-visible="true">{{ lang._('Zone') }}</th>
                     <th data-column-id="masterip" data-type="string" data-visible="true">{{ lang._('Master IPs') }}</th>
                     <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>


### PR DESCRIPTION
This cleans up the `master`/`slave` dialog boxes to only contain the items that are actually processed for each zone type. It also remove the Type column from the zone list since this is redundant information.