### PR TITLE
dns/ddclient: Handle empty response

### DIFF
--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/dyndns2.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/dyndns2.py
@@ -105,7 +105,11 @@ class DynDNS2(BaseAccount):
                         "Account %s set new ip %s [%s]" % (self.description, self.current_address, req.text.strip())
                     )
 
-                self.update_state(address=self.current_address, status=req.text.split()[0])
+                if req.text is None or req.text == "":
+                    self.update_state(address=self.current_address)
+                else:
+                    self.update_state(address=self.current_address, status=req.text.split()[0])
+
                 return True
             else:
                 syslog.syslog(


### PR DESCRIPTION
When getting a 204 response back the response text will be empty and a split will end up with an empty list, in turn leading to an `raised fatal error (list index out of range)` error.