### PR TITLE
net/udpbroadcastrelay: Add --msearch option

### DIFF
--- a/net/udpbroadcastrelay/Makefile
+++ b/net/udpbroadcastrelay/Makefile
@@ -1,6 +1,6 @@
 PLUGIN_NAME=		udpbroadcastrelay
-PLUGIN_VERSION=		1.0
-PLUGIN_REVISION=	3
+PLUGIN_VERSION=		1.1
+PLUGIN_REVISION=	1
 PLUGIN_COMMENT=		Control ubpbroadcastrelay processes
 PLUGIN_DEPENDS=		udpbroadcastrelay
 PLUGIN_MAINTAINER=	mjwasley@gmail.com

--- a/net/udpbroadcastrelay/src/opnsense/mvc/app/controllers/OPNsense/UDPBroadcastRelay/Api/SettingsController.php
+++ b/net/udpbroadcastrelay/src/opnsense/mvc/app/controllers/OPNsense/UDPBroadcastRelay/Api/SettingsController.php
@@ -321,6 +321,7 @@ class SettingsController extends ApiMutableModelControllerBase
                 "listenport",
                 "InstanceID",
                 "RevertTTL",
+                "msearch",
                 "description"
         );
         $mdlUDPBroadcastRelay = new UDPBroadcastRelay();

--- a/net/udpbroadcastrelay/src/opnsense/mvc/app/controllers/OPNsense/UDPBroadcastRelay/forms/dialogEdit.xml
+++ b/net/udpbroadcastrelay/src/opnsense/mvc/app/controllers/OPNsense/UDPBroadcastRelay/forms/dialogEdit.xml
@@ -44,6 +44,12 @@
       <help><![CDATA[Use the ID to set the TTL Value of the packet (Original method) rather than DSCP, default is not ticked]]></help>
    </field>
    <field>
+      <id>udpbroadcastrelay.msearch</id>
+      <label>SSDP M-SEARCH handling</label>I
+      <type>dropdown</type>
+      <help><![CDATA[Set how SSDP M-SEARCH packets are treated. Options are block, fwd, proxy and dial.]]></help>
+   </field>
+   <field>
       <id>udpbroadcastrelay.description</id>
       <label>Description</label>
       <type>text</type>

--- a/net/udpbroadcastrelay/src/opnsense/mvc/app/models/OPNsense/UDPBroadcastRelay/UDPBroadcastRelay.xml
+++ b/net/udpbroadcastrelay/src/opnsense/mvc/app/models/OPNsense/UDPBroadcastRelay/UDPBroadcastRelay.xml
@@ -50,6 +50,16 @@
             <default>0</default>
             <Required>Y</Required>
          </RevertTTL>
+         <msearch type="OptionField">
+            <default>fwd</default>
+            <Required>Y</Required>
+            <OptionValues>
+               <block>block</block>
+               <fwd>fwd</fwd>
+               <proxy>proxy</proxy>
+               <dial>dial</dial>
+            </OptionValues>
+         </msearch>
          <description type="TextField">
             <Required>N</Required>
             <mask>/^([\t\n\v\f\r 0-9a-zA-Z.,_\x{00A0}-\x{FFFF}]){1,255}$/u</mask>

--- a/net/udpbroadcastrelay/src/opnsense/mvc/app/views/OPNsense/UDPBroadcastRelay/index.volt
+++ b/net/udpbroadcastrelay/src/opnsense/mvc/app/views/OPNsense/UDPBroadcastRelay/index.volt
@@ -96,6 +96,7 @@ POSSIBILITY OF SUCH DAMAGE.
                 <th data-column-id="description" data-width="2em" data-type="string">{{ lang._('Description') }}</th>
                 <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
                 <th data-column-id="RevertTTL" data-width="2em" data-type="string"  data-visible="true" data-formatter="boolean">{{ lang._('Use ID as TTL') }}</th>
+                <th data-column-id="msearch" data-width="2em" data-type="string" data-visible="true">{{ lang._('M-SEARCH') }}</th>
                 <th data-column-id="commands" data-width="2em" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
             </tr>
             </thead>

--- a/net/udpbroadcastrelay/src/opnsense/service/templates/OPNsense/UDPBroadcastRelay/rc.conf.d
+++ b/net/udpbroadcastrelay/src/opnsense/service/templates/OPNsense/UDPBroadcastRelay/rc.conf.d
@@ -28,6 +28,7 @@ osudpbroadcastrelay_enable="YES"
 {%     do Parameters.append("-t ") %}
 {%    endif %}
 {%     do Parameters.append("-f") %}
+{%     do Parameters.append("--msearch " ~ osudpbroadcastrelay.msearch) %}
 {%    set Instance=osudpbroadcastrelay.InstanceID %}
 osudpbroadcastrelay_{{Instance}}="{% for Parameter in Parameters %} {{Parameter}}{% endfor %}"
 {%     do Instances.append(Instance) %}


### PR DESCRIPTION
This adds the OPNSense side of adding the `--msearch` parameter of marjohn56/udpbroadcastrelay. 

However, the current version of the udpbroadcastrelay package that is currently in OPNSense and upstream HardenedBSD ports is too outdated to actually use it. I believe that is maintained by @mimugmail – I would appreciate if you could bump the version of that upstream. 

For that reason I'm leaving this as a draft for now.