### PR TITLE
Update max value forms display text for acme client

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogCertificate.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogCertificate.xml
@@ -56,7 +56,7 @@
         <id>certificate.renewInterval</id>
         <label>Renewal Interval</label>
         <type>text</type>
-        <help><![CDATA[Specifies the days to renew the cert. The max value is 60 days.]]></help>
+        <help><![CDATA[Specifies the days to renew the cert. The max value is 5000 days.]]></help>
     </field>
     <field>
         <label>Security Settings</label>


### PR DESCRIPTION
With the pull #3252 the limit was increased on the software side, but the display text in the configuration dialogue was not adjusted. This misguided me, you could have simply set a higher value.