### PR TITLE
security/acme-client: Add TOTP authentication support to Synology DSM automation.

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogAction.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogAction.xml
@@ -237,6 +237,12 @@
         <help>If Synology DSM has OTP enabled, then the device ID has to be provided so that no OTP is required when running the automation.</help>
     </field>
     <field>
+        <id>action.acme_synology_dsm_totp</id>
+        <label>TOTP secret key</label>
+        <type>password</type>
+        <help>Instead of provide the device ID, You can provide the TOTP secret key so that the action script authenticates by itself. You can acquire the TOTP secret key only once while issuing an OTP.</help>
+    </field>
+    <field>
         <id>action.acme_synology_dsm_create</id>
         <label>Create certificates</label>
         <type>checkbox</type>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeAutomation/AcmeSynologyDsm.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeAutomation/AcmeSynologyDsm.php
@@ -50,6 +50,9 @@ class AcmeSynologyDsm extends Base implements LeAutomationInterface
         if (!empty((string)$this->config->acme_synology_dsm_deviceid)) {
             $this->acme_env['SYNO_DID'] = (string)$this->config->acme_synology_dsm_deviceid;
         }
+        if (!empty((string)$this->config->acme_synology_dsm_totp)) {
+            $this->acme_env['SYNO_TOTP_SECRET'] = (string)$this->config->acme_synology_dsm_totp;
+        }
         $this->acme_args[] = '--deploy-hook synology_dsm';
         return true;
     }

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -1336,6 +1336,11 @@
                     <mask>/^.{1,1024}$/u</mask>
                     <ValidationMessage>Should be a string between 1 and 1024 characters.</ValidationMessage>
                 </acme_synology_dsm_deviceid>
+                <acme_synology_dsm_totp type="TextField">
+                    <Required>N</Required>
+                    <mask>/^([\w\d]){16}$/u</mask>
+                    <ValidationMessage>Should be a 16-character string consisting of letters and numbers.</ValidationMessage>
+                </acme_synology_dsm_totp>
                 <acme_fritzbox_url type="TextField">
                     <Required>N</Required>
                     <mask>/^.{1,1024}$/u</mask>


### PR DESCRIPTION
acme-client: Automation - Upload certificate to Synology DSM

TOTP authentification might be needed because the Synology server will require sign-in again sometimes,
like after rebooting the system

referenced [acme.sh deploy script](https://github.com/acmesh-official/acme.sh/blob/master/deploy/synology_dsm.sh)