### PR TITLE
dns/bind: add RNDC key UI support

### DIFF
--- a/dns/bind/pkg-descr
+++ b/dns/bind/pkg-descr
@@ -11,6 +11,7 @@ Plugin Changelog
 
 1.25
 
+* Add UI for RNDC Key configuration (contributed by Robbert Rijkse)
 * Revamp the logging page with proper columns (contributed by Robbert Rijkse)
 * Update base to BIND 9.18
 

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/GeneralController.php
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/GeneralController.php
@@ -34,6 +34,7 @@ class GeneralController extends \OPNsense\Base\IndexController
     {
         $this->view->generalForm = $this->getForm("general");
         $this->view->dnsblForm = $this->getForm("dnsbl");
+        $this->view->rndcKeyForm = $this->getForm("rndcKey");
         $this->view->formDialogEditBindAcl = $this->getForm("dialogEditBindAcl");
         $this->view->formDialogEditBindMasterDomain = $this->getForm("dialogEditBindMasterDomain");
         $this->view->formDialogEditBindSlaveDomain = $this->getForm("dialogEditBindSlaveDomain");

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/rndcKey.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/rndcKey.xml
@@ -1,0 +1,14 @@
+<form>
+    <field>
+        <id>general.rndcalgo</id>
+        <label>Algorithm</label>
+        <type>dropdown</type>
+        <help>Set the authentication algorithm for the RNDC key.</help>
+    </field>
+    <field>
+        <id>general.rndcsecret</id>
+        <label>Secret</label>
+        <type>text</type>
+        <help>The base64-encoded RNDC key.</help>
+    </field>
+</form>

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/General.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/General.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/bind/general</mount>
     <description>BIND configuration</description>
-    <version>1.0.8</version>
+    <version>1.0.9</version>
     <items>
         <enabled type="BooleanField">
             <default>0</default>
@@ -143,5 +143,21 @@
             <Required>Y</Required>
             <asList>Y</asList>
         </ratelimitexcept>
+        <rndcalgo type="OptionField">
+            <Required>Y</Required>
+            <default>hmac-sha256</default>
+            <OptionValues>
+                <hmac-sha512>HMAC-SHA512</hmac-sha512>
+                <hmac-sha384>HMAC-SHA384</hmac-sha384>
+                <hmac-sha256>HMAC-SHA256</hmac-sha256>
+                <hmac-sha224>HMAC-SHA224</hmac-sha224>
+                <hmac-sha1>HMAC-SHA1</hmac-sha1>
+                <hmac-md5>HMAC-MD5</hmac-md5>
+            </OptionValues>
+        </rndcalgo>
+        <rndcsecret type="TextField">
+            <Required>Y</Required>
+            <default>VxtIzJevSQXqnr7h2qerrcwjnZlMWSGGFBndKeNIDfw=</default>
+        </rndcsecret>
     </items>
 </model>

--- a/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/general.volt
+++ b/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/general.volt
@@ -346,8 +346,6 @@ $( document ).ready(function() {
             $("#saveRestartAct_rndckey_progress").removeClass("fa fa-spinner fa-pulse");
         });
     });
-
-
     $(".saveAct_domain").click(function(){
         $(".saveAct_domain_progress").addClass("fa fa-spinner fa-pulse");
         ajaxCall("/api/bind/service/reconfigure", {}, function(data,status) {

--- a/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/general.volt
+++ b/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/general.volt
@@ -32,6 +32,7 @@ POSSIBILITY OF SUCH DAMAGE.
     <li class="active"><a data-toggle="tab" href="#general">{{ lang._('General') }}</a></li>
     <li><a data-toggle="tab" href="#dnsbl">{{ lang._('DNSBL') }}</a></li>
     <li><a data-toggle="tab" href="#acls">{{ lang._('ACLs') }}</a></li>
+    <li><a data-toggle="tab" href="#keys">{{ lang._('Keys') }}</a></li>
     <li><a data-toggle="tab" href="#master-domains">{{ lang._('Master Zones') }}</a></li>
     <li><a data-toggle="tab" href="#slave-domains">{{ lang._('Slave Zones') }}</a></li>
 </ul>
@@ -81,6 +82,21 @@ POSSIBILITY OF SUCH DAMAGE.
         <div class="col-md-12">
             <hr />
             <button class="btn btn-primary" id="saveAct_acl" type="button"><b>{{ lang._('Save') }}</b> <i id="saveAct_acl_progress"></i></button>
+            <br /><br />
+        </div>
+    </div>
+     <div id="keys" class="tab-pane fade in">
+        <div class="content-box">
+            <div class="col-md-12">
+                <h2>{{ lang._('RNDC Key') }}</h2>
+            </div>
+            {{ partial("layout_partials/base_form",['fields':rndcKeyForm,'id':'frm_general_settings'])}}
+        </div>
+        <div class="col-md-12">
+            <hr />
+            <button class="btn btn-primary" id="saveRestartAct_rndckey" type="button"><b>{{ lang._('Save & Restart') }}</b> <i id="saveRestartAct_rndckey_progress"></i></button>
+            <br />
+            <b>Note:</b> Bind will be restarted when you Save, this is required when the RNDC key changes.
             <br /><br />
         </div>
     </div>
@@ -324,6 +340,15 @@ $( document ).ready(function() {
             });
         });
     });
+
+    $("#saveRestartAct_rndckey").click(function(){
+        $("#saveRestartAct_rndckey_progress").addClass("fa fa-spinner fa-pulse");
+        ajaxCall("/api/bind/service/restart", {}, function(data,status) {
+            updateServiceControlUI('bind');
+            $("#saveRestartAct_rndckey_progress").removeClass("fa fa-spinner fa-pulse");
+        });
+    });
+
 
     $(".saveAct_domain").click(function(){
         $(".saveAct_domain_progress").addClass("fa fa-spinner fa-pulse");

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
@@ -88,14 +88,16 @@ options {
 {% endif %}
 };
 
+{% if helpers.exists('OPNsense.bind.general.rndcalgo') and helpers.exists('OPNsense.bind.general.rndcsecret') %}
 key "rndc-key" {
-        algorithm hmac-sha256;
-        secret "VxtIzJevSQXqnr7h2qerrcwjnZlMWSGGFBndKeNIDfw=";
+        algorithm "{{ OPNsense.bind.general.rndcalgo }}";
+        secret "{{ OPNsense.bind.general.rndcsecret }}";
 };
 controls {
         inet 127.0.0.1 port 9530
                 allow { 127.0.0.1; } keys { "rndc-key"; };
 };
+{% endif %}
 
 zone "." { type hint; file "/usr/local/etc/namedb/named.root"; };
 

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/rndc.conf
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/rndc.conf
@@ -1,6 +1,7 @@
+{% if helpers.exists('OPNsense.bind.general.rndcalgo') and helpers.exists('OPNsense.bind.general.rndcsecret') %}
 key "rndc-key" {
-        algorithm hmac-sha256;
-        secret "VxtIzJevSQXqnr7h2qerrcwjnZlMWSGGFBndKeNIDfw=";
+        algorithm "{{ OPNsense.bind.general.rndcalgo }}";
+        secret "{{ OPNsense.bind.general.rndcsecret }}";
 };
 
 options {
@@ -8,3 +9,4 @@ options {
         default-server 127.0.0.1;
         default-port 9530;
 };
+{% endif %}


### PR DESCRIPTION
This adds RNDC Key UI support which closes #2196. This restarts the `named` service when the RNDC key changes instead of doing a reconfigure.