### PR TITLE
[net-snmp]- Fix mib_indexes directory path

### DIFF
--- a/net-mgmt/net-snmp/src/opnsense/scripts/OPNsense/Netsnmp/setup.sh
+++ b/net-mgmt/net-snmp/src/opnsense/scripts/OPNsense/Netsnmp/setup.sh
@@ -5,5 +5,5 @@ chown -R root:wheel /var/net-snmp
 chmod 755 /var/net-snmp
 
 mkdir -p /var/net-snmp/mib_indexes
-chown -R root:wheel /var/mib_indexes
+chown -R root:wheel /var/net-snmp/mib_indexes
 chmod 700 /var/net-snmp/mib_indexes


### PR DESCRIPTION
```
chown: /var/mib_indexes: No such file or directory
Starting snmpd.

```

Someone reported ages ago [at the forums](https://forum.opnsense.org/index.php?topic=21432.0)