### PR TITLE
Fix `proc_*` usages for running shell commands not correctly returning the child process status code due to quirky `proc_*` behaviours

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeAccount.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeAccount.php
@@ -126,9 +126,19 @@ class LeAccount extends LeCommon
                 // Make sure the resource could be setup properly
                 if (is_resource($proc)) {
                     // Close all pipes
+                    // We need to read from each pipe to ensure proc_close returns the actual child process return code
+                    // See oohay251 comment at https://www.php.net/manual/en/function.proc-close.php
                     fclose($proc_pipes[0]);
+                    $output = array();
+                    while (!feof($proc_pipes[1])) {
+                        $output[] = rtrim(fgets($proc_pipes[1], 1024), "\n");
+                    }
                     fclose($proc_pipes[1]);
+                    while (!feof($proc_pipes[2])) {
+                        $output[] = rtrim(fgets($proc_pipes[2], 1024), "\n");
+                    }
                     fclose($proc_pipes[2]);
+
                     // Get exit code
                     $result = proc_close($proc);
                 } else {
@@ -240,9 +250,19 @@ class LeAccount extends LeCommon
             // Make sure the resource could be setup properly
             if (is_resource($proc)) {
                 // Close all pipes
+                // We need to read from each pipe to ensure proc_close returns the actual child process return code
+                // See oohay251 comment at https://www.php.net/manual/en/function.proc-close.php
                 fclose($proc_pipes[0]);
+                $output = array();
+                while (!feof($proc_pipes[1])) {
+                    $output[] = rtrim(fgets($proc_pipes[1], 1024), "\n");
+                }
                 fclose($proc_pipes[1]);
+                while (!feof($proc_pipes[2])) {
+                    $output[] = rtrim(fgets($proc_pipes[2], 1024), "\n");
+                }
                 fclose($proc_pipes[2]);
+
                 // Get exit code
                 $result = proc_close($proc);
             } else {

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeAutomation/Base.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeAutomation/Base.php
@@ -140,9 +140,19 @@ abstract class Base extends \OPNsense\AcmeClient\LeCommon
         // Make sure the resource could be setup properly
         if (is_resource($proc)) {
             // Close all pipes
+            // We need to read from each pipe to ensure proc_close returns the actual child process return code
+            // See oohay251 comment at https://www.php.net/manual/en/function.proc-close.php
             fclose($proc_pipes[0]);
+            $output = array();
+            while (!feof($proc_pipes[1])) {
+                $output[] = rtrim(fgets($proc_pipes[1], 1024), "\n");
+            }
             fclose($proc_pipes[1]);
+            while (!feof($proc_pipes[2])) {
+                $output[] = rtrim(fgets($proc_pipes[2], 1024), "\n");
+            }
             fclose($proc_pipes[2]);
+
             // Get exit code
             $result = proc_close($proc);
         } else {

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeCertificate.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeCertificate.php
@@ -494,9 +494,19 @@ class LeCertificate extends LeCommon
         // Make sure the resource could be setup properly
         if (is_resource($proc)) {
             // Close all pipes
+            // We need to read from each pipe to ensure proc_close returns the actual child process return code
+            // See oohay251 comment at https://www.php.net/manual/en/function.proc-close.php
             fclose($proc_pipes[0]);
+            $output = array();
+            while (!feof($proc_pipes[1])) {
+                $output[] = rtrim(fgets($proc_pipes[1], 1024), "\n");
+            }
             fclose($proc_pipes[1]);
+            while (!feof($proc_pipes[2])) {
+                $output[] = rtrim(fgets($proc_pipes[2], 1024), "\n");
+            }
             fclose($proc_pipes[2]);
+
             // Get exit code
             $result = proc_close($proc);
         } else {

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeUtils.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeUtils.php
@@ -195,9 +195,19 @@ class LeUtils
         // Make sure the resource could be setup properly
         if (is_resource($proc)) {
             // Close all pipes
+            // We need to read from each pipe to ensure proc_close returns the actual child process return code
+            // See oohay251 comment at https://www.php.net/manual/en/function.proc-close.php
             fclose($proc_pipes[0]);
+            $output = array();
+            while (!feof($proc_pipes[1])) {
+                $output[] = rtrim(fgets($proc_pipes[1], 1024), "\n");
+            }
             fclose($proc_pipes[1]);
+            while (!feof($proc_pipes[2])) {
+                $output[] = rtrim(fgets($proc_pipes[2], 1024), "\n");
+            }
             fclose($proc_pipes[2]);
+
             // Get exit code
             $result = proc_close($proc);
             log_error(sprintf("AcmeClient: The shell command '%s' returned exit code '%d'", $proc_cmd, $result));

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/Base.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/Base.php
@@ -178,9 +178,19 @@ abstract class Base extends \OPNsense\AcmeClient\LeCommon
         // Make sure the resource could be setup properly
         if (is_resource($proc)) {
             // Close all pipes
+            // We need to read from each pipe to ensure proc_close returns the actual child process return code
+            // See oohay251 comment at https://www.php.net/manual/en/function.proc-close.php
             fclose($proc_pipes[0]);
+            $output = array();
+            while (!feof($proc_pipes[1])) {
+                $output[] = rtrim(fgets($proc_pipes[1], 1024), "\n");
+            }
             fclose($proc_pipes[1]);
+            while (!feof($proc_pipes[2])) {
+                $output[] = rtrim(fgets($proc_pipes[2], 1024), "\n");
+            }
             fclose($proc_pipes[2]);
+
             // Get exit code
             $result = proc_close($proc);
         } else {


### PR DESCRIPTION
Using `proc_*` instead of `shell_exec` does give an extra degree of control over the execution of commands, but also introduces quirky behaviour (present for nearly 20 years) whereby if the pipes aren't read before we close them, the return code given by `proc_close` is incorrect.

This fixes a number of issues on the AcmeClient where commands would apparently fail with return code `120` when in fact they actually succeeded. 

This actually fixes https://github.com/opnsense/plugins/issues/1915 and https://github.com/opnsense/plugins/issues/2710

The better solution would be to use one of the more established libraries (eg `symfony/process`) but it seems that introducing dependencies is a no-no given the project structure.

I've noticed that all of the `proc_` usages dotted around the code are pretty much copy paste. 

**Synthetic test: running a command that fails with before / after the fix:**
![image](https://github.com/opnsense/plugins/assets/6388823/3e345a94-efca-408e-a42a-6a14ed4a7b24)

**Similar test, but with a succeeding command**
![image](https://github.com/opnsense/plugins/assets/6388823/3dc9c9ee-f7ae-4426-bcab-1e53c6b58f8f)

**Here's an example of the anomalous behaviour while running a google cloud DNS cert update**
![image](https://github.com/opnsense/plugins/assets/6388823/649d7c09-4623-418c-8944-23298ca78109)

**And this is after the patches above:**
![image](https://github.com/opnsense/plugins/assets/6388823/a92e66dd-e3e3-462d-bd09-6690560c72b9)

**Again, when running acme.sh:**
![image](https://github.com/opnsense/plugins/assets/6388823/ccd07e61-8028-4e4c-ac90-4df8efd5085d)

**And after the fix:**
![image](https://github.com/opnsense/plugins/assets/6388823/fdf7a1a0-380a-4c4e-b5dc-e231bc06e815)


