### PR TITLE
security/acme: expose new values for Proxmox VE deployhook, closes #3516

### DIFF
--- a/security/acme-client/pkg-descr
+++ b/security/acme-client/pkg-descr
@@ -13,6 +13,7 @@ Plugin Changelog
 Added:
 * add support for TrueNAS deployhook (#3421)
 * add support for Proxmox VE deployhook (#3422)
+* add server,port and node name values for Proxmox VE deployhook (#3516)
 * add Google Domains DNS API
 
 3.17

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogAction.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogAction.xml
@@ -295,6 +295,24 @@
         <help>The user who owns the API key. Defaults to root.</help>
     </field>
     <field>
+        <id>action.acme_proxmoxve_server</id>
+        <label>Proxmox VE server</label>
+        <type>text</type>
+        <help>The hostname of the proxmox ve node.</help>
+    </field>
+    <field>
+        <id>action.acme_proxmoxve_port</id>
+        <label>Proxmox VE server port</label>
+        <type>text</type>
+        <help>The port number the management interface is on. Defaults to 8006.</help>
+    </field>
+    <field>
+        <id>action.acme_proxmoxve_nodename</id>
+        <label>Proxmox VE node name</label>
+        <type>text</type>
+        <help>The name of the node we will be connecting to.</help>
+    </field>
+    <field>
         <id>action.acme_proxmoxve_realm</id>
         <label>Proxmox VE realm</label>
         <type>text</type>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeAutomation/AcmeProxmoxve.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeAutomation/AcmeProxmoxve.php
@@ -39,6 +39,9 @@ class AcmeProxmoxve extends Base implements LeAutomationInterface
     public function prepare()
     {
         $this->acme_env['DEPLOY_PROXMOXVE_USER'] = (string)$this->config->acme_proxmoxve_user;
+        $this->acme_env['DEPLOY_PROXMOXVE_SERVER'] = (string)$this->config->acme_proxmoxve_server;
+        $this->acme_env['DEPLOY_PROXMOXVE_SERVER_PORT'] = (string)$this->config->acme_proxmoxve_port;
+        $this->acme_env['DEPLOY_PROXMOXVE_NODE_NAME'] = (string)$this->config->acme_proxmoxve_nodename;
         $this->acme_env['DEPLOY_PROXMOXVE_USER_REALM'] = (string)$this->config->acme_proxmoxve_realm;
         $this->acme_env['DEPLOY_PROXMOXVE_API_TOKEN_NAME'] = (string)$this->config->acme_proxmoxve_tokenid;
         $this->acme_env['DEPLOY_PROXMOXVE_API_TOKEN_KEY'] = (string)$this->config->acme_proxmoxve_tokenkey;

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -1395,9 +1395,22 @@
                     <mask>/^.{1,1024}$/u</mask>
                     <ValidationMessage>Should be a string between 1 and 1024 characters.</ValidationMessage>
                 </acme_proxmoxve_user>
+                <acme_proxmoxve_server type="TextField">
+                    <Required>N</Required>
+                    <mask>/^.{1,1024}$/u</mask>
+                    <ValidationMessage>Should be a string between 1 and 1024 characters.</ValidationMessage>
+                </acme_proxmoxve_server>
+                <acme_proxmoxve_port type="PortField">
+                    <default>8006</default>
+                    <Required>N</Required>
+                </acme_proxmoxve_port>
+                <acme_proxmoxve_nodename type="TextField">
+                    <Required>N</Required>
+                    <mask>/^.{1,1024}$/u</mask>
+                    <ValidationMessage>Should be a string between 1 and 1024 characters.</ValidationMessage>
+                </acme_proxmoxve_nodename>
                 <acme_proxmoxve_realm type="TextField">
                     <default>pam</default>
-                    <Required>N</Required>
                     <Required>N</Required>
                     <mask>/^.{1,1024}$/u</mask>
                     <ValidationMessage>Should be a string between 1 and 1024 characters.</ValidationMessage>


### PR DESCRIPTION
closes #3516