### PR TITLE
security/openconnect - added option to enable the use of insecure ciphers

### DIFF
--- a/security/openconnect/src/opnsense/mvc/app/controllers/OPNsense/Openconnect/forms/general.xml
+++ b/security/openconnect/src/opnsense/mvc/app/controllers/OPNsense/Openconnect/forms/general.xml
@@ -60,6 +60,12 @@
         <help>Enter a secret to use with one-time password generation.</help>
     </field>
     <field>
+        <id>general.allowinsecure</id>
+        <label>Allow Insecure Ciphers</label>
+        <type>checkbox</type>
+        <help>This option allows the use of insecure ciphers.</help>
+    </field>
+    <field>
         <id>general.protocol</id>
         <label>Protocol</label>
         <type>dropdown</type>

--- a/security/openconnect/src/opnsense/mvc/app/models/OPNsense/Openconnect/General.xml
+++ b/security/openconnect/src/opnsense/mvc/app/models/OPNsense/Openconnect/General.xml
@@ -58,6 +58,10 @@
         <tokensecret type="TextField">
             <Required>N</Required>
         </tokensecret>
+        <allowinsecure type="BooleanField">
+            <Default>0</Default>
+            <Required>N</Required>
+        </allowinsecure>
         <protocol type="OptionField">
             <Default>anyconnect</Default>
             <Required>Y</Required>

--- a/security/openconnect/src/opnsense/service/templates/OPNsense/Openconnect/openconnect.conf
+++ b/security/openconnect/src/opnsense/service/templates/OPNsense/Openconnect/openconnect.conf
@@ -25,6 +25,9 @@ token-mode={{ OPNsense.openconnect.general.tokenmode }}
 token-secret={{ OPNsense.openconnect.general.tokensecret }}
 {%     endif %}
 {%   endif %}
+{%   if OPNsense.openconnect.general.allowinsecure|default('0') == '1' %}
+allow-insecure-crypto
+{%   endif %}
 {%   if helpers.exists('OPNsense.openconnect.general.protocol') and OPNsense.openconnect.general.protocol != '' %}
 protocol={{ OPNsense.openconnect.general.protocol }}
 {%     if OPNsense.openconnect.general.protocol == 'anyconnect' %}


### PR DESCRIPTION
Adds an option to enable the use of insecure ciphers and fixes this regression: https://github.com/opnsense/plugins/issues/3814

This change was tested with: 

OPNsense 24.1.1-amd64
FreeBSD 13.2-RELEASE-p9
OpenSSL 3.0.13

![image](https://github.com/opnsense/plugins/assets/38880514/213b16e6-2270-4862-8cac-55fdd4988d7a)

If enabled `allow-insecure-crypto` is added to openconnect.conf:

       --allow-insecure-crypto
	      The  ancient,  broken  3DES and RC4 ciphers are insecure;	we ex-
	      plicitly disable them by default.	However, some still-in-use VPN
	      servers can't do any better.

	      This option enables use of these insecure	ciphers,  as  well  as
	      the use of SHA1 for server certificate validation.