### PR TITLE
security/acme-client: Add domains.google support

### DIFF
--- a/security/acme-client/pkg-descr
+++ b/security/acme-client/pkg-descr
@@ -7,6 +7,10 @@ WWW: https://github.com/acmesh-official/acme.sh
 
 Plugin Changelog
 ================
+3.19
+
+Added:
+* add Google Domains DNS API
 
 3.18
 

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -557,6 +557,21 @@
         <type>text</type>
     </field>
     <field>
+        <label>Google Domains</label>
+        <type>header</type>
+        <style>table_dns table_dns_googledomains</style>
+    </field>
+    <field>
+        <id>validation.dns_googledomains_access_token</id>
+        <label>Access Token</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_googledomains_zone</id>
+        <label>Zone</label>
+        <type>text</type>
+    </field>
+    <field>
         <label>hosting.de</label>
         <type>header</type>
         <style>table_dns table_dns_hostingde</style>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsGoogledomains.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsGoogledomains.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * Copyright (C) 2023 Cannon Matthews <cannonmatthews@google.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\AcmeClient\LeValidation;
+
+use OPNsense\AcmeClient\LeValidationInterface;
+use OPNsense\Core\Config;
+
+/**
+ * Google Domains DNS API
+ * @package OPNsense\AcmeClient
+ */
+class DnsGoogleDomains extends Base implements LeValidationInterface
+{
+    public function prepare()
+    {
+        // It is possible to override $GOOGLEDOMAINS_API env variable to
+        // control the endpoint acme.sh talks to. However there is only one
+        // option (https://acmedns.googleapis.com/v1/acmeChallengeSets) that is
+        // currently the default, so exposing this only adds to confusion and
+        // noise in the UI.
+        $this->acme_env['GOOGLEDOMAINS_ACCESS_TOKEN'] = (string)$this->config->dns_googledomains_access_token;
+        $this->acme_env['GOOGLEDOMAINS_ZONE'] = (string)$this->config->dns_googledomains_zone;
+    }
+}

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -456,6 +456,7 @@
                         <dns_gandi_livedns>Gandi LiveDNS</dns_gandi_livedns>
                         <dns_gd>GoDaddy.com</dns_gd>
                         <dns_gcloud>Google Cloud DNS</dns_gcloud>
+                        <dns_googledomains>Google Domains</dns_googledomains>
                         <dns_gdnsdk>GratisDNS.dk</dns_gdnsdk>
                         <dns_hetzner>Hetzner</dns_hetzner>
                         <dns_hexonet>hexonet.com</dns_hexonet>
@@ -668,6 +669,12 @@
                 <dns_gcloud_key type="TextField">
                     <Required>N</Required>
                 </dns_gcloud_key>
+                <dns_googledomains_access_token type="TextField">
+                    <Required>N</Required>
+                </dns_googledomains_access_token>
+                <dns_googledomains_zone type="TextField">
+                    <Required>N</Required>
+                </dns_googledomains_zone>
                 <dns_gd_key type="TextField">
                     <Required>N</Required>
                 </dns_gd_key>


### PR DESCRIPTION
## Based on PR: #3429
## Changes: 
- Rename `DnsGoogleDomains.php`->`DnsGoogledomains.php`

## Context from #3429 

Adds support for Google Domains DNS-01 ACME challenge API added to latest upstream acme.sh. This is separate from the Google Cloud API.

https://domains.google/learn/gts-acme/

See acmesh-official/acme.sh#4542

## Test Plan
Manually tested with `opnsense-patch -c plugins 4714943b1888`