### PR TITLE
[os-bind] #3650 - break-dnssec toggle needed for Enable filter-aaaa on IPv4/IPv6 clients

### DIFF
--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/general.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/general.xml
@@ -73,13 +73,13 @@
         <id>general.filteraaaav4</id>
         <label>Enable filter-aaaa on IPv4 Clients</label>
         <type>checkbox</type>
-        <help>This will filter AAAA records on IPv4 Clients</help>
+        <help>This will filter AAAA records on IPv4 Clients. Set "DNSSEC Validation" to "No" and AAAA records will be omitted even if they are signed.</help>
     </field>
     <field>
         <id>general.filteraaaav6</id>
         <label>Enable filter-aaaa on IPv6 Clients</label>
         <type>checkbox</type>
-        <help>This will filter AAAA records on IPv6 Clients</help>
+        <help>This will filter AAAA records on IPv6 Clients. Set "DNSSEC Validation" to "No" and AAAA records will be omitted even if they are signed.</help>
     </field>
     <field>
         <id>general.filteraaaaacl</id>

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
@@ -222,10 +222,18 @@ logging {
 {% if helpers.exists('OPNsense.bind.general.filteraaaav4') and OPNsense.bind.general.filteraaaav4 == '1' or helpers.exists('OPNsense.bind.general.filteraaaav6') and OPNsense.bind.general.filteraaaav6 == '1' %}
 plugin query "/usr/local/lib/bind/filter-aaaa.so" {
 {% if helpers.exists('OPNsense.bind.general.filteraaaav4') and OPNsense.bind.general.filteraaaav4 == '1' %}
+{%   if OPNsense.bind.general.dnssecvalidation == 'no' %}
+                   filter-aaaa-on-v4 break-dnssec;
+{%     else %}
                    filter-aaaa-on-v4 yes;
+{%   endif %}
 {% endif %}
 {% if helpers.exists('OPNsense.bind.general.filteraaaav6') and OPNsense.bind.general.filteraaaav6 == '1' %}
+{%   if OPNsense.bind.general.dnssecvalidation == 'no' %}
+                   filter-aaaa-on-v6 break-dnssec;
+{%     else %}
                    filter-aaaa-on-v6 yes;
+{%   endif %}
 {% endif %}
 {% if helpers.exists('OPNsense.bind.general.filteraaaaacl') and OPNsense.bind.general.filteraaaaacl != '' %}
         filter-aaaa    { {{ OPNsense.bind.general.filteraaaaacl.replace(',', '; ') }}; };

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
@@ -231,7 +231,7 @@ plugin query "/usr/local/lib/bind/filter-aaaa.so" {
 {% if helpers.exists('OPNsense.bind.general.filteraaaav6') and OPNsense.bind.general.filteraaaav6 == '1' %}
 {%   if OPNsense.bind.general.dnssecvalidation == 'no' %}
                    filter-aaaa-on-v6 break-dnssec;
-{%     else %}
+{%   else %}
                    filter-aaaa-on-v6 yes;
 {%   endif %}
 {% endif %}

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
@@ -224,7 +224,7 @@ plugin query "/usr/local/lib/bind/filter-aaaa.so" {
 {% if helpers.exists('OPNsense.bind.general.filteraaaav4') and OPNsense.bind.general.filteraaaav4 == '1' %}
 {%   if OPNsense.bind.general.dnssecvalidation == 'no' %}
                    filter-aaaa-on-v4 break-dnssec;
-{%     else %}
+{%   else %}
                    filter-aaaa-on-v4 yes;
 {%   endif %}
 {% endif %}


### PR DESCRIPTION
Fixes #3650. This works for me for the mentioned issue and use case. Not exactly familiar with the templates.