### PR TITLE
Add "friendly_name" to wg config for prom wg exporter

### DIFF
--- a/net/wireguard/src/opnsense/service/templates/OPNsense/Wireguard/wireguard-server.conf
+++ b/net/wireguard/src/opnsense/service/templates/OPNsense/Wireguard/wireguard-server.conf
@@ -30,6 +30,7 @@ PostDown = route {{- ' -6' if ':' in server_list.gateway }} del {{ server_list.g
 {%             if peerlist2_data != {} and peerlist2_data.enabled == '1' %}
 
 [Peer]
+# friendly_name = {{ peerlist2_data.name }}
 PublicKey = {{ peerlist2_data.pubkey }}
 {%               if peerlist2_data.psk|default('') != '' %}
 PresharedKey = {{ peerlist2_data.psk }}


### PR DESCRIPTION
This adds '# friendly_name = {{ peerlist2_data.name }}" for each peer.

With this it is possible to run the [MindFlavor/prometheus_wireguard_exporter](https://github.com/MindFlavor/prometheus_wireguard_exporter) on OPNsense and get the prom label `friendly_name` - if enabled in the exporter.

IMO there is no downside in writing this to the wg config because _everyone_ could get this information anyway from the local filesystem.

i will eventually figure out how to make a plugin / package for the exporter itself and submit that as well.
(dunno how / what is necessary but im familiar with RPM building and hope the difference is minimal)
in the meantime this change would make it easy for everyone willing to install the exporter on their own.

despite the fact that there is basically no real world use for this change i hope you consider accepting this PR.
even if it is useless for most user - at least ATM. 😄 