### PR TITLE
Update et-open-extra.xml

### DIFF
--- a/security/intrusion-detection-content-et-open/src/opnsense/scripts/suricata/metadata/rules/et-open-extra.xml
+++ b/security/intrusion-detection-content-et-open/src/opnsense/scripts/suricata/metadata/rules/et-open-extra.xml
@@ -4,7 +4,7 @@
     <version url="https://rules.emergingthreats.net/open/suricata-7.0/version.txt"/>
     <files>
         <file description="3coresec" url="inline::rules/3coresec.rules">3coresec.rules</file>
-        <file description="botcc.portgrouped" url="inline::rules/botcc.portgrouped.rules">et_open-botcc.portgrouped.rules</file>
+        <file description="botcc.portgrouped" url="inline::rules/botcc.portgrouped.rules">botcc.portgrouped.rules</file>
         <file description="botcc" url="inline::rules/botcc.rules">et_open.botcc.rules</file>
         <file description="ciarmy" url="inline::rules/ciarmy.rules">et_open.ciarmy.rules</file>
         <file description="compromised" url="inline::rules/compromised.rules">et_open.compromised.rules</file>


### PR DESCRIPTION
Because of the changes in #3797 the etpro-telemetry group botcc_portgrouped got renamed to "emerging-botcc_portgrouped". This caused a double entry for "ET open/botcc.portgrouped" when both the et-open and etpro-temetry ruleset are installed.

This PR fixes that double entry.