### PR TITLE
dns/bind: fix bug in ACL processing for `allow-query` section

### DIFF
--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
@@ -68,7 +68,7 @@ options {
 {% if helpers.exists('OPNsense.bind.general.allowquery') and OPNsense.bind.general.allowquery != '' %}
         allow-query {
 {%              for acl in helpers.toList('OPNsense.bind.general.allowquery') %}
-{%              set query_acl = helpers.getUUID(list) %}
+{%              set query_acl = helpers.getUUID(acl) %}
                 {{ query_acl.name }};
 {%              endfor %}
         };


### PR DESCRIPTION
Obviously a typo the `query-source` section in the generated named.conf is always empty because of the wrong loop variable referenced in the code. This leads to BIND failing to start up.

If you agree, shall I update the plugin version and `pkg-descr` accordingly or just bump the plugin revision? I'm not quite familiar with the meaning of the latter.

Kind regards,
Patrick