### PR TITLE
net/upnp: Correct crash due to LOG_WARNING typo.

### DIFF
--- a/net/upnp/src/etc/inc/plugins.inc.d/miniupnpd.inc
+++ b/net/upnp/src/etc/inc/plugins.inc.d/miniupnpd.inc
@@ -159,7 +159,7 @@ function miniupnpd_configure_do($verbose = false)
                         $ifaces_active .= ", {$iface}";
                     }
                 } else {
-                    log_msg("miniupnpd: Interface {$iface} has no ip address, ignoring", LOG_WARING);
+                    log_msg("miniupnpd: Interface {$iface} has no ip address, ignoring", LOG_WARNING);
                 }
             } else {
                 log_msg("miniupnpd: Could not resolve real interface for {$iface}", LOG_ERR);


### PR DESCRIPTION
I've never committed to this project, so apologies I'm not sure if its my job to point to the stable branch or maintainers pluck changes.

I upgraded to 23.1 this morning and a crash was detected.

```
[28-Jan-2023 07:09:40 America/New_York] Error: Undefined constant "LOG_WARING" in /usr/local/etc/inc/plugins.inc.d/miniupnpd.inc:162
Stack trace:
#0 /usr/local/etc/inc/plugins.inc(292): miniupnpd_configure_do(true)
#1 /usr/local/etc/rc.bootup(106): plugins_configure('bootup', true)
#2 {main}
```

It looks like it regressed here: https://github.com/opnsense/plugins/commit/ec1399c9a24285f8bba3dc689fbbd0c1e7ea212b