### PR TITLE
os-ddclient: opnsense backend and cloudflare: use API token if available

### DIFF
--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/cloudflare.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/cloudflare.py
@@ -60,16 +60,24 @@ class Cloudflare(BaseAccount):
 
             # get ZoneID
             url = "https://%s/client/v4/zones" % self._services[self.settings.get('service')]
+            
+            # get appropiate headers
+            headers = {
+                'User-Agent': 'OPNsense-dyndns'
+            }
+            
+            if self.settings.get('username') == 'token':
+                headers["Authorization"] = "Bearer " + self.settings.get('password')
+            else:
+                headers["X-Auth-Email"] = self.settings.get('username')
+                headers["X-Auth-Key"] = self.settings.get('password')
+            
             req_opts = {
                 'url': url,
                 'params': {
                     'name': self.settings.get('zone')
                 },
-                'headers': {
-                    'User-Agent': 'OPNsense-dyndns',
-                    'X-Auth-Email': self.settings.get('username'),
-                    'X-Auth-Key': self.settings.get('password')
-                }
+                'headers': headers
             }
             response = requests.get(**req_opts)
             try:


### PR DESCRIPTION
If the username is "token", use the password as an API token instead of a global one. Tested locally. This should fix bug  #3427.

I'm not a python programmer, please feel free to fix the style.