### PR TITLE
dns/dnscrypt-proxy: fix GUI with more than one disabled server

### DIFF
--- a/dns/dnscrypt-proxy/pkg-descr
+++ b/dns/dnscrypt-proxy/pkg-descr
@@ -5,6 +5,10 @@ such as DNSCrypt v2 and DNS-over-HTTPS.
 Plugin Changelog
 ================
 
+1.14
+
+* Fix display of the config with more than one disabled server in GUI (contributed by Evgeny Grin (karlson2k))
+
 1.13
 
 * Add necessary hooks to allow the plugin to be used as a standalone core DNS server

--- a/dns/dnscrypt-proxy/src/opnsense/mvc/app/models/OPNsense/Dnscryptproxy/General.xml
+++ b/dns/dnscrypt-proxy/src/opnsense/mvc/app/models/OPNsense/Dnscryptproxy/General.xml
@@ -140,12 +140,11 @@
             <default>1</default>
             <Required>Y</Required>
         </query_logs>
-        <disabled_serverlist type="TextField">
-            <mask>/^([a-z0-9.,\-]{1,70})$/</mask>
+        <disabled_serverlist type="CSVListField">
+            <mask>/^[A-Za-z0-9\._\-]{1,70}(,[A-Za-z0-9\._\-]{1,70})*$/</mask>
             <default></default>
             <Required>N</Required>
-            <FieldSeparator>,</FieldSeparator>
-            <asList>Y</asList>
+            <ValidationMessage>Please use valid server names.</ValidationMessage>
         </disabled_serverlist>
         <relaylist type="CSVListField">
             <Required>N</Required>


### PR DESCRIPTION
Currently GUI fails to display disabled servers, when more than one server is configured.
Also added `ValidationMessage`.