### PR TITLE
dns/ddclient: Treat 204 response as successful

### DIFF
--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/dyndns2.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/dyndns2.py
@@ -98,7 +98,7 @@ class DynDNS2(BaseAccount):
                 }
                 req = requests.get(**req_opts)
 
-            if req.status_code == 200:
+            if req.status_code in [200, 204]:
                 if self.is_verbose:
                     syslog.syslog(
                         syslog.LOG_NOTICE,


### PR DESCRIPTION
Treat a 204 response code as successful when using the dyndns2 provider. Should help with #3585 (by using the custom provider) until we get a proper provider for domeneshop.