### PR TITLE
net/frr register_sas script/setkey add SAD entries for both IPv6 and IPv4

### DIFF
--- a/net/frr/src/opnsense/scripts/frr/register_sas
+++ b/net/frr/src/opnsense/scripts/frr/register_sas
@@ -60,9 +60,9 @@ if __name__ == '__main__':
     with tempfile.NamedTemporaryFile(mode='wt', delete=False) as fo:
         temp_filename = fo.name
         for policy in registered_policies:
-            fo.write("delete -4 %(src)s %(dst)s tcp 0x1000;\n" % policy)
+            fo.write("delete -n %(src)s %(dst)s tcp 0x1000;\n" % policy)
         for new_policy in frr_sad:
-            fo.write('add -4 %(src)s %(dst)s %(protocol)s %(spi)s -A %(aalgo)s "%(key)s";\n' % frr_sad[new_policy])
+            fo.write('add -n %(src)s %(dst)s %(protocol)s %(spi)s -A %(aalgo)s "%(key)s";\n' % frr_sad[new_policy])
 
     if temp_filename:
         subprocess.run(["/sbin/setkey", "-f", fo.name], capture_output=True, text=True)


### PR DESCRIPTION
OPNsense supports BGP on both IPv4 and IPv6, but the current frr/setkey script implementation only adds SAD entries for IPv4. Changing -4 to -n keeps filtering on numeric addresses, but adds SAD entries for both IPv4 and IPv6 instead of only IPv4.

Tested working on a Vultr VM with BGP enabled and MD5 password on the Vultr side.