### PR TITLE
wg - fix error when empty tunnel address in instance

### DIFF
--- a/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardServer.xml
+++ b/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardServer.xml
@@ -57,7 +57,7 @@
         <style>tokenize</style>
         <type>select_multiple</type>
         <allownew>true</allownew>
-        <help>List of addresses to configure on the device. Please use CIDR notation like 10.0.0.1/24. Can be left empty for point to point connections.</help>
+        <help>List of addresses to configure on the device. Please use CIDR notation like 10.0.0.1/24.</help>
     </field>
     <field>
         <id>server.carp_depend_on</id>

--- a/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardServer.xml
+++ b/net/wireguard/src/opnsense/mvc/app/controllers/OPNsense/Wireguard/forms/dialogEditWireguardServer.xml
@@ -57,7 +57,7 @@
         <style>tokenize</style>
         <type>select_multiple</type>
         <allownew>true</allownew>
-        <help>List of addresses to configure on the device. Please use CIDR notation like 10.0.0.1/24.</help>
+        <help>List of addresses to configure on the device. Please use CIDR notation like 10.0.0.1/24. Can be left empty for point to point connections.</help>
     </field>
     <field>
         <id>server.carp_depend_on</id>

--- a/net/wireguard/src/opnsense/scripts/Wireguard/wg-service-control.php
+++ b/net/wireguard/src/opnsense/scripts/Wireguard/wg-service-control.php
@@ -68,10 +68,8 @@ function wg_start($server, $fhandle, $ifcfgflag = 'up')
     }
     mwexecf('/usr/bin/wg setconf %s %s', [$server->interface, $server->cnfFilename]);
 
-    /**
-     * The tunneladdress can be empty, so any string with a length of 0 bytes is removed.
-     */
-    foreach (array_filter(explode(',', (string)$server->tunneladdress), 'strlen') as $alias) {
+    /* The tunneladdress can be empty, so array_filter without callback filters empty strings out. */
+    foreach (array_filter(explode(',', (string)$server->tunneladdress)) as $alias) {
         $proto = strpos($alias, ':') === false ? "inet" : "inet6";
         mwexecf('/sbin/ifconfig %s %s %s alias', [$server->interface, $proto, $alias]);
     }

--- a/net/wireguard/src/opnsense/scripts/Wireguard/wg-service-control.php
+++ b/net/wireguard/src/opnsense/scripts/Wireguard/wg-service-control.php
@@ -71,11 +71,10 @@ function wg_start($server, $fhandle, $ifcfgflag = 'up')
     /**
      * The tunneladdress can be empty, so any string with a length of 0 bytes is removed.
      */
-    $addresses = array_filter(explode(',', (string)$server->tunneladdress), 'strlen');
-        foreach ($addresses as $alias) {
-            $proto = strpos($alias, ':') === false ? "inet" : "inet6";
-            mwexecf('/sbin/ifconfig %s %s %s alias', [$server->interface, $proto, $alias]);
-        }
+    foreach (array_filter(explode(',', (string)$server->tunneladdress), 'strlen') as $alias) {
+        $proto = strpos($alias, ':') === false ? "inet" : "inet6";
+        mwexecf('/sbin/ifconfig %s %s %s alias', [$server->interface, $proto, $alias]);
+    }
     if (!empty((string)$server->mtu)) {
         mwexecf('/sbin/ifconfig %s mtu %s', [$server->interface, $server->mtu]);
     }

--- a/net/wireguard/src/opnsense/scripts/Wireguard/wg-service-control.php
+++ b/net/wireguard/src/opnsense/scripts/Wireguard/wg-service-control.php
@@ -68,10 +68,14 @@ function wg_start($server, $fhandle, $ifcfgflag = 'up')
     }
     mwexecf('/usr/bin/wg setconf %s %s', [$server->interface, $server->cnfFilename]);
 
-    foreach (explode(',', (string)$server->tunneladdress) as $alias) {
-        $proto = strpos($alias, ':') === false ? "inet" : "inet6";
-        mwexecf('/sbin/ifconfig %s %s %s alias', [$server->interface, $proto, $alias]);
-    }
+    /**
+     * The tunneladdress can be empty, so any string with a length of 0 bytes is removed.
+     */
+    $addresses = array_filter(explode(',', (string)$server->tunneladdress), 'strlen');
+        foreach ($addresses as $alias) {
+            $proto = strpos($alias, ':') === false ? "inet" : "inet6";
+            mwexecf('/sbin/ifconfig %s %s %s alias', [$server->interface, $proto, $alias]);
+        }
     if (!empty((string)$server->mtu)) {
         mwexecf('/sbin/ifconfig %s mtu %s', [$server->interface, $server->mtu]);
     }


### PR DESCRIPTION
Issue: https://forum.opnsense.org/index.php?topic=36503.0

Error message:
`Error	wireguard	/usr/local/opnsense/scripts/Wireguard/wg-service-control.php: The command '/sbin/ifconfig 'wg1' 'inet' '' alias' returned exit code '1', the output was 'ifconfig: : bad value'`

I have edited the wg-service-control.php to implement an array_filter() function that filters empty strings for tunnel address by checking the byte length with strlen. This way, it will be empty if no tunnel address is given, instead of "".

Also adjusted the help text to hint leaving the tunnel address empty for point to point connections.
