### PR TITLE
security/stunnel: Add missing inclusion

### DIFF
--- a/security/stunnel/src/opnsense/scripts/stunnel/generate_certs.php
+++ b/security/stunnel/src/opnsense/scripts/stunnel/generate_certs.php
@@ -27,6 +27,7 @@
  *    POSSIBILITY OF SUCH DAMAGE.
  */
 
+require_once('util.inc');
 require_once('plugins.inc');
 require_once('config.inc');
 require_once('certs.inc');


### PR DESCRIPTION
```
PHP Fatal error:  Uncaught Error: Call to undefined function log_msg() in /usr/local/etc/inc/plugins.inc:251 Stack trace:
#0 /usr/local/opnsense/scripts/stunnel/generate_certs.php(89): plugins_configure('crl')
#1 {main}
  thrown in /usr/local/etc/inc/plugins.inc on line 251
```