### PR TITLE
security/acme-client: http/tlsalpn libs typos

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/HttpOpnsense.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/HttpOpnsense.php
@@ -50,7 +50,7 @@ class HttpOpnsense extends Base implements LeValidationInterface
         $iplist = array();
 
         // Add IP addresses from auto-discovery feature
-        if ($this->config->http_opn_autodiscovery == 1) {
+        if ($this->config->http_opn_autodiscovery == '1') {
             $dnslist = explode(',', $this->cert_altnames);
             $dnslist[] = $this->cert_name;
             foreach ($dnslist as $fqdn) {
@@ -73,9 +73,9 @@ class HttpOpnsense extends Base implements LeValidationInterface
         // Add IP address from chosen interface
         if (!empty((string)$this->config->http_opn_interface)) {
             $backend = new \OPNsense\Core\Backend();
-            $response = $backend->configdpRun('interface address', [(string)$this->config->http_opn_interface]);
-            if (!empty($response['address'])) {
-                $iplist[] = $response['address'];
+            $response = json_decode($backend->configdpRun('interface address', [(string)$this->config->http_opn_interface]));
+            if (!empty($response->address)) {
+                $iplist[] = $response->address;
             }
         }
 

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/TlsalpnAcme.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/TlsalpnAcme.php
@@ -51,7 +51,7 @@ class TlsalpnAcme extends Base implements LeValidationInterface
         $iplist = array();
 
         // Add IP addresses from auto-discovery feature
-        if ($this->config->tlsalpn_acme_autodiscovery == 1) {
+        if ($this->config->tlsalpn_acme_autodiscovery == '1') {
             $dnslist = explode(',', $this->cert_altnames);
             $dnslist[] = $this->cert_name;
             foreach ($dnslist as $fqdn) {
@@ -74,9 +74,9 @@ class TlsalpnAcme extends Base implements LeValidationInterface
         // Add IP address from chosen interface
         if (!empty((string)$this->config->tlsalpn_acme_interface)) {
             $backend = new \OPNsense\Core\Backend();
-            $response = $backend->configdpRun('interface address', [(string)$this->config->tlsalpn_acme_interface]);
-            if (!empty($response['address'])) {
-                $iplist[] = $response['address'];
+            $response = json_decode($backend->configdpRun('interface address', [(string)$this->config->tlsalpn_acme_interface]));
+            if (!empty($response->address)) {
+                $iplist[] = $response->address;
             }
         }
 


### PR DESCRIPTION
Hi!
just a typos quick fix:
-json_decode backend response before use (to make adding an IP by the selected interface work)
-more strict type for "IP Auto-Discovery" check (to make it possible to turn the autodiscovery off)
Thanks!