### PR TITLE
os-nginx: fix #3161 upstream.tls_session_reuse

### DIFF
--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/location.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/location.conf
@@ -199,8 +199,8 @@ location {{ location.matchtype }} {{ location.urlpattern }} {
 {%     if upstream.tls_protocol_versions is defined and upstream.tls_protocol_versions != '' %}
     proxy_ssl_protocols {{ upstream.tls_protocol_versions.replace(',', ' ') }};
 {%     endif %}
-{%     if upstream.tls_name_override is defined %}
-    proxy_ssl_session_reuse {% if upstream.tls_name_override != '0' %}off{% else %}on{% endif %};
+{%     if upstream.tls_session_reuse is defined %}
+    proxy_ssl_session_reuse {% if upstream.tls_session_reuse == '1' %}on{% else %}off{% endif %};
 {%     endif %}
 {%     if upstream.tls_trusted_certificate is defined and upstream.tls_trusted_certificate != '' %}
     proxy_ssl_trusted_certificate /usr/local/etc/nginx/key/trust_upstream_{{ location.upstream }}.pem;


### PR DESCRIPTION
Fix #3161.

Using wrong variable in nginx template causing `proxy_ssl_session_reuse` not to be properly set when enabling upstream TLS session reuse. Changed from `upstream.tls_name_override` to `upstream.tls_session_reuse`.

This has also been fixed in PR https://github.com/opnsense/plugins/pull/3205, but the PR seems to be stuck on some unrelated issues and I would like this fix to be merged sooner rather than later.