### PR TITLE
security/acme: increase max value for certificate renewal interval

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -283,7 +283,7 @@
                 <renewInterval type="IntegerField">
                     <Required>Y</Required>
                     <MinimumValue>1</MinimumValue>
-                    <MaximumValue>60</MaximumValue>
+                    <MaximumValue>5000</MaximumValue>
                     <default>60</default>
                 </renewInterval>
                 <aliasmode type="OptionField">


### PR DESCRIPTION
Allow certificate renewal intervals up to 5000 days. 
refs https://github.com/opnsense/plugins/issues/3219