### PR TITLE
dns/bind: Add DDNS zone updates

### DIFF
--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/Api/DomainController.php
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/Api/DomainController.php
@@ -53,7 +53,7 @@ class DomainController extends ApiMutableModelControllerBase
     {
         return $this->searchBase(
             'domains.domain',
-            [ 'enabled', 'type', 'domainname', 'ttl', 'refresh', 'retry', 'expire', 'negative' ],
+            [ 'enabled', 'type', 'domainname', 'ttl', 'refresh', 'retry', 'expire', 'negative', 'allowddnsupdate' ],
             'domainname',
             function ($record) {
                 return $record->type->getNodeData()['primary']['selected'] === 1;

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindPrimaryDomain.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindPrimaryDomain.xml
@@ -65,4 +65,10 @@
         <type>text</type>
         <help>Set the DNS server hosting this file. This should usually be the FQDN of your firewall where the BIND plugin is installed.</help>
     </field>
+    <field>
+        <id>domain.allowddnsupdate</id>
+        <label>Allow DDNS Updates from a dhcp server</label>
+        <type>checkbox</type>
+        <help>This will enable a ddns updates from a dhcp-server for this zone (key defined in "General").</help>
+    </field>
 </form>

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/general.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/general.xml
@@ -171,6 +171,28 @@
     </field>
     <field>
         <type>header</type>
+        <label>Dynamic DNS from DHCP-Server</label>
+    </field>
+    <field>
+        <id>general.enableddnsupdates</id>
+        <label>Enable DDNS Updates from a dhcp server</label>
+        <type>checkbox</type>
+        <help>This will enable a ddns updates from a dhcp-server with the key options below.</help>
+    </field>
+    <field>
+        <id>general.ddnsalgorithm</id>
+        <label>DDNS Updates Key Algorithm</label>
+        <type>dropdown</type>
+        <help>Option "algorithm" of the DDNS-update-key</help>
+    </field>
+    <field>
+        <id>general.ddnssecret</id>
+        <label>DDNS Updates Key Secret</label>
+        <type>text</type>
+        <help>Option "secret" of the DDNS update-key "dhcp-key", generate with tsig-keygen</help>
+    </field>
+    <field>
+        <type>header</type>
         <label>RNDC Key</label>
         <advanced>true</advanced>
     </field>

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/general.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/general.xml
@@ -192,6 +192,12 @@
         <help>Option "secret" of the DDNS update-key "dhcp-key", generate with tsig-keygen</help>
     </field>
     <field>
+        <id>general.dhcpstaticmappings</id>
+        <label>Add DHCP static mappings</label>
+        <type>checkbox</type>
+        <help>Add DNS entries for the static dhcp mappings if the ddns-domain in dhcp network is set.</help>
+    </field>
+    <field>
         <type>header</type>
         <label>RNDC Key</label>
         <advanced>true</advanced>

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Domain.php
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Domain.php
@@ -44,8 +44,9 @@ class Domain extends BaseModel
             }
         }
         // new serials on changed records
+        $lastupdate = (string)time();
         foreach ($serialsToSet as $domain) {
-            $domain->serial = (string)date("ymdHi");
+            $domain->serial = $lastupdate;
         }
         return parent::serializeToConfig($validateFullModel, $disable_validation);
     }
@@ -58,7 +59,7 @@ class Domain extends BaseModel
     {
         foreach ($this->domains->domain->iterateItems() as $domain) {
             if ($domain->getAttribute('uuid') == $uuid) {
-                $domain->serial = (string)date("ymdHi");
+                $domain->serial = (string)time();
                 return $this;
             }
         }

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Domain.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Domain.xml
@@ -72,6 +72,10 @@
                     <Multiple>Y</Multiple>
                     <Required>N</Required>
                 </allowquery>
+                <allowddnsupdate type="BooleanField">
+                    <default>0</default>
+                    <Required>N</Required>
+                </allowddnsupdate>
                 <serial type="TextField">
                     <Required>N</Required>
                 </serial>

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/General.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/General.xml
@@ -170,5 +170,23 @@
             <Required>Y</Required>
             <default>VxtIzJevSQXqnr7h2qerrcwjnZlMWSGGFBndKeNIDfw=</default>
         </rndcsecret>
+        <enableddnsupdates type="BooleanField">
+            <default>0</default>
+            <Required>N</Required>
+        </enableddnsupdates>
+        <ddnsalgorithm type="OptionField">
+            <OptionValues>
+                <hmac-md5>HMAC-MD5</hmac-md5>
+                <hmac-sha256>HMAC-SHA256</hmac-sha256>
+                <hmac-sha512>HMAC-SHA512</hmac-sha512>
+            </OptionValues>
+            <default>hmac-sh256</default>
+            <Multiple>N</Multiple>
+            <Required>N</Required>
+        </ddnsalgorithm>
+         <ddnssecret type="TextField">
+            <default></default>
+            <Required>N</Required>
+        </ddnssecret>
     </items>
 </model>

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/General.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/General.xml
@@ -188,5 +188,9 @@
             <default></default>
             <Required>N</Required>
         </ddnssecret>
+        <dhcpstaticmappings type="BooleanField">
+            <default>0</default>
+            <Required>N</Required>
+        </dhcpstaticmappings>
     </items>
 </model>

--- a/dns/bind/src/opnsense/scripts/OPNsense/Bind/setup.sh
+++ b/dns/bind/src/opnsense/scripts/OPNsense/Bind/setup.sh
@@ -15,3 +15,6 @@ chmod 755 /var/stats
 mkdir -p /var/log/named
 chown -R bind:bind /var/log/named
 chmod 755 /var/log/named
+
+chown bind /usr/local/etc/namedb/primary
+chown bind /usr/local/etc/namedb/secondary

--- a/dns/bind/src/opnsense/service/conf/actions.d/actions_bind.conf
+++ b/dns/bind/src/opnsense/service/conf/actions.d/actions_bind.conf
@@ -5,13 +5,13 @@ type:script
 message:starting BIND
 
 [stop]
-command:/usr/local/etc/rc.d/named stop
+command:rndc -c /usr/local/etc/namedb/rndc.conf sync -clean; /usr/local/etc/rc.d/named stop
 parameters:
 type:script
 message:stopping BIND
 
 [restart]
-command:/usr/local/etc/rc.d/named restart
+command:rndc -c /usr/local/etc/namedb/rndc.conf sync -clean; /usr/local/etc/rc.d/named restart
 parameters:
 type:script
 message:restarting BIND

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/domain.db
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/domain.db
@@ -10,6 +10,22 @@ $TTL {{ domaindb.ttl }}
 {{ record.name }}                {{ record.type }} {{ record.value }}
 {%             endif %}
 {%           endfor %}
+{%           if helpers.exists('dhcpd') and helpers.exists('OPNsense.bind.general.dhcpstaticmappings') and OPNsense.bind.general.dhcpstaticmappings == '1' %}
+{%             for interface_name, interface in dhcpd.items() %}
+{%               if 'staticmap' in interface %}
+{%                 for staticmapping in interface.staticmap %}
+{%                   if (('ddnsdomain' in staticmapping) or ('ddnsdomain' in interface)) and 'ipaddr' in staticmapping and 'hostname' in staticmapping %}
+{%                     set ddnsdomain=staticmapping.ddnsdomain if ('ddnsdomain' in staticmapping) else interface.ddnsdomain %}
+{%                     if domaindb.domainname == ddnsdomain %}
+{{ staticmapping.hostname }}                A {{ staticmapping.ipaddr }}
+{%                     elif domaindb.domainname == '.'.join(staticmapping.ipaddr.split('.')[-2::-1]) + '.in-addr.arpa' %}
+{{ staticmapping.ipaddr.split('.')[3] }}                PTR {{ staticmapping.hostname }}.{{ ddnsdomain }}.
+{%                     endif %}
+{%                   endif %}
+{%                 endfor %}
+{%               endif %}
+{%             endfor %}
+{%           endif %}
 {%         endif %}
 {%       endif %}
 {%     endfor %}

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
@@ -14,6 +14,7 @@ options {
         pid-file        "/var/run/named/pid";
         dump-file       "/var/dump/named_dump.db";
         statistics-file "/var/stats/named.stats";
+        serial-update-method unixtime;
 
 {% for listenv4 in OPNsense.bind.general.listenv4.split(',') %}
         listen-on port {{ OPNsense.bind.general.port }} { {% if listenv4 == '0.0.0.0' %}any{% else %}{{ listenv4 }}{% endif %}; };
@@ -112,6 +113,13 @@ controls {
 };
 {% endif %}
 
+{% if helpers.exists('OPNsense.bind.general.enableddnsupdates') and OPNsense.bind.general.enableddnsupdates == '1' %}
+key "dhcp-key" {
+        algorithm {{ OPNsense.bind.general.ddnsalgorithm }};
+        secret "{{ OPNsense.bind.general.ddnssecret }}";
+};
+{% endif %}
+
 zone "." { type hint; file "/usr/local/etc/namedb/named.root"; };
 
 zone "localhost"        { type primary; file "/usr/local/etc/namedb/primary/localhost-forward.db"; };
@@ -180,6 +188,9 @@ zone "{{ domain.domainname }}" {
 {%              endfor %}
         };
 {%      endif %}
+{% if domain.allowddnsupdate is defined and domain.allowddnsupdate == '1' %}
+        allow-update { key "dhcp-key"; };
+{% endif %}
 };
 {%       if domain.type == 'secondary' and domain.transferkey is defined and not(domain.transferkeyname in usedkeys) %}
 {%         do usedkeys.append(domain.transferkeyname) %}


### PR DESCRIPTION
The DDNS zone updates from an DHCP-Server are pretty rudimentary but should work quite stable. If there are any suggestions to improve this, let me know.
Please keep in mind: All dynamically added DNS Entries are lost after a restart of bind. If you enable the option for the static dhcp mappings to be added, they would be added after a restart.