### PR TITLE
security/acme: minor lighty config fixes

### DIFF
--- a/security/acme-client/src/opnsense/service/templates/OPNsense/AcmeClient/lighttpd-acme-challenge.conf
+++ b/security/acme-client/src/opnsense/service/templates/OPNsense/AcmeClient/lighttpd-acme-challenge.conf
@@ -72,18 +72,16 @@ $SERVER["socket"]  == "[::1]:{{OPNsense.AcmeClient.settings.challengePort}}" { }
 # to help the rc.scripts
 server.pid-file = "/var/run/lighttpd-acme-challenge.pid"
 
-# virtual directory listings
-server.dir-listing = "disable"
-
 # enable debugging
 debug.log-request-header   = "disable"
 debug.log-response-header  = "disable"
 debug.log-request-handling = "disable"
 debug.log-file-not-found   = "disable"
 
-# gzip compression
-compress.cache-dir = "/tmp/acmelighttpdcompress/"
-compress.filetype  = ("text/plain","text/css", "text/xml", "text/javascript" )
+# enable compression
+deflate.cache-dir = "/tmp/acmelighttpdcompress/"
+deflate.mimetypes = ("text/plain", "text/css", "text/xml", "text/javascript")
+deflate.allowed-encodings = ("br", "gzip", "deflate")
 
 server.max-request-size = 4096
 server.tag = "lighttpd/ACME"


### PR DESCRIPTION
Hi!
on ACME Client plugin reload it produces warnings in Web GUI log (since it lighttpd proc name also):
![acme-lighty](https://user-images.githubusercontent.com/36099472/220620357-e53f1d65-083d-4b8b-b573-591d5f560521.PNG)

pr tries to fix this by:
use '`deflate.`' options to enable compression
remove `server.dir-listing = "disable"` since mod_dirlisting is disabled by default

thanks!