### PR TITLE
security/acme-client: support token authentication in Gandi LiveDNS

### DIFF
--- a/security/acme-client/pkg-descr
+++ b/security/acme-client/pkg-descr
@@ -15,6 +15,9 @@ Added:
 * add DNSExit DNS API (#3724)
 * add World4You DNS API (#3722)
 
+Changed:
+* support token authentication in Gandi LiveDNS (#3526)
+
 Fixed:
 * fix 2FA support in Synology automation (#3627)
 

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -543,9 +543,15 @@
         <style>table_dns table_dns_gandi_livedns</style>
     </field>
     <field>
-        <id>validation.dns_gandi_livedns_key</id>
-        <label>Key</label>
+        <id>validation.dns_gandi_livedns_token</id>
+        <label>Personal Access Token</label>
         <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_gandi_livedns_key</id>
+        <label>API Key (DEPRECATED)</label>
+        <type>text</type>
+        <help>The API Key is the previous mechanism that was replaced with Personal Access Tokens. API Keys should no longer be used.</help>
     </field>
     <field>
         <label>Google Cloud DNS</label>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsGandiLivedns.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsGandiLivedns.php
@@ -39,6 +39,10 @@ class DnsGandiLivedns extends Base implements LeValidationInterface
 {
     public function prepare()
     {
-        $this->acme_env['GANDI_LIVEDNS_KEY'] = (string)$this->config->dns_gandi_livedns_key;
+        if (!empty((string)$this->config->dns_gandi_livedns_token)) {
+            $this->acme_env['GANDI_LIVEDNS_TOKEN'] = (string)$this->config->dns_gandi_livedns_token;
+        } else {
+            $this->acme_env['GANDI_LIVEDNS_KEY'] = (string)$this->config->dns_gandi_livedns_key;
+        }
     }
 }

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -683,6 +683,9 @@
                 <dns_gandi_livedns_key type="TextField">
                     <Required>N</Required>
                 </dns_gandi_livedns_key>
+                <dns_gandi_livedns_token type="TextField">
+                    <Required>N</Required>
+                </dns_gandi_livedns_token>
                 <dns_gcloud_key type="TextField">
                     <Required>N</Required>
                 </dns_gcloud_key>


### PR DESCRIPTION
closes #3526