### PR TITLE
sysutils/smart: smart services tab with full smartctl devices support

### DIFF
--- a/sysutils/smart/src/opnsense/mvc/app/controllers/OPNsense/Smart/Api/ServiceController.php
+++ b/sysutils/smart/src/opnsense/mvc/app/controllers/OPNsense/Smart/Api/ServiceController.php
@@ -38,7 +38,7 @@ class ServiceController extends ApiControllerBase
     {
         $backend = new Backend();
 
-        $devices = preg_split("/[\s]+/", trim($backend->configdRun("smart list")));
+        $devices = preg_split("/\\n/", trim($backend->configdRun("smart list")));
 
         return $devices;
     }
@@ -71,7 +71,7 @@ class ServiceController extends ApiControllerBase
 
             $backend = new Backend();
 
-            $params = array($mode, $type, "/dev/" . $device);
+            $params = array($mode, $type, $device );
 
             $output = $backend->configdpRun("smart", $params);
             if ($mode == 'info_json') {
@@ -102,7 +102,7 @@ class ServiceController extends ApiControllerBase
 
             $backend = new Backend();
 
-            $output = $backend->configdpRun("smart", array("log", $type, "/dev/" . $device));
+            $output = $backend->configdpRun("smart", array("log", $type, $device));
 
             return array("output" => $output);
         }
@@ -128,7 +128,7 @@ class ServiceController extends ApiControllerBase
 
             $backend = new Backend();
 
-            $output = $backend->configdpRun("smart", array("test", $type, "/dev/" . $device));
+            $output = $backend->configdpRun("smart", array("test", $type, $device));
 
             return array("output" => $output);
         }
@@ -147,7 +147,7 @@ class ServiceController extends ApiControllerBase
 
             $backend = new Backend();
 
-            $output = $backend->configdpRun("smart", array("abort", "/dev/" . $device));
+            $output = $backend->configdpRun("smart", array("abort", $device));
 
             return array("output" => $output);
         }

--- a/sysutils/smart/src/opnsense/mvc/app/views/OPNsense/Smart/index.volt
+++ b/sysutils/smart/src/opnsense/mvc/app/views/OPNsense/Smart/index.volt
@@ -143,7 +143,7 @@
 		    </td>
 		</tr>
 		<tr>
-		    <td><label for="device1">{{ lang._('Device: /dev/') }}</label></td>
+		    <td><label for="device1">{{ lang._('Device: ') }}</label></td>
 		    <td >
 			<select id="device1" name="device" class="form-control">
 			</select>
@@ -179,7 +179,7 @@
                     </td>
                 </tr>
 		<tr>
-                    <td><label for="device2">{{ lang._('Device: /dev/') }}</label></td>
+                    <td><label for="device2">{{ lang._('Device: ') }}</label></td>
                     <td>
 			<select id="device2" name="device" class="form-control">
 			</select>
@@ -213,7 +213,7 @@
                     </td>
 		</tr>
 		<tr>
-                    <td><label for="device3">{{ lang._('Device: /dev/') }}</label></td>
+                    <td><label for="device3">{{ lang._('Device: ') }}</label></td>
                     <td >
 			<select id="device3" name="device" class="form-control">
 			</select>
@@ -238,7 +238,7 @@
                     <th colspan="2" style="vertical-align:top" class="listtopic">{{ lang._('Abort tests') }}</th>
                 </tr>
 		<tr>
-                    <td><label for="device4">{{ lang._('Device: /dev/') }}</label></td>
+                    <td><label for="device4">{{ lang._('Device: ') }}</label></td>
                     <td >
 			<select id="device4" name="device" class="form-control">
 			</select>

--- a/sysutils/smart/src/opnsense/scripts/OPNsense/Smart/actions.sh
+++ b/sysutils/smart/src/opnsense/scripts/OPNsense/Smart/actions.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Proxy for smartctl and configctl parameter issue
+# We added single quotes for inseparable device string
+
+# Parse all parameter from the actions.d file and add them to A, B or C.
+case $1 in
+    -l) A="-l"
+        shift 
+        A="$A $1"
+        shift 
+        ;;
+    --json=c)  B="--json=c"
+        shift
+        ;;
+    -t) A="-t"
+        shift 
+        A="$A $1"
+        shift
+        ;;
+    -X) A="-X"
+        shift
+        ;; 
+    -i|-H|-a|-c|-A) A=$1
+        shift
+        ;; 
+    *)
+      ;; 
+esac
+
+# remove the single quotes for regular paramter strings
+C=$(echo $1 | /usr/bin/tr -d "'")
+# execute the command
+/usr/local/sbin/smartctl $A $B $C 

--- a/sysutils/smart/src/opnsense/service/conf/actions.d/actions_smart.conf
+++ b/sysutils/smart/src/opnsense/service/conf/actions.d/actions_smart.conf
@@ -1,5 +1,5 @@
 [list]
-command:sysctl -n kern.disks | sed s:nvd:nvme:g
+command:/usr/local/sbin/smartctl --scan | /usr/bin/awk -F# -v q="'" '{print q$1q}'
 parameters:
 type:script_output
 message:list installed devices
@@ -11,59 +11,59 @@ type:script_output
 message:list installed devices
 
 [info]
-command:/usr/local/sbin/smartctl
+command:/usr/local/opnsense/scripts/OPNsense/Smart/actions.sh
 parameters:-%s %s; exit 0
 type:script_output
 message:exec smartctl -%s for device %s
 
 [info_json]
-command:/usr/local/sbin/smartctl
+command:/usr/local/opnsense/scripts/OPNsense/Smart/actions.sh
 parameters:-%s --json=c %s; exit 0
 type:script_output
 message:exec smartctl -%s (JSON) for device %s
 
 [log.error]
-command:/usr/local/sbin/smartctl -l error
+command:/usr/local/opnsense/scripts/OPNsense/Smart/actions.sh -l error
 parameters:%s; exit 0
 type:script_output
 message:Get error log for device %s
 
 [log.selftest]
-command:/usr/local/sbin/smartctl -l selftest
+command:/usr/local/opnsense/scripts/OPNsense/Smart/actions.sh -l selftest
 parameters:%s; exit 0
 type:script_output
 message:Get selftest log for device %s
 
 [test.offline]
-command:/usr/local/sbin/smartctl -t offline
+command:/usr/local/opnsense/scripts/OPNsense/Smart/actions.sh -t offline
 parameters:%s; exit 0
 type:script_output
 message:Testing device %s (offline)
 description:Run SMART test (offline)
 
 [test.short]
-command:/usr/local/sbin/smartctl -t short
+command:/usr/local/opnsense/scripts/OPNsense/Smart/actions.sh -t short
 parameters:%s; exit 0
 type:script_output
 message:Testing device %s (short)
 description:Run SMART test (short)
 
 [test.long]
-command:/usr/local/sbin/smartctl -t long
+command:/usr/local/opnsense/scripts/OPNsense/Smart/actions.sh -t long
 parameters:%s; exit 0
 type:script_output
 message:Testing device %s (long)
 description:Run SMART test (long)
 
 [test.conveyance]
-command:/usr/local/sbin/smartctl -t conveyance
+command:/usr/local/opnsense/scripts/OPNsense/Smart/actions.sh -t conveyance
 parameters:%s; exit 0
 type:script_output
 message:Testing device %s (conveyance)
 description:Run SMART test (conveyance)
 
 [abort]
-command:/usr/local/sbin/smartctl -X
+command:/usr/local/opnsense/scripts/OPNsense/Smart/actions.sh -X
 parameters:%s; exit 0
 type:script_output
 message:Abort test on device %s


### PR DESCRIPTION
- actions.d part has to add quotes for the device names inside the webview to preserve the full string for actions.sh
- added a proxy script for actions.d and updated actions.d
- updated the controller part for correct device handling
- removed the '/dev' prefix from the website

Images: https://cloud.thhcx.de/index.php/s/fAnfkG3grrig55K