### PR TITLE
security/crowdsec: bump version 1.0.3; acquire packet filter logs.

### DIFF
--- a/security/crowdsec/Makefile
+++ b/security/crowdsec/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		crowdsec
-PLUGIN_VERSION=		1.0.2
+PLUGIN_VERSION=		1.0.3
 PLUGIN_DEPENDS=		crowdsec
 PLUGIN_COMMENT=		Lightweight and collaborative security engine
 PLUGIN_MAINTAINER=	marco@crowdsec.net

--- a/security/crowdsec/pkg-descr
+++ b/security/crowdsec/pkg-descr
@@ -8,6 +8,12 @@ WWW: https://crowdsec.net/
 Plugin Changelog
 ================
 
+1.0.3
+
+* acquire filter logs for the firewallservices/pf collection (port scans).
+  If you already added it manually, you can remove it now to avoid counting
+  the events twice.
+
 1.0.2
 
 * updated cron job (reload only when there are updates), added small random delay

--- a/security/crowdsec/src/etc/crowdsec/acquis.d/opnsense.yaml
+++ b/security/crowdsec/src/etc/crowdsec/acquis.d/opnsense.yaml
@@ -14,5 +14,7 @@ filenames:
   - /var/log/audit/latest.log
   # collection: crowdsecurity/opnsense-gui (web admin)
   - /var/log/lighttpd/latest.log
+  # collection: firewallservices/pf
+  - /var/log/filter/latest.log
 labels:
   type: syslog

--- a/security/crowdsec/src/opnsense/mvc/app/models/OPNsense/CrowdSec/General.xml
+++ b/security/crowdsec/src/opnsense/mvc/app/models/OPNsense/CrowdSec/General.xml
@@ -1,7 +1,7 @@
 <model>
   <mount>//OPNsense/crowdsec/general</mount>
   <description>CrowdSec general configuration</description>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
   <items>
 
     <agent_enabled type="BooleanField">


### PR DESCRIPTION
The filter logs are used by a new scenario in the opnsense collections to detect port scans.