### PR TITLE
sysutils/git-backup: encrypt config when encryption password is provided

### DIFF
--- a/sysutils/git-backup/src/etc/rc.syshook.d/config/10-git-backup
+++ b/sysutils/git-backup/src/etc/rc.syshook.d/config/10-git-backup
@@ -1,5 +1,6 @@
 #!/usr/local/bin/python3
 """
+    Copyright (c) 2023 Thomas Rogdakis <thomas@rogdakis.com>
     Copyright (c) 2020 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
     Redistribution and use in source and binary forms, with or without
@@ -25,9 +26,12 @@ import os
 import subprocess
 import sys
 import xml.etree.ElementTree as ET
+import syslog
 
 
 if len(sys.argv) > 1:
+    syslog.openlog('git-backup', facility=syslog.LOG_LOCAL4)
+
     commit_msg =  "unknown change"
     try:
         tree = ET.parse(sys.argv[1])
@@ -70,6 +74,11 @@ if len(sys.argv) > 1:
         # snapshot provided config.xml into git staging and commit with extracted data
         os.chdir('/conf/backup/git/')
         subprocess.run(['cp', sys.argv[1], '/conf/backup/git/config.xml'])
+        # encrypt before staging the file
+        encrypt_result = subprocess.run(['/usr/local/bin/php', '/usr/local/opnsense/scripts/OPNsense/GitBackup/EncryptConfig.php'])
+        if encrypt_result.returncode != 0:
+             syslog.syslog(syslog.LOG_ERR, f'EncryptConfig script returned unexpected code: {encrypt_result.returncode}')
+             os.exit(1)
         subprocess.run(['/usr/local/bin/git', 'add', 'config.xml'])
         message = "%s @ %s (%s)" % (metadata['./revision/description'], revdate, metadata['./revision/username'])
         subprocess.run(['/usr/local/bin/git', 'commit', '--author', "%s<%s>" % (fullname, user_email), '-m', message])

--- a/sysutils/git-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Git.php
+++ b/sysutils/git-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Git.php
@@ -1,6 +1,7 @@
 <?php
 
 /**
+ *    Copyright (C) 2023 Thomas Rogdakis <thomas@rogdakis.com>
  *    Copyright (C) 2020 Deciso B.V.
  *
  *    All rights reserved.
@@ -84,6 +85,16 @@ class Git extends Base implements IBackupProvider
              "type" => "password",
              "label" => gettext("Password"),
              "value" => null
+           ],
+           [
+             "name" => "encryption_password",
+             "type" => "password",
+             "label" => gettext("Encryption Password"),
+             "value" => null,
+             'help' => gettext(
+                "When provided, the config will be encrypted before pushing it to Git.<br/>" .
+                "Disclaimer: When encryption is enabled, git diff will not be possible."
+             )
            ]
         ];
         $mdl = new GitSettings();

--- a/sysutils/git-backup/src/opnsense/mvc/app/models/OPNsense/Backup/GitSettings.xml
+++ b/sysutils/git-backup/src/opnsense/mvc/app/models/OPNsense/Backup/GitSettings.xml
@@ -49,5 +49,8 @@
         </user>
         <password type="TextField">
         </password>
+        <encryption_password type="TextField">
+          <Required>N</Required>
+        </encryption_password>
     </items>
 </model>

--- a/sysutils/git-backup/src/opnsense/scripts/OPNsense/GitBackup/EncryptConfig.php
+++ b/sysutils/git-backup/src/opnsense/scripts/OPNsense/GitBackup/EncryptConfig.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ *    Copyright (C) 2023 Thomas Rogdakis <thomas@rogdakis.com>
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+require_once('script/load_phalcon.php');
+
+use OPNsense\Backup\Local;
+use OPNsense\Core\Config;
+
+$local = new Local();
+$config = Config::getInstance()->object();
+$gitSettings = $config->system?->backup?->git;
+
+if ($gitSettings === null) {
+  syslog(LOG_ERR, 'git-backup: failed to fetch git backup settings from config');
+  exit(1);
+}
+
+$password = $gitSettings->encryption_password;
+
+// if the password is empty, we don't want to encrypt the config
+if ($password === null || mb_strlen($password) === 0) {
+  exit(0);
+}
+
+$data = file_get_contents('/conf/backup/git/config.xml');
+$encryptedData = $local->encrypt($data, $password);
+
+file_put_contents('/conf/backup/git/config.xml', $encryptedData);


### PR DESCRIPTION
This PR allows users to provide an encryption password to encrypt the backup config before pushing it to Git.