### PR TITLE
net/upnp: Update plugin wording to include PCP as supported

### DIFF
--- a/net/upnp/Makefile
+++ b/net/upnp/Makefile
@@ -1,8 +1,8 @@
 PLUGIN_NAME=		upnp
 PLUGIN_VERSION=		1.5
-PLUGIN_REVISION=	5
+PLUGIN_REVISION=	6
 PLUGIN_DEPENDS=		miniupnpd
-PLUGIN_COMMENT=		Universal Plug and Play Service
+PLUGIN_COMMENT=		Universal Plug and Play (UPnP IGD & PCP/NAT-PMP) Service
 PLUGIN_MAINTAINER=	franco@opnsense.org
 
 .include "../../Mk/plugins.mk"

--- a/net/upnp/pkg-descr
+++ b/net/upnp/pkg-descr
@@ -1,8 +1,8 @@
-Mini UPnPd is a lightweight implementation of a UPnP IGD daemon. This is
-supposed to be run on your gateway machine to allow client systems to redirect
-ports and punch holes in the firewall.
+MiniUPnPd is a lightweight implementation of a UPnP IGD & PCP/NAT-PMP daemon.
+This is supposed to be run on your gateway machine to allow client systems to
+map ports and punch holes in the firewall.
 
-WWW: http://miniupnp.free.fr/
+WWW: https://miniupnp.tuxfamily.org/
 
 Plugin Changelog
 ================

--- a/net/upnp/src/etc/inc/plugins.inc.d/miniupnpd.inc
+++ b/net/upnp/src/etc/inc/plugins.inc.d/miniupnpd.inc
@@ -230,7 +230,7 @@ function miniupnpd_configure_do($verbose = false)
                 $config_text .= "deny 0-65535 0.0.0.0/0 0-65535\n";
             }
 
-            /* Allow UPnP or NAT-PMP as requested */
+            /* Allow UPnP IGD or PCP/NAT-PMP as requested */
             $config_text .= "enable_upnp="   . ( $upnp_config['enable_upnp']   ? "yes\n" : "no\n" );
             $config_text .= "enable_natpmp=" . ( $upnp_config['enable_natpmp'] ? "yes\n" : "no\n" );
 

--- a/net/upnp/src/www/services_upnp.php
+++ b/net/upnp/src/www/services_upnp.php
@@ -102,7 +102,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 
     // validate form data
     if (!empty($pconfig['enable']) && (empty($pconfig['enable_upnp']) && empty($pconfig['enable_natpmp']))) {
-        $input_errors[] = gettext('At least one of \'UPnP\' or \'NAT-PMP\' must be allowed');
+        $input_errors[] = gettext('At least one of \'UPnP IGD\' or \'PCP/NAT-PMP\' must be allowed');
     }
     if (!empty($pconfig['iface_array'])) {
         foreach($pconfig['iface_array'] as $iface) {
@@ -210,7 +210,7 @@ include("head.inc");
                   <thead>
                     <tr>
                       <td style="width:22%">
-                        <strong><?=gettext("UPnP and NAT-PMP Settings");?></strong>
+                        <strong><?=gettext("UPnP IGD & PCP/NAT-PMP Settings");?></strong>
                       </td>
                       <td style="width:78%; text-align:right">
                         <small><?=gettext("full help"); ?> </small>
@@ -227,7 +227,7 @@ include("head.inc");
                       </td>
                     </tr>
                     <tr>
-                      <td><a id="help_for_enable_upnp" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Allow UPnP Port Mapping");?></td>
+                      <td><a id="help_for_enable_upnp" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Allow UPnP IGD Port Mapping");?></td>
                       <td>
                        <input name="enable_upnp" type="checkbox" value="yes" <?=!empty($pconfig['enable_upnp']) ? "checked=\"checked\"" : ""; ?> />
                        <div class="hidden" data-for="help_for_enable_upnp">
@@ -236,7 +236,7 @@ include("head.inc");
                       </td>
                     </tr>
                     <tr>
-                      <td><a id="help_for_enable_natpmp" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Allow NAT-PMP Port Mapping");?></td>
+                      <td><a id="help_for_enable_natpmp" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Allow PCP/NAT-PMP Port Mapping");?></td>
                       <td>
                        <input name="enable_natpmp" type="checkbox" value="yes" <?=!empty($pconfig['enable_natpmp']) ? "checked=\"checked\"" : ""; ?> />
                        <div class="hidden" data-for="help_for_enable_natpmp">
@@ -291,7 +291,7 @@ include("head.inc");
 <?php endfor ?>
                         </select>
                         <div class="hidden" data-for="help_for_overridesubnet">
-                          <?=gettext("You can override a single LAN interface subnet here. Useful if you are rebroadcasting UPNP traffic across networks.");?>
+                          <?=gettext("You can override a single LAN interface subnet here. Useful if you are rebroadcasting service traffic across networks.");?>
                         </div>
                       </td>
                     </tr>
@@ -338,11 +338,11 @@ include("head.inc");
                       </td>
                     </tr>
                     <tr>
-                      <td><a id="help_for_logpackets" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Log NAT-PMP");?></td>
+                      <td><a id="help_for_logpackets" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> <?=gettext("Log packets");?></td>
                       <td>
                        <input name="logpackets" type="checkbox" value="yes" <?=!empty($pconfig['logpackets']) ? "checked=\"checked\"" : ""; ?> />
                        <div class="hidden" data-for="help_for_logpackets">
-                         <?=gettext("Log packets handled by UPnP and NAT-PMP rules?");?>
+                         <?=gettext("Log packets handled by service rules?");?>
                        </div>
                       </td>
                     </tr>
@@ -351,7 +351,7 @@ include("head.inc");
                       <td>
                        <input name="sysuptime" type="checkbox" value="yes" <?=!empty($pconfig['sysuptime']) ? "checked=\"checked\"" : ""; ?> />
                        <div class="hidden" data-for="help_for_sysuptime">
-                         <?=gettext("Use system uptime instead of UPnP and NAT-PMP service uptime?");?>
+                         <?=gettext("Use system uptime instead of service uptime?");?>
                        </div>
                       </td>
                     </tr>
@@ -360,7 +360,7 @@ include("head.inc");
                       <td>
                        <input name="permdefault" type="checkbox" value="yes" <?=!empty($pconfig['permdefault']) ? "checked=\"checked\"" : ""; ?> />
                        <div class="hidden" data-for="help_for_permdefault">
-                         <?=gettext("By default deny access to UPnP and NAT-PMP?");?>
+                         <?=gettext("By default deny access to service?");?>
                        </div>
                       </td>
                     </tr>


### PR DESCRIPTION
and also mention `UPnP IGD` as `UPnP` is probably not specific enough.

Port Control Protocol (PCP) is the successor to NAT-PMP and has similar protocol concepts and packet formats, but adds IPv6 support.
*PCP standard:*
https://datatracker.ietf.org/doc/html/rfc6887
https://en.wikipedia.org/wiki/Port_Control_Protocol
*NAT-PMP std. (see 9.1 Simplicity - 9.3 for some diff. to UPnP IGD):*
https://datatracker.ietf.org/doc/html/rfc6886