### PR TITLE
net/wireguard: Change WG naming convention

### DIFF
--- a/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardClient.xml
+++ b/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardClient.xml
@@ -33,15 +33,15 @@
     </field>
     <field>
         <id>client.serveraddress</id>
-        <label>Endpoint Address</label>
+        <label>Peer Address</label>
         <type>text</type>
-        <help>Set public IP address the endpoint listens to.</help>
+        <help>Set public IP address the peer listens to.</help>
     </field>
     <field>
         <id>client.serverport</id>
-        <label>Endpoint Port</label>
+        <label>Peer Port</label>
         <type>text</type>
-        <help>Set port the endpoint listens to.</help>
+        <help>Set port the peer listens to.</help>
     </field>
     <field>
         <id>client.keepalive</id>

--- a/net/wireguard/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
+++ b/net/wireguard/src/opnsense/mvc/app/views/OPNsense/Wireguard/general.volt
@@ -28,8 +28,8 @@
 <!-- Navigation bar -->
 <ul class="nav nav-tabs" data-tabs="tabs" id="maintabs">
     <li class="active"><a data-toggle="tab" href="#general">{{ lang._('General') }}</a></li>
-    <li><a data-toggle="tab" href="#servers">{{ lang._('Local') }}</a></li>
-    <li><a data-toggle="tab" href="#clients">{{ lang._('Endpoints') }}</a></li>
+    <li><a data-toggle="tab" href="#servers">{{ lang._('Interfaces') }}</a></li>
+    <li><a data-toggle="tab" href="#clients">{{ lang._('Peers') }}</a></li>
     <li><a data-toggle="tab" href="#showconf">{{ lang._('Status') }}</a></li>
     <li><a data-toggle="tab" href="#showhandshake">{{ lang._('Handshakes') }}</a></li>
 </ul>
@@ -50,8 +50,8 @@
                 <tr>
                     <th data-column-id="enabled" data-type="string" data-formatter="rowtoggle">{{ lang._('Enabled') }}</th>
                     <th data-column-id="name" data-type="string" data-visible="true">{{ lang._('Name') }}</th>
-                    <th data-column-id="serveraddress" data-type="string" data-visible="true">{{ lang._('Endpoint Address') }}</th>
-                    <th data-column-id="serverport" data-type="string" data-visible="true">{{ lang._('Endpoint Port') }}</th>
+                    <th data-column-id="serveraddress" data-type="string" data-visible="true">{{ lang._('Peer Address') }}</th>
+                    <th data-column-id="serverport" data-type="string" data-visible="true">{{ lang._('Peer Port') }}</th>
                     <th data-column-id="tunneladdress" data-type="string" data-visible="true">{{ lang._('Allowed IPs') }}</th>
                     <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
                     <th data-column-id="commands" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
@@ -83,7 +83,7 @@
                     <th data-column-id="interface" data-type="string" data-visible="true">{{ lang._('Interface') }}</th>
                     <th data-column-id="tunneladdress" data-type="string" data-visible="true">{{ lang._('Tunnel Address') }}</th>
                     <th data-column-id="port" data-type="string" data-visible="true">{{ lang._('Port') }}</th>
-                    <th data-column-id="peers" data-type="string" data-visible="true">{{ lang._('Endpoints') }}</th>
+                    <th data-column-id="peers" data-type="string" data-visible="true">{{ lang._('Peers') }}</th>
                     <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
                     <th data-column-id="commands" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
                 </tr>
@@ -113,8 +113,8 @@
     </div>
 </div>
 
-{{ partial("layout_partials/base_dialog",['fields':formDialogEditWireguardClient,'id':'dialogEditWireguardClient','label':lang._('Edit Endpoint')])}}
-{{ partial("layout_partials/base_dialog",['fields':formDialogEditWireguardServer,'id':'dialogEditWireguardServer','label':lang._('Edit Local Configuration')])}}
+{{ partial("layout_partials/base_dialog",['fields':formDialogEditWireguardClient,'id':'dialogEditWireguardClient','label':lang._('Edit Peer')])}}
+{{ partial("layout_partials/base_dialog",['fields':formDialogEditWireguardServer,'id':'dialogEditWireguardServer','label':lang._('Edit Interfaces')])}}
 
 <script>
 

--- a/net/wireguard/src/www/widgets/widgets/wireguard.widget.php
+++ b/net/wireguard/src/www/widgets/widgets/wireguard.widget.php
@@ -40,7 +40,7 @@ $enabled = ($config["OPNsense"]["wireguard"]["general"]["enabled"] === "1" ? tru
         <tr>
             <th><?= gettext("Name") ?></th>
             <th><?= gettext("Interface") ?></th>
-            <th><?= gettext("Endpoint") ?></th>
+            <th><?= gettext("Peer") ?></th>
             <th><?= gettext("Public Key") ?></th>
             <th><?= gettext("Latest Handshake") ?></th>
         </tr>


### PR DESCRIPTION
Fixing WG naming convention for 23.1 GA.
Follow-up to original discussion in #3116