### PR TITLE
net/frr: Add plain password authentication to OSPF

### DIFF
--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF.xml
@@ -149,6 +149,7 @@
                                 <default></default>
                                 <OptionValues>
                                         <message-digest>MD5</message-digest>
+					<plain>plain</plain>
                                 </OptionValues>
                         </authtype>
                         <authkey type="TextField">

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
@@ -34,6 +34,8 @@ interface {{ physical_interface(interface.interfacename) }}
 {{       cline("authentication",interface.authtype)
 }}{% if interface.authtype and interface.authtype == 'message-digest'
 %}{{       cline("message-digest-key " + interface.authkey_id + " md5",interface.authkey)
+}}{% elseif interface.authtype and interface.authtype == 'plain'
+%}{{       cline("authentication-key,interface.authkey)
 }}{% endif
 %}{{       cline("area",interface.area)
 }}{{       cline("cost",interface.cost)

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
@@ -34,8 +34,7 @@ interface {{ physical_interface(interface.interfacename) }}
 {% if interface.authtype and interface.authtype == 'message-digest'
 %}{{       cline("authentication",interface.authtype)
 }}{{       cline("message-digest-key " + interface.authkey_id + " md5",interface.authkey)
-}}{% endif
-%}{% if interface.authtype and interface.authtype == 'plain'
+}}{% elif interface.authtype and interface.authtype == 'plain'
 %}{{       cline("authentication",' ')
 }}{{       cline("authentication-key",interface.authkey)
 }}{% endif

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
@@ -34,7 +34,7 @@ interface {{ physical_interface(interface.interfacename) }}
 {{       cline("authentication",interface.authtype)
 }}{% if interface.authtype and interface.authtype == 'message-digest'
 %}{{       cline("message-digest-key " + interface.authkey_id + " md5",interface.authkey)
-}}{% elseif interface.authtype and interface.authtype == 'plain'
+}}{% elif interface.authtype and interface.authtype == 'plain'
 %}{{       cline("authentication-key,interface.authkey)
 }}{% endif
 %}{{       cline("area",interface.area)

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
@@ -33,10 +33,12 @@ interface {{ physical_interface(interface.interfacename) }}
 }}{% endif %}
 {{       cline("authentication",interface.authtype)
 }}{% if interface.authtype and interface.authtype == 'message-digest'
-%}{{       cline("message-digest-key " + interface.authkey_id + " md5",interface.authkey)
+%}{{       cline("authentication",interface.authtype)
+}}{{       cline("message-digest-key " + interface.authkey_id + " md5",interface.authkey)
 }}{% endif
 %}{% if interface.authtype and interface.authtype == 'plain'
-%}{{       cline("authentication-key",interface.authkey)
+%}{{       cline("authentication")
+}}{{       cline("authentication-key",interface.authkey)
 }}{% endif
 %}{{       cline("area",interface.area)
 }}{{       cline("cost",interface.cost)

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
@@ -36,7 +36,7 @@ interface {{ physical_interface(interface.interfacename) }}
 }}{{       cline("message-digest-key " + interface.authkey_id + " md5",interface.authkey)
 }}{% endif
 %}{% if interface.authtype and interface.authtype == 'plain'
-%}{{       cline("authentication",)
+%}{{       cline("authentication",'')
 }}{{       cline("authentication-key",interface.authkey)
 }}{% endif
 %}{{       cline("area",interface.area)

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
@@ -34,7 +34,8 @@ interface {{ physical_interface(interface.interfacename) }}
 {{       cline("authentication",interface.authtype)
 }}{% if interface.authtype and interface.authtype == 'message-digest'
 %}{{       cline("message-digest-key " + interface.authkey_id + " md5",interface.authkey)
-}}{% elif interface.authtype and interface.authtype == 'plain'
+}}{% endif
+%}{% if interface.authtype and interface.authtype == 'plain'
 %}{{       cline("authentication-key,interface.authkey)
 }}{% endif
 %}{{       cline("area",interface.area)

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
@@ -36,7 +36,7 @@ interface {{ physical_interface(interface.interfacename) }}
 %}{{       cline("message-digest-key " + interface.authkey_id + " md5",interface.authkey)
 }}{% endif
 %}{% if interface.authtype and interface.authtype == 'plain'
-%}{{       cline("authentication-key,interface.authkey)
+%}{{       cline("authentication-key",interface.authkey)
 }}{% endif
 %}{{       cline("area",interface.area)
 }}{{       cline("cost",interface.cost)

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
@@ -31,13 +31,12 @@ interface {{ physical_interface(interface.interfacename) }}
 {% if interface.networktype %}
 {{       cline("network",interface.networktype)
 }}{% endif %}
-{{       cline("authentication",interface.authtype)
-}}{% if interface.authtype and interface.authtype == 'message-digest'
+{% if interface.authtype and interface.authtype == 'message-digest'
 %}{{       cline("authentication",interface.authtype)
 }}{{       cline("message-digest-key " + interface.authkey_id + " md5",interface.authkey)
 }}{% endif
 %}{% if interface.authtype and interface.authtype == 'plain'
-%}{{       cline("authentication")
+%}{{       cline("authentication",)
 }}{{       cline("authentication-key",interface.authkey)
 }}{% endif
 %}{{       cline("area",interface.area)

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
@@ -36,7 +36,7 @@ interface {{ physical_interface(interface.interfacename) }}
 }}{{       cline("message-digest-key " + interface.authkey_id + " md5",interface.authkey)
 }}{% endif
 %}{% if interface.authtype and interface.authtype == 'plain'
-%}{{       cline("authentication",'')
+%}{{       cline("authentication",' ')
 }}{{       cline("authentication-key",interface.authkey)
 }}{% endif
 %}{{       cline("area",interface.area)


### PR DESCRIPTION
Some legacy devices needs plain authentication, quite simple