### PR TITLE
sysutils/node_exporter: Allow setting IPv6 address as Listen Address

### DIFF
--- a/sysutils/node_exporter/src/opnsense/mvc/app/models/OPNsense/NodeExporter/General.xml
+++ b/sysutils/node_exporter/src/opnsense/mvc/app/models/OPNsense/NodeExporter/General.xml
@@ -15,11 +15,9 @@
           <NetMaskAllowed>N</NetMaskAllowed>
           <ValidationMessage>Please provide a valid IP address.</ValidationMessage>
         </listenaddress>
-        <listenport type="IntegerField">
+        <listenport type="PortField">
           <default>9100</default>
           <Required>Y</Required>
-          <MinimumValue>1</MinimumValue>
-          <MaximumValue>65535</MaximumValue>
           <ValidationMessage>Please provide a valid port number between 1 and 65535. Port 9100 is the default.</ValidationMessage>
         </listenport>
         <cpu type="BooleanField">

--- a/sysutils/node_exporter/src/opnsense/mvc/app/models/OPNsense/NodeExporter/General.xml
+++ b/sysutils/node_exporter/src/opnsense/mvc/app/models/OPNsense/NodeExporter/General.xml
@@ -3,17 +3,17 @@
     <description>
         node_exporter - Prometheus exporter for hardware and OS metrics.
     </description>
-    <version>0.1.0</version>
+    <version>0.2.0</version>
     <items>
         <enabled type="BooleanField">
           <default>0</default>
           <Required>Y</Required>
         </enabled>
-        <listenaddress type="TextField">
+        <listenaddress type="NetworkField">
           <default>0.0.0.0</default>
           <Required>Y</Required>
-          <mask>/^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-4]|2[0-5][0-9]|[01]?[0-9][0-9]?)$/</mask>
-          <ValidationMessage>Please provide a valid IPv4 address.</ValidationMessage>
+          <NetMaskAllowed>N</NetMaskAllowed>
+          <ValidationMessage>Please provide a valid IP address.</ValidationMessage>
         </listenaddress>
         <listenport type="IntegerField">
           <default>9100</default>

--- a/sysutils/node_exporter/src/opnsense/service/templates/OPNsense/NodeExporter/node_exporter
+++ b/sysutils/node_exporter/src/opnsense/service/templates/OPNsense/NodeExporter/node_exporter
@@ -46,8 +46,14 @@
     {%- set zfs = no_collector + "zfs " -%}
 {%- endif -%}
 
+{%- if ':' in OPNsense.NodeExporter.listenaddress -%}
+  {%- set listenaddress = '[' + OPNsense.NodeExporter.listenaddress + ']' -%}
+{%- else -%}
+  {%- set listenaddress = OPNsense.NodeExporter.listenaddress -%}
+{%- endif -%}
+
 node_exporter_args="{{ cpu }}{{ exec }}{{ filesystem }}{{ loadavg }}{{ meminfo }}{{ netdev }}{{ ntp }}{{ time }}{{ devstat }}{{ zfs }}"
-node_exporter_listen_address="{{ OPNsense.NodeExporter.listenaddress }}:{{ OPNsense.NodeExporter.listenport }}"
+node_exporter_listen_address="{{ listenaddress }}:{{ OPNsense.NodeExporter.listenport }}"
 node_exporter_enable="YES"
 
 {%- else -%}


### PR DESCRIPTION
Hi all,

I noticed that the Node Exporter Plugin does currently not allow an IPv6 address to be set as a Listen Address, even though that is well supported by Node Exporter itself and is something I need for my setup.
I made the necessary changes to accommodate both address types, plus a little improvement on the port field.

Changes I did:
1. Change address from TextField to NetworkField and remove old validation regex
2. Change port from IntegerField to PortField
3. Add if to template to check for an IPv6 address and surround it with square brackets, as that's what is required by the Node Exporter config. IPv4 addresses are used directly as before.

I have tested these changes on my OPNsense and they seem to work fine.
Node Exporter picks up the changes and runs as expected.