### PR TITLE
Update DynDNS.xml to provide access to Mythic Beasts dynamic dns service via their API V2

### DIFF
--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
@@ -69,6 +69,7 @@
                         <inwx>INWX</inwx>
                         <keysystems>Key-Systems</keysystems>
                         <loopia>Loopia</loopia>
+                        <mythicdyn>Mythic Beasts API V2</mythicdyn>
                         <namecheap>NameCheap</namecheap>
                         <nfsn>NearlyFreeSpeech.net</nfsn>
                         <njalla>Njalla</njalla>

--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
@@ -69,7 +69,7 @@
                         <inwx>INWX</inwx>
                         <keysystems>Key-Systems</keysystems>
                         <loopia>Loopia</loopia>
-                        <mythicdyn>Mythic Beasts API V2</mythicdyn>
+                        <mythicdyn>Mythic Beasts</mythicdyn>
                         <namecheap>NameCheap</namecheap>
                         <nfsn>NearlyFreeSpeech.net</nfsn>
                         <njalla>Njalla</njalla>


### PR DESCRIPTION
Enable access to the **Mythic Beasts** service which is built into **ddclient**.  This will not work correctly in ddclient v3.11.2 or lower.  However, I have had a PR accepted (& merged) to fix ddclient and this will provide support for IPV4 and IPV6 updates in a single invocation.

This change to DynDNS.xml appears to be the only change necessary to produce a correct `/usr/local/etc/ddclient.conf` file (containing the line `protocol=mythicdyn` )