### PR TITLE
dns/ddclient: update ddclient.conf interface template for ifv4 and ifv6

### DIFF
--- a/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
+++ b/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
@@ -24,9 +24,9 @@ ssl=yes
 {%  for account in accounts %}
 {%     if account.checkip == 'if' %}
 {%        if not helpers.empty('OPNsense.DynDNS.general.allowipv6') %}
-usev6=ifv6, \
+usev6=ifv6, ifv6={{physical_interface(account.interface)}}, \
 {%        endif %}
-usev4=ifv4, if={{physical_interface(account.interface)}}, \
+usev4=ifv4, ifv4={{physical_interface(account.interface)}}, \
 {%      elif account.checkip.startswith('web_') %}
 {%          if account.interface %}
 use=cmd, cmd="/usr/local/opnsense/scripts/ddclient/checkip -i {{physical_interface(account.interface)}} -t {{account.force_ssl}} -s {{account.checkip[4:]}} --timeout {{account.checkip_timeout|default('10')}}",


### PR DESCRIPTION
Fixes #3450

Adjusts ddclient.conf to use `ifv4`/`ifv6` fields for interface monitoring, as the `if` field is deprecated, and causes ddclient to fall back to "default interface" detection logic.