### PR TITLE
security/acme: Surfacing EasyDNS plugin for acme.sh

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -1327,6 +1327,21 @@
         <label>Password</label>
         <type>password</type>
     </field>
+     <field>
+        <label>EasyDNS</label>
+        <type>header</type>
+        <style>table_dns table_dns_easydns</style>
+    </field>
+    <field>
+        <id>validation.dns_easydns_apikey</id>
+        <label>Api Key</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_easydns_apitoken</id>
+        <label>API Token</label>
+        <type>password</type>
+    </field>
     <field>
         <label>EUserv</label>
         <type>header</type>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsEasydns.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsEasydns.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Copyright (C) 2023 gregorsharpe
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\AcmeClient\LeValidation;
+
+use OPNsense\AcmeClient\LeValidationInterface;
+use OPNsense\Core\Config;
+
+/**
+ * Selfhost API
+ * @package OPNsense\AcmeClient
+ */
+class EasyDNS extends Base implements LeValidationInterface
+{
+    public function prepare()
+    {
+        $this->acme_env['EASYDNS_Key'] = (string)$this->config->dns_easydns_apikey;
+        $this->acme_env['EASYDNS_Token'] = (string)$this->config->dns_easydns_apitoken;
+    }
+}

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -450,6 +450,7 @@
                         <dns_dyn>Dyn Managed</dns_dyn>
                         <dns_dynu>Dynu</dns_dynu>
                         <dns_dynv6>dynv6</dns_dynv6>
+                        <dns_easydns>EasyDNS</dns_easydns>
                         <dns_euserv>EUserv</dns_euserv>
                         <dns_freedns>FreeDNS</dns_freedns>
                         <dns_gandi_livedns>Gandi LiveDNS</dns_gandi_livedns>
@@ -1042,6 +1043,12 @@
                 <dns_schlundtech_password type="TextField">
                     <Required>N</Required>
                 </dns_schlundtech_password>
+                <dns_easydns_apikey type="TextField">
+                    <Required>N</Required>
+                </dns_easydns_apikey>
+                <dns_easydns_apitoken type="TextField">
+                    <Required>N</Required>
+                </dns_easydns_apitoken>
                 <dns_euserv_user type="TextField">
                     <Required>N</Required>
                 </dns_euserv_user>


### PR DESCRIPTION
This PR adds compatibility with the EasyDNS acme.sh module, surfacing it as an option in the plugin UI making it much easier to manage in opnsense. 