### PR TITLE
net/haproxy: fix HAProxy SSL preferences in healthchecks

### DIFF
--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -1825,7 +1825,7 @@ backend {{backend.name}}
 {#               # 2. in health checks: to verify *only* health check communication to this server #}
 {#               # When 1. is enabled, health checks are automatically secured. #}
 {#               # Use-case for 2: when using TCP for server communication, but HTTPS for health checks. #}
-{%               if server_data.ssl|default("") == '1' or (healthcheck_enabled == '1' and healthcheck_data.force_ssl|default('') == '1') %}
+{%               if server_data.ssl|default("") == '1' or (healthcheck_enabled == '1' and (healthcheck_data.ssl|default('') == 'ssl' or healthcheck_data.ssl|default('') == 'sslsni')) %}
 {#                 # get status of ssl verification #}
 {%                 set ssl_verify_enabled = '0' %}
 {%                 if helpers.exists('OPNsense.HAProxy.general.tuning.sslServerVerify') and OPNsense.HAProxy.general.tuning.sslServerVerify|default("") != 'ignore' %}


### PR DESCRIPTION
Use the option field _ssl_ instead of boolean _force_ssl_ for case 2. in health checks