### PR TITLE
security/openconnect: useragent="AnyConnect" for better compatibility

### DIFF
--- a/security/openconnect/Makefile
+++ b/security/openconnect/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		openconnect
-PLUGIN_VERSION=		1.4.3
+PLUGIN_VERSION=		1.4.4
 PLUGIN_COMMENT=		OpenConnect Client
 PLUGIN_DEPENDS=		openconnect
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/security/openconnect/pkg-descr
+++ b/security/openconnect/pkg-descr
@@ -6,6 +6,10 @@ the Juniper SSL VPN which is now known as Pulse Connect Secure.
 Plugin Changelog
 ================
 
+1.4.4
+
+* Improve compatibility via useragent="AnyConnect"
+
 1.4.3
 
 * Add support for one-time password generation

--- a/security/openconnect/src/opnsense/service/templates/OPNsense/Openconnect/openconnect.conf
+++ b/security/openconnect/src/opnsense/service/templates/OPNsense/Openconnect/openconnect.conf
@@ -27,5 +27,8 @@ token-secret={{ OPNsense.openconnect.general.tokensecret }}
 {%   endif %}
 {%   if helpers.exists('OPNsense.openconnect.general.protocol') and OPNsense.openconnect.general.protocol != '' %}
 protocol={{ OPNsense.openconnect.general.protocol }}
+{%     if OPNsense.openconnect.general.protocol == 'anyconnect' %}
+useragent=AnyConnect
+{%     endif %}
 {%   endif %}
 {% endif %}


### PR DESCRIPTION
Required for some VPN hosts, in my case was needed for my university VPN. Tested by changing the equivalent file on my installation, correctly only adds this useragent for the case of anyconnect VPNs.