### PR TITLE
Shadowsocks plugin tcp_and_udp mode

### DIFF
--- a/net/shadowsocks/src/opnsense/service/templates/OPNsense/Shadowsocks/shadowsocks.conf
+++ b/net/shadowsocks/src/opnsense/service/templates/OPNsense/Shadowsocks/shadowsocks.conf
@@ -5,6 +5,7 @@
     "local_port":{{ OPNsense.shadowsocks.general.localport }},
     "password":"{{ OPNsense.shadowsocks.general.password }}",
     "timeout":60,
+    "mode":"tcp_and_udp",
     "method":"{{ OPNsense.shadowsocks.general.cipher }}"
 }
 {% endif %}

--- a/net/shadowsocks/src/opnsense/service/templates/OPNsense/Shadowsocks/ss_local.conf
+++ b/net/shadowsocks/src/opnsense/service/templates/OPNsense/Shadowsocks/ss_local.conf
@@ -6,6 +6,7 @@
     "local_port":{{ OPNsense.shadowsocks.local.localport }},
     "password":"{{ OPNsense.shadowsocks.local.password }}",
     "timeout":60,
+    "mode":"tcp_and_udp",
     "method":"{{ OPNsense.shadowsocks.local.cipher }}"
 }
 {% endif %}


### PR DESCRIPTION
Please add the ability of Shadowsocks plugin to work with udp ("mode": "tcp_and_udp").