### PR TITLE
Add desec service provider to ddclient OPnsense backend

### DIFF
--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/dyndns2.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/dyndns2.py
@@ -34,6 +34,8 @@ class DynDNS2(BaseAccount):
 
     _services = {
         'dyndns2': 'members.dyndns.org',
+        'desec-v4': 'update.dedyn.io',
+        'desec-v6': 'update6.dedyn.io',
         'dns-o-matic': 'updates.dnsomatic.com',
         'dynu': 'api.dynu.com',
         'he-net': 'dyn.dns.he.net',


### PR DESCRIPTION
desec uses also dyndns2 protocol and can therefore directly added to the list of supported services. config is

- Services: Dynamic DNS: Settings: Edit Account Enabled [X]
Service [desec (v6)]
Protocol  [DynDNS2]
Username [Your Domain]
Password [Your DeSec Token]
Hostname(s) [Your Domain]
Check ip method [Interface [IPv6]]
Force SSL [X]
Interface to monitor [Your WAN Interface]

- Services: Dynamic DNS: Settings: Edit Account Enabled [X]
Service [desec (v4)]
Protocol  [DynDNS2]
Username [Your Domain]
Password [Your DeSec Token]
Hostname(s) [Your Domain]
Check ip method [Interface [IPv4]]
Force SSL [X]
Interface to monitor [Your WAN Interface]