### PR TITLE
dns/bind: allow multiple acls

### DIFF
--- a/dns/bind/pkg-descr
+++ b/dns/bind/pkg-descr
@@ -11,6 +11,8 @@ Plugin Changelog
 
 1.26
 
+* Allow multiple ACLs to be selected for Transfers/Queries (contributed by Robbert Rijkse)
+* Add PR record type (contributed by Robbert Rijkse)
 * Rename Master/Slave to Primary/Secondary (contributed by Robbert Rijkse)
 
 1.25

--- a/dns/bind/pkg-descr
+++ b/dns/bind/pkg-descr
@@ -12,8 +12,8 @@ Plugin Changelog
 1.26
 
 * Allow multiple ACLs to be selected for Transfers/Queries (contributed by Robbert Rijkse)
-* Add PR record type (contributed by Robbert Rijkse)
 * Rename Master/Slave to Primary/Secondary (contributed by Robbert Rijkse)
+* Add PR record type (contributed by Robbert Rijkse)
 
 1.25
 

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindPrimaryDomain.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindPrimaryDomain.xml
@@ -14,14 +14,14 @@
     <field>
         <id>domain.allowtransfer</id>
         <label>Allow Transfer</label>
-        <type>dropdown</type>
-        <help>Define an ACL where you allow which server can retrieve this zone.</help>
+        <type>select_multiple</type>
+        <help>Define the ACLs where you allow which server can retrieve this zone.</help>
     </field>
     <field>
         <id>domain.allowquery</id>
         <label>Allow Query</label>
-        <type>dropdown</type>
-        <help>Define an ACL where you allow which client are allowed to query this zone.</help>
+        <type>select_multiple</type>
+        <help>Define the ACLs where you allow which client are allowed to query this zone.</help>
     </field>
     <field>
         <id>domain.ttl</id>

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindSecondaryDomain.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindSecondaryDomain.xml
@@ -14,14 +14,14 @@
     <field>
         <id>domain.allowtransfer</id>
         <label>Allow Transfer</label>
-        <type>dropdown</type>
-        <help>Define an ACL where you allow which server can retrieve this zone.</help>
+        <type>select_multiple</type>
+        <help>Define the ACLs where you allow which server can retrieve this zone.</help>
     </field>
     <field>
         <id>domain.allowquery</id>
         <label>Allow Query</label>
-        <type>dropdown</type>
-        <help>Define an ACL where you allow which client are allowed to query this zone.</help>
+        <type>select_multiple</type>
+        <help>Define the ACLs where you allow which client are allowed to query this zone.</help>
     </field>
     <field>
         <id>domain.primaryip</id>

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/general.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/general.xml
@@ -110,8 +110,14 @@
     <field>
         <id>general.allowtransfer</id>
         <label>Allow Transfer</label>
-        <type>dropdown</type>
-        <help>Define an ACL where you allow which server can retrieve zones.</help>
+        <type>select_multiple</type>
+        <help>Define the ACLs where you allow which server can retrieve zones.</help>
+    </field>
+    <field>
+        <id>general.allowquery</id>
+        <label>Allow Transfer</label>
+        <type>select_multiple</type>
+        <help>Define the ACLs where you allow which client are allowed to query this server.</help>
     </field>
     <field>
         <id>general.dnssecvalidation</id>

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/general.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/general.xml
@@ -115,7 +115,7 @@
     </field>
     <field>
         <id>general.allowquery</id>
-        <label>Allow Transfer</label>
+        <label>Allow Query</label>
         <type>select_multiple</type>
         <help>Define the ACLs where you allow which client are allowed to query this server.</help>
     </field>

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Domain.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Domain.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/bind/domain</mount>
     <description>BIND domain configuration</description>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <items>
         <domains>
             <domain type="ArrayField">
@@ -58,7 +58,7 @@
                             <display>name</display>
                         </template>
                     </Model>
-                    <Multiple>N</Multiple>
+                    <Multiple>Y</Multiple>
                     <Required>N</Required>
                 </allowtransfer>
                 <allowquery type="ModelRelationField">
@@ -69,7 +69,7 @@
                             <display>name</display>
                         </template>
                     </Model>
-                    <Multiple>N</Multiple>
+                    <Multiple>Y</Multiple>
                     <Required>N</Required>
                 </allowquery>
                 <serial type="TextField">

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/General.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/General.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/bind/general</mount>
     <description>BIND configuration</description>
-    <version>1.0.9</version>
+    <version>1.0.10</version>
     <items>
         <enabled type="BooleanField">
             <default>0</default>
@@ -91,7 +91,7 @@
                     <display>name</display>
                 </template>
             </Model>
-            <Multiple>N</Multiple>
+            <Multiple>Y</Multiple>
             <Required>N</Required>
             <ValidationMessage>Choose an ACL.</ValidationMessage>
         </recursion>
@@ -103,9 +103,20 @@
                     <display>name</display>
                 </template>
             </Model>
-            <Multiple>N</Multiple>
+            <Multiple>Y</Multiple>
             <Required>N</Required>
         </allowtransfer>
+        <allowquery type="ModelRelationField">
+            <Model>
+                <template>
+                    <source>OPNsense.Bind.Acl</source>
+                    <items>acls.acl</items>
+                    <display>name</display>
+                </template>
+            </Model>
+            <Multiple>Y</Multiple>
+            <Required>N</Required>
+        </allowquery>
         <dnssecvalidation type="OptionField">
             <OptionValues>
                 <no>No</no>

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
@@ -49,28 +49,28 @@ options {
 {% if helpers.exists('OPNsense.bind.general.recursion') and OPNsense.bind.general.recursion != '' %}
         recursion          yes;
         allow-recursion {
-{%          for acl in helpers.toList('OPNsense.bind.general.recursion') %}
-{%          set recursion_acl = helpers.getUUID(acl) %}
-            {{ recursion_acl.name }};
-{%          endfor %}
+{%              for acl in helpers.toList('OPNsense.bind.general.recursion') %}
+{%              set recursion_acl = helpers.getUUID(acl) %}
+                {{ recursion_acl.name }};
+{%              endfor %}
         };
 {% endif %}
 
 {% if helpers.exists('OPNsense.bind.general.allowtransfer') and OPNsense.bind.general.allowtransfer != '' %}
         allow-transfer {
-        {%   for acl in helpers.toList('OPNsense.bind.general.allowtransfer') %}
-        {%   set transfer_acl = helpers.getUUID(list) %}
+{%              for acl in helpers.toList('OPNsense.bind.general.allowtransfer') %}
+{%              set transfer_acl = helpers.getUUID(acl) %}
                 {{ transfer_acl.name }};
-        {%   endfor %}
+{%              endfor %}
         };
 {% endif %}
 
 {% if helpers.exists('OPNsense.bind.general.allowquery') and OPNsense.bind.general.allowquery != '' %}
         allow-query {
-        {%   for acl in helpers.toList('OPNsense.bind.general.allowquery') %}
-        {%   set query_acl = helpers.getUUID(list) %}
+{%              for acl in helpers.toList('OPNsense.bind.general.allowquery') %}
+{%              set query_acl = helpers.getUUID(list) %}
                 {{ query_acl.name }};
-        {%   endfor %}
+{%              endfor %}
         };
 {% endif %}
 
@@ -166,18 +166,18 @@ zone "{{ domain.domainname }}" {
 {%       endif %}
 {%      if domain.allowtransfer is defined %}
         allow-transfer {
-{%         for acl in domain.allowtransfer.split(',') %}
-{%         set transfer_acl = helpers.getUUID(acl) %}
+{%              for acl in domain.allowtransfer.split(',') %}
+{%              set transfer_acl = helpers.getUUID(acl) %}
                 {{ transfer_acl.name }};
-{%         endfor %}
+{%              endfor %}
         };
 {%      endif %}
 {%      if domain.allowquery is defined %}
         allow-query {
-{%         for acl in domain.allowquery.split(',') %}
-{%         set query_acl = helpers.getUUID(acl) %}
+{%              for acl in domain.allowquery.split(',') %}
+{%              set query_acl = helpers.getUUID(acl) %}
                 {{ query_acl.name }};
-{%         endfor %}
+{%              endfor %}
         };
 {%      endif %}
 };

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
@@ -49,7 +49,7 @@ options {
 {% if helpers.exists('OPNsense.bind.general.recursion') and OPNsense.bind.general.recursion != '' %}
         recursion          yes;
         allow-recursion {
-{%          for acl in helpers.toList('OPNsense.bind.general.recursion) %}
+{%          for acl in helpers.toList('OPNsense.bind.general.recursion') %}
 {%          set recursion_acl = helpers.getUUID(acl) %}
             {{ recursion_acl.name }};
 {%          endfor %}
@@ -62,18 +62,17 @@ options {
         {%   set transfer_acl = helpers.getUUID(list) %}
                 {{ transfer_acl.name }};
         {%   endfor %}
-        {%}
+        };
 {% endif %}
 
 {% if helpers.exists('OPNsense.bind.general.allowquery') and OPNsense.bind.general.allowquery != '' %}
         allow-query {
         {%   for acl in helpers.toList('OPNsense.bind.general.allowquery') %}
         {%   set query_acl = helpers.getUUID(list) %}
-                {{ transfer_acl.name }};
+                {{ query_acl.name }};
         {%   endfor %}
-        {%}
+        };
 {% endif %}
-
 
 {% if helpers.exists('OPNsense.bind.general.maxcachesize') and OPNsense.bind.general.maxcachesize != '' %}
         max-cache-size    {{ OPNsense.bind.general.maxcachesize }}%;

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
@@ -47,19 +47,33 @@ options {
 {% endif %}
 
 {% if helpers.exists('OPNsense.bind.general.recursion') and OPNsense.bind.general.recursion != '' %}
-{%   for list in helpers.toList('OPNsense.bind.general.recursion') %}
-{%   set recursionlist = helpers.getUUID(list) %}
         recursion          yes;
-        allow-recursion    { {{ recursionlist.name }}; };
-{%   endfor %}
+        allow-recursion {
+{%          for acl in helpers.toList('OPNsense.bind.general.recursion) %}
+{%          set recursion_acl = helpers.getUUID(acl) %}
+            {{ recursion_acl.name }};
+{%          endfor %}
+        };
 {% endif %}
 
 {% if helpers.exists('OPNsense.bind.general.allowtransfer') and OPNsense.bind.general.allowtransfer != '' %}
-{%   for list in helpers.toList('OPNsense.bind.general.allowtransfer') %}
-{%   set allowtransfer = helpers.getUUID(list) %}
-        allow-transfer    { {{ allowtransfer.name }}; };
-{%   endfor %}
+        allow-transfer {
+        {%   for acl in helpers.toList('OPNsense.bind.general.allowtransfer') %}
+        {%   set transfer_acl = helpers.getUUID(list) %}
+                {{ transfer_acl.name }};
+        {%   endfor %}
+        {%}
 {% endif %}
+
+{% if helpers.exists('OPNsense.bind.general.allowquery') and OPNsense.bind.general.allowquery != '' %}
+        allow-query {
+        {%   for acl in helpers.toList('OPNsense.bind.general.allowquery') %}
+        {%   set query_acl = helpers.getUUID(list) %}
+                {{ transfer_acl.name }};
+        {%   endfor %}
+        {%}
+{% endif %}
+
 
 {% if helpers.exists('OPNsense.bind.general.maxcachesize') and OPNsense.bind.general.maxcachesize != '' %}
         max-cache-size    {{ OPNsense.bind.general.maxcachesize }}%;

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
@@ -136,8 +136,6 @@ zone "rpzbing" { type primary; file "/usr/local/etc/namedb/primary/bing.db"; not
 {%   set usedkeys = [] %}
 {%   for domain in helpers.toList('OPNsense.bind.domain.domains.domain') %}
 {%     if domain.enabled == '1' %}
-{%     set allow_transfer = helpers.getUUID(domain.allowtransfer) %}
-{%     set allow_query = helpers.getUUID(domain.allowquery) %}
 zone "{{ domain.domainname }}" {
         type {{ domain.type }};
 {%       if domain.type == 'secondary' %}
@@ -153,12 +151,22 @@ zone "{{ domain.domainname }}" {
 {%       else %}
         file "/usr/local/etc/namedb/primary/{{ domain.domainname }}.db";
 {%       endif %}
-{%       if domain.allowtransfer is defined %}
-        allow-transfer { {{ allow_transfer.name }}; };
-{%       endif %}
-{%       if domain.allowquery is defined %}
-        allow-query { {{ allow_query.name }}; };
-{%       endif %}
+{%      if domain.allowtransfer is defined %}
+        allow-transfer {
+{%         for acl in domain.allowtransfer.split(',') %}
+{%         set transfer_acl = helpers.getUUID(acl) %}
+                {{ transfer_acl.name }};
+{%         endfor %}
+        };
+{%      endif %}
+{%      if domain.allowquery is defined %}
+        allow-query {
+{%         for acl in domain.allowquery.split(',') %}
+{%         set query_acl = helpers.getUUID(acl) %}
+                {{ query_acl.name }};
+{%         endfor %}
+        };
+{%      endif %}
 };
 {%       if domain.type == 'secondary' and domain.transferkey is defined and not(domain.transferkeyname in usedkeys) %}
 {%         do usedkeys.append(domain.transferkeyname) %}


### PR DESCRIPTION
This would allow multiple ACLs to be defined for `Allow Transfer` and `Allow Query`. This needs to be merged after #3234 since it updates the `domain` model version higher than that PR.

This is the initial work to allow for key based `allow transfer` statements and also to allow nested ACLs.