### PR TITLE
net/frr: Add BGP peer-groups and distance

### DIFF
--- a/net/frr/Makefile
+++ b/net/frr/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		frr
-PLUGIN_VERSION=		1.38
+PLUGIN_VERSION=		1.39
 PLUGIN_COMMENT=		The FRRouting Protocol Suite
 PLUGIN_DEPENDS=		frr8
 PLUGIN_MAINTAINER=	franz.fabian.94@gmail.com

--- a/net/frr/pkg-descr
+++ b/net/frr/pkg-descr
@@ -12,6 +12,11 @@ WWW: https://frrouting.org/
 Plugin Changelog
 ================
 
+1.39
+
+* Add distance to BGP
+* Add BGP peer-group support
+
 1.38
 
 * Add "soft-reconfiguration inbound" neighbor option

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/Api/BgpController.php
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/Api/BgpController.php
@@ -3,7 +3,7 @@
 /*
  * Copyright (C) 2015-2017 Deciso B.V.
  * Copyright (C) 2017 Fabian Franz
- * Copyright (C) 2017-2020 Michael Muenz <m.muenz@gmail.com>
+ * Copyright (C) 2017-2024 Michael Muenz <m.muenz@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -197,6 +197,43 @@ class BgpController extends ApiMutableModelControllerBase
         return $this->setBase('routemap', 'routemaps.routemap', $uuid);
     }
 
+    public function searchPeergroupAction()
+    {
+        return $this->searchBase(
+            'peergroups.peergroup',
+            array("enabled",
+                  "name",
+                  "updatesource",
+                  "nexthopself",
+                  "defaultoriginate",
+                  "linkedPrefixlistIn",
+                  "linkedPrefixlistOut",
+                  "linkedRoutemapIn",
+                  "linkedRoutemapOut")
+        );
+    }
+
+    public function getPeergroupAction($uuid = null)
+    {
+        $this->sessionClose();
+        return $this->getBase('peergroup', 'peergroups.peergroup', $uuid);
+    }
+
+    public function addPeergroupAction()
+    {
+        return $this->addBase('peergroup', 'peergroups.peergroup');
+    }
+
+    public function delPeergroupAction($uuid)
+    {
+        return $this->delBase('peergroups.peergroup', $uuid);
+    }
+
+    public function setPeergroupAction($uuid)
+    {
+        return $this->setBase('peergroup', 'peergroups.peergroup', $uuid);
+    }
+
     public function toggleCommunitylistAction($uuid)
     {
         return $this->toggleBase('communitylists.communitylist', $uuid);
@@ -220,5 +257,10 @@ class BgpController extends ApiMutableModelControllerBase
     public function toggleRoutemapAction($uuid)
     {
         return $this->toggleBase('routemaps.routemap', $uuid);
+    }
+
+    public function togglePeergrouppAction($uuid)
+    {
+        return $this->toggleBase('peergroups.peergroup', $uuid);
     }
 }

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/Api/BgpController.php
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/Api/BgpController.php
@@ -203,6 +203,7 @@ class BgpController extends ApiMutableModelControllerBase
             'peergroups.peergroup',
             array("enabled",
                   "name",
+                  "remoteas",
                   "updatesource",
                   "nexthopself",
                   "defaultoriginate",
@@ -259,7 +260,7 @@ class BgpController extends ApiMutableModelControllerBase
         return $this->toggleBase('routemaps.routemap', $uuid);
     }
 
-    public function togglePeergrouppAction($uuid)
+    public function togglePeergroupAction($uuid)
     {
         return $this->toggleBase('peergroups.peergroup', $uuid);
     }

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/BgpController.php
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/BgpController.php
@@ -2,7 +2,7 @@
 
 /*
  * Copyright (C) 2017 Fabian Franz
- * Copyright (C) 2017-2020 Michael Muenz <m.muenz@gmail.com>
+ * Copyright (C) 2017-2024 Michael Muenz <m.muenz@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -38,6 +38,7 @@ class BgpController extends \OPNsense\Base\IndexController
         $this->view->formDialogEditBGPPrefixLists = $this->getForm("dialogEditBGPPrefixLists");
         $this->view->formDialogEditBGPCommunityLists = $this->getForm("dialogEditBGPCommunityLists");
         $this->view->formDialogEditBGPRouteMaps = $this->getForm("dialogEditBGPRouteMaps");
+        $this->view->formDialogEditBGPPeergroups = $this->getForm("dialogEditBGPPeergroups");
         $this->view->pick('OPNsense/Quagga/bgp');
     }
 }

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/bgp.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/bgp.xml
@@ -15,6 +15,7 @@
         <id>bgp.distance</id>
         <label>BGP AD Distance</label>
         <type>text</type>
+        <advanced>true</advanced>
         <help>BGP routes usually have an administrative distance of 20. Here you can adjust these values, e.g. when you want to prefer OSPF learned routes.</help>
     </field>
     <field>

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/bgp.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/bgp.xml
@@ -12,6 +12,12 @@
         <help>Your AS Number here</help>
     </field>
     <field>
+        <id>bgp.distance</id>
+        <label>BGP AD Distance</label>
+        <type>text</type>
+        <help>BGP routes usually have an administrative distance of 20. Here you can adjust these values, e.g. when you want to prefer OSPF learned routes.</help>
+    </field>
+    <field>
         <id>bgp.routerid</id>
         <label>Router ID</label>
         <type>text</type>

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPNeighbor.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPNeighbor.xml
@@ -169,4 +169,10 @@
     <type>dropdown</type>
     <help>Route-Map for outbound direction</help>
   </field>
+  <field>
+    <id>neighbor.peergroup</id>
+    <label>Peer Group</label>
+    <type>dropdown</type>
+    <help>Peer Group this neighbor belongs to.</help>
+  </field>
 </form>

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPPeergroups.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPPeergroups.xml
@@ -1,0 +1,53 @@
+<form>
+  <field>
+    <id>peergroup.enabled</id>
+    <label>Enabled</label>
+    <type>checkbox</type>
+  </field>
+  <field>
+    <id>peergroup.name</id>
+    <label>Name</label>
+    <type>text</type>
+    <help>Specify the name of this peergroup.</help>
+  </field>
+  <field>
+    <id>peergroup.remoteas</id>
+    <label>Remote AS</label>
+    <type>text</type>
+    <help>Remote AS for tthis peergroup.</help>
+  </field>
+  <field>
+    <id>peergroup.nexthopself</id>
+    <label>Next-Hop-Self</label>
+    <type>checkbox</type>
+  </field>
+    <field>
+    <id>peergroup.defaultoriginate</id>
+    <label>Send Defaultroute</label>
+    <type>checkbox</type>
+  </field>
+  <field>
+    <id>peergroup.linkedPrefixlistIn</id>
+    <label>Prefix-List In</label>
+    <type>dropdown</type>
+    <help>Prefix-List for inbound direction.</help>
+  </field>
+  <field>
+    <id>peergroup.linkedPrefixlistOut</id>
+    <label>Prefix-List Out</label>
+    <type>dropdown</type>
+    <help>Prefix-List for outbound direction.</help>
+  </field>
+  <field>
+    <id>peergroup.linkedRoutemapIn</id>
+    <label>Route-Map In</label>
+    <type>dropdown</type>
+    <help>Route-Map for inbound direction.</help>
+  </field>
+  <field>
+    <id>peergroup.linkedRoutemapOut</id>
+    <label>Route-Map Out</label>
+    <type>dropdown</type>
+    <help>Route-Map for outbound direction.</help>
+  </field>
+</form>

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPPeergroups.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPPeergroups.xml
@@ -17,6 +17,12 @@
     <help>Remote AS for tthis peergroup.</help>
   </field>
   <field>
+    <id>peergroup.updatesource</id>
+    <label>Update-Source Interface</label>
+    <type>dropdown</type>
+    <help><![CDATA[Physical name of the IPv4 interface facing the peer. Please refer to the <a href="http://docs.frrouting.org/en/stable-7.4/bgp.html#clicmd-[no]neighborPEERupdate-source%3CIFNAME|ADDRESS%3E">FRR documentation</a> for more information.]]></help>
+  </field> 
+  <field>
     <id>peergroup.nexthopself</id>
     <label>Next-Hop-Self</label>
     <type>checkbox</type>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
@@ -224,7 +224,7 @@
                                 <Multiple>N</Multiple>
                                 <Required>N</Required>
                         </peergroup>
-            </neighbor>
+                </neighbor>
         </neighbors>
         <aspaths>
                 <aspath type="ArrayField">

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
@@ -408,7 +408,7 @@
                         </set>
                 </routemap>
         </routemaps>
-                <peergroups>
+        <peergroups>
                 <peergroup type="ArrayField">
                         <enabled type="BooleanField">
                                 <default>1</default>
@@ -424,6 +424,15 @@
                                 <MinimumValue>1</MinimumValue>
                                 <MaximumValue>4294967295</MaximumValue>
                         </remoteas>
+                        <updatesource type="InterfaceField">
+                                <default></default>
+                                <Required>N</Required>
+                                <multiple>N</multiple>
+                                <AllowDynamic>Y</AllowDynamic>
+                                <filters>
+                                        <enable>/^(?!0).*$/</enable>
+                                </filters>
+                        </updatesource>
                         <nexthopself type="BooleanField">
                                 <default>0</default>
                                 <Required>N</Required>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
@@ -211,6 +211,19 @@
                                 <Multiple>N</Multiple>
                                 <Required>N</Required>
                         </linkedRoutemapOut>
+                        <peergroup type="ModelRelationField">
+                                <Model>
+                                        <template>
+                                                <source>OPNsense.quagga.bgp</source>
+                                                <items>peergroups.peergroup</items>
+                                                <display>name</display>
+                                                <group>name</group>
+                                        </template>
+                                </Model>
+                                <ValidationMessage>Related Peer Group item not found</ValidationMessage>
+                                <Multiple>N</Multiple>
+                                <Required>N</Required>
+                        </peergroup>
             </neighbor>
         </neighbors>
         <aspaths>
@@ -395,5 +408,83 @@
                         </set>
                 </routemap>
         </routemaps>
+                <peergroups>
+                <peergroup type="ArrayField">
+                        <enabled type="BooleanField">
+                                <default>1</default>
+                                <Required>Y</Required>
+                        </enabled>
+                        <name type="TextField">
+                                <default></default>
+                                <Required>Y</Required>
+                        </name>
+                        <remoteas type="IntegerField">
+                                <default></default>
+                                <Required>Y</Required>
+                                <MinimumValue>1</MinimumValue>
+                                <MaximumValue>4294967295</MaximumValue>
+                        </remoteas>
+                        <nexthopself type="BooleanField">
+                                <default>0</default>
+                                <Required>N</Required>
+                        </nexthopself>
+                        <defaultoriginate type="BooleanField">
+                                <default>0</default>
+                                <Required>N</Required>
+                        </defaultoriginate>
+                        <linkedPrefixlistIn type="ModelRelationField">
+                                <Model>
+                                        <template>
+                                                <source>OPNsense.quagga.bgp</source>
+                                                <items>prefixlists.prefixlist</items>
+                                                <display>name</display>
+                                                <group>name</group>
+                                        </template>
+                                </Model>
+                                <ValidationMessage>Related Prefix-List item not found</ValidationMessage>
+                                <Multiple>N</Multiple>
+                                <Required>N</Required>
+                        </linkedPrefixlistIn>
+                        <linkedPrefixlistOut type="ModelRelationField">
+                                <Model>
+                                        <template>
+                                                <source>OPNsense.quagga.bgp</source>
+                                                <items>prefixlists.prefixlist</items>
+                                                <display>name</display>
+                                                <group>name</group>
+                                        </template>
+                                </Model>
+                                <ValidationMessage>Related Prefix-List item not found</ValidationMessage>
+                                <Multiple>N</Multiple>
+                                <Required>N</Required>
+                        </linkedPrefixlistOut>
+                        <linkedRoutemapIn type="ModelRelationField">
+                                <Model>
+                                        <template>
+                                                <source>OPNsense.quagga.bgp</source>
+                                                <items>routemaps.routemap</items>
+                                                <display>name</display>
+                                                <group>name</group>
+                                        </template>
+                                </Model>
+                                <ValidationMessage>Related Route-Map item not found</ValidationMessage>
+                                <Multiple>N</Multiple>
+                                <Required>N</Required>
+                        </linkedRoutemapIn>
+                        <linkedRoutemapOut type="ModelRelationField">
+                                <Model>
+                                        <template>
+                                                <source>OPNsense.quagga.bgp</source>
+                                                <items>routemaps.routemap</items>
+                                                <display>name</display>
+                                                <group>name</group>
+                                        </template>
+                                </Model>
+                                <ValidationMessage>Related Route-Map item not found</ValidationMessage>
+                                <Multiple>N</Multiple>
+                                <Required>N</Required>
+                        </linkedRoutemapOut>
+            </peergroup>
+        </peergroups>
     </items>
 </model>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
@@ -13,6 +13,10 @@
             <MinimumValue>1</MinimumValue>
             <MaximumValue>4294967295</MaximumValue>
         </asnumber>
+        <distance type="IntegerField">
+            <MinimumValue>1</MinimumValue>
+            <MaximumValue>255</MaximumValue>
+        </distance>
         <routerid type="TextField">
             <Required>N</Required>
             <mask>/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/</mask>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/quagga/bgp</mount>
     <description>BGP Routing configuration</description>
-    <version>1.0.8</version>
+    <version>1.0.9</version>
     <items>
         <enabled type="BooleanField">
             <default>0</default>
@@ -61,7 +61,7 @@
                         </address>
                         <remoteas type="IntegerField">
                                 <default></default>
-                                <Required>Y</Required>
+                                <Required>N</Required>
                                 <MinimumValue>1</MinimumValue>
                                 <MaximumValue>4294967295</MaximumValue>
                         </remoteas>

--- a/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/bgp.volt
+++ b/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/bgp.volt
@@ -35,6 +35,7 @@ POSSIBILITY OF SUCH DAMAGE.
     <li><a data-toggle="tab" href="#prefixlists">{{ lang._('Prefix Lists') }}</a></li>
     <li><a data-toggle="tab" href="#communitylists">{{ lang._('Community Lists') }}</a></li>
     <li><a data-toggle="tab" href="#routemaps">{{ lang._('Route Maps') }}</a></li>
+    <li><a data-toggle="tab" href="#peergroups">{{ lang._('Peer Groups') }}</a></li>
 </ul>
 <div class="tab-content content-box tab-content">
     <div id="general" class="tab-pane fade in active">
@@ -189,6 +190,35 @@ POSSIBILITY OF SUCH DAMAGE.
             </tfoot>
         </table>
     </div>
+    <div id="peergroups" class="tab-pane fade in">
+        <table id="grid-peergroups" class="table table-responsive" data-editDialog="DialogEditBGPPeergroups">
+            <thead>
+                <tr>
+                    <th data-column-id="enabled" data-type="string" data-formatter="rowtoggle">{{ lang._('Enabled') }}</th>
+                    <th data-column-id="name" data-type="string" data-visible="true">{{ lang._('Name') }}</th>
+                    <th data-column-id="nexthopself" data-type="string" data-formatter="rowtoggle">{{ lang._('Next Hop Self') }}</th>
+                    <th data-column-id="defaultoriginate" data-type="string" data-formatter="rowtoggle">{{ lang._('Default Originate') }}</th>
+                    <th data-column-id="linkedPrefixlistIn" data-type="string" data-visible="true">{{ lang._('Prefix List inbound') }}</th>
+                    <th data-column-id="linkedPrefixlistOut" data-type="string" data-visible="true">{{ lang._('Prefix List outbound') }}</th>
+                    <th data-column-id="linkedRoutemapIn" data-type="string" data-visible="true">{{ lang._('Route Map inbound') }}</th>
+                    <th data-column-id="linkedRoutemapOut" data-type="string" data-visible="true">{{ lang._('Route Map outbound') }}</th>
+                    <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
+                    <th data-column-id="commands" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
+                </tr>
+            </thead>
+            <tbody>
+            </tbody>
+            <tfoot>
+                <tr>
+                    <td colspan="10"></td>
+                    <td colspan="1">
+                        <button data-action="add" type="button" class="btn btn-xs btn-default"><span class="fa fa-plus"></span></button>
+                        <button type="button" class="btn btn-xs reload_btn btn-primary"><span class="fa fa-refresh reloadAct_progress"></span></button>
+                    </td>
+                </tr>
+            </tfoot>
+        </table>
+    </div>
 </div>
 
 <script>
@@ -275,6 +305,16 @@ $(document).ready(function() {
       'options':{selection:false, multiSelect:false}
     }
   );
+  $("#grid-peergroups").UIBootgrid(
+    { 'search':'/api/quagga/bgp/searchPeergroup',
+      'get':'/api/quagga/bgp/getPeergroup/',
+      'set':'/api/quagga/bgp/setPeergroup/',
+      'add':'/api/quagga/bgp/addPeergroup/',
+      'del':'/api/quagga/bgp/delPeergroup/',
+      'toggle':'/api/quagga/bgp/togglePeergroup/',
+      'options':{selection:false, multiSelect:false}
+    }
+  );
     });
 </script>
 
@@ -283,3 +323,4 @@ $(document).ready(function() {
 {{ partial("layout_partials/base_dialog",['fields':formDialogEditBGPPrefixLists,'id':'DialogEditBGPPrefixLists','label':lang._('Edit Prefix Lists')])}}
 {{ partial("layout_partials/base_dialog",['fields':formDialogEditBGPCommunityLists,'id':'DialogEditBGPCommunityLists','label':lang._('Edit Community Lists')])}}
 {{ partial("layout_partials/base_dialog",['fields':formDialogEditBGPRouteMaps,'id':'DialogEditBGPRouteMaps','label':lang._('Edit Route Maps')])}}
+{{ partial("layout_partials/base_dialog",['fields':formDialogEditBGPPeergroups,'id':'DialogEditBGPPeergroups','label':lang._('Edit Peer Groups')])}}

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -60,7 +60,7 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
  bgp router-id {{ OPNsense.quagga.bgp.routerid }}
 {%   endif %}
 {%   if helpers.exists('OPNsense.quagga.bgp.distance') and OPNsense.quagga.bgp.distance != '' %}
- bgp distance {{ OPNsense.quagga.bgp.routerid }} {{ OPNsense.quagga.bgp.routerid }} {{ OPNsense.quagga.bgp.routerid }}
+ bgp distance {{ OPNsense.quagga.bgp.distance }} {{ OPNsense.quagga.bgp.distance }} {{ OPNsense.quagga.bgp.distance }}
 {%   endif %}
 {%   if helpers.exists('OPNsense.quagga.bgp.peergroups.peergroup') %}
 {%     for peergroup in helpers.toList('OPNsense.quagga.bgp.peergroups.peergroup') %}

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -59,6 +59,58 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%   if helpers.exists('OPNsense.quagga.bgp.routerid') and OPNsense.quagga.bgp.routerid != '' %}
  bgp router-id {{ OPNsense.quagga.bgp.routerid }}
 {%   endif %}
+{%   if helpers.exists('OPNsense.quagga.bgp.peergroups.peergroup') %}
+{%     for peergroup in helpers.toList('OPNsense.quagga.bgp.peergroups.peergroup') %}
+{%       if peergroup.enabled == '1' %}
+ neighbor {{ peergroup.name }} peer-group
+{%         if 'remoteas' in peergroup and peergroup.remoteas != '' %}
+ neighbor {{ peergroup.name }} remote-as {{ peergroup.remoteas }}
+{%         endif %}
+{%         if 'updatesource' in peergroup and peergroup.updatesource == '1' %}
+ neighbor {{ peergroup.name }} update-source {{ physical_interface(peergroup.updatesource) }}
+{%         endif %}
+ neighbor {{ peergroup.name }} activate
+{%         if 'nexthopself' in peergroup and peergroup.nexthopself == '1' %}
+ neighbor {{ peergroup.name }} next-hop-self
+{%         endif %}
+{%         if 'defaultoriginate' in peergroup and peergroup.defaultoriginate == '1' %}
+ neighbor {{ peergroup.name }} default-originate
+{%         endif %}
+{%         if peergroup.linkedPrefixlistIn|default("") != "" %}
+{%           for prefixlist in peergroup.linkedPrefixlistIn.split(",") %}
+{%             set prefixlist2_data = helpers.getUUID(prefixlist) %}
+{%             if prefixlist2_data != {} and prefixlist2_data.enabled == '1' %}
+ neighbor {{ peergroup.name }} prefix-list {{ prefixlist2_data.name }} in
+{%             endif %}
+{%           endfor %}
+{%         endif %}
+{%         if peergroup.linkedPrefixlistOut|default("") != "" %}
+{%           for prefixlist in peergroup.linkedPrefixlistOut.split(",") %}
+{%             set prefixlist_data = helpers.getUUID(prefixlist) %}
+{%             if prefixlist_data != {} and prefixlist_data.enabled == '1' %}
+ neighbor {{ peergroup.name }} prefix-list {{ prefixlist_data.name }} out
+{%             endif %}
+{%           endfor %}
+{%         endif %}
+{%         if peergroup.linkedRoutemapIn|default("") != "" %}
+{%           for aspath in peergroup.linkedRoutemapIn.split(",") %}
+{%             set routemap2_data = helpers.getUUID(aspath) %}
+{%             if routemap2_data != {} and routemap2_data.enabled == '1' %}
+ neighbor {{ peergroup.name }} route-map {{ routemap2_data.name }} in
+{%             endif %}
+{%           endfor %}
+{%         endif %}
+{%         if peergroup.linkedRoutemapOut|default("") != "" %}
+{%           for aspath in peergroup.linkedRoutemapOut.split(",") %}
+{%             set routemap_data = helpers.getUUID(aspath) %}
+{%             if routemap_data != {} and routemap_data.enabled == '1' %}
+ neighbor {{ peergroup.name }} route-map {{ routemap_data.name }} out
+{%             endif %}
+{%           endfor %}
+{%         endif %}
+{%       endif %}
+{%     endfor %}
+{%   endif %}
 {%   if helpers.exists('OPNsense.quagga.bgp.neighbors.neighbor') %}
 {%     for neighbor in helpers.toList('OPNsense.quagga.bgp.neighbors.neighbor') %}
 {%       if neighbor.enabled == '1' %}

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -152,7 +152,7 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%         if 'attributeunchanged' in neighbor and neighbor.attributeunchanged != '' %}
  neighbor {{ neighbor.address }} attribute-unchanged {{ neighbor.attributeunchanged }}
 {%         endif %}
-{%         if neighbor.peergroup is defined %}
+{%         if neighbor.peergroup|default('') != '' %}
 {%         set pgname = helpers.getUUID(neighbor.peergroup) %}
  neighbor {{ neighbor.address }} peer-group {{ pgname.name }}
 {%         endif %}

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -59,6 +59,9 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%   if helpers.exists('OPNsense.quagga.bgp.routerid') and OPNsense.quagga.bgp.routerid != '' %}
  bgp router-id {{ OPNsense.quagga.bgp.routerid }}
 {%   endif %}
+{%   if helpers.exists('OPNsense.quagga.bgp.distance') and OPNsense.quagga.bgp.distance != '' %}
+ bgp distance {{ OPNsense.quagga.bgp.routerid }} {{ OPNsense.quagga.bgp.routerid }} {{ OPNsense.quagga.bgp.routerid }}
+{%   endif %}
 {%   if helpers.exists('OPNsense.quagga.bgp.peergroups.peergroup') %}
 {%     for peergroup in helpers.toList('OPNsense.quagga.bgp.peergroups.peergroup') %}
 {%       if peergroup.enabled == '1' %}

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -60,7 +60,7 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
  bgp router-id {{ OPNsense.quagga.bgp.routerid }}
 {%   endif %}
 {%   if helpers.exists('OPNsense.quagga.bgp.distance') and OPNsense.quagga.bgp.distance != '' %}
- bgp distance {{ OPNsense.quagga.bgp.distance }} {{ OPNsense.quagga.bgp.distance }} {{ OPNsense.quagga.bgp.distance }}
+ distance bgp {{ OPNsense.quagga.bgp.distance }} {{ OPNsense.quagga.bgp.distance }} {{ OPNsense.quagga.bgp.distance }}
 {%   endif %}
 {%   if helpers.exists('OPNsense.quagga.bgp.peergroups.peergroup') %}
 {%     for peergroup in helpers.toList('OPNsense.quagga.bgp.peergroups.peergroup') %}
@@ -117,7 +117,9 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%   if helpers.exists('OPNsense.quagga.bgp.neighbors.neighbor') %}
 {%     for neighbor in helpers.toList('OPNsense.quagga.bgp.neighbors.neighbor') %}
 {%       if neighbor.enabled == '1' %}
+{%         if 'remoteas' in neighbor and neighbor.remoteas != '' %}
  neighbor {{ neighbor.address }} remote-as {{ neighbor.remoteas }}
+{%         endif %}
 {%         if neighbor.bfd|default('') == '1' %}
  neighbor {{ neighbor.address }} bfd
 {%         endif %}

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -147,6 +147,10 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%         if 'attributeunchanged' in neighbor and neighbor.attributeunchanged != '' %}
  neighbor {{ neighbor.address }} attribute-unchanged {{ neighbor.attributeunchanged }}
 {%         endif %}
+{%         if neighbor.peergroup is defined %}
+{%         set pgname = helpers.getUUID(neighbor.peergroup) %}
+ neighbor {{ neighbor.address }} peer-group {{ pgname.name }}
+{%         endif %}
 {%       endif %}
 {%     endfor %}
 {%   endif %}


### PR DESCRIPTION
Hi,

this PR adds a new grid for using peer-groups to simplify multiple peer configurations and also a new field for manipulating the adminstrative distance for BGP routes. 