### PR TITLE
[chrony] Allow symmetric NTP authentication.

### DIFF
--- a/net/chrony/src/opnsense/mvc/app/controllers/OPNsense/Chrony/forms/general.xml
+++ b/net/chrony/src/opnsense/mvc/app/controllers/OPNsense/Chrony/forms/general.xml
@@ -45,4 +45,22 @@
         <allownew>true</allownew>
         <help>Set the networks allowed to synchronize time with this server. If this value is not set it will also not listen to the port and just synchronize the time for itself.</help>
     </field>
+    <field>
+        <id>general.symmetric_auth</id>
+        <label>NTP Symmetric Authentication</label>
+        <type>checkbox</type>
+        <help>This enabled enables symmetric authentication.</help>
+    </field>
+    <field>
+        <id>general.symmetric_keys_file</id>
+        <label>NTP Symmetric Keys</label>
+        <type>textbox</type>
+        <help>This is the symmetric keys file.  IT is used to authenticate NTP packets.  For further information, please see chrony.conf(5).</help>
+    </field>
+    <field>
+        <id>general.auth_servers</id>
+        <label>NTP Authenticated Servers</label>
+        <type>textbox</type>
+        <help>This is the list of authenticated servers. For further information, please see chrony.conf(5).</help>
+    </field>
 </form>

--- a/net/chrony/src/opnsense/mvc/app/models/OPNsense/Chrony/General.xml
+++ b/net/chrony/src/opnsense/mvc/app/models/OPNsense/Chrony/General.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/chrony/general</mount>
     <description>Chrony configuration</description>
-    <version>0.0.2</version>
+    <version>0.0.3</version>
     <items>
         <enabled type="BooleanField">
             <default>0</default>
@@ -33,5 +33,17 @@
             <FieldSeparator>,</FieldSeparator>
             <asList>Y</asList>
         </allowednetworks>
+        <symmetric_auth type="BooleanField">
+            <default>0</default>
+            <Required>N</Required>
+        </symmetric_auth>
+        <symmetric_keys_file>
+            <default></default>
+            <Required>N</Required>
+        </symmetric_keys_file>
+        <auth_servers>
+            <default></default>
+            <Required>N</Required>
+        </auth_servers>
     </items>
 </model>

--- a/net/chrony/src/opnsense/service/templates/OPNsense/Chrony/chrony.conf
+++ b/net/chrony/src/opnsense/service/templates/OPNsense/Chrony/chrony.conf
@@ -15,12 +15,25 @@ nosystemcert
 nocerttimecheck 1
 {%   endif %}
 
+{%   if helpers.exists('OPNsense.chrony.general.symmetric_auth') and OPNsense.chrony.general.symmetric_auth == '1' %}
+{%     if helpers.exists('OPNsense.chrony.general.symmetric_keys_file') and not helpers.empty('OPNsense.chrony.general.symmetric_keys_file') %}
+keyfile /usr/local/etc/chrony.keys
+{%     endif %}
+{%   endif %}
+
+
 {%   if not helpers.empty('OPNsense.chrony.general.peers') %}
 {%     for peer in OPNsense.chrony.general.peers.split(',') %}
 server {{ peer }} iburst {% if helpers.exists('OPNsense.chrony.general.ntsclient') and OPNsense.chrony.general.ntsclient == '1' %}nts{% endif %}
-
 {%     endfor %}
 {%   endif %}
+
+{%   if helpers.exists('OPNsense.chrony.general.symmetric_auth') and OPNsense.chrony.general.symmetric_auth == '1' %}
+{%     if helpers.exists('OPNsense.chrony.general.auth_servers') and not helpers.empty('OPNsense.chrony.general.auth_servers') %}
+{{ OPNsense.chrony.general.auth_servers }}
+{%     endif %}
+{%   endif %}
+
 
 {%   if helpers.exists('OPNsense.chrony.general.fallbackpeers') and OPNsense.chrony.general.fallbackpeers != '' %}
 authselectmode mix

--- a/net/chrony/src/opnsense/service/templates/OPNsense/Chrony/chrony.keys
+++ b/net/chrony/src/opnsense/service/templates/OPNsense/Chrony/chrony.keys
@@ -1,0 +1,21 @@
+{% if helpers.exists('OPNsense.chrony.general.enabled') and OPNsense.chrony.general.enabled == '1' %}
+
+{%   if helpers.exists('OPNsense.chrony.general.symmetric_auth') and OPNsense.chrony.general.symmetric_auth == '1' %}
+
+{%     if helpers.exists('OPNsense.chrony.general.symmetric_keys_file') and not helpers.empty('OPNsense.chrony.general.symmetric_keys_file') == '1' %}
+
+# This is the chrony keys file.  It enables authentication of NTP
+# packets with symmetric keys when its location is specified by the keyfile
+# directive in chrony.conf(5).  It should be readable only by root and the
+# user under which chronyd is running.
+#
+# Don't use example keys!  It's recommended to generate random keys using
+# the chronyc keygen command.
+
+{{ OPNsense.chrony.general.symmetric_keys_file }}
+
+{%     endif %}
+
+{%   endif %}
+
+{% endif %}


### PR DESCRIPTION
Candidate solution for [Feature request] Chrony Security - chrony.keys #3823
