### PR TITLE
net/wireguard: Check if wg-kmod exists; if so then hide in services

### DIFF
--- a/net/wireguard/src/etc/inc/plugins.inc.d/wireguard.inc
+++ b/net/wireguard/src/etc/inc/plugins.inc.d/wireguard.inc
@@ -26,6 +26,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+use OPNsense\Core\Backend;
+
 function wireguard_enabled()
 {
     $model = new \OPNsense\Wireguard\General();
@@ -37,6 +39,12 @@ function wireguard_services()
     $services = array();
 
     if (!wireguard_enabled()) {
+        return $services;
+    }
+
+    // If kmod file exists, we won't return the go-based service.
+    $kmod = trim((new Backend())->configdRun("wireguard status_kmod"));
+    if ($kmod === "true") {
         return $services;
     }
 

--- a/net/wireguard/src/opnsense/service/conf/actions.d/actions_wireguard.conf
+++ b/net/wireguard/src/opnsense/service/conf/actions.d/actions_wireguard.conf
@@ -41,3 +41,9 @@ command:/usr/local/bin/wg show all latest-handshakes
 parameters:
 type:script_output
 message:Show WireGuard handshakes
+
+[status_kmod]
+command:[ -f "/boot/modules/if_wg.ko" ] && echo true || echo false
+parameters:
+type:script_output
+message:Returns true if wireguard kmod file exists


### PR DESCRIPTION
I think this is a quite small, handy, non-invasive change to hide the `wireguard-go` service when the kmod module is found on the OPNsense system. That should avoid any confusion going forward from end-users. The logic can be improved over time if needed.

```shell
root@OPNsense:~ # ls -lsh /boot/modules/if_wg.ko
144 -r-xr-xr-x  1 root  wheel   142K Jan 19 01:57 /boot/modules/if_wg.ko

root@OPNsense:~ # [ -f "/boot/modules/if_wg.ko" ] && echo true || echo false
true

root@OPNsense:~ # configctl wireguard status_kmod
true
```

If it returns `true`, the service will be hidden.

IMHO this should be included in 23.1 before GA and is an acceptable workaround/solution until a more complex solution has been found. Should avoid confusion, anger that e.g. start action not working or similar.

Closes #3268