### PR TITLE
benchmarks/iperf: add rubygem-rexml dependency

### DIFF
--- a/benchmarks/iperf/Makefile
+++ b/benchmarks/iperf/Makefile
@@ -1,6 +1,6 @@
 PLUGIN_NAME=		iperf
 PLUGIN_VERSION=		1.0
-PLUGIN_REVISION=	2
+PLUGIN_REVISION=	1
 PLUGIN_COMMENT=		Connection speed tester
 PLUGIN_DEPENDS=		iperf3 ruby rubygem-rexml
 PLUGIN_MAINTAINER=	franz.fabian.94@gmail.com

--- a/benchmarks/iperf/Makefile
+++ b/benchmarks/iperf/Makefile
@@ -1,8 +1,8 @@
 PLUGIN_NAME=		iperf
 PLUGIN_VERSION=		1.0
-PLUGIN_REVISION=	1
+PLUGIN_REVISION=	2
 PLUGIN_COMMENT=		Connection speed tester
-PLUGIN_DEPENDS=		iperf3 ruby
+PLUGIN_DEPENDS=		iperf3 ruby rubygem-rexml
 PLUGIN_MAINTAINER=	franz.fabian.94@gmail.com
 
 .include "../../Mk/plugins.mk"


### PR DESCRIPTION
Adds the missing rubygem-rexml dependency to os-iperf
This makes the service startable and allows the Interfaces -> Diagnostics -> iperf GUI to work again

Fixes #3522