### PR TITLE
dns/bind: fix possible template error

### DIFF
--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/domain.db
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/domain.db
@@ -5,11 +5,13 @@
 {%         if domaindb.enabled == '1' and domaindb.type == 'primary' %}
 $TTL {{ domaindb.ttl }}
 @       IN      SOA    {{ domaindb.dnsserver }}. {{ domaindb.mailadmin|replace('@', '.') }}. ( {{ domaindb.serial|trim }} {{ domaindb.refresh }} {{ domaindb.retry }} {{ domaindb.expire }} {{ domaindb.negative }} )
-{%           for record in helpers.sortDictList(OPNsense.bind.record.records.record, 'name', 'type' ) %}
-{%             if record.domain == domaindb['@uuid'] %}
+{%           if helpers.exists('OPNsense.bind.record.records.record') %}
+{%             for record in helpers.sortDictList(OPNsense.bind.record.records.record, 'name', 'type' ) %}
+{%               if record.domain == domaindb['@uuid'] %}
 {{ record.name }}                {{ record.type }} {{ record.value }}
-{%             endif %}
-{%           endfor %}
+{%               endif %}
+{%             endfor %}
+{%           endif %}
 {%         endif %}
 {%       endif %}
 {%     endfor %}


### PR DESCRIPTION
Hi!
can close https://github.com/opnsense/plugins/issues/3703 i hope
- template may throw an error if there is no `records` at all in config
- primary zone MUST have NS record

pr tries to solve this by adding a check before sorting ~~and adding fallback NS from SOA record (technically not very correct, but its realy frequently used (MNAME as one of NS-servers) imho)~~

Thanks!