### PR TITLE
ddclient: Domeneshop - use '==' instead of 'is'

### DIFF
--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/domeneshop.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/domeneshop.py
@@ -67,7 +67,7 @@ class Domeneshop(BaseAccount):
             response = requests.get(**req_opts)
 
             # Parse response and update state and log
-            if response.status_code is 204:
+            if response.status_code == 204:
                 if self.is_verbose:
                     syslog.syslog(
                         syslog.LOG_NOTICE,
@@ -75,7 +75,7 @@ class Domeneshop(BaseAccount):
                     )
                 self.update_state(address=self.current_address, status=response.text.split()[0] if response.text else '')
                 return True
-            elif response.status_code is 404:
+            elif response.status_code == 404:
                 syslog.syslog(
                     syslog.LOG_ERR,
                     "Account %s failed to set new ip %s [%d - %s], because %s could not be found" % (


### PR DESCRIPTION
Since Python 3.8, 'is' and 'is not' produce warnings when its behavior is undefined by the language spec.

See: https://docs.python.org/3.8/whatsnew/3.8.html#changes-in-python-behavior

---

(First time contributor to this project, let me know if there's anything I need to do).

More specifically, inside of the OPNsense backend logs, I get this "Error"-level message from configd.py (spaced for clarity):

<details>

```
[b1725c24-8952-4125-944c-66b8132873f5] Script action stderr returned "b'/usr/local/opnsense/scripts/ddclient/lib/account/domeneshop.py:70: SyntaxWarning: "is" with a literal. Did you mean "=="?
if response.status_code is 204:
/usr/local/opnsense/scripts/ddclient/lib/account/domeneshop.py:78: SyntaxWarning: "is" with a liter'"
```
</details>

The fix is simply to use `==` instead.

I have not tested this code on my system.

## Licensing

Copyright (c) 2024 Sohum Mendon <<smendon@proton.me>>

This contribution is licensed under the 2-Clause BSD License.