### PR TITLE
net/freeradius: Support NT hash of user password

### DIFF
--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/dialogEditFreeRADIUSUser.xml
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/dialogEditFreeRADIUSUser.xml
@@ -18,6 +18,13 @@
         <help>Set the password for the user. Allowed characters are 0-9, a-z, A-Z, and ,._-!$%/()+#= with up to 128 characters.</help>
     </field>
     <field>
+        <id>user.passwordencryption</id>
+        <label>Password Encryption</label>
+        <type>dropdown</type>
+        <advanced>true</advanced>
+        <help><![CDATA[Set encryption or hash for stored password.<br/><b>Cleartext-Password</b> The password will be stored in plaintext. This may be less secure than alternatives. Works with all RADIUS authentication protocols.<br/><b>NT-Password (pre-hashed)</b> An NT hash of the password will be stored. First the NT hash of the password should be generated; this will be a string such as 469DCB69D4A58A5F29272787713D96F8. Then the hash (not the password) should be entered into the password field above. A command such as <code>smbencrypt secret123</code> may be used to generate the pre-hashed NT Password. Works with the following RADIUS authentication protocols: PEAP, EAP-MSCHAPv2, EAP-GTC, PAP, MS-CHAP, Cisco LEAP.]]></help>
+    </field>
+    <field>
         <id>user.description</id>
         <label>Description</label>
         <type>text</type>

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/User.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/User.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/freeradius/user</mount>
     <description>FreeRADIUS user configuration</description>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
     <items>
         <users>
             <user type="ArrayField">

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/User.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/User.xml
@@ -17,6 +17,15 @@
                     <Required>Y</Required>
                     <mask>/^([0-9a-zA-Z._\-\!\$\%\/\(\)\+\#\=\{\}]){1,128}$/u</mask>
                 </password>
+                <passwordencryption type="OptionField">
+                    <default>Cleartext-Password</default>
+                    <Required>Y</Required>
+                    <multiple>N</multiple>
+                    <OptionValues>
+                        <cleartext value="Cleartext-Password">Cleartext-Password</cleartext>
+                        <ntprehashed value="NT-Password">NT-Password (pre-hashed)</ntprehashed>
+                    </OptionValues>
+                </passwordencryption>
                 <description type="TextField">
                     <Required>N</Required>
                 </description>

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/users
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/users
@@ -3,7 +3,7 @@
 {%     for user_list in helpers.toList('OPNsense.freeradius.user.users.user') %}
 {%       if user_list.enabled == '1' %}
 
-{{ user_list.username }}  Cleartext-Password := "{{ user_list.password }}"{% if helpers.exists('OPNsense.freeradius.general.sessionlimit') and OPNsense.freeradius.general.sessionlimit == '1' %}{% if user_list.sessionlimit_max_session_limit is defined %}, Max-Daily-Session := {{ user_list.sessionlimit_max_session_limit }}{% endif %}{% endif %}{% if user_list.simuse is defined %}, Simultaneous-Use := "{{ user_list.simuse }}"{% endif %}{% if user_list.logintime is defined %}, Login-Time := "{{ user_list.logintime }}"{% endif %}
+{{ user_list.username }} {{ user_list.passwordencryption }} := "{{ user_list.password }}"{% if helpers.exists('OPNsense.freeradius.general.sessionlimit') and OPNsense.freeradius.general.sessionlimit == '1' %}{% if user_list.sessionlimit_max_session_limit is defined %}, Max-Daily-Session := {{ user_list.sessionlimit_max_session_limit }}{% endif %}{% endif %}{% if user_list.simuse is defined %}, Simultaneous-Use := "{{ user_list.simuse }}"{% endif %}{% if user_list.logintime is defined %}, Login-Time := "{{ user_list.logintime }}"{% endif %}
 
 {%       if user_list.ip is defined %}
        Framed-IP-Address = {{ user_list.ip }},


### PR DESCRIPTION
To improve security provide an "advanced" option to avoid storing
users' radius passwords in plaintext.

The default behaviour is unchanged.

Tested using an openwrt access point as a client with the opnsense
freeradius plugin set to use PEAP.

Compare: https://github.com/pfsense/FreeBSD-ports/pull/822