### PR TITLE
www/nginx: Update help text to clarify https redirect actions

### DIFF
--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/httpserver.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/httpserver.xml
@@ -156,7 +156,7 @@
     <id>httpserver.https_only</id>
     <label>HTTPS Only</label>
     <type>checkbox</type>
-    <help>If you check this box, a TLS encrypted connection is enforced.</help>
+    <help>If the request scheme is not https, redirect to use https for this server.</help>
   </field>
   <field>
     <id>httpserver.tls_protocols</id>

--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/httpserver.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/httpserver.xml
@@ -156,7 +156,7 @@
     <id>httpserver.https_only</id>
     <label>HTTPS Only</label>
     <type>checkbox</type>
-    <help>If the request scheme is not https, redirect to use https for this server.</help>
+    <help>If the request scheme is not HTTPS, redirect to use HTTPS for this server.</help>
   </field>
   <field>
     <id>httpserver.tls_protocols</id>

--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/location.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/location.xml
@@ -204,7 +204,7 @@
     <id>location.force_https</id>
     <label>Force HTTPS</label>
     <type>checkbox</type>
-    <help>Force encrypted connections.</help>
+    <help>If the request scheme is not https, redirect to use https for this location.</help>
   </field>
   <field>
     <id>location.http2_push_preload</id>

--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/location.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/location.xml
@@ -204,7 +204,7 @@
     <id>location.force_https</id>
     <label>Force HTTPS</label>
     <type>checkbox</type>
-    <help>If the request scheme is not https, redirect to use https for this location.</help>
+    <help>If the request scheme is not HTTPS, redirect to use HTTPS for this location.</help>
   </field>
   <field>
     <id>location.http2_push_preload</id>


### PR DESCRIPTION
The previous help text left me confused about what enabling these settings would do. I think this new text makes it more clear that these settings only add an `if () { redirect }`.