### PR TITLE
crowdsec: update 1.0.6 - correct option to detect changes from symlinks

### DIFF
--- a/security/crowdsec/+POST_INSTALL.post
+++ b/security/crowdsec/+POST_INSTALL.post
@@ -1,3 +1,6 @@
 #!/bin/sh
 
 configctl crowdsec reconfigure
+
+# apply new configuration immediately, don't wait for hub updates
+service crowdsec reload >/dev/null 2>&1 || :

--- a/security/crowdsec/Makefile
+++ b/security/crowdsec/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		crowdsec
-PLUGIN_VERSION=		1.0.5
+PLUGIN_VERSION=		1.0.6
 PLUGIN_DEPENDS=		crowdsec
 PLUGIN_COMMENT=		Lightweight and collaborative security engine
 PLUGIN_MAINTAINER=	marco@crowdsec.net

--- a/security/crowdsec/pkg-descr
+++ b/security/crowdsec/pkg-descr
@@ -8,6 +8,11 @@ WWW: https://crowdsec.net/
 Plugin Changelog
 ================
 
+1.0.6
+
+ * default acquis.d/opnsense.yaml to "poll_without_inotify=true" which is now required
+   to acquire content from symlinks.
+
 1.0.5
 
 * fix ban example

--- a/security/crowdsec/src/etc/crowdsec/acquis.d/opnsense.yaml
+++ b/security/crowdsec/src/etc/crowdsec/acquis.d/opnsense.yaml
@@ -24,5 +24,9 @@ filenames:
 # but the option works with both.
 force_inotify: true
 
+# this option is required from crowdsec v1.5.0 to follow
+# changes in symlinks
+poll_without_inotify: true
+
 labels:
   type: syslog

--- a/security/crowdsec/src/opnsense/mvc/app/models/OPNsense/CrowdSec/General.xml
+++ b/security/crowdsec/src/opnsense/mvc/app/models/OPNsense/CrowdSec/General.xml
@@ -1,7 +1,7 @@
 <model>
   <mount>//OPNsense/crowdsec/general</mount>
   <description>CrowdSec general configuration</description>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <items>
 
     <agent_enabled type="BooleanField">

--- a/security/crowdsec/src/opnsense/mvc/app/views/OPNsense/CrowdSec/general.volt
+++ b/security/crowdsec/src/opnsense/mvc/app/views/OPNsense/CrowdSec/general.volt
@@ -78,6 +78,11 @@
 
         <ul>
             <li>
+                New acquisition files go under <code>/usr/local/etc/crowdsec/acquis.d</code>. See opnsense.yaml for details.
+                The option <code>poll_without_inotify: true</code> is required if the acquitision targets are symlinks (which
+                is the case for most opnsense logs).
+            </li>
+            <li>
                 If your OPNsense is &lt;22.1, you must check "Disable circular logs" in the Settings menu for the
                 ssh and web-auth parsers to work. If you upgrade to 22.1, it will be done automatically.
                 See <a href="https://github.com/crowdsecurity/opnsense-plugin-crowdsec/blob/main/src/etc/crowdsec/acquis.d/opnsense.yaml">acquis.d/opnsense.yaml</a>


### PR DESCRIPTION
This update is required to use crowdsec 1.5+ due to upstream changes in the way logs are acquired.

