### PR TITLE
Smart status rework

### DIFF
--- a/sysutils/smart/src/opnsense/mvc/app/controllers/OPNsense/Smart/Api/ServiceController.php
+++ b/sysutils/smart/src/opnsense/mvc/app/controllers/OPNsense/Smart/Api/ServiceController.php
@@ -38,7 +38,7 @@ class ServiceController extends ApiControllerBase
     {
         $backend = new Backend();
 
-        $devices = preg_split("/[\s]+/", trim($backend->configdRun("smart list")));
+        $devices = preg_split("/\\n/", trim($backend->configdRun("smart list")));
 
         return $devices;
     }
@@ -71,7 +71,7 @@ class ServiceController extends ApiControllerBase
 
             $backend = new Backend();
 
-            $params = array($mode, $type, "/dev/" . $device);
+            $params = array($mode, $type, $device );
 
             $output = $backend->configdpRun("smart", $params);
             if ($mode == 'info_json') {
@@ -102,7 +102,7 @@ class ServiceController extends ApiControllerBase
 
             $backend = new Backend();
 
-            $output = $backend->configdpRun("smart", array("log", $type, "/dev/" . $device));
+            $output = $backend->configdpRun("smart", array("log", $type, $device));
 
             return array("output" => $output);
         }
@@ -128,7 +128,7 @@ class ServiceController extends ApiControllerBase
 
             $backend = new Backend();
 
-            $output = $backend->configdpRun("smart", array("test", $type, "/dev/" . $device));
+            $output = $backend->configdpRun("smart", array("test", $type, $device));
 
             return array("output" => $output);
         }
@@ -147,7 +147,7 @@ class ServiceController extends ApiControllerBase
 
             $backend = new Backend();
 
-            $output = $backend->configdpRun("smart", array("abort", "/dev/" . $device));
+            $output = $backend->configdpRun("smart", array("abort", $device));
 
             return array("output" => $output);
         }

--- a/sysutils/smart/src/opnsense/mvc/app/views/OPNsense/Smart/index.volt
+++ b/sysutils/smart/src/opnsense/mvc/app/views/OPNsense/Smart/index.volt
@@ -143,7 +143,7 @@
 		    </td>
 		</tr>
 		<tr>
-		    <td><label for="device1">{{ lang._('Device: /dev/') }}</label></td>
+		    <td><label for="device1">{{ lang._('Device: ') }}</label></td>
 		    <td >
 			<select id="device1" name="device" class="form-control">
 			</select>
@@ -179,7 +179,7 @@
                     </td>
                 </tr>
 		<tr>
-                    <td><label for="device2">{{ lang._('Device: /dev/') }}</label></td>
+                    <td><label for="device2">{{ lang._('Device: ') }}</label></td>
                     <td>
 			<select id="device2" name="device" class="form-control">
 			</select>
@@ -213,7 +213,7 @@
                     </td>
 		</tr>
 		<tr>
-                    <td><label for="device3">{{ lang._('Device: /dev/') }}</label></td>
+                    <td><label for="device3">{{ lang._('Device: ') }}</label></td>
                     <td >
 			<select id="device3" name="device" class="form-control">
 			</select>
@@ -238,7 +238,7 @@
                     <th colspan="2" style="vertical-align:top" class="listtopic">{{ lang._('Abort tests') }}</th>
                 </tr>
 		<tr>
-                    <td><label for="device4">{{ lang._('Device: /dev/') }}</label></td>
+                    <td><label for="device4">{{ lang._('Device: ') }}</label></td>
                     <td >
 			<select id="device4" name="device" class="form-control">
 			</select>

--- a/sysutils/smart/src/opnsense/scripts/OPNsense/Smart/actions.sh
+++ b/sysutils/smart/src/opnsense/scripts/OPNsense/Smart/actions.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Proxy for smartctl and configctl parameter issue
+# We added single quotes for inseparable device string
+
+# Parse all parameter from the actions.d file and add them to A, B or C.
+case $1 in
+    -l) A="-l"
+        shift 
+        A="$A $1"
+        shift 
+        ;;
+    --json=c)  B="--json=c"
+        shift
+        ;;
+    -t) A="-t"
+        shift 
+        A="$A $1"
+        shift
+        ;;
+    -X) A="-X"
+        shift
+        ;; 
+    -i|-H|-a|-c|-A) A=$1
+        shift
+        ;; 
+    *)
+      ;; 
+esac
+
+# remove the single quotes for regular paramter strings
+C=$(echo $1 | /usr/bin/tr -d "'")
+# execute the command
+/usr/local/sbin/smartctl $A $B $C 

--- a/sysutils/smart/src/opnsense/scripts/OPNsense/Smart/detailed_list.sh
+++ b/sysutils/smart/src/opnsense/scripts/OPNsense/Smart/detailed_list.sh
@@ -27,21 +27,36 @@
 
 RESULT=
 
-for DEV in $(sysctl -n kern.disks); do
-    IDENT=$(/usr/sbin/diskinfo -s ${DEV})
+OIFS="$IFS"
+IFS=$'\n' # use newline separator to get the whole smartctl device string
+C=0
+# Operate only devices that smartctl can handle. 
+# This creates variables DEVICE_1 ... DEVICE_<number of devices>.
+for I in $(/usr/local/sbin/smartctl --scan | /usr/bin/awk -F# '{print $1}'); do
+   C=$(expr $C + 1)
+   eval DEVICE_${C}="\$I";
+done
+IFS="$OIFS" # restore the previous IFS settings
 
-    if [ "${DEV#nvd}" != "${DEV}" ]; then
-        # the disk formerly know as nvdX
-        DEV="nvme${DEV#nvd}"
-    fi
 
-    STATE=$(/usr/local/sbin/smartctl -jH /dev/${DEV})
+for I in $(/usr/bin/seq 1 $C); do
+   eval DEV="\$DEVICE_$I"
 
-    if [ -n "${RESULT}" ]; then
-        RESULT="${RESULT},";
-    fi
+   STATE=$(/usr/local/sbin/smartctl -jH  ${DEV})
 
-    RESULT="${RESULT}{\"device\":\"${DEV}\",\"ident\":\"${IDENT}\",\"state\":${STATE}}";
+   # If there is no valid state, skip it
+   if [ $? -ne 0 ]; then
+      continue;
+   fi
+
+   if [ -n "${RESULT}" ]; then
+      RESULT="${RESULT},";
+   fi
+   # get a valid identifier for the device, the serial number
+   IDENT=$(/usr/local/sbin/smartctl -a  ${DEV} | /usr/bin/awk '/^Serial number:/{print $3}')
+
+   RESULT="${RESULT}{\"device\":\"${DEV##*-d}\",\"ident\":\"${IDENT}\",\"state\":${STATE}}";
+
 done
 
 echo "[${RESULT}]"

--- a/sysutils/smart/src/opnsense/scripts/OPNsense/Smart/detailed_list.sh
+++ b/sysutils/smart/src/opnsense/scripts/OPNsense/Smart/detailed_list.sh
@@ -25,6 +25,17 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
+# get the tempdir, because there is no environment variable
+TMPFILE=$(/usr/bin/mktemp)
+CACHEFILE="$(dirname $TMPFILE)/smart.json"
+rm -f $TMPFILE
+
+printout()
+{
+   cat ${CACHEFILE}
+   exit
+}
+
 RESULT=
 
 OIFS="$IFS"
@@ -37,6 +48,12 @@ for I in $(/usr/local/sbin/smartctl --scan | /usr/bin/awk -F# '{print $1}'); do
    eval DEVICE_${C}="\$I";
 done
 IFS="$OIFS" # restore the previous IFS settings
+
+# Delete expired cache file
+/usr/bin/find ${CACHEFILE}  -type f -mmin +5  -delete 2>/dev/null
+
+# If there is a cache file, use it.
+[ -f "${CACHEFILE}" ] && printout
 
 
 for I in $(/usr/bin/seq 1 $C); do

--- a/sysutils/smart/src/opnsense/service/conf/actions.d/actions_smart.conf
+++ b/sysutils/smart/src/opnsense/service/conf/actions.d/actions_smart.conf
@@ -1,5 +1,5 @@
 [list]
-command:sysctl -n kern.disks | sed s:nvd:nvme:g
+command:/usr/local/sbin/smartctl --scan | /usr/bin/awk -F# -v q="'" '{print q$1q}'
 parameters:
 type:script_output
 message:list installed devices
@@ -11,59 +11,59 @@ type:script_output
 message:list installed devices
 
 [info]
-command:/usr/local/sbin/smartctl
+command:/usr/local/opnsense/scripts/OPNsense/Smart/actions.sh
 parameters:-%s %s; exit 0
 type:script_output
 message:exec smartctl -%s for device %s
 
 [info_json]
-command:/usr/local/sbin/smartctl
+command:/usr/local/opnsense/scripts/OPNsense/Smart/actions.sh
 parameters:-%s --json=c %s; exit 0
 type:script_output
 message:exec smartctl -%s (JSON) for device %s
 
 [log.error]
-command:/usr/local/sbin/smartctl -l error
+command:/usr/local/opnsense/scripts/OPNsense/Smart/actions.sh -l error
 parameters:%s; exit 0
 type:script_output
 message:Get error log for device %s
 
 [log.selftest]
-command:/usr/local/sbin/smartctl -l selftest
+command:/usr/local/opnsense/scripts/OPNsense/Smart/actions.sh -l selftest
 parameters:%s; exit 0
 type:script_output
 message:Get selftest log for device %s
 
 [test.offline]
-command:/usr/local/sbin/smartctl -t offline
+command:/usr/local/opnsense/scripts/OPNsense/Smart/actions.sh -t offline
 parameters:%s; exit 0
 type:script_output
 message:Testing device %s (offline)
 description:Run SMART test (offline)
 
 [test.short]
-command:/usr/local/sbin/smartctl -t short
+command:/usr/local/opnsense/scripts/OPNsense/Smart/actions.sh -t short
 parameters:%s; exit 0
 type:script_output
 message:Testing device %s (short)
 description:Run SMART test (short)
 
 [test.long]
-command:/usr/local/sbin/smartctl -t long
+command:/usr/local/opnsense/scripts/OPNsense/Smart/actions.sh -t long
 parameters:%s; exit 0
 type:script_output
 message:Testing device %s (long)
 description:Run SMART test (long)
 
 [test.conveyance]
-command:/usr/local/sbin/smartctl -t conveyance
+command:/usr/local/opnsense/scripts/OPNsense/Smart/actions.sh -t conveyance
 parameters:%s; exit 0
 type:script_output
 message:Testing device %s (conveyance)
 description:Run SMART test (conveyance)
 
 [abort]
-command:/usr/local/sbin/smartctl -X
+command:/usr/local/opnsense/scripts/OPNsense/Smart/actions.sh -X
 parameters:%s; exit 0
 type:script_output
 message:Abort test on device %s


### PR DESCRIPTION
The smart status was not working with RAID devices because the device handling chose device names, which smartctl could not handle. The rework is based on --scan feature of smartctl, which gets all devices that smartctl knew.

5756ce8d249bd7f49523deaceed4b0acda99505d  Basic work for the status feature at the lobby.
5e72d18c3b665fe0140853e71197c8dca4bd6998  Get the service tab working. All part were test for basic function.


Unsightly part:  - The devices names in the service tab had to be quoted to preserve the full device name that smartctl can handle.
                          -  At the smart status widget the device part (-d) from smartctl was used)

The  commit d43b662edcc16f6b5b614544d3c97fd89db79dca contains a version with cache feature as POC. 

Images may be found at https://cloud.thhcx.de/index.php/s/fAnfkG3grrig55K

