### PR TITLE
net/frr - add default-information originate option for OSPFv3. 

### DIFF
--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/ospf6.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/ospf6.xml
@@ -28,4 +28,25 @@
         <type>text</type>
         <help>Router ID as IPv4 Address</help>
     </field>
+    <field>
+        <id>ospf6.originate</id>
+        <label>Advertise Default Gateway</label>
+        <type>checkbox</type>
+        <help>This will send the information that we have a default gateway.</help>
+        <style>opt_checkbox</style>
+    </field>
+    <field>
+        <id>ospf6.originatealways</id>
+        <label>Always Advertise Default Gateway</label>
+        <type>checkbox</type>
+        <help>This will send the information that we have a default gateway, regardless of if it is available.</help>
+        <style>ospf6_originate</style>
+    </field>
+    <field>
+        <id>ospf6.originatemetric</id>
+        <label>Advertise Default Gateway Metric</label>
+        <type>text</type>
+        <help>This let you manipulate the metric when advertising default gateway.</help>
+        <style>ospf6_originate</style>
+    </field>
 </form>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF6.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF6.xml
@@ -25,6 +25,20 @@
                 <Required>N</Required>
                 <mask>/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/</mask>
         </routerid>
+        <originate type="BooleanField">
+            <default>0</default>
+            <Required>Y</Required>
+        </originate>
+        <originatealways type="BooleanField">
+            <default>0</default>
+            <Required>Y</Required>
+        </originatealways>
+        <originatemetric type="IntegerField">
+            <Required>N</Required>
+            <MinimumValue>0</MinimumValue>
+            <MaximumValue>16777214</MaximumValue>
+            <ValidationMessage>Must be a number between 0 and 16777214.</ValidationMessage>
+        </originatemetric>
         <interfaces>
                 <interface type="ArrayField">
                         <enabled type="BooleanField">

--- a/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/ospf6.volt
+++ b/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/ospf6.volt
@@ -1,6 +1,6 @@
 {#
 
-OPNsense® is Copyright © 2014 – 2017 by Deciso B.V.
+OPNsense® is Copyright © 2014 – 2023 by Deciso B.V.
 This file is Copyright © 2017 by Fabian Franz
 This file is Copyright © 2017 by Michael Muenz <m.muenz@gmail.com>
 All rights reserved.
@@ -64,7 +64,6 @@ POSSIBILITY OF SUCH DAMAGE.
                     <td colspan="5"></td>
                     <td>
                         <button data-action="add" type="button" class="btn btn-xs btn-default"><span class="fa fa-plus"></span></button>
-                        <!-- <button data-action="deleteSelected" type="button" class="btn btn-xs btn-default"><span class="fa fa-trash-o"></span></button> -->
                         <button type="button" class="btn btn-xs reload_btn btn-primary"><span class="fa fa-refresh reloadAct_progress"></span> {{ lang._('Reload Service') }}</button>
                     </td>
                 </tr>
@@ -76,10 +75,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 <script>
 
-function quagga_update_status() {
-  updateServiceControlUI('quagga');
-}
-
 $( document ).ready(function() {
   var data_get_map = {'frm_ospf6_settings':"/api/quagga/ospf6settings/get"};
   mapDataToFormUI(data_get_map).done(function(data){
@@ -87,14 +82,14 @@ $( document ).ready(function() {
       $('.selectpicker').selectpicker('refresh');
   });
 
-  quagga_update_status();
+  updateServiceControlUI('quagga');
 
   // link save button to API set action
   $("#saveAct").click(function(){
       saveFormToEndpoint(url="/api/quagga/ospf6settings/set",formid='frm_ospf6_settings',callback_ok=function(){
         $("#saveAct_progress").addClass("fa fa-spinner fa-pulse");
         ajaxCall(url="/api/quagga/service/reconfigure", sendData={}, callback=function(data,status) {
-          quagga_update_status();
+          updateServiceControlUI('quagga');
           $("#saveAct_progress").removeClass("fa fa-spinner fa-pulse");
         });
       });
@@ -104,7 +99,7 @@ $( document ).ready(function() {
   $('.reload_btn').click(function reload_handler() {
     $(".reloadAct_progress").addClass("fa-spin");
     ajaxCall(url="/api/quagga/service/reconfigure", sendData={}, callback=function(data,status) {
-      quagga_update_status();
+      updateServiceControlUI('quagga');
       $(".reloadAct_progress").removeClass("fa-spin");
     });
   });
@@ -119,6 +114,15 @@ $( document ).ready(function() {
       'options':{selection:false, multiSelect:false}
     }
   );
+
+  // hook checkbox item with conditional options
+  $(".opt_checkbox").change(function(){
+      if ($(this).is(':checked')) {
+          $("." + $(this).attr('id').replace('.', '_')).closest('tr').show();
+      } else {
+          $("." + $(this).attr('id').replace('.', '_')).closest('tr').hide();
+      }
+  });
 });
 </script>
 

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospf6d.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospf6d.conf
@@ -48,6 +48,10 @@ router ospf6
 {% if helpers.exists('OPNsense.quagga.ospf6.routerid') and OPNsense.quagga.ospf6.routerid != '' %}
  ospf6 router-id {{ OPNsense.quagga.ospf6.routerid }}
 {% endif %}
+{% if not helpers.empty('OPNsense.quagga.ospf6.originate') %}
+ default-information originate{% if not helpers.empty('OPNsense.quagga.ospf6.originatealways')  %} always {% endif %}{% if OPNsense.quagga.ospf6.originatemetric|default('') != '' %} metric {{ OPNsense.quagga.ospf6.originatemetric }}{% endif %}
+
+{% endif %}
 {% if helpers.exists('OPNsense.quagga.ospf6.redistribute') and OPNsense.quagga.ospf6.redistribute != '' %}
 {% for line in OPNsense.quagga.ospf6.redistribute.split(',') %}
  redistribute {{ line }}


### PR DESCRIPTION
Add "Advertise Default Gateway" option in Routing: OSPFv3, closes https://github.com/opnsense/plugins/issues/3519. 

upstream documentation reference : 
* https://docs.frrouting.org/en/latest/ospf6d.html#clicmd-default-information-originate-always-metric-0-16777214-metric-type-1-2-route-map-WORD

