### PR TITLE
sysutils/auto-recovery: a new plugin to rollback configuration changes

### DIFF
--- a/sysutils/auto-recovery/Makefile
+++ b/sysutils/auto-recovery/Makefile
@@ -1,0 +1,6 @@
+PLUGIN_NAME=		auto-recovery
+PLUGIN_VERSION=		1.0
+PLUGIN_COMMENT=		A configuration rollback functionality for OPNsense
+PLUGIN_MAINTAINER=	opnsense@moov.de
+
+.include "../../Mk/plugins.mk"

--- a/sysutils/auto-recovery/pkg-descr
+++ b/sysutils/auto-recovery/pkg-descr
@@ -1,0 +1,9 @@
+Set a timer to perform a rollback to a previous configuration state.
+It is a safety net when making critical configuration on a remote device.
+
+Plugin Changelog
+================
+
+1.0
+
+* initial release

--- a/sysutils/auto-recovery/src/opnsense/mvc/app/controllers/OPNsense/AutoRecovery/Api/ServiceController.php
+++ b/sysutils/auto-recovery/src/opnsense/mvc/app/controllers/OPNsense/AutoRecovery/Api/ServiceController.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ *    Copyright (C) 2023 Frank Wall
+ *    Copyright (C) 2015 Deciso B.V.
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+namespace OPNsense\AutoRecovery\Api;
+
+use OPNsense\Base\ApiMutableServiceControllerBase;
+use OPNsense\Core\Backend;
+use OPNsense\AutoRecovery\AutoRecovery;
+
+/**
+ * Class ServiceController
+ * @package OPNsense\AutoRecovery
+ */
+class ServiceController extends ApiMutableServiceControllerBase
+{
+    protected static $internalServiceClass = '\OPNsense\AutoRecovery\AutoRecovery';
+    protected static $internalServiceTemplate = 'OPNsense/AutoRecovery';
+    protected static $internalServiceEnabled = 'general.Enabled';
+    protected static $internalServiceName = 'autorecovery';
+
+    /**
+     * start countdown
+     * @return string
+     */
+    public function countdownAction()
+    {
+        $model = new AutoRecovery();
+        $action = (string)$model->general->action;
+        if (!empty((string)$model->general->configd_command)) {
+          // Replace spaces with colons before passing the value to configdRun().
+          $configdcmd = str_replace(' ', ':',(string)$model->general->configd_command);
+        } else {
+          $configdcmd = 'not_found';
+        }
+        // Convert minutes to seconds
+        $countdown = 60 * (string)$model->general->countdown;
+
+        $backend = new Backend();
+        $response = $backend->configdRun("autorecovery countdown ${action} ${configdcmd} ${countdown}");
+        return array("response" => $response);
+    }
+
+    /**
+     * get remaining time for current countdown
+     * @return string
+     */
+    public function timeAction()
+    {
+        $backend = new Backend();
+        $response = $backend->configdRun("autorecovery status");
+        return array("response" => $response);
+    }
+
+    /**
+     * abort countdown
+     * @return string
+     */
+    public function abortAction()
+    {
+        $backend = new Backend();
+        $response = $backend->configdRun("autorecovery abort");
+        return array("response" => $response);
+    }
+}

--- a/sysutils/auto-recovery/src/opnsense/mvc/app/controllers/OPNsense/AutoRecovery/Api/SettingsController.php
+++ b/sysutils/auto-recovery/src/opnsense/mvc/app/controllers/OPNsense/AutoRecovery/Api/SettingsController.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ *    Copyright (C) 2023 Frank Wall
+ *    Copyright (C) 2015-2019 Deciso B.V.
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+namespace OPNsense\AutoRecovery\Api;
+
+use OPNsense\Base\ApiMutableModelControllerBase;
+use OPNsense\Core\Config;
+use OPNsense\AutoRecovery\AutoRecovery;
+
+/**
+ * Class SettingsController Handles settings related API actions for the AutoRecovery module
+ * @package OPNsense\AutoRecovery
+ */
+class SettingsController extends ApiMutableModelControllerBase
+{
+    protected static $internalModelName = 'autorecovery';
+    protected static $internalModelClass = 'OPNsense\AutoRecovery\AutoRecovery';
+}

--- a/sysutils/auto-recovery/src/opnsense/mvc/app/controllers/OPNsense/AutoRecovery/IndexController.php
+++ b/sysutils/auto-recovery/src/opnsense/mvc/app/controllers/OPNsense/AutoRecovery/IndexController.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ *    Copyright (C) 2023 Frank Wall
+ *    Copyright (C) 2015 Deciso B.V.
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+namespace OPNsense\AutoRecovery;
+
+/**
+ * Class IndexController
+ * @package OPNsense\AutoRecovery
+ */
+class IndexController extends \OPNsense\Base\IndexController
+{
+    public function indexAction()
+    {
+        // pick the template to serve to our users.
+        $this->view->pick('OPNsense/AutoRecovery/index');
+        // fetch form data "general" in
+        $this->view->generalForm = $this->getForm("general");
+    }
+}

--- a/sysutils/auto-recovery/src/opnsense/mvc/app/controllers/OPNsense/AutoRecovery/forms/general.xml
+++ b/sysutils/auto-recovery/src/opnsense/mvc/app/controllers/OPNsense/AutoRecovery/forms/general.xml
@@ -1,0 +1,29 @@
+<form>
+    <field>
+        <label>Configuration</label>
+        <type>header</type>
+    </field>
+    <field>
+        <id>autorecovery.general.countdown</id>
+        <label>Countdown in minutes</label>
+        <type>text</type>
+        <help>The number of minutes to wait before starting recovery procedures.</help>
+    </field>
+    <field>
+        <id>autorecovery.general.action</id>
+        <label>Recovery action</label>
+        <type>dropdown</type>
+        <help>The recovery action that should be performed.</help>
+    </field>
+    <field>
+        <label>Required Parameters</label>
+        <type>header</type>
+        <style>table_configd</style>
+    </field>
+    <field>
+        <id>autorecovery.general.configd_command</id>
+        <label>System Command</label>
+        <type>dropdown</type>
+        <help>Select a pre-defined system command which should be run.</help>
+    </field>
+</form>

--- a/sysutils/auto-recovery/src/opnsense/mvc/app/models/OPNsense/AutoRecovery/ACL/ACL.xml
+++ b/sysutils/auto-recovery/src/opnsense/mvc/app/models/OPNsense/AutoRecovery/ACL/ACL.xml
@@ -1,0 +1,9 @@
+<acl>
+    <page-user-autorecovery>
+        <name>System: Auto Recovery</name>
+        <patterns>
+            <pattern>ui/autorecovery/*</pattern>
+            <pattern>api/autorecovery/*</pattern>
+        </patterns>
+    </page-user-autorecovery>
+</acl>

--- a/sysutils/auto-recovery/src/opnsense/mvc/app/models/OPNsense/AutoRecovery/AutoRecovery.php
+++ b/sysutils/auto-recovery/src/opnsense/mvc/app/models/OPNsense/AutoRecovery/AutoRecovery.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ *    Copyright (C) 2023 Frank Wall
+ *    Copyright (C) 2015 Deciso B.V.
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+namespace OPNsense\AutoRecovery;
+
+use OPNsense\Base\BaseModel;
+
+class AutoRecovery extends BaseModel
+{
+}

--- a/sysutils/auto-recovery/src/opnsense/mvc/app/models/OPNsense/AutoRecovery/AutoRecovery.xml
+++ b/sysutils/auto-recovery/src/opnsense/mvc/app/models/OPNsense/AutoRecovery/AutoRecovery.xml
@@ -1,0 +1,37 @@
+<model>
+    <mount>//OPNsense/AutoRecovery</mount>
+    <version>1.0.0</version>
+    <description>A configuration rollback functionality for OPNsense</description>
+    <items>
+        <general>
+            <countdown type="IntegerField">
+                <default>10</default>
+                <MinimumValue>1</MinimumValue>
+                <!-- max value is 7 days -->
+                <MaximumValue>10080</MaximumValue>
+                <ValidationMessage>Please specify a value between 1 and 10080 minutes.</ValidationMessage>
+                <Required>Y</Required>
+            </countdown>
+            <action type="OptionField">
+                <Required>Y</Required>
+                <default>restore_reboot</default>
+                <OptionValues>
+                    <restore_reboot>Restore config and reboot [default]</restore_reboot>
+                    <restore_reload>Restore config and restart all services</restore_reload>
+                    <restore_configd>Restore config and run system command</restore_configd>
+                    <restore>Restore config</restore>
+                    <reboot>Reboot OPNsense</reboot>
+                    <configd>Run system command</configd>
+                    <noop>Do nothing (for testing purpose)</noop>
+                </OptionValues>
+            </action>
+            <configd_command type="ConfigdActionsField">
+                <filters>
+                    <description>/(.){1,255}/</description>
+                </filters>
+                <ValidationMessage>Select a command from the list.</ValidationMessage>
+                <Required>N</Required>
+            </configd_command>
+        </general>
+    </items>
+</model>

--- a/sysutils/auto-recovery/src/opnsense/mvc/app/models/OPNsense/AutoRecovery/Menu/Menu.xml
+++ b/sysutils/auto-recovery/src/opnsense/mvc/app/models/OPNsense/AutoRecovery/Menu/Menu.xml
@@ -1,0 +1,5 @@
+<menu>
+    <System>
+        <AutoRecovery VisibleName="Auto Recovery" cssClass="fa fa-history fa-fw" url="/ui/autorecovery"/>
+    </System>
+</menu>

--- a/sysutils/auto-recovery/src/opnsense/mvc/app/views/OPNsense/AutoRecovery/index.volt
+++ b/sysutils/auto-recovery/src/opnsense/mvc/app/views/OPNsense/AutoRecovery/index.volt
@@ -1,0 +1,113 @@
+{#
+
+Copyright (C) 2023 Frank Wall
+OPNsense® is Copyright © 2014 – 2015 by Deciso B.V.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1.  Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2.  Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+#}
+
+<script>
+    $( document ).ready(function() {
+        var data_get_map = {'frm_GeneralSettings':"/api/autorecovery/settings/get"};
+        mapDataToFormUI(data_get_map).done(function(data){
+            formatTokenizersUI();
+            $('.selectpicker').selectpicker('refresh');
+        });
+
+        // save settings and start countdown
+        $("#countdownAct").click(function(){
+            saveFormToEndpoint(url="/api/autorecovery/settings/set",formid='frm_GeneralSettings',callback_ok=function(){
+                // after successful save, start the countdown
+                ajaxCall(url="/api/autorecovery/service/countdown", sendData={},callback=function(data,status) {
+                    // reload page to show countdown timer
+                    setTimeout(function () {
+                        window.location.reload(true)
+                    }, 1000);
+                });
+            });
+        });
+
+        // link save button to API set action
+        $("#abortAct").click(function(){
+            ajaxCall(url="/api/autorecovery/service/abort", sendData={},callback=function(data,status) {
+                // reload page to hide countdown timer
+                setTimeout(function () {
+                    window.location.reload(true)
+                }, 1000);
+            });
+        });
+
+        // show reminder when config has pending changes
+        function show_countdown_alert() {
+            ajaxCall(url="/api/autorecovery/service/time", sendData={}, callback=function(data,status) {
+                if (data['response'] && data['response'].trim() && data['response'] > 0) {
+                    var countdowndate = new Date(data['response']*1000);
+                    $("#countdownRunning").append(countdowndate.toLocaleString());
+                    $("#countdownRunning").show();
+                    $("#countdownAct").hide(); // hide button
+                } else {
+                    $("#countdownRunning").hide();
+                    $("#abortAct").hide(); // hide button
+                }
+            });
+        }
+        show_countdown_alert();
+
+        // hide configd field when not required
+        $("#autorecovery\\.general\\.action").change(function () {
+            var recovery_action = $(this).val();
+            if (['restore_configd', 'configd'].includes(recovery_action)) {
+                $(".table_configd").show();
+            } else {
+                $(".table_configd").hide();
+            }
+        });
+        $("#autorecovery\\.general\\.action").change();
+    });
+</script>
+
+<div  class="col-md-12">
+    {{ partial("layout_partials/base_form",['fields':generalForm,'id':'frm_GeneralSettings'])}}
+</div>
+
+<div class="col-md-12">
+    <hr/>
+    <div id="countdownRunning" class="alert alert-danger" style="display: none" role="alert">
+      {{ lang._('WARNING! The countdown is on. Time of scheduled system recovery: ') }}
+    </div>
+    <p>{{ lang._('%sHOW IT WORKS:%s') | format('<b>', '</b>') }}</p>
+    <ul>
+      <li>{{ lang._("Enter the countdown and choose a recovery action.") }}</li>
+      <li>{{ lang._("Hit the Start Countdown button.") }}</li>
+      <li>{{ lang._("Auto Recovery automatically creates a configuration backup and starts the countdown.") }}</li>
+      <li>{{ lang._("The GUI will refresh and display the recovery time.") }}</li>
+      <li>{{ lang._("When the countdown reaches 0, the selected recovery actions are performed.") }}</li>
+      <li>{{ lang._("Depending on the selected recovery action, the previous configuration will be restored and all configuration changes since starting the countdown are lost.") }}</li>
+    </ul>
+    <hr/>
+    {{ lang._('%sPLEASE NOTE:%s Auto Recovery is a community plugin without support or guarantees. Auto Recovery can only restore the OPNsense system configuration to a previous state. It does not restore any other files nor does it revert any filesystem modifications. It certainly is not meant to replace a backup, nor does it protect against failed software upgrades.') | format('<b>', '</b>') }}
+    <hr/>
+    <button class="btn btn-primary" id="countdownAct" type="button"><b>{{ lang._('Start Countdown') }}</b></button>
+    <button class="btn btn-primary" id="abortAct" type="button"><b>{{ lang._('Abort Countdown') }}</b></button>
+</div>

--- a/sysutils/auto-recovery/src/opnsense/scripts/OPNsense/AutoRecovery/auto-recovery.sh
+++ b/sysutils/auto-recovery/src/opnsense/scripts/OPNsense/AutoRecovery/auto-recovery.sh
@@ -1,0 +1,256 @@
+#!/bin/sh
+
+# Copyright (c) 2023 Frank Wall
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+
+# Configuration variables.
+BASE_DIR='/var/etc/auto-recovery'
+ABORT_FILE="${BASE_DIR}/autorecover.abort"
+CONFIG_FILE='/conf/config.xml'
+CONFIG_BACKUP_FILE="${BASE_DIR}/config.xml_recover"
+CONFIG_ORIGINAL_FILE="${BASE_DIR}/config.xml_orig"
+COUNTDOWN=0
+SCRIPT_NAME='AutoRecovery'
+START_TIME="`date +%s`"
+STATE_FILE="${BASE_DIR}/countdown.state"
+VERBOSE=0
+
+# Possible recovery actions.
+DO_RESTORE=0
+DO_REBOOT=0
+DO_RELOAD=0
+DO_CONFIGD=0
+
+# Recovery commands.
+RESTORE_CMD='configctl template reload \*'
+REBOOT_CMD='configctl system reboot'
+RELOAD_CMD='configctl service reload all'
+CONFIGD_CMD='configctl'
+
+# Print usage information.
+usage() {
+  echo "usage: `basename $0` COUNTDOWN_IN_SECONDS" 
+}
+
+# Print fatal errors on STDERR and exit.
+fatal() {
+  1>&2 echo "[ERROR] $@"
+  syslog $@
+  cleanup
+  exit 1
+}
+
+# Print errors on STDERR.
+error() {
+  1>&2 echo "[ERROR] $@"
+  syslog $@
+}
+
+# Print message on STDOUT.
+log() {
+  1>&2 echo "$@"
+  syslog $@
+}
+
+# Print debug messages.
+verbose() {
+  [ "$VERBOSE" = "1" ] && echo $@
+}
+
+# Send message to syslog.
+syslog() {
+  logger "${SCRIPT_NAME}: $@"
+}
+
+# Remove state information.
+cleanup() {
+  rm -f $ABORT_FILE $STATE_FILE
+}
+
+# Check args.
+if [ "$#" -lt "1" ]; then
+  usage
+  exit 1
+fi
+
+# Get user input.
+while [ "$1" != "" ]; do
+  case "$1" in
+    --action*)
+      RECOVERY_ACTION="`echo $1 | cut -d= -f2`"
+      shift
+      ;;
+    --configd*)
+      _tmp_cmd="${CONFIGD_CMD} `echo $1 | cut -d= -f2`"
+      # Replace colons with spaces to restore correct configd command.
+      CONFIGD_CMD="`echo ${_tmp_cmd} | sed -e 's/:/ /'`"
+      shift
+      ;;
+    -v*)
+      VERBOSE=1
+      shift
+      ;;
+    *)
+      COUNTDOWN=$1
+      shift
+      ;;
+  esac
+done
+
+# Enable selected recovery actions.
+case "$RECOVERY_ACTION" in
+  restore_reboot)
+    DO_RESTORE=1
+    DO_REBOOT=1
+    ;;
+  restore_reload)
+    DO_RESTORE=1
+    DO_RELOAD=1
+    ;;
+  restore_configd)
+    DO_RESTORE=1
+    DO_CONFIGD=1
+    ;;
+  restore)
+    DO_RESTORE=1
+    ;;
+  reboot)
+    DO_REBOOT=1
+    ;;
+  configd)
+    DO_CONFIGD=1
+    ;;
+  noop)
+    log "test mode enabled"
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac
+
+# Verify args
+if [ "${COUNTDOWN}" -le 1 ]; then
+  usage
+  exit 1
+fi
+
+mkdir -p $BASE_DIR || fatal "Unable to create ${BASE_DIR}"
+
+# Save the current configuration.
+if [ "${DO_RESTORE}" == "1" ]; then
+  cp $CONFIG_FILE $CONFIG_BACKUP_FILE
+  if [ "$?" -gt "0" ]; then
+    fatal "Unable to create a backup of the config file"
+  fi
+fi
+
+# Calculate target time.
+TARGET_TIME="`expr $START_TIME + $COUNTDOWN`"
+
+# Start countdown.
+echo $TARGET_TIME > $STATE_FILE
+if [ "$?" -gt "0" ]; then
+  fatal "Unable to create state file"
+fi
+log "Countdown initiated: ${COUNTDOWN} seconds remaining"
+
+# Main loop
+while [ 1 ]; do
+  # Check if the countdown must be aborted.
+  if [ -f "$ABORT_FILE" ]; then
+    verbose "Found file: $ABORT_FILE"
+    log "Countdown aborted on user request"
+    cleanup
+    exit 0
+  fi
+
+  # Check if target time is reached.
+  cur_time="`date +%s`"
+  if [ "$cur_time" -ge "$TARGET_TIME" ]; then
+    log "Performing system recovery... (${RECOVERY_ACTION})"
+
+    # Restore configuration backup.
+    if [ "${DO_RESTORE}" == "1" ]; then
+      log "Restoring configuration backup"
+
+      # Perform an additional backup of the currently running configuration.
+      # Just for extra safekeeping if the recovery process goes horribly wrong.
+      cp $CONFIG_FILE $CONFIG_ORIGINAL_FILE
+
+      # Restore the backup configuration.
+      cp $CONFIG_BACKUP_FILE $CONFIG_FILE
+      if [ "$?" -gt "0" ]; then
+        fatal "Unable to restore config file"
+      fi
+
+      # Reload all templates.
+      eval $RESTORE_CMD
+      if [ "$?" -gt "0" ]; then
+        error "Reload templates command exited with non-zero exit code"
+      fi
+    fi
+
+    # Restart all services.
+    if [ "${DO_RELOAD}" == "1" ]; then
+      log "Restarting all services"
+      eval $RELOAD_CMD
+      if [ "$?" -gt "0" ]; then
+        error "Restart services command exited with non-zero exit code"
+      fi
+    fi
+
+    # Run configd command.
+    if [ "${DO_CONFIGD}" == "1" ]; then
+      log "Running system command: ${CONFIGD_CMD}"
+      eval $CONFIGD_CMD
+      if [ "$?" -gt "0" ]; then
+        error "System command exited with non-zero exit code"
+      fi
+    fi
+
+    # Reboot the system.
+    if [ "${DO_REBOOT}" == "1" ]; then
+      # Need to cleanup before issuing the reboot command, otherwise
+      # the state file would not get removed.
+      cleanup
+      log "Rebooting the system"
+      eval $REBOOT_CMD
+      if [ "$?" -gt "0" ]; then
+        error "Reboot command exited with non-zero exit code"
+      fi
+    fi
+
+    cleanup
+    exit 0
+  fi
+
+  # Print status information.
+  remaining_time="`expr $TARGET_TIME - $cur_time`"
+  verbose "Countdown: $remaining_time seconds"
+  sleep 1
+done
+
+exit 0

--- a/sysutils/auto-recovery/src/opnsense/service/conf/actions.d/actions_autorecovery.conf
+++ b/sysutils/auto-recovery/src/opnsense/service/conf/actions.d/actions_autorecovery.conf
@@ -1,0 +1,17 @@
+[countdown]
+command:/usr/sbin/daemon -f /usr/local/opnsense/scripts/OPNsense/AutoRecovery/auto-recovery.sh
+parameters:--action=%s --configd=%s %s
+type:script
+message:starting auto recovery countdown
+
+[abort]
+command:touch /var/etc/auto-recovery/autorecover.abort
+parameters:
+type:script_output
+message:aborting auto recovery countdown
+
+[status]
+command:cat /var/etc/auto-recovery/countdown.state 2>/dev/null || echo -1
+parameters:
+type:script_output
+message:requesting auto recovery status


### PR DESCRIPTION
### Preface

This new community plugin tries to immitate the `reload in 5` feature found in some routers/switches. It will start a countdown and restore all configuration changes if the countdown is not aborted. This is especially useful when working on remote devices.

This PR implements the feature request #2976 using an extremely simplified approach. The main feature is implemented, but it may not be sufficient for production environments.

_DISCLAIMER: Auto Recovery is a community plugin without support or guarantees. Auto Recovery can only restore the OPNsense system configuration to a previous state. It does not restore any other files, packages or revert any filesystem modification. It certainly is not meant to replace a backup, nor does it protect against failed software upgrades._ 

### Testing

This plugin is expected to be able to reliably restore a working system configuration. Hence we need more people to test it's features, before this plugin can be released.

Adding the development version of the plugin on OPNsense 23.1 is simple:

```
opnsense-patch -c plugins ae2ff84b
service configd restart
```

Please let me know if it works for you, or if you experience any issues.

### Screenshots

Configuration screen:

![autorecovery_1](https://user-images.githubusercontent.com/909706/220777132-76ef5dd9-06f1-4696-aa2f-7ff73cd5b8ce.png)

When the countdown is on:

![autorecovery_2](https://user-images.githubusercontent.com/909706/220777159-80101da3-862a-4ec9-97c5-cab09aae8023.png)

Log messages in `System: Log Files: General`:

![autorecovery_3](https://user-images.githubusercontent.com/909706/220777179-b2919ed6-446d-4005-9124-8503ce5336db.png)
