### PR TITLE
security/tinc: add support for "StrictSubnets" variable

### DIFF
--- a/security/tinc/src/opnsense/mvc/app/controllers/OPNsense/Tinc/forms/dialogNetwork.xml
+++ b/security/tinc/src/opnsense/mvc/app/controllers/OPNsense/Tinc/forms/dialogNetwork.xml
@@ -33,6 +33,15 @@
         </help>
     </field>
     <field>
+        <id>network.StrictSubnets</id>
+        <label>StrictSubnets</label>
+        <type>checkbox</type>
+        <help>When this option is enabled tinc will only use Subnet statements which are present in the host config files in the local /etc/tinc/netname/hosts/ directory.
+          Subnets learned via connections to other nodes and which are not present in the local host config files are ignored.
+        </help>
+        <advanced>true</advanced>
+    </field>
+    <field>
       <id>network.cipher</id>
       <label>Cipher</label>
       <type>dropdown</type>

--- a/security/tinc/src/opnsense/mvc/app/models/OPNsense/Tinc/Tinc.xml
+++ b/security/tinc/src/opnsense/mvc/app/models/OPNsense/Tinc/Tinc.xml
@@ -60,6 +60,10 @@
                     <MaximumValue>65535</MaximumValue>
                     <ValidationMessage>Ping timeout must be between 1...65535</ValidationMessage>
                 </pingtimeout>
+                    <StrictSubnets type="BooleanField">
+                        <default>0</default>
+                        <Required>N</Required>
+                    </StrictSubnets>
                 <privkey type="TextField">
                     <Required>Y</Required>
                 </privkey>

--- a/security/tinc/src/opnsense/scripts/OPNsense/Tinc/lib/objects.py
+++ b/security/tinc/src/opnsense/scripts/OPNsense/Tinc/lib/objects.py
@@ -69,6 +69,7 @@ class Network(NetwConfObject):
         self._payload['debuglevel'] = 'd0'
         self._payload['mode'] = 'switch'
         self._payload['PMTUDiscovery'] = 'yes'
+        self._payload['StrictSubnets'] = 'no'
         self._hosts = list()
 
     def get_id(self):
@@ -99,6 +100,12 @@ class Network(NetwConfObject):
         else:
             self._payload['PMTUDiscovery'] = 'yes'
 
+    def set_StrictSubnets(self, value):
+        if value.text != '1':
+            self._payload['StrictSubnets'] = 'no'
+        else:
+            self._payload['StrictSubnets'] = 'yes'
+
     def config_text(self):
         result = list()
         result.append('AddressFamily=any')
@@ -106,6 +113,7 @@ class Network(NetwConfObject):
         result.append('PMTUDiscovery=%(PMTUDiscovery)s' % self._payload)
         result.append('Port=%(port)s' % self._payload)
         result.append('PingTimeout=%(pingtimeout)s' % self._payload)
+        result.append('StrictSubnets=%(StrictSubnets)s' % self._payload)
         for host in self._hosts:
             if host.connect_to_this_host():
                 result.append('ConnectTo = %s' % (host.get_hostname(),))

--- a/security/tinc/src/opnsense/service/templates/OPNsense/Tinc/tinc_deploy.xml
+++ b/security/tinc/src/opnsense/service/templates/OPNsense/Tinc/tinc_deploy.xml
@@ -14,6 +14,7 @@
         <port>{{network.extport}}</port>
         <debuglevel>{{network.debuglevel}}</debuglevel>
         <pingtimeout>{{network.pingtimeout}}</pingtimeout>
+        <StrictSubnets>{{network.StrictSubnets}}</StrictSubnets>
         <hosts>
             <host>
                 <hostname>{{network.hostname}}</hostname>


### PR DESCRIPTION
In our setup we need to set the "StrictSubnets" variable to "yes", in order to prevent traffic to hosts not directly known (please see more extensive explanation [here](https://tinc-vpn.org/documentation/Main-configuration-variables.html#index-StrictSubnets)).

This commit allows to set the value, defaulting to "no", thus without impacting existing configurations.