### PR TITLE
[C-ICAP] Change ACL Sytax

### DIFF
--- a/www/c-icap/src/opnsense/service/templates/OPNsense/CICAP/c-icap.conf
+++ b/www/c-icap/src/opnsense/service/templates/OPNsense/CICAP/c-icap.conf
@@ -46,7 +46,8 @@ ServerName {{ system.hostname }}
 {%      if helpers.exists('OPNsense.proxy.forward.icap.SendUsername') and OPNsense.proxy.forward.icap.SendUsername == '1' %}
 RemoteProxyUsers on
 acl AUTH auth *
-icap_access allow AUTH 127.0.0.1
+acl localserver srvip 127.0.0.1   
+icap_access allow AUTH localserver
 {%      else %}
 RemoteProxyUsers off
 {%      endif %}
@@ -61,7 +62,8 @@ RemoteProxyUserHeader {{OPNsense.proxy.forward.icap.UsernameHeader}}
 {% else %}
 RemoteProxyUsers on
 acl AUTH auth *
-icap_access allow AUTH 127.0.0.1
+acl localserver srvip 127.0.0.1   
+icap_access allow AUTH localserver
 RemoteProxyUserHeaderEncoded on
 RemoteProxyUserHeader X-Authenticated-User
 {% endif %}


### PR DESCRIPTION
With OPNSense 23.7.8 and c-icap 0.5.11, the service refuses to start using the generated config.
This commit changes the acl-syntax as suggested by [this forum post](https://forum.opnsense.org/index.php?topic=36895.msg180513#msg180513).