### PR TITLE
Correct 'Help Text' for Remote Port - Maltrail - Sensor Settings

### DIFF
--- a/security/maltrail/src/opnsense/mvc/app/controllers/OPNsense/Maltrail/forms/sensor.xml
+++ b/security/maltrail/src/opnsense/mvc/app/controllers/OPNsense/Maltrail/forms/sensor.xml
@@ -27,7 +27,7 @@
         <id>sensor.remoteport</id>
         <label>Remote Port</label>
         <type>text</type>
-        <help>Port of the logging server. Leave empty when sensor and server run on the same system.</help>
+        <help>Port of the logging server.</help>
     </field>
     <field>
         <id>sensor.syslogserver</id>


### PR DESCRIPTION
Correct 'Help Text' for Remote Port, the removed text mentions that field can be left blank which is incorrect. A value needs to be specified for the service to run correctly.