### PR TITLE
bugfix/fallback resolver dnscrypt deprecated

### DIFF
--- a/dns/dnscrypt-proxy/src/opnsense/service/templates/OPNsense/Dnscryptproxy/dnscrypt-proxy.toml
+++ b/dns/dnscrypt-proxy/src/opnsense/service/templates/OPNsense/Dnscryptproxy/dnscrypt-proxy.toml
@@ -89,7 +89,7 @@ tls_disable_session_tickets = true
 tls_disable_session_tickets = false
 {%   endif %}
 
-fallback_resolver = '{{ OPNsense.dnscryptproxy.general.fallback_resolver }}'
+bootstrap_resolvers = '{{ OPNsense.dnscryptproxy.general.fallback_resolver }}'
 
 {%   if helpers.exists('OPNsense.dnscryptproxy.general.ignore_system_dns') and OPNsense.dnscryptproxy.general.ignore_system_dns == '1' %}
 ignore_system_dns = true


### PR DESCRIPTION
This PR fixes `[FATAL] Unsupported key in configuration file: [fallback_resolver]`.

For more info see - https://github.com/DNSCrypt/dnscrypt-proxy/discussions/1979.