### PR TITLE
net-mgmt/telegraf: Add mqtt output

### DIFF
--- a/net-mgmt/telegraf/Makefile
+++ b/net-mgmt/telegraf/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		telegraf
-PLUGIN_VERSION=		1.12.8
+PLUGIN_VERSION=		1.12.9
 PLUGIN_COMMENT=		Agent for collecting metrics and data
 PLUGIN_DEPENDS=		telegraf
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net-mgmt/telegraf/pkg-descr
+++ b/net-mgmt/telegraf/pkg-descr
@@ -12,6 +12,10 @@ WWW: https://www.influxdata.com/time-series-platform/telegraf/
 Plugin Changelog
 ================
 
+1.12.9
+
+* Add MQTT output
+
 1.12.8
 
 * bug: fix InfluxDB v2 template to remove erroneous `timeout` value (issue #3265, contributed by Gavin Chappell)

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/output.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/output.xml
@@ -215,4 +215,64 @@
         <type>text</type>
         <help>Set the API Key for accessing Datadog.</help>
     </field>
+    <field>
+        <id>output.mqtt_enable</id>
+        <label>Enable MQTT</label>
+        <type>checkbox</type>
+        <help>This will enable writes to a MQTT Broker acting as a mqtt Producer.</help>
+    </field>
+    <field>
+        <id>output.mqtt_topic_prefix</id>
+        <label>MQTT topic</label>
+        <type>text</type>
+        <help>Topic for producer messages.</help>
+    </field>
+    <field>
+        <id>output.mqtt_servers</id>
+        <label>MQTT brokers</label>
+        <type>text</type>
+        <help>URLs of mqtt brokers. Format is without square brackets, just like localhost:8083.</help>
+    </field>
+    <field>
+        <id>output.mqtt_qos</id>
+        <label>MQTT QoS</label>
+        <type>text</type>
+        <help>QoS policy for messages. 0 = at most once, 1 = at least once, 2 = exactly once. Defaults to 2. </help>
+    </field>
+    <field>
+        <id>output.mqtt_username</id>
+        <label>MQTT Username</label>
+        <type>text</type>
+        <help>Set the username for authentication.</help>
+    </field>
+    <field>
+        <id>output.mqtt_password</id>
+        <label>MQTT Password</label>
+        <type>text</type>
+        <help>Set the password for authentication.</help>
+    </field>
+    <field>
+        <id>output.mqtt_client_id</id>
+        <label>MQTT Client ID</label>
+        <type>text</type>
+        <help>Client ID, if not set a random ID is generated.</help>
+    </field>
+    <field>
+        <id>output.mqtt_timeout</id>
+        <label>MQTT Timeout</label>
+        <type>text</type>
+        <help>Timeout for write operations. Default is 5s. </help>
+    </field>
+    <field>
+        <id>output.mqtt_insecure_skip_verify</id>
+        <label>MQTT Client ID</label>
+        <type>checkbox</type>
+        <help>Use TLS, but skip chain & host verification.</help>
+    </field>
+    <field>
+        <id>output.mqtt_format</id>
+        <label>MQTT Format</label>
+        <type>text</type>
+        <help>Data format to output. Defaults to "influx".</help>
+    </field>
 </form>

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/output.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/output.xml
@@ -267,7 +267,7 @@
         <id>output.mqtt_insecure_skip_verify</id>
         <label>MQTT Client ID</label>
         <type>checkbox</type>
-        <help>Use TLS, but skip chain & host verification.</help>
+        <help>Use TLS, but skip chain and host verification.</help>
     </field>
     <field>
         <id>output.mqtt_format</id>

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Output.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Output.xml
@@ -139,5 +139,45 @@
             <default></default>
             <Required>N</Required>
         </datadog_apikey>
+        <mqtt_enable type="BooleanField">
+            <default>0</default>
+            <Required>N</Required>
+        </mqtt_enable>
+        <mqtt_topic_prefix type="TextField">
+            <default></default>
+            <Required>N</Required>
+        </mqtt_topic_prefix>
+        <mqtt_servers type="TextField">
+            <default></default>
+            <Required>N</Required>
+        </mqtt_servers>
+        <mqtt_client_id type="TextField">
+            <default></default>
+            <Required>N</Required>
+        </mqtt_client_id>
+        <mqtt_qos type="IntegerField">
+            <default></default>
+            <Required>N</Required>
+        </mqtt_qos>
+        <mqtt_timeout type="IntegerField">
+            <default>5</default>
+            <Required>N</Required>
+        </mqtt_timeout>
+        <mqtt_username type="TextField">
+            <default></default>
+            <Required>N</Required>
+        </mqtt_username>
+        <mqtt_password type="TextField">
+            <default></default>
+            <Required>N</Required>
+        </mqtt_password>
+        <mqtt_insecure_skip_verify type="BooleanField">
+            <default>0</default>
+            <Required>N</Required>
+        </mqtt_insecure_skip_verify>
+        <mqtt_format type="TextField">
+            <default></default>
+            <Required>N</Required>
+        </mqtt_format>
     </items>
 </model>

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Output.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Output.xml
@@ -146,6 +146,8 @@
         <mqtt_topic_prefix type="TextField">
             <default></default>
             <Required>N</Required>
+            <mask>/^([0-9a-zA-Z._\-]){1,128}$/u</mask>
+            <ValidationMessage>Only characters, numbers, a dot, underscore and hyphen allowed. Do not use more than 128 characters.</ValidationMessage>
         </mqtt_topic_prefix>
         <mqtt_servers type="TextField">
             <default></default>
@@ -154,10 +156,15 @@
         <mqtt_client_id type="TextField">
             <default></default>
             <Required>N</Required>
+            <mask>/^([0-9a-zA-Z._\-]){1,128}$/u</mask>
+            <ValidationMessage>Only characters, numbers, a dot, underscore and hyphen allowed. Do not use more than 128 characters.</ValidationMessage>
         </mqtt_client_id>
         <mqtt_qos type="IntegerField">
             <default></default>
             <Required>N</Required>
+            <MinimumValue>0</MinimumValue>
+            <MaximumValue>2</MaximumValue>
+            <ValidationMessage>Allowed values are 0-2</ValidationMessage>
         </mqtt_qos>
         <mqtt_timeout type="IntegerField">
             <default>5</default>
@@ -166,6 +173,8 @@
         <mqtt_username type="TextField">
             <default></default>
             <Required>N</Required>
+            <mask>/^([0-9a-zA-Z._\-]){1,128}$/u</mask>
+            <ValidationMessage>Only characters, numbers, a dot, underscore and hyphen allowed. Do not use more than 128 characters.</ValidationMessage>
         </mqtt_username>
         <mqtt_password type="TextField">
             <default></default>
@@ -178,6 +187,8 @@
         <mqtt_format type="TextField">
             <default></default>
             <Required>N</Required>
+            <mask>/^([0-9a-zA-Z._\-]){1,128}$/u</mask>
+            <ValidationMessage>Only characters, numbers, a dot, underscore and hyphen allowed. Do not use more than 128 characters.</ValidationMessage>
         </mqtt_format>
     </items>
 </model>

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Output.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Output.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/telegraf/output</mount>
     <description>Telegraf outputs configuration</description>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <items>
         <influx_enable type="BooleanField">
             <default>0</default>

--- a/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
+++ b/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
@@ -103,7 +103,7 @@
   topic_prefix = "{{ OPNsense.telegraf.output.mqtt_qos }}"
 {%   endif %}
 {%   if helpers.exists('OPNsense.telegraf.output.mqtt_client_id') and OPNsense.telegraf.output.mqtt_client_id != '' %}
-  client_id = "{{ OPNsense.telegraf.output.mqtt_client_id }}s"
+  client_id = "{{ OPNsense.telegraf.output.mqtt_client_id }}"
 {%   endif %}
 {%   if helpers.exists('OPNsense.telegraf.output.mqtt_timeout') and OPNsense.telegraf.output.mqtt_timeout != '' %}
   timeout = "{{ OPNsense.telegraf.output.mqtt_timeout }}s"

--- a/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
+++ b/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
@@ -91,6 +91,39 @@
   timeout = "5s"
 {% endif %}
 
+{% if helpers.exists('OPNsense.telegraf.output.mqtt_enable') and OPNsense.telegraf.output.mqtt_enable == '1' %}
+[[outputs.mqtt]]
+{%   if helpers.exists('OPNsense.telegraf.output.mqtt_servers') and OPNsense.telegraf.output.mqtt_servers != '' %}
+  servers = ["{{ OPNsense.telegraf.output.mqtt_servers }}"]
+{%   endif %}
+{%   if helpers.exists('OPNsense.telegraf.output.mqtt_topic_prefix') and OPNsense.telegraf.output.mqtt_topic_prefix != '' %}
+  topic_prefix = "{{ OPNsense.telegraf.output.mqtt_topic_prefix }}"
+{%   endif %}
+{%   if helpers.exists('OPNsense.telegraf.output.mqtt_qos') and OPNsense.telegraf.output.mqtt_qos != '' %}
+  topic_prefix = "{{ OPNsense.telegraf.output.mqtt_qos }}"
+{%   endif %}
+{%   if helpers.exists('OPNsense.telegraf.output.mqtt_client_id') and OPNsense.telegraf.output.mqtt_client_id != '' %}
+  client_id = "{{ OPNsense.telegraf.output.mqtt_client_id }}s"
+{%   endif %}
+{%   if helpers.exists('OPNsense.telegraf.output.mqtt_timeout') and OPNsense.telegraf.output.mqtt_timeout != '' %}
+  timeout = "{{ OPNsense.telegraf.output.mqtt_timeout }}s"
+{%   endif %}
+{%   if helpers.exists('OPNsense.telegraf.output.mqtt_username') and OPNsense.telegraf.output.mqtt_username != '' %}
+  username = "{{ OPNsense.telegraf.output.mqtt_username }}"
+{%   endif %}
+{% if helpers.exists('OPNsense.telegraf.output.mqtt_password') and OPNsense.telegraf.output.mqtt_password != '' %}
+  password = "{{ OPNsense.telegraf.output.mqtt_password }}"
+{%   endif %}
+{% if helpers.exists('OPNsense.telegraf.output.mqtt_insecure_skip_verify') and OPNsense.telegraf.output.mqtt_insecure_skip_verify == '1' %}
+  insecure_skip_verify = true
+{%   else %}
+  insecure_skip_verify = false
+{%   endif %}
+{%   if helpers.exists('OPNsense.telegraf.output.mqtt_data_format') and OPNsense.telegraf.output.mqtt_data_format != '' %}
+  data_format = "{{ OPNsense.telegraf.output.mqtt_data_format }}"
+{%   endif %}
+{% endif %}
+
 {% if helpers.exists('OPNsense.telegraf.output.graphite_enable') and OPNsense.telegraf.output.graphite_enable == '1' %}
 [[outputs.graphite]]
 {%   if helpers.exists('OPNsense.telegraf.output.graphite_server') and OPNsense.telegraf.output.graphite_server != '' %}


### PR DESCRIPTION
Hi,

it seems I need a pair of fresh eyes finding my error in this PR. Want to add mqtt as output and to me everything looks good, but when clicking on the submenu "Output" in Telegraf, I immediately get redirected to crash reporter with:

```
[08-Oct-2023 07:27:43 Europe/Berlin] Exception: form xml /usr/local/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/output.xml not valid in /usr/local/opnsense/mvc/app/controllers/OPNsense/Base/ControllerBase.php:161
Stack trace:
#0 /usr/local/opnsense/mvc/app/controllers/OPNsense/Telegraf/OutputController.php(35): OPNsense\Base\ControllerBase->getForm('output')
#1 [internal function]: OPNsense\Telegraf\OutputController->indexAction()
#2 [internal function]: Phalcon\Dispatcher\AbstractDispatcher->callActionMethod(Object(OPNsense\Telegraf\OutputController), 'indexAction', Array)
#3 [internal function]: Phalcon\Dispatcher\AbstractDispatcher->dispatch()
#4 /usr/local/opnsense/www/index.php(70): Phalcon\Mvc\Application->handle('/ui/telegraf/ou...')
#5 {main}
```

I checked the syntax of form so often and can't find the error, tought it was something like `<type>test</type>` instead of `text`