### PR TITLE
nginx: Exclude okhttp from bots

### DIFF
--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/http.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/http.conf
@@ -262,7 +262,7 @@ server {
 {% endif %}
 {% if server.disable_bot_protection is not defined or server.disable_bot_protection != '1' %}
     # block based on User Agents - stuff I have found over the years in my server log
-    if ($http_user_agent ~* Python-urllib|Nmap|python-requests|libwww-perl|MJ12bot|Jorgee|fasthttp|libwww|Telesphoreo|A6-Indexer|ltx71|okhttp|ZmEu|sqlmap|LMAO/2.0|l9explore|l9tcpid|Masscan|zgrab|Ronin/2.0|Hakai/2.0) {
+    if ($http_user_agent ~* Python-urllib|Nmap|python-requests|libwww-perl|MJ12bot|Jorgee|fasthttp|libwww|Telesphoreo|A6-Indexer|ltx71|ZmEu|sqlmap|LMAO/2.0|l9explore|l9tcpid|Masscan|zgrab|Ronin/2.0|Hakai/2.0) {
       return 418;
     }
     {# MSIE 7 cannot be blocked - used for compatibility mode - https://blogs.msdn.microsoft.com/ieinternals/2013/09/21/internet-explorer-11s-many-user-agent-strings/ #}


### PR DESCRIPTION
okhttp is regular library used on java/android devices. having it in list forces admins to disable bot check when android apps are used