### PR TITLE
security/acme: Add online.net API for dns challenge type

### DIFF
--- a/security/acme-client/pkg-descr
+++ b/security/acme-client/pkg-descr
@@ -8,6 +8,11 @@ WWW: https://github.com/acmesh-official/acme.sh
 Plugin Changelog
 ================
 
+3.15
+
+Added:
+* add online.net DNS API (#3213)
+
 3.14
 
 NOTE: Users of Selfhost need to manually fix their configuration, see

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -953,6 +953,16 @@
         <help>Optionally set the name of the hosted zone (e.g. example.com) as some DNS Providers require, like dyn.com's 'Standard DNS'.</help>
     </field>
     <field>
+        <label>online.net</label>
+        <type>header</type>
+        <style>table_dns table_dns_online</style>
+    </field>
+    <field>
+        <id>validation.dns_online_key</id>
+        <label>API key</label>
+        <type>text</type>
+    </field>
+    <field>
         <label>opnsense</label>
         <type>header</type>
         <style>table_dns table_dns_opnsense</style>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsOnline.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsOnline.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Copyright (C) 2023 Jan Winkler
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\AcmeClient\LeValidation;
+
+use OPNsense\AcmeClient\LeValidationInterface;
+use OPNsense\Core\Config;
+
+/**
+ * online.net API
+ * @package OPNsense\AcmeClient
+ */
+class DnsOnline extends Base implements LeValidationInterface
+{
+    public function prepare()
+    {
+        $this->acme_env['ONLINE_API_KEY'] = (string)$this->config->dns_online_key;
+    }
+}

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -484,6 +484,7 @@
                         <dns_njalla>Njalla</dns_njalla>
                         <dns_nsone>NS1.com</dns_nsone>
                         <dns_nsupdate>nsupdate (RFC 2136)</dns_nsupdate>
+                        <dns_online>online.net</dns_online>
                         <dns_opnsense>OPNsense BIND Plugin</dns_opnsense>
                         <dns_ovh>OVH, kimsufi, soyoustart and runabove</dns_ovh>
                         <dns_pdns>PowerDNS.com</dns_pdns>
@@ -887,6 +888,9 @@
                 <dns_nsupdate_key type="TextField">
                     <Required>N</Required>
                 </dns_nsupdate_key>
+                <dns_online_key type="TextField">
+                    <Required>N</Required>
+                </dns_online_key>
                 <dns_opnsense_host type="TextField">
                     <Required>N</Required>
                     <default>localhost</default>


### PR DESCRIPTION
Add new API for ACME dns challenge type:
* online.net
refs https://github.com/opnsense/plugins/issues/3213