### PR TITLE
Add extra arguments field for node_exporter

### DIFF
--- a/sysutils/node_exporter/src/opnsense/mvc/app/controllers/OPNsense/NodeExporter/forms/general.xml
+++ b/sysutils/node_exporter/src/opnsense/mvc/app/controllers/OPNsense/NodeExporter/forms/general.xml
@@ -83,4 +83,10 @@
     <type>checkbox</type>
     <help>Enable the ZFS collector.</help>
   </field>
+  <field>
+    <id>general.extraargs</id>
+    <label>Extra arguments</label>
+    <type>text</type>
+    <help>Add extra arguments not covered in these options</help>
+  </field>
 </form>

--- a/sysutils/node_exporter/src/opnsense/mvc/app/models/OPNsense/NodeExporter/General.xml
+++ b/sysutils/node_exporter/src/opnsense/mvc/app/models/OPNsense/NodeExporter/General.xml
@@ -66,5 +66,9 @@
           <default>0</default>
           <Required>N</Required>
         </zfs>
+        <extraargs type="TextField">
+          <default></default>
+          <Required>N</Required>
+        </extraargs>
     </items>
 </model>

--- a/sysutils/node_exporter/src/opnsense/service/templates/OPNsense/NodeExporter/node_exporter
+++ b/sysutils/node_exporter/src/opnsense/service/templates/OPNsense/NodeExporter/node_exporter
@@ -46,7 +46,11 @@
     {%- set zfs = no_collector + "zfs " -%}
 {%- endif -%}
 
-node_exporter_args="{{ cpu }}{{ exec }}{{ filesystem }}{{ loadavg }}{{ meminfo }}{{ netdev }}{{ ntp }}{{ time }}{{ devstat }}{{ zfs }}"
+{%- if OPNsense.NodeExporter.extraargs -%}
+    {%- set extraargs -%}
+{%- endif -%}
+
+node_exporter_args="{{ cpu }}{{ exec }}{{ filesystem }}{{ loadavg }}{{ meminfo }}{{ netdev }}{{ ntp }}{{ time }}{{ devstat }}{{ zfs }}{{ extraargs }}"
 node_exporter_listen_address="{{ OPNsense.NodeExporter.listenaddress }}:{{ OPNsense.NodeExporter.listenport }}"
 node_exporter_enable="YES"
 


### PR DESCRIPTION
I'm not sure if this is the way to go but made this so I can add `--collector.netdev.address-info` to get additional metrics from the router. It's not enabled in node_exporter by default and not sure if it's appropriate to add a checkbox.

Feeling my way around, would appreciate comments. Thank you!