### PR TITLE
net-mgmt/telegraf: don't set timeout for disabled InfluxDB v2

### DIFF
--- a/net-mgmt/telegraf/Makefile
+++ b/net-mgmt/telegraf/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		telegraf
-PLUGIN_VERSION=		1.12.7
+PLUGIN_VERSION=		1.12.8
 PLUGIN_COMMENT=		Agent for collecting metrics and data
 PLUGIN_DEPENDS=		telegraf
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net-mgmt/telegraf/pkg-descr
+++ b/net-mgmt/telegraf/pkg-descr
@@ -12,6 +12,10 @@ WWW: https://www.influxdata.com/time-series-platform/telegraf/
 Plugin Changelog
 ================
 
+1.12.8
+
+* bug: fix InfluxDB v2 template to remove erroneous `timeout` value (issue #3265, contributed by Gavin Chappell)
+
 1.12.7
 
 * Add Influx v2 flush timeout

--- a/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
+++ b/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
@@ -175,10 +175,10 @@
 {%   else %}
   insecure_skip_verify = false
 {%   endif %}
-{% endif %}
 {%   if helpers.exists('OPNsense.telegraf.output.influx_v2_timeout') and OPNsense.telegraf.output.influx_v2_timeout != '' %}
   timeout = "{{ OPNsense.telegraf.output.influx_v2_timeout }}s"
 {%   endif %}
+{% endif %}
 
 {% if helpers.exists('OPNsense.telegraf.input.cpu') and OPNsense.telegraf.input.cpu == '1' %}
 [[inputs.cpu]]


### PR DESCRIPTION
Fixes: #3265 

If you have a populated InfluxDB v2 configuration, and you want to disable it, then the timeout should be removed from the configuration file. The Jinja2 template had an incorrectly nested loop so if the InfluxDB v2 timeout was set, the `timeout` key/value would still be put into the configuration file and may cause Telegraf to fail to start for several reasons (depending on your exact configuration:

`2023-02-17T13:38:15Z E! [telegraf] Error running agent: error loading config file /usr/local/etc/telegraf.conf: error parsing data: line 34: key 'timeout' is in conflict with line 18d`

`2023-02-17T13:46:19Z E! [telegraf] Error running agent: error loading config file /usr/local/etc/telegraf.conf: plugin outputs.prometheus_client: line 19: configuration specified the fields ["timeout"], but they weren't used`

This pull request addresses this by correctly ordering the `{% endif %}` so that if InfluxDB v2 is disabled, none of the settings are placed in the configuration file.