### PR TITLE
security/crowdsec - add option `retry_initial_connect` to bouncer configuration for more robust startup

### DIFF
--- a/security/crowdsec/Makefile
+++ b/security/crowdsec/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		crowdsec
-PLUGIN_VERSION=		1.0.6
+PLUGIN_VERSION=		1.0.7
 PLUGIN_DEPENDS=		crowdsec
 PLUGIN_COMMENT=		Lightweight and collaborative security engine
 PLUGIN_MAINTAINER=	marco@crowdsec.net

--- a/security/crowdsec/pkg-descr
+++ b/security/crowdsec/pkg-descr
@@ -8,6 +8,10 @@ WWW: https://crowdsec.net/
 Plugin Changelog
 ================
 
+1.0.7
+
+* Add option `retry_initial_connect` to bouncer configuration for more robust startup. The option was introduced in Crowdsec 1.5.4.
+
 1.0.6
 
  * default acquis.d/opnsense.yaml to "poll_without_inotify=true" which is now required

--- a/security/crowdsec/src/opnsense/scripts/OPNsense/CrowdSec/reconfigure.py
+++ b/security/crowdsec/src/opnsense/scripts/OPNsense/CrowdSec/reconfigure.py
@@ -69,6 +69,7 @@ def configure_bouncer(settings):
     config['log_dir'] = '/var/log/crowdsec'
     config['blacklists_ipv4'] = 'crowdsec_blacklists'
     config['blacklists_ipv6'] = 'crowdsec6_blacklists'
+    config['retry_initial_connect'] = True
     config['pf'] = {'anchor_name': ''}
 
     if not int(settings.get('lapi_manual_configuration', '0')):


### PR DESCRIPTION
I am confident this option does not need to be exposed in the UI and can be enabled unconditionally. It was introduced in Crowdsec 1.5.4 to make the bouncer retry contacting the LAPI endpoint if the first try fails. I don't see how this could ever hurt.

Kind regards,
Patrick