### PR TITLE
www/squid: add Squid `tls_key_log` option

### DIFF
--- a/www/squid/Makefile
+++ b/www/squid/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		squid
-PLUGIN_VERSION=		1.0
+PLUGIN_VERSION=		1.1
 PLUGIN_COMMENT=		Squid is a caching proxy for the web
 PLUGIN_DEPENDS=		squid squid-langpack
 PLUGIN_TIER=		2

--- a/www/squid/src/opnsense/mvc/app/controllers/OPNsense/Proxy/Api/ExportController.php
+++ b/www/squid/src/opnsense/mvc/app/controllers/OPNsense/Proxy/Api/ExportController.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ *    Copyright (C) 2024 0xThiebaut
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+namespace OPNsense\Proxy\Api;
+
+use OPNsense\Base\ApiControllerBase;
+use OPNsense\Core\Backend;
+use OPNsense\Proxy\Proxy;
+
+/**
+ * Class ExportController
+ * @package OPNsense\Proxy
+ */
+class ExportController extends ApiControllerBase
+{
+    /**
+     * download TLS keys
+     * @return array|mixed
+     */
+    public function downloadAction()
+    {
+        $this->sessionClose();
+        $result = (new Backend())->configdRun("proxy export_keys");
+        $filename = '/tmp/squid-tlskeys.zip';
+        if (!empty($result) && !empty($filename) && filesize($filename) > 0) {
+            $this->response->setContentType('application/zip');
+            $this->response->setRawHeader("Content-Disposition: attachment; filename=" . basename($filename));
+            $this->response->setRawHeader("Content-length: " . filesize($filename));
+            $this->response->setRawHeader("Pragma: no-cache");
+            $this->response->setRawHeader("Expires: 0");
+            ob_clean();
+            flush();
+            readfile($filename);
+        }
+    }
+}

--- a/www/squid/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
+++ b/www/squid/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
@@ -320,6 +320,12 @@
                 <help>Do not decode and/or filter SSL content, only log requested domains and IP addresses. Some old servers may not provide SNI, so their addresses will not be indicated.</help>
             </field>
             <field>
+                <id>proxy.forward.tlskeylog</id>
+                <label>Record TLS connection pre-master secret and encryption details</label>
+                <type>checkbox</type>
+                <help>Record pre-master secret and related encryption details for accepted or established TLS connections. This log (a.k.a. SSLKEYLOGFILE) is meant for triage with traffic inspection tools like Wireshark and allows anybody to decrypt the corresponding encrypted TLS connections, both in-flight and postmortem. TLS connections include connections accepted on the SSL proxy port, TLS connections opened to origin servers/cache_peers/ICAP services, and bumped TLS tunnels. Enabling this setting also disables incompatible TLS protocols such as TLS 1.3.</help>
+            </field>
+            <field>
                 <id>proxy.forward.sslbumpport</id>
                 <label>SSL Proxy port</label>
                 <type>text</type>

--- a/www/squid/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
+++ b/www/squid/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
@@ -263,6 +263,13 @@
                             <field1>sslurlonly</field1>
                         </addFields>
                     </check001>
+                    <check002>
+                        <ValidationMessage>When enabling "Record TLS connection pre-master secret and encryption details", SSL inspection must also be enabled</ValidationMessage>
+                        <type>DependConstraint</type>
+                        <addFields>
+                            <field1>tlskeylog</field1>
+                        </addFields>
+                    </check002>
                 </Constraints>
             </sslbump>
             <sslurlonly type="BooleanField">
@@ -274,6 +281,15 @@
                     </check001>
                 </Constraints>
             </sslurlonly>
+            <tlskeylog type="BooleanField">
+                <Default>0</Default>
+                <Required>Y</Required>
+                <Constraints>
+                    <check001>
+                        <reference>sslbump.check002</reference>
+                    </check001>
+                </Constraints>
+            </tlskeylog>
             <sslcertificate type="CertificateField">
                 <Type>ca</Type>
                 <ValidationMessage>Please select a valid certificate from the list</ValidationMessage>

--- a/www/squid/src/opnsense/mvc/app/views/OPNsense/Proxy/index.volt
+++ b/www/squid/src/opnsense/mvc/app/views/OPNsense/Proxy/index.volt
@@ -528,8 +528,16 @@
                       <button class="btn btn-primary" id="resetAct" type="button">{{ lang._('Reset') }}<i id="resetAct_progress" class=""></button>
                   </td>
                   <td>
-                      {{ lang._('Reset all generated content (cached files and certificates included) and restart the proxy.') }}
+                      {{ lang._('Reset all generated content (cached files, certificates and recorded encryption details included) and restart the proxy.') }}
                   </td>
+              </tr>
+              <tr>
+                <td>
+                    <a class="btn btn-primary" href="/api/proxy/export/download/" download>{{ lang._('Export') }}<i id="exportbtn_progress" class=""></a>
+                </td>
+                <td>
+                    {{ lang._('Export TLS connection pre-master secret and encryption details.') }}
+                </td>
               </tr>
             </tbody>
         </table>

--- a/www/squid/src/opnsense/service/conf/actions.d/actions_proxy.conf
+++ b/www/squid/src/opnsense/service/conf/actions.d/actions_proxy.conf
@@ -30,6 +30,7 @@ command:
     /usr/bin/killall -9 squid;
     rm /var/run/squid/squid.pid;
     rm -rf /var/squid/*;
+    rm -f /var/log/squid/tlskey.log*;
     /usr/local/sbin/pluginctl -c webproxy start;
     /usr/local/etc/rc.d/squid start
 parameters:
@@ -80,3 +81,9 @@ command:/usr/local/opnsense/scripts/proxy/download_error_pages.py
 parameters:
 type:script_output
 message:download error pages
+
+[export_keys]
+command:/usr/local/bin/zip -FSjr /tmp/squid-tlskeys.zip /var/log/squid/tlskey.log*
+parameters:
+type:script_output
+message:Export TLS connection pre-master secret and encryption details

--- a/www/squid/src/opnsense/service/templates/OPNsense/Proxy/newsyslog.conf
+++ b/www/squid/src/opnsense/service/templates/OPNsense/Proxy/newsyslog.conf
@@ -1,6 +1,7 @@
 # logfilename                   [owner:group]   mode    count size      when    flags   [/pid_file]               [sig_num]
 {% if helpers.exists('OPNsense.proxy.general.enabled') and OPNsense.proxy.general.enabled|default("0") == "1" %}
-/var/log/squid/access.log   squid:squid     644     14       *      @T00     ZB      /var/run/squid/squid.pid       30
+/var/log/squid/access.log   squid:squid     644     14      *       @T00     ZB      /var/run/squid/squid.pid       30
 /var/log/squid/cache.log    squid:squid     644     2       *       @T00     ZB      /var/run/squid/squid.pid       30
 /var/log/squid/store.log    squid:squid     644     2       *       @T00     ZB      /var/run/squid/squid.pid       30
+/var/log/squid/tlskey.log   squid:squid     644     14      *       @T00     ZB      /var/run/squid/squid.pid       30
 {% endif %}

--- a/www/squid/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
+++ b/www/squid/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
@@ -13,6 +13,9 @@
 {%     set sslparams = '' %}
 {%     if helpers.exists('OPNsense.proxy.forward.sslbump') and OPNsense.proxy.forward.sslbump == '1' %}
 {%         set sslparams = 'ssl-bump cert=/var/squid/ssl/ca.pem dynamic_cert_mem_cache_size=10MB generate-host-certificates=on' %}
+{%         if helpers.exists('OPNsense.proxy.forward.tlskeylog') and OPNsense.proxy.forward.tlskeylog == '1' %}
+{%             set sslparams = sslparams ~ ' options=NO_TLSv1_3' %}
+{%         endif %}
 {%     endif %}
 {{listener_type}} {{network}}:{{port}} {{tags}} {{sslparams}}
 {%- endmacro %}
@@ -58,7 +61,13 @@
 sslcrtd_program /usr/local/libexec/squid/security_file_certgen -s /var/squid/ssl_crtd -M {{ OPNsense.proxy.forward.ssl_crtd_storage_max_size|default('4') }}MB
 sslcrtd_children {{ OPNsense.proxy.forward.sslcrtd_children|default('5') }}
 
-tls_outgoing_options options=NO_TLSv1 cipher=HIGH:MEDIUM:!RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS
+{% set tls_outgoing_options = 'NO_TLSv1' %}
+{% if helpers.exists('OPNsense.proxy.forward.tlskeylog') and OPNsense.proxy.forward.tlskeylog == '1' %}
+# Disable TLS 1.3 support when TLS key logging is enabled
+# https://lists.squid-cache.org/pipermail/squid-users/2022-January/024424.html
+{% set tls_outgoing_options = tls_outgoing_options ~ ',NO_TLSv1_3' %}
+{% endif %}
+tls_outgoing_options options={{tls_outgoing_options}} cipher=HIGH:MEDIUM:!RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS
 
 # setup ssl bump acl's
 acl bump_step1 at_step SslBump1
@@ -80,6 +89,11 @@ ssl_bump peek bump_step2 bump_nobumpsites
 ssl_bump splice bump_step3 bump_nobumpsites
 ssl_bump stare bump_step2
 ssl_bump bump bump_step3
+{% endif %}
+
+{% if helpers.exists('OPNsense.proxy.forward.tlskeylog') and OPNsense.proxy.forward.tlskeylog == '1' %}
+# setup tls key log
+tls_key_log stdio:/var/log/squid/tlskey.log
 {% endif %}
 
 sslproxy_cert_error deny all


### PR DESCRIPTION
Adds the `tls_key_log` option to close #3788. The option adds a checkbox within the Forward Proxy settings to enable the feature.

![image](https://github.com/opnsense/plugins/assets/46688461/d6ff30db-550c-4658-b155-823f502ec04b)

Additionally, a button has been added in the support tab to export the generated key log.

![image](https://github.com/opnsense/plugins/assets/46688461/e1cb4b82-9de6-4cfb-8eb7-d30e681d78a4)

When combined with the existing OPNsense PCAP functionality, Wireshark can decode proxied traffic.
![image](https://github.com/opnsense/plugins/assets/46688461/e2050afa-58d3-43bb-9016-7b09cf4258f5)
