### PR TITLE
net/frr: make restart action available in Cron settings

### DIFF
--- a/net/frr/src/opnsense/service/conf/actions.d/actions_quagga.conf
+++ b/net/frr/src/opnsense/service/conf/actions.d/actions_quagga.conf
@@ -15,6 +15,7 @@ command:/usr/local/etc/rc.d/frr restart
 parameters:
 type:script
 message:restarting frr
+description:Restart FRR
 
 [status]
 command:/usr/local/etc/rc.d/frr status; exit 0


### PR DESCRIPTION
I was trying to configure Cron to restart FRR periodically. Oddly enough, I could choose between a bunch of services to restart but not FRR.
After some troubleshooting, I figured only actions with a description were showing up in the list when setting up a Cron job.

This fixes the issue by adding a description to FRR's restart action.