### PR TITLE
dns/bind: Add forwarding domains

### DIFF
--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/Api/DomainController.php
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/Api/DomainController.php
@@ -73,6 +73,18 @@ class DomainController extends ApiMutableModelControllerBase
         );
     }
 
+    public function searchForwardDomainAction()
+    {
+        return $this->searchBase(
+            'domains.domain',
+            [   "enabled", "type", "domainname", "primaryip" ],
+            "domainname",
+            function ($record) {
+                return $record->type->getNodeData()["forward"]["selected"] === 1;
+            }
+        );
+    }
+
     public function getDomainAction($uuid = null)
     {
         $this->sessionClose();
@@ -87,6 +99,11 @@ class DomainController extends ApiMutableModelControllerBase
     public function addSecondaryDomainAction($uuid = null)
     {
         return $this->addBase('domain', 'domains.domain', ['type' => 'secondary']);
+    }
+
+    public function addForwardDomainAction($uuid = null)
+    {
+        return $this->addBase('domain', 'domains.domain', ['type' => 'forward']);
     }
 
     public function delDomainAction($uuid)

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/GeneralController.php
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/GeneralController.php
@@ -37,6 +37,7 @@ class GeneralController extends \OPNsense\Base\IndexController
         $this->view->formDialogEditBindAcl = $this->getForm("dialogEditBindAcl");
         $this->view->formDialogEditBindPrimaryDomain = $this->getForm("dialogEditBindPrimaryDomain");
         $this->view->formDialogEditBindSecondaryDomain = $this->getForm("dialogEditBindSecondaryDomain");
+        $this->view->formDialogEditBindForwardDomain = $this->getForm("dialogEditBindForwardDomain");
         $this->view->formDialogEditBindRecord = $this->getForm("dialogEditBindRecord");
         $this->view->pick('OPNsense/Bind/general');
     }

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindForwardDomain.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindForwardDomain.xml
@@ -1,0 +1,22 @@
+<form>
+    <field>
+        <id>domain.enabled</id>
+        <label>Enabled</label>
+        <type>checkbox</type>
+        <help>This will enable or disable this zone.</help>
+    </field>
+    <field>
+        <id>domain.domainname</id>
+        <label>Zone Name</label>
+        <type>text</type>
+        <help>Set the name for this zone. Both forward and reverse zones may be specified, i.e. example.com or 0.168.192.in-addr.arpa.</help>
+    </field>
+    <field>
+        <id>domain.primaryip</id>
+        <label>Primary IP</label>
+        <style>tokenize</style>
+        <type>select_multiple</type>
+        <allownew>true</allownew>
+        <help>Set the IP address of primary server.</help>
+    </field>
+</form>

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Domain.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Domain.xml
@@ -15,6 +15,7 @@
                     <OptionValues>
                         <primary>Primary</primary>
                         <secondary>Secondary</secondary>
+                        <forward>Forward</forward>
                     </OptionValues>
                 </type>
                 <primaryip type="NetworkField">

--- a/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/general.volt
+++ b/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/general.volt
@@ -34,6 +34,7 @@ POSSIBILITY OF SUCH DAMAGE.
     <li><a data-toggle="tab" href="#acls">{{ lang._('ACLs') }}</a></li>
     <li><a data-toggle="tab" href="#primary-domains">{{ lang._('Primary Zones') }}</a></li>
     <li><a data-toggle="tab" href="#secondary-domains">{{ lang._('Secondary Zones') }}</a></li>
+    <li><a data-toggle="tab" href="#forward-domains">{{ lang._('Forward Zones') }}</a></li>
 </ul>
 
 <div class="tab-content content-box tab-content">
@@ -187,11 +188,47 @@ POSSIBILITY OF SUCH DAMAGE.
             <br /><br />
         </div>
     </div>
+    <div id="forward-domains" class="tab-pane fade in">
+        <div class="col-md-12">
+            <h2>{{ lang._('Zones') }}</h2>
+        </div>
+        <table id="grid-forward-domains" class="table table-condensed table-hover table-striped table-responsive" data-editAlert="ChangeMessage" data-editDialog="dialogEditBindForwardDomain">
+            <thead>
+                <tr>
+                    <th data-column-id="enabled" data-type="string" data-formatter="rowtoggle">{{ lang._('Enabled') }}</th>
+                    <th data-column-id="domainname" data-type="string" data-visible="true">{{ lang._('Zone') }}</th>
+                    <th data-column-id="primaryip" data-type="string" data-visible="true">{{ lang._('Primary IPs') }}</th>
+                    <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
+                    <th data-column-id="commands" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
+                </tr>
+            </thead>
+            <tbody>
+            </tbody>
+            <tfoot>
+                <tr>
+                    <td colspan="5"></td>
+                    <td>
+                        <button data-action="add" type="button" class="btn btn-xs btn-default"><span class="fa fa-plus"></span></button>
+                    </td>
+                </tr>
+            </tfoot>
+        </table>
+        <hr/>
+        <div class="col-md-12">
+            <div id="ChangeMessage" class="alert alert-info" style="display: none" role="alert">
+                {{ lang._('After changing settings, please remember to apply them with the button below') }}
+            </div>
+            <hr />
+            <button class="btn btn-primary saveAct_domain" type="button"><b>{{ lang._('Save') }}</b> <i class="saveAct_domain_progress"></i></button>
+            <br /><br />
+        </div>
+    </div>
 </div>
 
 {{ partial("layout_partials/base_dialog",['fields':formDialogEditBindAcl,'id':'dialogEditBindAcl','label':lang._('Edit ACL')])}}
 {{ partial("layout_partials/base_dialog",['fields':formDialogEditBindPrimaryDomain,'id':'dialogEditBindPrimaryDomain','label':lang._('Edit Primary Zone')])}}
 {{ partial("layout_partials/base_dialog",['fields':formDialogEditBindSecondaryDomain,'id':'dialogEditBindSecondaryDomain','label':lang._('Edit Secondary Zone')])}}
+{{ partial("layout_partials/base_dialog",['fields':formDialogEditBindForwardDomain,'id':'dialogEditBindForwardDomain','label':lang._('Edit Forward Zone')])}}
 {{ partial("layout_partials/base_dialog",['fields':formDialogEditBindRecord,'id':'dialogEditBindRecord','label':lang._('Edit Record')])}}
 
 <script>
@@ -261,6 +298,26 @@ $( document ).ready(function() {
         let ids = $("#grid-secondary-domains").bootgrid("getCurrentRows");
         if (ids.length > 0) {
             $("#grid-secondary-domains").bootgrid('select', [ids[0].uuid]);
+        }
+    });
+
+    $("#grid-forward-domains").UIBootgrid({
+        'search':'/api/bind/domain/searchForwardDomain',
+        'get':'/api/bind/domain/getDomain/',
+        'set':'/api/bind/domain/setDomain/',
+        'add':'/api/bind/domain/addForwardDomain/',
+        'del':'/api/bind/domain/delDomain/',
+        'toggle':'/api/bind/domain/toggleDomain/',
+        options:{
+            selection: false,
+            multiSelect: false,
+            rowSelect: false,
+            rowCount: [7,14,20,50,100,-1]
+        }
+    }).on("loaded.rs.jquery.bootgrid", function (e) {
+        let ids = $("#grid-forward-domains").bootgrid("getCurrentRows");
+        if (ids.length > 0) {
+            $("#grid-forward-domains").bootgrid('select', [ids[0].uuid]);
         }
     });
 

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
@@ -161,6 +161,8 @@ zone "{{ domain.domainname }}" {
         allow-notify { {{ domain.allownotifysecondary.replace(',', '; ') }}; };
 {%         endif %}
         file "/usr/local/etc/namedb/secondary/{{ domain.domainname }}.db";
+{%       elif domain.type == 'forward' %}
+        forwarders { {{ domain.primaryip.replace(',', '; ') }}; };
 {%       else %}
         file "/usr/local/etc/namedb/primary/{{ domain.domainname }}.db";
 {%       endif %}


### PR DESCRIPTION
dns/bind: Add a new tab 'Forward Zones' where you can add zones with the 'forward' type, for when you want to for instance forward queries to an Active Directory