### PR TITLE
Fix unquoted array keys in EasyDNS validation

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsEasydns.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsEasydns.php
@@ -39,7 +39,7 @@ class DnsEasydns extends Base implements LeValidationInterface
 {
     public function prepare()
     {
-        $this->acme_env[EASYDNS_Key] = (string)$this->config->dns_easydns_apikey;
-        $this->acme_env[EASYDNS_Token] = (string)$this->config->dns_easydns_apitoken;
+        $this->acme_env['EASYDNS_Key'] = (string)$this->config->dns_easydns_apikey;
+        $this->acme_env['EASYDNS_Token'] = (string)$this->config->dns_easydns_apitoken;
     }
 }


### PR DESCRIPTION
Fixes the 'Undefined constant "OPNsense\AcmeClient\LeValidation\EASYDNS_Key"' error by properly quoting the array keys.