### PR TITLE
net/firewall: Make interface optional (like floating)

### DIFF
--- a/net/firewall/Makefile
+++ b/net/firewall/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		firewall
-PLUGIN_VERSION=		1.2
+PLUGIN_VERSION=		1.3
 PLUGIN_COMMENT=		Firewall API supplemental package
 PLUGIN_MAINTAINER=	ad@opnsense.org
 PLUGIN_TIER=		2

--- a/net/firewall/src/opnsense/mvc/app/models/OPNsense/Firewall/Filter.xml
+++ b/net/firewall/src/opnsense/mvc/app/models/OPNsense/Firewall/Filter.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/Firewall/Filter</mount>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <migration_prefix>MFP</migration_prefix>
     <description>
         OPNsense firewall filter rules
@@ -33,7 +33,7 @@
                     <Required>Y</Required>
                 </quick>
                 <interface type="InterfaceField">
-                    <Required>Y</Required>
+                    <Required>N</Required>
                     <multiple>Y</multiple>
                     <default>lan</default>
                     <AllowDynamic>Y</AllowDynamic>


### PR DESCRIPTION
Hi,

If you have a bash script calling couple of firewalls and don't want to care about interfaces (similar to floating rules), the API required an interface.

When setting this to `N` and applying the rules the rules.debug looks sane:

```
pass in quick on igb1 inet from {1.1.1.1} to {2.2.2.2} label "f24eb5c97fba314949e404267481211b" # testAPI
pass in quick inet from {1.1.1.1} to {2.2.2.2} label "00d1413e3dba729147b991cf3876a721" # testAPI2
```