### PR TITLE
security/acme-client: Expose acme.sh EasyDNS support

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -1387,6 +1387,21 @@
         <label>Password</label>
         <type>password</type>
     </field>
+     <field>
+        <label>EasyDNS</label>
+        <type>header</type>
+        <style>table_dns table_dns_easydns</style>
+    </field>
+    <field>
+        <id>validation.dns_easydns_apitoken</id>
+        <label>API Token</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_easydns_apikey</id>
+        <label>Api Key</label>
+        <type>password</type>
+    </field>
     <field>
         <label>EUserv</label>
         <type>header</type>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsEasydns.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsEasydns.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Copyright (C) 2023 mleinart
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\AcmeClient\LeValidation;
+
+use OPNsense\AcmeClient\LeValidationInterface;
+use OPNsense\Core\Config;
+
+/**
+ * Selfhost API
+ * @package OPNsense\AcmeClient
+ */
+class DnsEasydns extends Base implements LeValidationInterface
+{
+    public function prepare()
+    {
+        $this->acme_env[EASYDNS_Key] = (string)$this->config->dns_easydns_apikey;
+        $this->acme_env[EASYDNS_Token] = (string)$this->config->dns_easydns_apitoken;
+    }
+}

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -451,6 +451,7 @@
                         <dns_dyn>Dyn Managed</dns_dyn>
                         <dns_dynu>Dynu</dns_dynu>
                         <dns_dynv6>dynv6</dns_dynv6>
+                        <dns_easydns>EasyDNS</dns_easydns>
                         <dns_euserv>EUserv</dns_euserv>
                         <dns_freedns>FreeDNS</dns_freedns>
                         <dns_gandi_livedns>Gandi LiveDNS</dns_gandi_livedns>
@@ -1071,6 +1072,12 @@
                 <dns_schlundtech_password type="TextField">
                     <Required>N</Required>
                 </dns_schlundtech_password>
+                <dns_easydns_apitoken type="TextField">
+                    <Required>N</Required>
+                </dns_easydns_apitoken>
+                <dns_easydns_apikey type="TextField">
+                    <Required>N</Required>
+                </dns_easydns_apikey>
                 <dns_euserv_user type="TextField">
                     <Required>N</Required>
                 </dns_euserv_user>


### PR DESCRIPTION
acme.sh [has support for easyDNS](https://github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_easydns) as a dns01 provider. This adds support for OPNSense to expose this in the UI for easyDNS customers

Tested on OPNsense 23.7.9:

system.log:
```
<13>1 2023-12-12T17:39:33+00:00 opnsense opnsense 36298 - [meta sequenceId="88"] AcmeClient: certificate must be issued/renewed: <Removed>
<13>1 2023-12-12T17:39:33+00:00 opnsense opnsense 36298 - [meta sequenceId="89"] AcmeClient: issue certificate: <Removed>
<13>1 2023-12-12T17:39:33+00:00 opnsense opnsense 36298 - [meta sequenceId="90"] AcmeClient: using CA: letsencrypt
<13>1 2023-12-12T17:39:33+00:00 opnsense opnsense 36298 - [meta sequenceId="91"] AcmeClient: account is registered: <Removed>
<13>1 2023-12-12T17:39:33+00:00 opnsense opnsense 36298 - [meta sequenceId="92"] AcmeClient: using challenge type: EasyDNS
<13>1 2023-12-12T17:39:33+00:00 opnsense opnsense 36298 - [meta sequenceId="93"] AcmeClient: running acme.sh command: /usr/local/sbin/acme.sh --issue --syslog 7 --debug --server 'letsencrypt' --dns 'dns_easydns' --home '/var/etc/acme-client/home' --certpath '/var/etc/acme-client/certs/6510fb0e679187.91177093/cert.pem' --keypath '/var/etc/acme-client/keys/6510fb0e679187.91177093/private.key' --capath '/var/etc/acme-client/certs/6510fb0e679187.91177093/chain.pem' --fullchainpath '/var/etc/acme-client/certs/6510fb0e679187.91177093/fullchain.pem' --domain '<Removed>--days '1' --force  --keylength '4096' --accountconf '/var/etc/acme-client/accounts/650e7b4ed742a6.72982560_prod/account.conf'
<13>1 2023-12-12T17:40:29+00:00 opnsense opnsense 36298 - [meta sequenceId="100"] AcmeClient: successfully issued/renewed certificate: <Removed>
<13>1 2023-12-12T17:40:29+00:00 opnsense opnsense 36298 - [meta sequenceId="101"] AcmeClient: updated ACME X.509 certificate: <Removed>
```

