### PR TITLE
emulators/qemu-guest-agent: release 1.2

### DIFF
--- a/emulators/qemu-guest-agent/Makefile
+++ b/emulators/qemu-guest-agent/Makefile
@@ -1,6 +1,5 @@
 PLUGIN_NAME=		qemu-guest-agent
-PLUGIN_VERSION=		1.1
-PLUGIN_REVISION=	1
+PLUGIN_VERSION=		1.2
 PLUGIN_COMMENT=		QEMU Guest Agent for OPNsense
 PLUGIN_DEPENDS=		qemu-guest-agent
 PLUGIN_MAINTAINER=	opnsense@moov.de

--- a/emulators/qemu-guest-agent/pkg-descr
+++ b/emulators/qemu-guest-agent/pkg-descr
@@ -6,6 +6,11 @@ WWW: http://wiki.qemu.org/Main_Page
 Plugin Changelog
 ================
 
+1.2
+
+Changed:
+* switch to most recent version of qemu guest agent
+
 1.1
 
 Fixed:


### PR DESCRIPTION
fixes #3283
depends on https://github.com/opnsense/tools/pull/344

This release ensures that users are actually migrated to the new version.