### PR TITLE
dns/bind: ensure the ACL names are unique

### DIFF
--- a/dns/bind/pkg-descr
+++ b/dns/bind/pkg-descr
@@ -11,6 +11,7 @@ Plugin Changelog
 
 1.25
 
+* Ensure you can only add one ACL with the same name (contributed by Robbert Rijkse)
 * Revamp the logging page with proper columns (contributed by Robbert Rijkse)
 * Update base to BIND 9.18
 


### PR DESCRIPTION
This ensure that the ACL names are unique, since you can't add two ACLs with the same name in the `named.conf` file this ensures that you are given an error message in the UI when you try to add/update an ACL.