### PR TITLE
Make Wireguard CARP aware

### DIFF
--- a/net/wireguard/pkg-descr
+++ b/net/wireguard/pkg-descr
@@ -16,6 +16,10 @@ WWW: https://www.wireguard.com/
 Changelog
 ---------
 
+1.14
+
+* Added CARP awareness
+
 1.13
 
 * Reworked widget and assorted cleanups (contributed by Patrik Kernstock)

--- a/net/wireguard/src/etc/rc.syshook.d/carp/90-wireguard
+++ b/net/wireguard/src/etc/rc.syshook.d/carp/90-wireguard
@@ -1,0 +1,71 @@
+#!/usr/local/bin/php
+<?php
+
+/*
+ * Copyright (C) 2004 Scott Ullrich <sullrich@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+require_once("config.inc");
+require_once("interfaces.inc");
+require_once("util.inc");
+require_once("plugins.inc.d/wireguard.inc");
+
+$wireguard = new \OPNsense\Wireguard\General();
+
+$wireguard_carp_enabled =
+    (string)$wireguard->enabled == '1' &&
+    (string)$wireguard->enablecarp == '1';
+
+if ($wireguard_carp_enabled) {
+    $subsystem = !empty($argv[1]) ? $argv[1] : '';
+    $type = !empty($argv[2]) ? $argv[2] : '';
+
+    if ($type != 'MASTER' && $type != 'BACKUP') {
+        log_error("Carp '$type' event unknown from source '{$subsystem}'");
+        exit(1);
+    }
+
+    if (!strstr($subsystem, '@')) {
+        log_error("Carp '$type' event triggered from wrong source '{$subsystem}'");
+        exit(1);
+    }
+
+    $backend = new \OPNsense\Core\Backend();
+
+    switch ($type) {
+        case 'MASTER':
+            log_error("Enabling WireGuard due to CARP event '$type'");
+            touch('/var/run/wireguard.CARP_MASTER');
+            $backend->configdRun('wireguard start');
+            configd_run('wireguard start');
+            break;
+        case 'BACKUP':
+            log_error("Disabling WireGuard due to CARP event '$type'");
+            @unlink('/var/run/wireguard.CARP_MASTER');
+            $backend->configdRun('wireguard stop');
+            break;
+        }   
+}

--- a/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/general.xml
+++ b/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/general.xml
@@ -3,7 +3,7 @@
         <id>general.enabled</id>
         <label>Enable WireGuard</label>
         <type>checkbox</type>
-        <help>This will activate WireGuard and start all enabled instances. CARP aware will only start Wireguard when the firewall is a CARP MASTER.</help>
+        <help>This will activate WireGuard and start all enabled instances.</help>
     </field>
     <field>
        <id>general.enablecarp</id>

--- a/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/general.xml
+++ b/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/general.xml
@@ -3,6 +3,12 @@
         <id>general.enabled</id>
         <label>Enable WireGuard</label>
         <type>checkbox</type>
-        <help>This will activate WireGuard and start all enabled instances.</help>
+        <help>This will activate WireGuard and start all enabled instances. CARP aware will only start Wireguard when the firewall is a CARP MASTER.</help>
+    </field>
+    <field>
+       <id>general.enablecarp</id>
+       <label>CARP Failover</label>
+       <type>checkbox</type>
+       <help>This will activate Wireguard only when the firewall is a CARP master.</help>
     </field>
 </form>

--- a/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/General.xml
+++ b/net/wireguard/src/opnsense/mvc/app/models/OPNsense/Wireguard/General.xml
@@ -7,5 +7,9 @@
             <default>0</default>
             <Required>Y</Required>
         </enabled>
+        <enablecarp type="BooleanField">
+            <default>0</default>
+            <Required>Y</Required>
+        </enablecarp>
     </items>
 </model>

--- a/net/wireguard/src/opnsense/service/templates/OPNsense/Wireguard/wireguard
+++ b/net/wireguard/src/opnsense/service/templates/OPNsense/Wireguard/wireguard
@@ -1,6 +1,9 @@
 {% if helpers.exists('OPNsense.wireguard.general.enabled') and OPNsense.wireguard.general.enabled == '1' %}
 wireguard_setup="/usr/local/opnsense/scripts/OPNsense/Wireguard/setup.sh"
 wireguard_enable="YES"
+{% if helpers.exists('OPNsense.wireguard.general.enablecarp') and OPNsense.wireguard.general.enablecarp == '1' %}
+required_files="/var/run/wireguard.CARP_MASTER"
+{% endif %}
 {%   if helpers.exists('OPNsense.wireguard.server.servers.server') %}
 {%   set activeservers=[] %}
 {%     for servers in helpers.toList('OPNsense.wireguard.server.servers.server') %}


### PR DESCRIPTION
There has been many requests for Wireguard to be CARP aware. Many of those requests have included VHID awareness. This PR does NOT address VHID tracking. It is IMO an 80/20 solution. I suspect the vast majority of users have a Master/Backup setup and do not have VHIP/VIPs on separate devices at the same time. 

This particular PR does several things

* WG will only start on the master after a config sync or reboot.
* This PR will NOT prevent WG from starting if the admin manually starts the WG service on the backup node.
* In case of a failover, this PR will start WG in the case of a promotion to master OR stop WG in the case of a demotion to backup.
* The only new control is a check box to enable CARP awareness within the plugin.

Tests I have conducted

* Ran the CARP script from the command line to ensure it fails gracefully.
* Failed back and forth between firewalls to ensure failover works.
* Synchronized configs to ensure that if WG is in a stopped state, it does not start on a backup.

One note, I named the CARP script 90-wireguard to make it last as there have been concerns about race conditions, DNS weirdness etc. I think these issues are mitigated elsewhere and I saw no problem starting WG last in a failover. If a different designation (50-wirguard etc) is preferred, that's an easy enough fix.


In any event, here it is for your kind consideration. I hope others will test this further.

Much of the work is largely based on the MDNS-Repeater CARP code. There are other solutions I have seen used, but those tended to not use the actual calls and tools within OPNsense and talked to the OS a bit more than I think would be prudent.