### PR TITLE
security/acme-client: Add IPv64.net support

### DIFF
--- a/security/acme-client/pkg-descr
+++ b/security/acme-client/pkg-descr
@@ -14,6 +14,7 @@ Added:
 * add support for TrueNAS deployhook (#3421)
 * add support for Proxmox VE deployhook (#3422)
 * add Google Domains DNS API
+* add IPv64.net DNS API
 
 3.17
 

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -649,6 +649,16 @@
         <type>password</type>
     </field>
     <field>
+        <label>IPv64.net API</label>
+        <type>header</type>
+        <style>table_dns table_dns_ipv64</style>
+    </field>
+    <field>
+        <id>validation.dns_ipv64_token</id>
+        <label>IPv64.net API Token</label>
+        <type>password</type>
+    </field>
+    <field>
         <label>IPSConfig</label>
         <type>header</type>
         <style>table_dns table_dns_ispconfig</style>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsIpv64.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsIpv64.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Copyright (C) 2023 Oliver Hartl
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\AcmeClient\LeValidation;
+
+use OPNsense\AcmeClient\LeValidationInterface;
+use OPNsense\Core\Config;
+
+/**
+ * IPv64.net API
+ * @package OPNsense\AcmeClient
+ */
+class DnsIpv64 extends Base implements LeValidationInterface
+{
+    public function prepare()
+    {
+        $this->acme_env['IPv64_Token'] = (string)$this->config->dns_ipv64_token;
+    }
+}

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -466,6 +466,7 @@
                         <dns_infomaniak>Infomaniak</dns_infomaniak>
                         <dns_inwx>INWX XMLRPC</dns_inwx>
                         <dns_ionos>IONOS domain</dns_ionos>
+                        <dns_ipv64>IPv64.net</dns_ipv64>
                         <dns_ispconfig>ISPConfig 3.1+</dns_ispconfig>
                         <dns_jd>JD Cloud</dns_jd>
                         <dns_joker>Joker</dns_joker>
@@ -711,6 +712,9 @@
                 <dns_ionos_secret type="TextField">
                     <Required>N</Required>
                 </dns_ionos_secret>
+                <dns_ipv64_token type="TextField">
+                    <Required>N</Required>
+                </dns_ipv64_token>
                 <dns_ispconfig_user type="TextField">
                     <Required>N</Required>
                 </dns_ispconfig_user>


### PR DESCRIPTION
Adds support for IPv64.net DNS-01 ACME challenge API added to latest upstream acme.sh.

https://ipv64.net/

see acmesh-official/acme.sh#4420