### PR TITLE
Add post request custom protocol

### DIFF
--- a/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/dialogAccount.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/dialogAccount.xml
@@ -27,7 +27,7 @@
         <id>account.server</id>
         <label>Server</label>
         <type>text</type>
-        <help>DynDNS Server</help>
+        <help>DynDNS Server. For POST Request protocol type type the full url like api.example.com/2/ddns?domain=test.example.com&hostname=__HOSTNAME__&myip=__MYIP__. The placeholders are replaced with values from check ip method and the hostnames field</help>
         <style>optional_setting service_custom</style>
     </field>
     <field>

--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
@@ -93,6 +93,7 @@
                     <OptionValues>
                         <dyndns1>DynDns1</dyndns1>
                         <dyndns2>DynDns2</dyndns2>
+                        <postapi>POST Request</postapi>
                     </OptionValues>
                 </protocol>
                 <server type="HostnameField">


### PR DESCRIPTION
Still missing validation logic but besides that tries to implement post requests not using dyndns1 or dyndns2 protocols but instead a custom POST Request. Only difference is to choose `POST Request` protocol and for the server field type in a url like `api.example.com/2/ddns?domain=test.example.com&hostname=__HOSTNAME__&myip=__MYIP__` without http(s) scheme (it still respects force_ssl).