### PR TITLE
net/frr: Set multihop value to 255

### DIFF
--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -82,7 +82,7 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
  neighbor {{ neighbor.address }} interface {{ physical_interface(neighbor.linklocalinterface) }}
 {%         endif %}
 {%         if 'multihop' in neighbor and neighbor.multihop == '1' %}
- neighbor {{ neighbor.address }} ebgp-multihop
+ neighbor {{ neighbor.address }} ebgp-multihop 255
 {%         endif %}
 {%         if 'keepalive' in neighbor and neighbor.keepalive != '' %}
 {%           if 'holddown' in neighbor and neighbor.holddown != '' %}


### PR DESCRIPTION
Might fix #3763.

Basically, when using FRR, it doesn't set the value of ebgp-multihop by default, which defaults it to 1.

IMHO: Better to have a higher value than a lower value, so I set it to 255.