### PR TITLE
net/wireguard: widget, fix/improve colum public key overlapping latest handshake

### DIFF
--- a/net/wireguard/src/www/widgets/widgets/wireguard.widget.php
+++ b/net/wireguard/src/www/widgets/widgets/wireguard.widget.php
@@ -60,14 +60,12 @@ $enabled = ($config["OPNsense"]["wireguard"]["general"]["enabled"] === "1" ? tru
 $(window).on("load", function() {
     function wgGenerateRow(name, interface, peerName, publicKey, latestHandshake, status)
     {
-        publicKeyShort = publicKey.slice(0, 19) + '...';
-
         var tr = ''
         +'<tr>'
         +'    <td>' + name + '</td>'
         +'    <td>' + interface + '</td>'
         +'    <td>' + peerName  + '</td>'
-        +'    <td title="' + publicKey + '">' + publicKeyShort  + '</td>'
+        +'    <td style="overflow: hidden; text-overflow: ellipsis;" title="' + publicKey + '">' + publicKey  + '</td>'
         +'    <td>' + latestHandshake + '</td>'
         +'</tr>';
 


### PR DESCRIPTION
Fixes public key overlapping latest handshake, moving the ellipsis to css to allow full display and fix current overlap.

This appears for me with Dashboard at 3 columns, which makes widget width 230px, but it surely appears at other configs too.

Current overlap looks like this, which make nither pk nor date legible.
![screen-2023-03-05_Mar:03:%i](https://user-images.githubusercontent.com/1887628/225441129-eca80297-b8e3-43b1-aa4c-021232090eb4.png)

