### PR TITLE
dns/bind: ensure the ACL names are unique

### DIFF
--- a/dns/bind/pkg-descr
+++ b/dns/bind/pkg-descr
@@ -11,6 +11,7 @@ Plugin Changelog
 
 1.25
 
+* Ensure you can only add one ACL with the same name (contributed by Robbert Rijkse)
 * Cleanup/Fix the Master/Slave domain dialogs (contributed by Robbert Rijkse)
 * Revamp the logging page with proper columns (contributed by Robbert Rijkse)
 * Add UI for RNDC Key configuration (contributed by Robbert Rijkse)

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Acl.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Acl.xml
@@ -14,6 +14,12 @@
                     <Required>Y</Required>
                     <mask>/^(?!any$|localhost$|localnets$|none$)[0-9a-zA-Z_\-]{1,32}$/u</mask>
                     <ValidationMessage>Should be a string between 1 and 32 characters. Allowed characters are 0-9, a-z, A-Z, _ and -. Built-in ACL names must not be used: any, localhost, localnets, none.</ValidationMessage>
+                     <Constraints>
+                        <check001>
+                            <ValidationMessage>An ACL with this name already exists.</ValidationMessage>
+                            <type>UniqueConstraint</type>
+                        </check001>
+                    </Constraints>
                 </name>
                 <networks type="NetworkField">
                     <default></default>


### PR DESCRIPTION
This ensure that the ACL names are unique, since you can't add two ACLs with the same name in the `named.conf` file this ensures that you are given an error message in the UI when you try to add/update an ACL.

This PR supersedes #3235.