### PR TITLE
sysutils/api-backup: add json download functionality

### DIFF
--- a/sysutils/api-backup/Makefile
+++ b/sysutils/api-backup/Makefile
@@ -1,6 +1,5 @@
 PLUGIN_NAME=		api-backup
-PLUGIN_VERSION=		1.0
-PLUGIN_REVISION=	1
+PLUGIN_VERSION=		1.1
 PLUGIN_COMMENT=		Provide the functionality to download the config.xml
 PLUGIN_MAINTAINER=	franz.fabian.94@gmail.com
 

--- a/sysutils/api-backup/pkg-descr
+++ b/sysutils/api-backup/pkg-descr
@@ -1,1 +1,12 @@
 Provide the functionality to download the config.xml
+
+Plugin Changelog
+================
+
+1.1
+
+* add json download functionality
+
+1.0
+
+* initial release

--- a/sysutils/api-backup/src/opnsense/mvc/app/controllers/OPNsense/Backup/Api/BackupController.php
+++ b/sysutils/api-backup/src/opnsense/mvc/app/controllers/OPNsense/Backup/Api/BackupController.php
@@ -1,6 +1,7 @@
 <?php
 
 /*
+ * Copyright (C) 2023 Frank Wall
  * Copyright (C) 2018 Fabian Franz
  * All rights reserved.
  *
@@ -34,17 +35,56 @@ class BackupController extends ApiControllerBase
 {
     const CONFIG_XML = '/conf/config.xml';
 
-    public function downloadAction()
+    /**
+     * download system config
+     * @param string $format set to 'json' to get a base64 encoded config backup
+     * @return array|mixed
+     */
+    public function downloadAction($format='plain')
     {
-        $this->response->setStatusCode(200, "OK");
-        $this->response->setContentType('application/xml', 'UTF-8');
-        $this->response->setHeader("Content-Disposition", "attachment; filename=\"config.xml\"");
         $data = file_get_contents(self::CONFIG_XML);
-        $this->response->setContent($data);
+        $status = $data === false ? 'error' : 'success';
+
+        if ($format == 'json') {
+            $response = array(
+              'status' => $status,
+              'filename' => 'config.xml',
+              'filetype' => 'application/xml',
+              'content' => base64_encode($data),
+            );
+            return $response;
+        } else {
+            $this->response->setStatusCode(200, "OK");
+            $this->response->setContentType('application/xml', 'UTF-8');
+            $this->response->setHeader("Content-Disposition", "attachment; filename=\"config.xml\"");
+            $data = file_get_contents(self::CONFIG_XML);
+            $this->response->setContent($data);
+        }
     }
 
+    /**
+     * process API results, serialize return data to json.
+     * @param $dispatcher
+     * @return string json data
+     */
     public function afterExecuteRoute($dispatcher)
     {
-        $this->response->send();
+        // check if reponse headers are already set
+        if ($this->response->getHeaders()->get("Status") != null) {
+            // Headers already set, send unmodified response.
+        } else {
+            // process response, serialize to json object
+            $data = $dispatcher->getReturnedValue();
+            if (is_array($data)) {
+                $this->response->setContentType('application/json', 'UTF-8');
+                if ($this->isExternalClient()) {
+                    $this->response->setContent(json_encode($data));
+                } else {
+                    $this->response->setContent(htmlspecialchars(json_encode($data), ENT_NOQUOTES));
+                }
+            }
+        }
+
+        return $this->response->send();
     }
 }


### PR DESCRIPTION
This PR adds a new API endpoint `/api/backup/backup/download/json` that can be used to download a backup of the `config.xml` in JSON:

```
{"status":"success","filename":"config.xml","filetype":"application\/xml","content":"REDACTED"}
```

This is necessary for some cases where a "real" API is needed. The existing API endpoint `/api/backup/backup/download` is nice for shell scripts or when using curl to perform backups. However, it does not behave like any other OPNsense API, making it cumbersome to implement in existing systems/applications.

So this additional API endpoint provides a OPNsense-like API with the same goal: provide an easy way to perform automatic backups of the system configuration. And it does not increase code complexity in any meaningful way, so everyone wins. :)