### PR TITLE
Allow disabling of secure_mode for UPnP

### DIFF
--- a/net/upnp/src/etc/inc/plugins.inc.d/miniupnpd.inc
+++ b/net/upnp/src/etc/inc/plugins.inc.d/miniupnpd.inc
@@ -198,7 +198,8 @@ function miniupnpd_configure_do($verbose = false)
                 $config_text .= "bitrate_up={$upload}\n";
             }
 
-            $config_text .= "secure_mode=yes\n";
+            /* set secure mode, checkbox in ui is for disabling rather than enabling */
+            $config_text .= "secure_mode=" . (empty($upnp_config['secure_mode']) ? "yes" : "no") . "\n";
 
             /* enable logging of packets handled by miniupnpd rules */
             if (!empty($upnp_config['logpackets'])) {

--- a/net/upnp/src/www/services_upnp.php
+++ b/net/upnp/src/www/services_upnp.php
@@ -79,6 +79,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         'overridesubnet',
         'overridewanip',
         'permdefault',
+        'secure_mode',
         'stun_host',
         'stun_port',
         'num_permuser',
@@ -174,7 +175,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         // save form data
         $upnp = [];
         // boolean types
-        foreach (['enable', 'enable_upnp', 'enable_natpmp', 'logpackets', 'sysuptime', 'permdefault'] as $fieldname) {
+        foreach (['enable', 'enable_upnp', 'enable_natpmp', 'logpackets', 'sysuptime', 'permdefault', 'secure_mode'] as $fieldname) {
             $upnp[$fieldname] = !empty($pconfig[$fieldname]);
         }
         // numeric types
@@ -374,6 +375,15 @@ include("head.inc");
                        <input name="permdefault" type="checkbox" value="yes" <?=!empty($pconfig['permdefault']) ? "checked=\"checked\"" : ""; ?> />
                        <div class="hidden" data-for="help_for_permdefault">
                          <?=gettext("By default deny access to service?");?>
+                       </div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td><a id="help_for_secure_mode" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Disable secure mode");?></td>
+                      <td>
+                       <input name="secure_mode" type="checkbox" value="yes" <?=!empty($pconfig['secure_mode']) ? "checked=\"checked\"" : ""; ?> />
+                       <div class="hidden" data-for="help_for_secure_mode">
+                         <?=gettext("Secure mode means that a UPnP client can only add port mappings to its own IP address.");?>
                        </div>
                       </td>
                     </tr>


### PR DESCRIPTION
This will allow the disabling of secure mode for miniupnpd.

My reasoning for this is to allow upnp port forwarding of kubernetes services where the client requesting the port forward will not have the same IP as that in the request.