### PR TITLE
[ddclient] OPNsense backend, make sure address is string

### DIFF
--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/address.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/address.py
@@ -91,7 +91,7 @@ def checkip(service, proto='https', timeout='10', interface=None):
                     try:
                         address = ipaddress.ip_address(parts[1])
                         if address.is_global:
-                            return address
+                            return str(address)
                     except ValueError:
                         continue
     else:


### PR DESCRIPTION
Without this, I get the following in flush_status() in poller.py when it tries to dump the state to the file:

```
"IPv4Address('xx.xx.xx.xx') is not JSON serializable"
```

```
            fhandle.seek(0)
            fhandle.truncate()
            data = {}
            for acc_id in self._accounts:
                data[acc_id] = self._accounts[acc_id].state
            fhandle.write(ujson.dumps(data))
```

I am using custom dyndns2 if that is interesting at all, ~I am not sure how others have made this work so far without this change...~ Edit: Ah I bet they are using the curl methods instead of the interface for the IP
