### PR TITLE
net/relayd - sync with OpenBSD 

### DIFF
--- a/net/relayd/Makefile
+++ b/net/relayd/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		relayd
-PLUGIN_VERSION=		2.7
+PLUGIN_VERSION=		2.8
 PLUGIN_DEPENDS=		relayd
 PLUGIN_COMMENT=		Relayd Load Balancer
 PLUGIN_MAINTAINER=	frank.brendel@eurolog.com

--- a/net/relayd/src/opnsense/mvc/app/controllers/OPNsense/Relayd/Api/StatusController.php
+++ b/net/relayd/src/opnsense/mvc/app/controllers/OPNsense/Relayd/Api/StatusController.php
@@ -47,13 +47,13 @@ class StatusController extends ApiControllerBase
      */
     public function sumAction($wait = 0)
     {
-        $result = array("result" => "failed");
+        $result = ["result" => "failed"];
         $backend = new Backend();
         $relaydMdl = new Relayd();
 
         // when $wait is set, try for max 10 seconds to receive a sensible status (wait for unknowns to resolve)
         $max_tries = !empty($wait) ? 10 : 1;
-        $output = array();
+        $output = [];
         for ($i = 0; $i < $max_tries; $i++) {
             $output = explode("\n", trim($backend->configdRun('relayd summary')));
             $unknowns = 0;
@@ -75,8 +75,8 @@ class StatusController extends ApiControllerBase
         $virtualServerId = 0;
         $virtualServerType = '';
         $tableId = 0;
-        $virtualserver = array();
-        $rows = array();
+        $virtualserver = [];
+        $rows = [];
         foreach ($output as $line) {
             $words = array_map('trim', explode("\t", $line));
             $id = $words[0];
@@ -138,7 +138,7 @@ class StatusController extends ApiControllerBase
                 $virtualserver['id'] = $id;
                 $virtualserver['type'] = $type;
                 $virtualserver['name'] = $words[2];
-                $virtualserver['status'] = $words[4];
+                $virtualserver['status'] = $words[4] ?? null;
                 $objs = $relaydMdl->getObjectsByAttribute("virtualserver", "name", $virtualserver['name']);
                 if (count($objs) > 0) {
                     $obj = $objs[0];
@@ -200,7 +200,7 @@ class StatusController extends ApiControllerBase
      */
     public function toggleAction($nodeType = null, $id = null, $action = null)
     {
-        $result = array("result" => "failed", "function" => "toggle");
+        $result = ["result" => "failed", "function" => "toggle"];
         if ($this->request->isPost()) {
             $this->sessionClose();
             $backend = new Backend();

--- a/net/relayd/src/opnsense/mvc/app/models/OPNsense/Relayd/Migrations/M1_0_5.php
+++ b/net/relayd/src/opnsense/mvc/app/models/OPNsense/Relayd/Migrations/M1_0_5.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * Copyright (C) 2023 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Relayd\Migrations;
+
+use OPNsense\Base\BaseModelMigration;
+
+class M1_0_5 extends BaseModelMigration
+{
+    public function run($model)
+    {
+        foreach ($model->tablecheck->iterateItems() as $tablecheck) {
+            if ($tablecheck->type == 'ssl') {
+                $tablecheck->type = 'tls';
+            }
+        }
+    }
+}

--- a/net/relayd/src/opnsense/mvc/app/models/OPNsense/Relayd/Relayd.xml
+++ b/net/relayd/src/opnsense/mvc/app/models/OPNsense/Relayd/Relayd.xml
@@ -1,6 +1,6 @@
 <model>
    <mount>//OPNsense/relayd</mount>
-   <version>1.0.4</version>
+   <version>1.0.5</version>
    <description>Relayd settings</description>
    <items>
       <general>
@@ -113,7 +113,7 @@
             <OptionValues>
                <icmp>ICMP</icmp>
                <tcp>TCP</tcp>
-               <ssl>SSL</ssl>
+               <tls>TLS</tls>
                <send>SEND</send>
                <script>SCRIPT</script>
                <http>HTTP</http>

--- a/net/relayd/src/opnsense/service/templates/OPNsense/Relayd/relayd.conf
+++ b/net/relayd/src/opnsense/service/templates/OPNsense/Relayd/relayd.conf
@@ -7,7 +7,10 @@
 interval {{ OPNsense.relayd.general.interval }}
 {%  endif %}
 {%  if helpers.exists('OPNsense.relayd.general.log') %}
-log {{ OPNsense.relayd.general.log }}
+log state changes
+{%    if OPNsense.relayd.general.log == 'all' %}
+log host checks
+{%    endif %}
 {%  endif %}
 {%  if helpers.exists('OPNsense.relayd.general.prefork') %}
 prefork {{ OPNsense.relayd.general.prefork }}

--- a/net/relayd/src/opnsense/service/templates/OPNsense/Relayd/relayd.conf
+++ b/net/relayd/src/opnsense/service/templates/OPNsense/Relayd/relayd.conf
@@ -110,7 +110,7 @@ disable
 {%          elif tablecheck.type == 'send' and tablecheck.expect is defined %}
 {%            set _tablecheck = 'check ' ~ tablecheck.type ~ ' "' ~ tablecheck.data ~ '" expect "' ~ tablecheck.expect ~ '"' %}
 {%            if tablecheck.ssl|default('0') == '1' %}
-{%              set _tablecheck = _tablecheck ~ ' ssl' %}
+{%              set _tablecheck = _tablecheck ~ ' tls' %}
 {%            endif %}
 {%          else %}
 {%            set _tablecheck = 'check ' ~ tablecheck.type %}
@@ -145,7 +145,7 @@ disable
 {%          elif backuptablecheck.type == 'send' and backuptablecheck.expect is defined %}
 {%            set _backuptablecheck = 'check ' ~ backuptablecheck.type ~ ' "' ~ backuptablecheck.data ~ '" expect "' ~ backuptablecheck.expect ~ '"' %}
 {%            if backuptablecheck.ssl|default('0') == '1' %}
-{%              set _backuptablecheck = _backuptablecheck ~ ' ssl' %}
+{%              set _backuptablecheck = _backuptablecheck ~ ' tls' %}
 {%            endif %}
 {%          else %}
 {%            set _backuptablecheck = 'check ' ~ backuptablecheck.type %}


### PR DESCRIPTION
An updated relayd version is on it's way, which should bring FreeBSD's version in sync with upstream OpenBSD (https://github.com/freebsd/freebsd-ports/commit/c9ba90c07ddc5b9f4232f831cf301fdc939303f3). Since some small things have changed, we need a migration and a some small config changes.

A test build is available  at https://pkg.opnsense.org/FreeBSD:13:amd64/snapshots/misc/relayd-7.3.2023.05.09.p2.pkg

