### PR TITLE
sysutils/smart: add word break to ident in widget

### DIFF
--- a/sysutils/smart/src/www/widgets/widgets/smart_status.widget.php
+++ b/sysutils/smart/src/www/widgets/widgets/smart_status.widget.php
@@ -64,7 +64,7 @@ $devs = json_decode(configd_run('smart detailed list'));
 
     <tr>
       <td><?= html_safe($dev->device) ?></td>
-      <td><?= html_safe($dev->ident) ?></td>
+      <td style="word-break: break-word;"><?= html_safe($dev->ident) ?></td>
       <td><span class="label label-<?= $color ?>"><?= html_safe($dev_state_translated) ?></span></td>
     </tr>
 


### PR DESCRIPTION
Add word-breaking to the "Ident" column of the SMART Dashboard widget, to prevent long device names from causing the table to extend outside of the widget's div.

See the following example:
<img width="707" alt="SmartStatus" src="https://github.com/opnsense/plugins/assets/12772522/634a929a-9034-413b-9209-d638a86fcdec">

With this PR, this will get corrected to look as follows:
<img width="652" alt="SmartStatusWrapped" src="https://github.com/opnsense/plugins/assets/12772522/79d447af-d93f-49c9-bbd1-8a0a9615845a">

This style of word breaking is in line with the table in the "interface_list" widget. I had originally considered truncating the long "Ident" values with ellipsis; however, since there was already precedent in other widgets to use word-break, I wanted to stay consistent.