### PR TITLE
Fix opnsense#3390, wrong myhostname 

### DIFF
--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
@@ -43,7 +43,7 @@ smtp_tls_CAfile = /etc/ssl/cert.pem
 ##########################
 
 {% if helpers.exists('OPNsense.postfix.general.myhostname') and OPNsense.postfix.general.myhostname != '' %}
-myhostname = {{ OPNsense.postfix.general.myhostname }}
+myhostname = {{ OPNsense.postfix.general.myhostname }}.{{ OPNsense.postfix.general.mydomain }}
 {% else %}
 myhostname = {{ system.hostname }}.{{ system.domain }}
 {% endif %}

--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
@@ -45,7 +45,7 @@ smtp_tls_CAfile = /etc/ssl/cert.pem
 {% if helpers.exists('OPNsense.postfix.general.myhostname') and OPNsense.postfix.general.myhostname != '' %}
 myhostname = {{ OPNsense.postfix.general.myhostname }}
 {% else %}
-myhostname = {{ system.hostname }}
+myhostname = {{ system.hostname }}.{{ system.domain }}
 {% endif %}
 {% if helpers.exists('OPNsense.postfix.general.mydomain') and OPNsense.postfix.general.mydomain != '' %}
 mydomain = {{ OPNsense.postfix.general.mydomain }}


### PR DESCRIPTION
Fixed recording the official postfix documentation: https://www.postfix.org/postconf.5.html#myhostname