### PR TITLE
security/acme-client: Add support for Bunny DNS API

### DIFF
--- a/security/acme-client/pkg-descr
+++ b/security/acme-client/pkg-descr
@@ -8,6 +8,10 @@ WWW: https://github.com/acmesh-official/acme.sh
 Plugin Changelog
 ================
 
+3.20
+Added:
+* add Bunny DNS API
+
 3.19
 
 Added:

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -227,6 +227,16 @@
         <type>text</type>
     </field>
     <field>
+        <label>Bunny</label>
+        <type>header</type>
+        <style>table_dns table_dns_bunny</style>
+    </field>
+    <field>
+        <id>validation.dns_bunny_api_key</id>
+        <label>API Key</label>
+        <type>text</type>
+    </field>
+    <field>
         <label>Cloudflare</label>
         <type>header</type>
         <style>table_dns table_dns_cf</style>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsBunny.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsBunny.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * Copyright (C) 2023 Liam Steckler <liam@liamsteckler.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\AcmeClient\LeValidation;
+
+use OPNsense\AcmeClient\LeValidationInterface;
+use OPNsense\Core\Config;
+
+/**
+ * Bunny DNS API
+ * @package OPNsense\AcmeClient
+ */
+class DnsBunny extends Base implements LeValidationInterface
+{
+    public function prepare()
+    {
+        $this->acme_env['BUNNY_API_KEY'] = (string)$this->config->dns_bunny_api_key;
+    }
+}

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -429,6 +429,7 @@
                         <dns_autodns>AutoDNS (InterNetX)</dns_autodns>
                         <dns_aws>AWS Route 53</dns_aws>
                         <dns_azure>Azure DNS</dns_azure>
+                        <dns_bunny>Bunny</dns_bunny>
                         <dns_cloudns>ClouDNS</dns_cloudns>
                         <dns_cf>CloudFlare.com</dns_cf>
                         <dns_cx>CloudXNS.com</dns_cx>
@@ -558,6 +559,9 @@
                 <dns_azuredns_clientsecret type="TextField">
                     <Required>N</Required>
                 </dns_azuredns_clientsecret>
+                <dns_bunny_api_key type="TextField">
+                    <Required>N</Required>
+                </dns_bunny_api_key>
                 <dns_cf_email type="TextField">
                     <Required>N</Required>
                 </dns_cf_email>


### PR DESCRIPTION
Added support for Bunny DNS for the DNS-01 ACME challenge, which is supported by acme.sh.

Tested with `opnsense-patch -c plugins 8636a1f`, and confirmed it worked successfully