### PR TITLE
www/caddy: v1.5.3

### DIFF
--- a/www/caddy/Makefile
+++ b/www/caddy/Makefile
@@ -1,7 +1,7 @@
 PLUGIN_NAME=		caddy
-PLUGIN_VERSION=		1.5.2
+PLUGIN_VERSION=		1.5.3
 PLUGIN_DEPENDS=		caddy-custom
-PLUGIN_COMMENT=		Easy to configure Reverse Proxy based on Caddy with Automatic HTTPS and Dynamic DNS
+PLUGIN_COMMENT=		Easy to configure Reverse Proxy with Automatic HTTPS and Dynamic DNS
 PLUGIN_MAINTAINER=	cedrik@pischem.com
 
 .include "../../Mk/plugins.mk"

--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -19,6 +19,8 @@ Main features of this plugin:
 * Syslog-ng integration and HTTP Access Log
 * NTLM Transport
 
+DOC: https://docs.opnsense.org/manual/how-tos/caddy.html
+
 Plugin Changelog
 ================
 
@@ -26,7 +28,6 @@ Plugin Changelog
 
 * Change from Phalcon Messages to OPNsense Messages in Caddy.php.
 * Change default storage location from /usr/local/etc/caddy to /var/db/caddy/data/caddy/.
-* Improve ReverseProxyController.php SearchBase() by automatically reading all fields.
 * Add tls_insecure_skip_verify to handlers.
 * Change description from "TextField" to "DescriptionField" in Caddy.xml model.
 * Remove unmaintained DNS Providers: dnspod, hetzner, namesilo, vercel, alidns, metaname, openstack-designate.

--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -30,7 +30,8 @@ Plugin Changelog
 * Change default storage location from /usr/local/etc/caddy to /var/db/caddy/data/caddy/.
 * Change description from "TextField" to "DescriptionField" in Caddy.xml model.
 * Add tls_insecure_skip_verify to handlers.
-* Add possibility to restart Caddy with the ACME Client by using "Automations - Run Command - System or Plugin Command". 
+* Add possibility to restart Caddy with the ACME Client by using "Automations - Run Command - System or Plugin Command".
+* Add option to redirect the ACME HTTP-01 challenge to an upstream destination as advanced option in domains.
 * Remove unmaintained DNS Providers: dnspod, hetzner, namesilo, vercel, alidns, metaname, openstack-designate.
 * Cleanup dialogs and UI to present all options better.
 

--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -31,6 +31,7 @@ Plugin Changelog
 * Add tls_insecure_skip_verify to handlers.
 * Change description from "TextField" to "DescriptionField" in Caddy.xml model.
 * Remove unmaintained DNS Providers: dnspod, hetzner, namesilo, vercel, alidns, metaname, openstack-designate.
+* Implemented headers to forms to group options better, removed excessive use of advanced mode.
 
 1.5.2
 

--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -22,6 +22,15 @@ Main features of this plugin:
 Plugin Changelog
 ================
 
+1.5.3
+
+* Change from Phalcon Messages to OPNsense Messages in Caddy.php.
+* Change default storage location from /usr/local/etc/caddy to /var/db/caddy/data/caddy/.
+* Improve ReverseProxyController.php SearchBase() by automatically reading all fields.
+* Add tls_insecure_skip_verify to handlers.
+* Change description from "TextField" to "DescriptionField" in Caddy.xml model.
+* Remove unmaintained DNS Providers: dnspod, hetzner, namesilo, vercel, alidns, metaname, openstack-designate.
+
 1.5.2
 
 * Increased timeout of message area in reverse_proxy.volt and general.volt to 15 seconds.

--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -26,12 +26,13 @@ Plugin Changelog
 
 1.5.3
 
-* Change from Phalcon Messages to OPNsense Messages in Caddy.php.
+* Change from "Phalcon Messages" to "OPNsense Messages" in Caddy.php.
 * Change default storage location from /usr/local/etc/caddy to /var/db/caddy/data/caddy/.
-* Add tls_insecure_skip_verify to handlers.
 * Change description from "TextField" to "DescriptionField" in Caddy.xml model.
+* Add tls_insecure_skip_verify to handlers.
+* Add possibility to restart Caddy with the ACME Client by using "Automations - Run Command - System or Plugin Command". 
 * Remove unmaintained DNS Providers: dnspod, hetzner, namesilo, vercel, alidns, metaname, openstack-designate.
-* Implemented headers to forms to group options better, removed excessive use of advanced mode.
+* Cleanup dialogs and UI to present all options better.
 
 1.5.2
 

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/ReverseProxyController.php
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/ReverseProxyController.php
@@ -43,7 +43,7 @@ class ReverseProxyController extends ApiMutableModelControllerBase
 
     public function searchReverseProxyAction()
     {
-        return $this->searchBase("reverseproxy.reverse", ['enabled', 'FromDomain', 'FromPort', 'accesslist', 'basicauth', 'DnsChallenge', 'CustomCertificate', 'AccessLog', 'DynDns', 'AcmeRedirection', 'description']);
+        return $this->searchBase("reverseproxy.reverse", ['enabled', 'FromDomain', 'FromPort', 'accesslist', 'basicauth', 'DnsChallenge', 'CustomCertificate', 'AccessLog', 'DynDns', 'AcmePassthrough', 'description']);
     }
 
     public function setReverseProxyAction($uuid)

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/ReverseProxyController.php
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/ReverseProxyController.php
@@ -41,9 +41,9 @@ class ReverseProxyController extends ApiMutableModelControllerBase
 
     /*ReverseProxy Section*/
 
-    public function searchReverseProxyAction($add_empty='0')
+    public function searchReverseProxyAction()
     {
-        return $this->searchBase("reverseproxy.reverse", null, 'description');
+        return $this->searchBase("reverseproxy.reverse", ['enabled', 'FromDomain', 'FromPort', 'accesslist', 'basicauth', 'DnsChallenge', 'CustomCertificate', 'AccessLog', 'DynDns', 'description']);
     }
 
     public function setReverseProxyAction($uuid)
@@ -74,9 +74,9 @@ class ReverseProxyController extends ApiMutableModelControllerBase
 
     /*Subdomain Section*/
 
-    public function searchSubdomainAction($add_empty='0')
+    public function searchSubdomainAction()
     {
-        return $this->searchBase("reverseproxy.subdomain", null, 'description');
+        return $this->searchBase("reverseproxy.subdomain", ['enabled', 'reverse', 'FromDomain', 'FromPort', 'accesslist', 'basicauth', 'DynDns', 'description']);
     }
 
     public function setSubdomainAction($uuid)
@@ -107,9 +107,9 @@ class ReverseProxyController extends ApiMutableModelControllerBase
 
     /*Handler Section*/
 
-    public function searchHandleAction($add_empty='0')
+    public function searchHandleAction()
     {
-        return $this->searchBase("reverseproxy.handle", null, 'description');
+        return $this->searchBase("reverseproxy.handle", ['enabled', 'reverse', 'subdomain', 'HandleType', 'HandlePath', 'ToDomain', 'ToPort', 'ToPath', 'HttpTls', 'HttpTlsTrustedCaCerts', 'HttpTlsServerName', 'HttpNtlm', 'HttpTlsInsecureSkipVerify', 'description']);
     }
 
     public function setHandleAction($uuid)
@@ -140,9 +140,9 @@ class ReverseProxyController extends ApiMutableModelControllerBase
 
     /* AccessList Section */
 
-    public function searchAccessListAction($add_empty='0')
+    public function searchAccessListAction()
     {
-        return $this->searchBase("reverseproxy.accesslist", null, 'description');
+        return $this->searchBase("reverseproxy.accesslist", ['accesslistName', 'clientIps', 'accesslistInvert', 'description']);
     }
 
     public function setAccessListAction($uuid)
@@ -168,9 +168,9 @@ class ReverseProxyController extends ApiMutableModelControllerBase
 
     /* BasicAuth Section */
 
-    public function searchBasicAuthAction($add_empty='0')
+    public function searchBasicAuthAction()
     {
-        return $this->searchBase("reverseproxy.basicauth", null, 'description');
+        return $this->searchBase("reverseproxy.basicauth", ['basicauthuser', 'basicauthpass', 'description']);
     }
 
     public function setBasicAuthAction($uuid)

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/ReverseProxyController.php
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/ReverseProxyController.php
@@ -43,7 +43,7 @@ class ReverseProxyController extends ApiMutableModelControllerBase
 
     public function searchReverseProxyAction()
     {
-        return $this->searchBase("reverseproxy.reverse", ['enabled', 'FromDomain', 'FromPort', 'accesslist', 'basicauth', 'DnsChallenge', 'CustomCertificate', 'AccessLog', 'DynDns', 'description']);
+        return $this->searchBase("reverseproxy.reverse", ['enabled', 'FromDomain', 'FromPort', 'accesslist', 'basicauth', 'DnsChallenge', 'CustomCertificate', 'AccessLog', 'DynDns', 'AcmeRedirection', 'description']);
     }
 
     public function setReverseProxyAction($uuid)

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/ReverseProxyController.php
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/ReverseProxyController.php
@@ -41,9 +41,9 @@ class ReverseProxyController extends ApiMutableModelControllerBase
 
     /*ReverseProxy Section*/
 
-    public function searchReverseProxyAction()
+    public function searchReverseProxyAction($add_empty='0')
     {
-        return $this->searchBase("reverseproxy.reverse", ['enabled', 'FromDomain', 'FromPort', 'accesslist', 'basicauth', 'DnsChallenge', 'CustomCertificate', 'AccessLog', 'DynDns', 'description']);
+        return $this->searchBase("reverseproxy.reverse", null, 'description');
     }
 
     public function setReverseProxyAction($uuid)
@@ -74,9 +74,9 @@ class ReverseProxyController extends ApiMutableModelControllerBase
 
     /*Subdomain Section*/
 
-    public function searchSubdomainAction()
+    public function searchSubdomainAction($add_empty='0')
     {
-        return $this->searchBase("reverseproxy.subdomain", ['enabled', 'reverse', 'FromDomain', 'FromPort', 'accesslist', 'basicauth', 'DynDns', 'description']);
+        return $this->searchBase("reverseproxy.subdomain", null, 'description');
     }
 
     public function setSubdomainAction($uuid)
@@ -107,9 +107,9 @@ class ReverseProxyController extends ApiMutableModelControllerBase
 
     /*Handler Section*/
 
-    public function searchHandleAction()
+    public function searchHandleAction($add_empty='0')
     {
-        return $this->searchBase("reverseproxy.handle", ['enabled', 'reverse', 'subdomain', 'HandleType', 'HandlePath', 'ToDomain', 'ToPort', 'ToPath', 'HttpTls', 'HttpTlsTrustedCaCerts', 'HttpTlsServerName', 'HttpNtlm', 'description']);
+        return $this->searchBase("reverseproxy.handle", null, 'description');
     }
 
     public function setHandleAction($uuid)
@@ -140,9 +140,9 @@ class ReverseProxyController extends ApiMutableModelControllerBase
 
     /* AccessList Section */
 
-    public function searchAccessListAction()
+    public function searchAccessListAction($add_empty='0')
     {
-        return $this->searchBase("reverseproxy.accesslist", ['accesslistName', 'clientIps', 'accesslistInvert', 'description']);
+        return $this->searchBase("reverseproxy.accesslist", null, 'description');
     }
 
     public function setAccessListAction($uuid)
@@ -168,9 +168,9 @@ class ReverseProxyController extends ApiMutableModelControllerBase
 
     /* BasicAuth Section */
 
-    public function searchBasicAuthAction()
+    public function searchBasicAuthAction($add_empty='0')
     {
-        return $this->searchBase("reverseproxy.basicauth", ['basicauthuser', 'basicauthpass', 'description']);
+        return $this->searchBase("reverseproxy.basicauth", null, 'description');
     }
 
     public function setBasicAuthAction($uuid)

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -6,33 +6,6 @@
         <help><![CDATA[Enable this handler.]]></help>
     </field>
     <field>
-        <type>header</type>
-        <label>Handle</label>
-        <collapse>true</collapse>
-    </field>
-    <field>
-        <id>handle.HandleType</id>
-        <label>Handle Type</label>
-        <type>dropdown</type>
-        <help><![CDATA[Select the handler type. In most cases, leaving this as "handle" will be the best choice.]]></help>
-    </field>
-    <field>
-        <id>handle.HandlePath</id>
-        <label>Handle Path</label>
-        <type>text</type>
-        <help><![CDATA[Enter a handler like '/*' or '/example/*', or leave blank for a catch-all handler (recommended). You can define multiple handlers per domain/subdomain by creating additional entries. Save more specific handlers first, as the first matching handler is prioritized. Blank handlers are processed last automatically. To reorder, clone handlers in the desired sequence and delete old ones.]]></help>
-    </field>
-    <field>
-        <id>handle.description</id>
-        <label>Description</label>
-        <type>text</type>
-        <help><![CDATA[Enter a description for this handler.]]></help>
-    </field>
-    <field>
-        <type>header</type>
-        <label>Domain</label>
-    </field>
-    <field>
         <id>handle.reverse</id>
         <label>Domain</label>
         <type>dropdown</type>
@@ -42,7 +15,26 @@
         <id>handle.subdomain</id>
         <label>Subdomain</label>
         <type>dropdown</type>
-        <help><![CDATA[Optionally, select a reverse proxy subdomain to which this handler should be added. In most cases, leaving this as "None" will be the best choice.]]></help>
+        <help><![CDATA[Optionally, select a reverse proxy subdomain to which this handler should be added. If not using subdomains, leaving this as "None" will be the best choice.]]></help>
+    </field>
+    <field>
+        <id>handle.HandleType</id>
+        <label>Handle Type</label>
+        <type>dropdown</type>
+        <help><![CDATA[In most cases, leaving this as "handle" will be the best choice.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>handle.HandlePath</id>
+        <label>Handle Path</label>
+        <type>text</type>
+        <help><![CDATA[Enter a handler like '/*' or '/example/*', or leave blank for a catch-all handler (recommended). Any request matching this handler will be reverse proxied to the upstream destination.]]></help>
+    </field>
+    <field>
+        <id>handle.description</id>
+        <label>Description</label>
+        <type>text</type>
+        <help><![CDATA[Enter a description for this handler.]]></help>
     </field>
     <field>
         <type>header</type>
@@ -53,14 +45,14 @@
         <label>Upstream Domain</label>
         <type>text</type>
         <hint>192.168.1.1</hint>
-        <help><![CDATA[Enter the internal domain name or IP address of the upstream server destination for this handler.]]></help>
+        <help><![CDATA[Enter the internal domain name or IP address of the upstream destination for this handler.]]></help>
     </field>
     <field>
         <id>handle.ToPort</id>
         <label>Upstream Port</label>
         <type>text</type>
         <hint>80</hint>
-        <help><![CDATA[Enter the port number of the upstream server. Leave this empty for bind to port 80. For HTTPS, use 443.]]></help>
+        <help><![CDATA[Enter the port number of the upstream destination. Leave this empty to use port 80.]]></help>
     </field>
     <field>
         <id>handle.ToPath</id>
@@ -71,20 +63,21 @@
     </field>
     <field>
         <type>header</type>
-        <label>Upstream Trust</label>
+        <label>Trust</label>
         <collapse>true</collapse>
     </field>
     <field>
         <id>handle.HttpTls</id>
         <label>TLS</label>
         <type>checkbox</type>
-        <help><![CDATA[Use HTTP over TLS (HTTPS) to communicate with the Upstream Server. In most cases, leaving this unchecked will be the best choice. Caddy uses HTTP for communication with the Upstream Server by default.]]></help>
+        <help><![CDATA[Use HTTP over TLS (HTTPS) to communicate with the upstream destination. In most cases, leaving this unchecked will be the best choice. Caddy uses HTTP for communication with the upstream destination by default.]]></help>
     </field>
     <field>
         <id>handle.HttpNtlm</id>
         <label>NTLM</label>
         <type>checkbox</type>
         <help><![CDATA[If "TLS" has been checked, check "NTLM" in addition for reverse proxying an Exchange Server. In most other cases, leaving this unchecked will be the best choice.]]></help>
+        <advanced>true</advanced>
     </field>
     <field>
         <id>handle.HttpTlsInsecureSkipVerify</id>
@@ -97,7 +90,7 @@
         <id>handle.HttpTlsTrustedCaCerts</id>
         <label>TLS Trusted CA Certificate</label>
         <type>dropdown</type>
-        <help><![CDATA[If TLS is enabled, and you are not using a globally trusted server certificate on your Upstream Server, you can choose a CA certificate or self-signed certificate to trust from "System - Trust - Authorities".]]></help>
+        <help><![CDATA[Optionally, if TLS is enabled, choose a CA certificate or self-signed certificate to trust from "System - Trust - Authorities".]]></help>
     </field>
     <field>
         <id>handle.HttpTlsServerName</id>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -6,81 +6,85 @@
         <help><![CDATA[Enable this handler.]]></help>
     </field>
     <field>
-        <id>handle.reverse</id>
-        <label>Reverse Proxy Domain</label>
-        <type>dropdown</type>
-        <help><![CDATA[Select a reverse proxy domain to which this handler should be added.]]></help>
-    </field>
-    <field>
-        <id>handle.subdomain</id>
-        <label>Reverse Proxy Subdomain</label>
-        <type>dropdown</type>
-        <help><![CDATA[Optionally, select a reverse proxy subdomain to which this handler should be added. In most cases, leaving this as "None" will be the best choice.]]></help>
-        <advanced>true</advanced>
+        <type>header</type>
+        <label>Handle</label>
+        <collapse>true</collapse>
     </field>
     <field>
         <id>handle.HandleType</id>
         <label>Handle Type</label>
         <type>dropdown</type>
         <help><![CDATA[Select the handler type. In most cases, leaving this as "handle" will be the best choice.]]></help>
-        <advanced>true</advanced>
     </field>
     <field>
         <id>handle.HandlePath</id>
         <label>Handle Path</label>
         <type>text</type>
         <help><![CDATA[Enter a handler like '/*' or '/example/*', or leave blank for a catch-all handler (recommended). You can define multiple handlers per domain/subdomain by creating additional entries. Save more specific handlers first, as the first matching handler is prioritized. Blank handlers are processed last automatically. To reorder, clone handlers in the desired sequence and delete old ones.]]></help>
-        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>handle.description</id>
+        <label>Description</label>
+        <type>text</type>
+        <help><![CDATA[Enter a description for this handler.]]></help>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Domain</label>
+    </field>
+    <field>
+        <id>handle.reverse</id>
+        <label>Domain</label>
+        <type>dropdown</type>
+        <help><![CDATA[Select a reverse proxy domain to which this handler should be added.]]></help>
+    </field>
+    <field>
+        <id>handle.subdomain</id>
+        <label>Subdomain</label>
+        <type>dropdown</type>
+        <help><![CDATA[Optionally, select a reverse proxy subdomain to which this handler should be added. In most cases, leaving this as "None" will be the best choice.]]></help>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Upstream</label>
     </field>
     <field>
         <id>handle.ToDomain</id>
-        <label>Backend Server Domain</label>
+        <label>Upstream Domain</label>
         <type>text</type>
         <hint>192.168.1.1</hint>
-        <help><![CDATA[Enter the internal domain name or IP address of the backend server destination for this handler.]]></help>
+        <help><![CDATA[Enter the internal domain name or IP address of the upstream server destination for this handler.]]></help>
     </field>
     <field>
         <id>handle.ToPort</id>
-        <label>Backend Server Port</label>
+        <label>Upstream Port</label>
         <type>text</type>
-        <hint>443</hint>
-        <help><![CDATA[Enter the port number of the backend server. Leave this empty for bind to port 80. For HTTPS, use 443.]]></help>
-        <advanced>true</advanced>
+        <hint>80</hint>
+        <help><![CDATA[Enter the port number of the upstream server. Leave this empty for bind to port 80. For HTTPS, use 443.]]></help>
     </field>
     <field>
         <id>handle.ToPath</id>
-        <label>Backend Path</label>
+        <label>Upstream Path</label>
         <type>text</type>
-        <help><![CDATA[Enter a path prefix like '/guacamole' that should be prepended to the backend request because the application demands it.]]></help>
+        <help><![CDATA[Enter a path prefix like '/guacamole' that should be prepended to the upstream request because the application demands it.]]></help>
         <advanced>true</advanced>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Upstream Trust</label>
+        <collapse>true</collapse>
     </field>
     <field>
         <id>handle.HttpTls</id>
         <label>TLS</label>
         <type>checkbox</type>
-        <help><![CDATA[Use HTTP over TLS (HTTPS) to communicate with the Backend Server. In most cases, leaving this unchecked will be the best choice. Caddy uses HTTP for communication with the Backend Server by default.]]></help>
-        <advanced>true</advanced>
-    </field>
-    <field>
-        <id>handle.HttpTlsTrustedCaCerts</id>
-        <label>TLS Trusted CA Certificate</label>
-        <type>dropdown</type>
-        <help><![CDATA[If TLS is enabled, and you are not using a globally trusted server certificate on your Backend Server, you can choose a CA certificate or self-signed certificate to trust from "System - Trust - Authorities".]]></help>
-        <advanced>true</advanced>
-    </field>
-    <field>
-        <id>handle.HttpTlsServerName</id>
-        <label>TLS Server Name</label>
-        <type>text</type>
-        <help><![CDATA[Optionally, specify a hostname or IP address that matches the SAN of the "TLS Trusted CA Certificate". Please note that only SAN certificates are supported; CN will not work.]]></help>
-        <advanced>true</advanced>
+        <help><![CDATA[Use HTTP over TLS (HTTPS) to communicate with the Upstream Server. In most cases, leaving this unchecked will be the best choice. Caddy uses HTTP for communication with the Upstream Server by default.]]></help>
     </field>
     <field>
         <id>handle.HttpNtlm</id>
         <label>NTLM</label>
         <type>checkbox</type>
         <help><![CDATA[If "TLS" has been checked, check "NTLM" in addition for reverse proxying an Exchange Server. In most other cases, leaving this unchecked will be the best choice.]]></help>
-        <advanced>true</advanced>
     </field>
     <field>
         <id>handle.HttpTlsInsecureSkipVerify</id>
@@ -90,9 +94,15 @@
         <advanced>true</advanced>
     </field>
     <field>
-        <id>handle.description</id>
-        <label>Description</label>
+        <id>handle.HttpTlsTrustedCaCerts</id>
+        <label>TLS Trusted CA Certificate</label>
+        <type>dropdown</type>
+        <help><![CDATA[If TLS is enabled, and you are not using a globally trusted server certificate on your Upstream Server, you can choose a CA certificate or self-signed certificate to trust from "System - Trust - Authorities".]]></help>
+    </field>
+    <field>
+        <id>handle.HttpTlsServerName</id>
+        <label>TLS Server Name</label>
         <type>text</type>
-        <help><![CDATA[Enter a description for this handler.]]></help>
+        <help><![CDATA[Optionally, specify a hostname or IP address that matches the SAN of the "TLS Trusted CA Certificate". Please note that only SAN certificates are supported; CN will not work.]]></help>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -83,6 +83,13 @@
         <advanced>true</advanced>
     </field>
     <field>
+        <id>handle.HttpTlsInsecureSkipVerify</id>
+        <label>TLS Insecure Skip Verify</label>
+        <type>checkbox</type>
+        <help><![CDATA[Turns off TLS handshake verification, making the connection insecure and vulnerable to man-in-the-middle attacks. Do not use in production.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
         <id>handle.description</id>
         <label>Description</label>
         <type>text</type>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
@@ -28,7 +28,7 @@
     </field>
     <field>
         <type>header</type>
-        <label>Trust</label>
+        <label>DNS</label>
         <collapse>true</collapse>
     </field>
     <field>
@@ -37,6 +37,11 @@
         <type>checkbox</type>
         <help><![CDATA[Enable Dynamic DNS, please configure DNS Provider and API Key in General Settings. The DNS Records of this domain wi
 ll be automatically updated with your DNS Provider.]]></help>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Trust</label>
+        <collapse>true</collapse>
     </field>
     <field>
         <id>reverse.DnsChallenge</id>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
@@ -6,10 +6,6 @@
         <help><![CDATA[Enable this reverse proxy domain.]]></help>
     </field>
     <field>
-        <type>header</type>
-        <label>Domain</label>
-    </field>
-    <field>
         <id>reverse.FromDomain</id>
         <label>Domain</label>
         <type>text</type>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
@@ -6,34 +6,41 @@
         <help><![CDATA[Enable this reverse proxy domain.]]></help>
     </field>
     <field>
+        <type>header</type>
+        <label>Domain</label>
+    </field>
+    <field>
         <id>reverse.FromDomain</id>
-        <label>Reverse Proxy Domain</label>
+        <label>Domain</label>
         <type>text</type>
         <hint>example.com</hint>
         <help><![CDATA[Enter a domain name or IP address. For a wildcard domain, use *.example.com. Only use wildcard domains with a wildcard certificate. Don't forget to create a firewall rule that allows port 80 and 443 to "This Firewall".]]></help>
     </field>
     <field>
         <id>reverse.FromPort</id>
-        <label>Reverse Proxy Port</label>
+        <label>Port</label>
         <type>text</type>
         <hint>443</hint>
         <help><![CDATA[Enter the port number. Leave this empty to bind to port 80 and 443 with automatic redirection. Don't forget to create a firewall rule that allows this port to "This Firewall".]]></help>
-        <advanced>true</advanced>
     </field>
     <field>
-        <id>reverse.accesslist</id>
-        <label>Access List</label>
-        <type>dropdown</type>
-        <help><![CDATA[Optionally, select an Access List to restrict access to this domain. If left as "None", any local or remote client is allowed access. In most cases, leaving this as "None" will be the best choice.]]></help>
-        <advanced>true</advanced>
+        <id>reverse.description</id>
+        <label>Description</label>
+        <type>text</type>
+        <hint>example.com.443</hint>
+        <help><![CDATA[Enter a description for this reverse proxy domain.]]></help>
     </field>
     <field>
-        <id>reverse.basicauth</id>
-        <label>Basic Auth</label>
-        <type>select_multiple</type>
-        <size>5</size>
-        <help><![CDATA[Optionally, select Users to restrict access to this domain. Basic Auth matches after Access Lists. If left as "None", any client is allowed access. In most cases, leaving this as "None" will be the best choice.]]></help>
-        <advanced>true</advanced>
+        <type>header</type>
+        <label>Trust</label>
+        <collapse>true</collapse>
+    </field>
+    <field>
+        <id>reverse.DynDns</id>
+        <label>Dynamic DNS</label>
+        <type>checkbox</type>
+        <help><![CDATA[Enable Dynamic DNS, please configure DNS Provider and API Key in General Settings. The DNS Records of this domain wi
+ll be automatically updated with your DNS Provider.]]></help>
     </field>
     <field>
         <id>reverse.DnsChallenge</id>
@@ -42,30 +49,33 @@
         <help><![CDATA[Enable DNS-01 challenge for ACME, please configure DNS Provider and API Key in General Settings. In most cases, leaving this option unchecked will be the best choice. The automatic Let's Encrypt HTTP challenge will be used if this option is unchecked, which needs no further configuration.]]></help>
     </field>
     <field>
-        <id>reverse.DynDns</id>
-        <label>Dynamic DNS</label>
-        <type>checkbox</type>
-        <help><![CDATA[Enable Dynamic DNS, please configure DNS Provider and API Key in General Settings. The DNS Records of this domain will be automatically updated with your DNS Provider.]]></help>
-    </field>
-    <field>
         <id>reverse.CustomCertificate</id>
         <label>Custom Certificate</label>
         <type>dropdown</type>
         <help><![CDATA[Choose your own certificate from System Trust Certificates. Make sure you have imported the full chain. In most cases, leaving this as "None" will be the best choice.]]></help>
-        <advanced>true</advanced>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Access</label>
+        <collapse>true</collapse>
+    </field>
+    <field>
+        <id>reverse.accesslist</id>
+        <label>Access List</label>
+        <type>dropdown</type>
+        <help><![CDATA[Optionally, select an Access List to restrict access to this domain. If left as "None", any local or remote client is allowed access. In most cases, leaving this as "None" will be the best choice.]]></help>
+    </field>
+    <field>
+        <id>reverse.basicauth</id>
+        <label>Basic Auth</label>
+        <type>select_multiple</type>
+        <size>5</size>
+        <help><![CDATA[Optionally, select Users to restrict access to this domain. Basic Auth matches after Access Lists. If left as "None", any client is allowed access. In most cases, leaving this as "None" will be the best choice.]]></help>
     </field>
     <field>
         <id>reverse.AccessLog</id>
         <label>HTTP Access Log</label>
         <type>checkbox</type>
         <help><![CDATA[Enable the HTTP request logging for this domain and its subdomains. This option is mostly for troubleshooting since it will log every single request.]]></help>
-        <advanced>true</advanced>
-    </field>
-    <field>
-        <id>reverse.description</id>
-        <label>Description</label>
-        <type>text</type>
-        <hint>example.com.443</hint>
-        <help><![CDATA[Enter a description for this reverse proxy domain.]]></help>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
@@ -50,6 +50,13 @@ ll be automatically updated with your DNS Provider.]]></help>
         <help><![CDATA[Enable DNS-01 challenge for ACME, please configure DNS Provider and API Key in General Settings. In most cases, leaving this option unchecked will be the best choice. The automatic Let's Encrypt HTTP challenge will be used if this option is unchecked, which needs no further configuration.]]></help>
     </field>
     <field>
+        <id>reverse.AcmePassthrough</id>
+        <label>HTTP-01 challenge redirection</label>
+        <type>text</type>
+        <help><![CDATA[Enter a domain name or IP address. The HTTP-01 challenge will be redirected to that destination. This enables a server behind Caddy to serve "/.well-known/acme-challenge/". Caddy will issue a certificate for the same domain using the TLS-ALPN-01 challenge or DNS-01 challenge instead.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
         <id>reverse.CustomCertificate</id>
         <label>Custom Certificate</label>
         <type>dropdown</type>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogSubdomain.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogSubdomain.xml
@@ -20,7 +20,7 @@
     </field>
     <field>
         <id>subdomain.FromPort</id>
-        <label>Reverse Proxy Port</label>
+        <label>Port</label>
         <type>text</type>
         <hint>443</hint>
         <help><![CDATA[Enter the port number. Leave this empty to bind to port 80 and 443 with automatic redirection. Don't forget to create a firewall rule that allows this destination port to "This Firewall".]]></help>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogSubdomain.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogSubdomain.xml
@@ -6,10 +6,6 @@
         <help><![CDATA[Enable this reverse proxy subdomain.]]></help>
     </field>
     <field>
-        <type>header</type>
-        <label>Subdomain</label>
-    </field>
-    <field>
         <id>subdomain.reverse</id>
         <label>Domain</label>
         <type>dropdown</type>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogSubdomain.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogSubdomain.xml
@@ -34,7 +34,7 @@
     </field>
     <field>
         <type>header</type>
-        <label>Trust</label>
+        <label>DNS</label>
         <collapse>true</collapse>
     </field>
     <field>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogSubdomain.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogSubdomain.xml
@@ -6,14 +6,18 @@
         <help><![CDATA[Enable this reverse proxy subdomain.]]></help>
     </field>
     <field>
+        <type>header</type>
+        <label>Subdomain</label>
+    </field>
+    <field>
         <id>subdomain.reverse</id>
-        <label>Reverse Proxy Domain</label>
+        <label>Domain</label>
         <type>dropdown</type>
         <help><![CDATA[Select a domain, to which this subdomain should be added.]]></help>
     </field>
     <field>
         <id>subdomain.FromDomain</id>
-        <label>Reverse Proxy Subdomain</label>
+        <label>Subdomain</label>
         <type>text</type>
         <hint>opn.example.com</hint>
         <help><![CDATA[Enter the subdomain name (e.g., 'opn.example.com' if your wildcard domain is '*.example.com').]]></help>
@@ -24,22 +28,18 @@
         <type>text</type>
         <hint>443</hint>
         <help><![CDATA[Enter the port number. Leave this empty to bind to port 80 and 443 with automatic redirection. Don't forget to create a firewall rule that allows this destination port to "This Firewall".]]></help>
-        <advanced>true</advanced>
     </field>
     <field>
-        <id>subdomain.accesslist</id>
-        <label>Access List</label>
-        <type>dropdown</type>
-        <help><![CDATA[Optionally, select an Access List to restrict access to this subdomain. If left as "None", any local or remote client is allowed access. In most cases, leaving this as "None" will be the best choice.]]></help>
-        <advanced>true</advanced>
+        <id>subdomain.description</id>
+        <label>Description</label>
+        <type>text</type>
+        <hint>opn.example.com.443</hint>
+        <help><![CDATA[Enter a description for this reverse proxy subdomain.]]></help>
     </field>
     <field>
-        <id>subdomain.basicauth</id>
-        <label>Basic Auth</label>
-        <type>select_multiple</type>
-        <size>5</size>
-        <help><![CDATA[Optionally, select Users to restrict access to this subdomain. Basic Auth matches after Access Lists. If left as "None", any client is allowed access. In most cases, leaving this as "None" will be the best choice.]]></help>
-        <advanced>true</advanced>
+        <type>header</type>
+        <label>Trust</label>
+        <collapse>true</collapse>
     </field>
     <field>
         <id>subdomain.DynDns</id>
@@ -48,10 +48,21 @@
         <help><![CDATA[Enable Dynamic DNS, please configure DNS Provider and API Key in General Settings. The DNS Records of this subdomain will be automatically updated with your DNS Provider.]]></help>
     </field>
     <field>
-        <id>subdomain.description</id>
-        <label>Description</label>
-        <type>text</type>
-        <hint>opn.example.com.443</hint>
-        <help><![CDATA[Enter a description for this reverse proxy subdomain.]]></help>
+        <type>header</type>
+        <label>Access</label>
+        <collapse>true</collapse>
+    </field>
+    <field>
+        <id>subdomain.accesslist</id>
+        <label>Access List</label>
+        <type>dropdown</type>
+        <help><![CDATA[Optionally, select an Access List to restrict access to this subdomain. If left as "None", any local or remote client is allowed access. In most cases, leaving this as "None" will be the best choice.]]></help>
+    </field>
+    <field>
+        <id>subdomain.basicauth</id>
+        <label>Basic Auth</label>
+        <type>select_multiple</type>
+        <size>5</size>
+        <help><![CDATA[Optionally, select Users to restrict access to this subdomain. Basic Auth matches after Access Lists. If left as "None", any client is allowed access. In most cases, leaving this as "None" will be the best choice.]]></help>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dnsprovider.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dnsprovider.xml
@@ -12,38 +12,38 @@
         <help><![CDATA[This is the standard field for the API Key. Field can be left empty if optional: Cloudflare "api_token", Duckdns "api_token", DigitalOcean "auth_token", Godaddy "api_token", Gandi "bearer_token", IONOS "api_token", deSEC "token", Route53 "access_key_id", Porkbun "api_key", ACME-DNS "username", Netlify "personal_access_token", Njalla "api_token", Google Cloud DNS "gcp_project", Azure "tenant_id", OVH "endpoint", Namecheap "api_key", PowerDNS "server_url", DDNSS "api_token", Linode "api_token", Tencent Cloud "secret_id", Dinahosting "username", Hexonet "username", Mail-in-a-Box "api_url".]]></help>
     </field>
     <field>
+        <type>header</type>
+        <label>Additional Fields</label>
+        <collapse>true</collapse>
+    </field>
+    <field>
         <id>caddy.general.TlsDnsSecretApiKey</id>
         <label>DNS API Additional Field 1</label>
         <type>text</type>
         <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: Duckdns "override_domain", Route53 "secret_access_key", Porkbun "api_secret_key", ACME-DNS "password", Azure "client_id", OVH "application_key", Namecheap "user", PowerDNS "api_token", DDNSS "username", Linode "api_url", Tencent Cloud "secret_key", Dinahosting "password", Hexonet "password", Mail-in-a-Box "email_address".]]></help>
-        <advanced>true</advanced>
     </field>
     <field>
         <id>caddy.general.TlsDnsOptionalField1</id>
         <label>DNS API Additional Field 2</label>
         <type>text</type>
         <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: Route53 "max_retries", ACME-DNS "subdomain", Azure "client_secret", OVH "application_secret", Namecheap "api_endpoint", DDNSS "password", Linode "api_version", Mail-in-a-Box "password".]]></help>
-        <advanced>true</advanced>
     </field>
     <field>
         <id>caddy.general.TlsDnsOptionalField2</id>
         <label>DNS API Additional Field 3</label>
         <type>text</type>
         <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: Route53 "aws_profile", ACME-DNS "server_url", Azure "subscription_id", OVH "consumer_key", Namecheap "client_ip", DDNS "password".]]></help>
-        <advanced>true</advanced>
     </field>
     <field>
         <id>caddy.general.TlsDnsOptionalField3</id>
         <label>DNS API Additional Field 4</label>
         <type>text</type>
         <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: Route53 "region", Azure "resource_group_name".]]></help>
-        <advanced>true</advanced>
     </field>
     <field>
         <id>caddy.general.TlsDnsOptionalField4</id>
         <label>DNS API Additional Field 5</label>
         <type>text</type>
         <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: Route53 "token".]]></help>
-        <advanced>true</advanced>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dnsprovider.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dnsprovider.xml
@@ -9,55 +9,41 @@
         <id>caddy.general.TlsDnsApiKey</id>
         <label>DNS API Standard Field</label>
         <type>text</type>
-        <help><![CDATA[This is the standard field for the API Key. Field can be left empty if optional: Cloudflare "api_token", Duckdns "api_token", DigitalOcean "auth_token", DNSPod "auth_token", Hetzner "api_token", Godaddy "api_token", Gandi "bearer_token", IONOS "api_token", deSEC "token", Route53 "access_key_id", Porkbun "api_key", ACME-DNS "username", Netlify "personal_access_token", Namesilo "api_token", Njalla "api_token", Vercel "api_token",  Google Cloud DNS "gcp_project", Alidns "access_key_id", Azure "tenant_id", OpenStack Designate "region_name", OVH "endpoint", Namecheap "api_key", PowerDNS "server_url", DDNSS "api_token", Metaname "api_key", Linode "api_token", Tencent Cloud "secret_id", Dinahosting "username", Hexonet "username", Mail-in-a-Box "api_url".]]></help>
+        <help><![CDATA[This is the standard field for the API Key. Field can be left empty if optional: Cloudflare "api_token", Duckdns "api_token", DigitalOcean "auth_token", Godaddy "api_token", Gandi "bearer_token", IONOS "api_token", deSEC "token", Route53 "access_key_id", Porkbun "api_key", ACME-DNS "username", Netlify "personal_access_token", Njalla "api_token", Google Cloud DNS "gcp_project", Azure "tenant_id", OVH "endpoint", Namecheap "api_key", PowerDNS "server_url", DDNSS "api_token", Linode "api_token", Tencent Cloud "secret_id", Dinahosting "username", Hexonet "username", Mail-in-a-Box "api_url".]]></help>
     </field>
     <field>
         <id>caddy.general.TlsDnsSecretApiKey</id>
         <label>DNS API Additional Field 1</label>
         <type>text</type>
-        <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: Duckdns "override_domain", Route53 "secret_access_key", Porkbun "api_secret_key", ACME-DNS "password", Alidns "access_key_secret", Azure "client_id", OpenStack Designate "tenant_id", OVH "application_key", Namecheap "user", PowerDNS "api_token", DDNSS "username", Metaname "account_reference", Linode "api_url", Tencent Cloud "secret_key", Dinahosting "password", Hexonet "password", Mail-in-a-Box "email_address".]]></help>
+        <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: Duckdns "override_domain", Route53 "secret_access_key", Porkbun "api_secret_key", ACME-DNS "password", Azure "client_id", OVH "application_key", Namecheap "user", PowerDNS "api_token", DDNSS "username", Linode "api_url", Tencent Cloud "secret_key", Dinahosting "password", Hexonet "password", Mail-in-a-Box "email_address".]]></help>
         <advanced>true</advanced>
     </field>
     <field>
         <id>caddy.general.TlsDnsOptionalField1</id>
         <label>DNS API Additional Field 2</label>
         <type>text</type>
-        <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: Route53 "max_retries", ACME-DNS "subdomain", Azure "client_secret", OpenStack Designate "identity_api_version", OVH "application_secret", Namecheap "api_endpoint", DDNSS "password", Linode "api_version", Mail-in-a-Box "password".]]></help>
+        <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: Route53 "max_retries", ACME-DNS "subdomain", Azure "client_secret", OVH "application_secret", Namecheap "api_endpoint", DDNSS "password", Linode "api_version", Mail-in-a-Box "password".]]></help>
         <advanced>true</advanced>
     </field>
     <field>
         <id>caddy.general.TlsDnsOptionalField2</id>
         <label>DNS API Additional Field 3</label>
         <type>text</type>
-        <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: Route53 "aws_profile", ACME-DNS "server_url", Azure "subscription_id", OpenStack Designate "password", OVH "consumer_key", Namecheap "client_ip", DDNS "password".]]></help>
+        <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: Route53 "aws_profile", ACME-DNS "server_url", Azure "subscription_id", OVH "consumer_key", Namecheap "client_ip", DDNS "password".]]></help>
         <advanced>true</advanced>
     </field>
     <field>
         <id>caddy.general.TlsDnsOptionalField3</id>
         <label>DNS API Additional Field 4</label>
         <type>text</type>
-        <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: Route53 "region", Azure "resource_group_name", OpenStack Designate "username".]]></help>
+        <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: Route53 "region", Azure "resource_group_name".]]></help>
         <advanced>true</advanced>
     </field>
     <field>
         <id>caddy.general.TlsDnsOptionalField4</id>
         <label>DNS API Additional Field 5</label>
         <type>text</type>
-        <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: Route53 "token", OpenStack Designate "tenant_name".]]></help>
-        <advanced>true</advanced>
-    </field>
-    <field>
-        <id>caddy.general.TlsDnsOptionalField5</id>
-        <label>DNS API Additional Field 6</label>
-        <type>text</type>
-        <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: OpenStack Designate "auth_url".]]></help>
-        <advanced>true</advanced>
-    </field>
-    <field>
-        <id>caddy.general.TlsDnsOptionalField6</id>
-        <label>DNS API Additional Field 7</label>
-        <type>text</type>
-        <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: OpenStack Designate "endpoint_type".]]></help>
+        <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: Route53 "token".]]></help>
         <advanced>true</advanced>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dynamicdns.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dynamicdns.xml
@@ -1,17 +1,9 @@
 <form>
     <field>
-        <id>caddy.general.DynDnsSimpleHttp</id>
-        <label>DynDns Check Http</label>
-        <type>text</type>
-        <help><![CDATA[Optionally, enter a URL to test the current IP address of the firewall via HTTP protocol. Generally, this is not needed. Caddy uses default providers to test the current IP addresses. If you'd rather use your own, enter the https:// link to an IP address testing website.]]></help>
-        <advanced>true</advanced>
-    </field>
-    <field>
-        <id>caddy.general.DynDnsInterface</id>
-        <label>DynDns Check Interface</label>
+        <id>caddy.general.DynDnsIpVersions</id>
+        <label>DynDns IP Version</label>
         <type>dropdown</type>
-        <help><![CDATA[Optionally, select an interface to extract the current IP addresses of the firewall. At most, one IPv6 Global Unicast Address and one IPv4 non-RFC1918 Address will be extracted. This depends on the DynDns IP Version that's specified.]]></help>
-        <advanced>true</advanced>
+        <help><![CDATA[Leave on None to set IPv4 A-Records and IPv6 AAAA-Records. Select "IPv4 only" for setting A-Records. Select "IPv6 only" for setting AAAA-Records.]]></help>
     </field>
     <field>
         <id>caddy.general.DynDnsCheckInterval</id>
@@ -20,15 +12,26 @@
         <help><![CDATA[Interval to poll for changes of the IP address. The default is 5 minutes. Can be a number between 1 to 1440 minutes.]]></help>
     </field>
     <field>
-        <id>caddy.general.DynDnsIpVersions</id>
-        <label>DynDns IP Version</label>
-        <type>dropdown</type>
-        <help><![CDATA[Leave on None to set IPv4 A-Records and IPv6 AAAA-Records. Select "IPv4 only" for setting A-Records. Select "IPv6 only" for setting AAAA-Records.]]></help>
-    </field>
-    <field>
         <id>caddy.general.DynDnsTTL</id>
         <label>DynDns TTL</label>
         <type>text</type>
         <help><![CDATA[Set the TTL (time to live) for DNS Records. The default is 1 hour. Can be a number between 1 to 24 hours.]]></help>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Additional Checks</label>
+        <collapse>true</collapse>
+    </field>
+    <field>
+        <id>caddy.general.DynDnsSimpleHttp</id>
+        <label>DynDns Check Http</label>
+        <type>text</type>
+        <help><![CDATA[Optionally, enter a URL to test the current IP address of the firewall via HTTP protocol. Generally, this is not needed. Caddy uses default providers to test the current IP addresses. If you'd rather use your own, enter the https:// link to an IP address testing website.]]></help>
+    </field>
+    <field>
+        <id>caddy.general.DynDnsInterface</id>
+        <label>DynDns Check Interface</label>
+        <type>dropdown</type>
+        <help><![CDATA[Optionally, select an interface to extract the current IP addresses of the firewall. At most, one IPv6 Global Unicast Address and one IPv4 non-RFC1918 Address will be extracted. This depends on the DynDns IP Version that's specified.]]></help>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
@@ -19,15 +19,15 @@
         <help><![CDATA[Select the auto HTTPS option. "On" (default) creates automatic certificates using Let's Encrypt or ZeroSSL without needing any configuration.]]></help>
     </field>
     <field>
-        <id>caddy.general.abort</id>
-        <label>Abort Connections</label>
-        <type>checkbox</type>
-        <help><![CDATA[Abort all connections that don't have a matching handle or access list. This option doesn't conflict with Let's Encrypt. Disable it for troubleshooting purposes, e.g., testing if the Reverse Proxy Domain works and the Certificate has been installed. For production use, enabling this option is recommended.]]></help>
-    </field>
-    <field>
         <id>caddy.general.accesslist</id>
         <label>Trusted Proxies</label>
         <type>dropdown</type>
         <help><![CDATA[Select an Access List of Trusted Proxies. If Caddy is not the first server being connected to by your clients (for example when a CDN is in front of Caddy), you may configure trusted_proxies with a list of IP ranges (CIDRs) from which incoming requests are trusted to have sent good values for these headers. Additionally, set the same Access List to the Domains your Trusted Proxy connects to.]]></help>
+    </field>
+    <field>
+        <id>caddy.general.abort</id>
+        <label>Abort Connections</label>
+        <type>checkbox</type>
+        <help><![CDATA[Abort all connections that don't have a matching handle or access list. This option doesn't conflict with Let's Encrypt. Disable it for troubleshooting purposes, e.g., testing if the Reverse Proxy Domain works and the Certificate has been installed. For production use, enabling this option is recommended.]]></help>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/logsettings.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/logsettings.xml
@@ -10,7 +10,6 @@
         <label>Log HTTP Access in JSON Format</label>
         <type>checkbox</type>
         <help><![CDATA[Log HTTP access in a standard JSON logfile per domain, e.g for processing by CrowdSec. Use combined with HTTP Access Log in the Reverse Proxy Domain. Enabling this will make the HTTP Access Log dissappear from the standard "Log File" in the GUI. They can be found in the filesystem "/var/log/caddy/access/"]]></help>
-        <advanced>true</advanced>
     </field>
     <field>
         <id>caddy.general.LogAccessPlainKeep</id>
@@ -18,6 +17,5 @@
         <hint>10</hint>
         <type>text</type>
         <help><![CDATA[How many days to keep the JSON access logs.]]></help>
-        <advanced>true</advanced>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
@@ -31,7 +31,7 @@
 namespace OPNsense\Caddy;
 
 use OPNsense\Base\BaseModel;
-use Phalcon\Messages\Message;
+use OPNsense\Base\Messages\Message;
 
 class Caddy extends BaseModel
 {

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -144,6 +144,10 @@
                 <CustomCertificate type="CertificateField"/>
                 <AccessLog type="BooleanField"/>
                 <DynDns type="BooleanField"/>
+                <AcmePassthrough type="HostnameField">
+                    <ValidationMessage>Please enter a valid 'to' domain or IP address.</ValidationMessage>
+                    <IpAllowed>Y</IpAllowed>
+                </AcmePassthrough>
             </reverse>
             <subdomain type="ArrayField">
                 <enabled type="BooleanField">

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//Pischem/caddy</mount>
     <description>A GUI model for configuring a reverse proxy in the Caddy web server.</description>
-    <version>1.1.4</version>
+    <version>1.1.5</version>
     <items>
         <general>
             <enabled type="BooleanField">
@@ -26,8 +26,6 @@
                     <cloudflare>Cloudflare</cloudflare>
                     <duckdns>Duck DNS</duckdns>
                     <digitalocean>DigitalOcean</digitalocean>
-                    <dnspod>DNSPod</dnspod>
-                    <hetzner>Hetzner</hetzner>
                     <godaddy>GoDaddy</godaddy>
                     <gandi>Gandi</gandi>
                     <ionos>IONOS</ionos>
@@ -35,19 +33,14 @@
                     <porkbun>Porkbun</porkbun>
                     <route53>Route53</route53>
                     <acmedns>ACME-DNS</acmedns>
-                    <alidns>Alidns</alidns>
                     <googleclouddns>Google Cloud DNS</googleclouddns>
                     <azure>Azure</azure>
-                    <openstack-designate>OpenStack Designate</openstack-designate>
                     <ovh>OVH</ovh>
                     <namecheap>Namecheap</namecheap>
                     <netlify>Netlify</netlify>
-                    <namesilo>Namesilo</namesilo>
                     <powerdns>PowerDNS</powerdns>
-                    <vercel>Vercel</vercel>
                     <ddnss>DDNSS</ddnss>
                     <njalla>Njalla</njalla>
-                    <metaname>Metaname</metaname>
                     <linode>Linode</linode>
                     <tencentcloud>Tencent Cloud</tencentcloud>
                     <dinahosting>Dinahosting</dinahosting>
@@ -61,8 +54,6 @@
             <TlsDnsOptionalField2 type="TextField"/>
             <TlsDnsOptionalField3 type="TextField"/>
             <TlsDnsOptionalField4 type="TextField"/>
-            <TlsDnsOptionalField5 type="TextField"/>
-            <TlsDnsOptionalField6 type="TextField"/>
             <accesslist type="ModelRelationField">
                 <Model>
                     <reverseproxy>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -259,6 +259,7 @@
                 </ToPath>
                 <HttpTls type="BooleanField"/>
                 <HttpNtlm type="BooleanField"/>
+                <HttpTlsInsecureSkipVerify type="BooleanField"/>
                 <HttpTlsTrustedCaCerts type="CertificateField">
                     <Type>ca</Type>
                 </HttpTlsTrustedCaCerts>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -166,7 +166,7 @@
                             <th data-column-id="DynDns" data-type="boolean" data-formatter="boolean" data-visible="false">Dynamic DNS</th>
                             <th data-column-id="AccessLog" data-type="boolean" data-formatter="boolean" data-visible="false">HTTP Access Log</th>
                             <th data-column-id="CustomCertificate" data-type="string" data-visible="false">Custom Certificate</th>
-                            <th data-column-id="AcmeRedirection" data-type="string" data-visible="false">HTTP-01 redirection</th>
+                            <th data-column-id="AcmePassthrough" data-type="string" data-visible="false">HTTP-01 redirection</th>
                             <th data-column-id="description" data-type="string">Description</th>
                             <th data-column-id="commands" data-width="7em" data-formatter="commands" data-sortable="false">Commands</th>
                         </tr>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -232,10 +232,10 @@
                             <th data-column-id="reverse" data-type="string">Domain</th>
                             <th data-column-id="subdomain" data-type="string">Subdomain</th>
                             <th data-column-id="HandleType" data-type="string" data-visible="false">Handle Type</th>
-                            <th data-column-id="HandlePath" data-type="string">Handle Path</th>
-                            <th data-column-id="ToDomain" data-type="string">Backend Domain</th>
-                            <th data-column-id="ToPort" data-type="string">Backend Port</th>
-                            <th data-column-id="ToPath" data-type="string" data-visible="false">Backend Path</th>
+                            <th data-column-id="HandlePath" data-type="string" data-visible="false">Handle Path</Th>
+                            <th data-column-id="ToDomain" data-type="string">Upstream Domain</th>
+                            <th data-column-id="ToPort" data-type="string">Upstream Port</th>
+                            <th data-column-id="ToPath" data-type="string" data-visible="false">Upstream Path</th>
                             <th data-column-id="HttpTls" data-type="boolean" data-formatter="boolean" data-visible="false">TLS</th>
                             <th data-column-id="HttpTlsTrustedCaCerts" data-type="string" data-visible="false">TLS CA</th>
                             <th data-column-id="HttpTlsServerName" data-type="string" data-visible="false">TLS Server Name</th>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -166,6 +166,7 @@
                             <th data-column-id="DynDns" data-type="boolean" data-formatter="boolean" data-visible="false">Dynamic DNS</th>
                             <th data-column-id="AccessLog" data-type="boolean" data-formatter="boolean" data-visible="false">HTTP Access Log</th>
                             <th data-column-id="CustomCertificate" data-type="string" data-visible="false">Custom Certificate</th>
+                            <th data-column-id="AcmeRedirection" data-type="string" data-visible="false">HTTP-01 redirection</th>
                             <th data-column-id="description" data-type="string">Description</th>
                             <th data-column-id="commands" data-width="7em" data-formatter="commands" data-sortable="false">Commands</th>
                         </tr>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -240,6 +240,7 @@
                             <th data-column-id="HttpTlsTrustedCaCerts" data-type="string" data-visible="false">TLS CA</th>
                             <th data-column-id="HttpTlsServerName" data-type="string" data-visible="false">TLS Server Name</th>
                             <th data-column-id="HttpNtlm" data-type="boolean" data-formatter="boolean" data-visible="false">NTLM</th>
+                            <th data-column-id="HttpTlsInsecureSkipVerify" data-type="boolean" data-formatter="boolean" data-visible="false">TLS Insecure Skip Verify</th>
                             <th data-column-id="description" data-type="string">Description</th>
                             <th data-column-id="commands" data-width="7em" data-formatter="commands" data-sortable="false">Commands</th>
                         </tr>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -232,7 +232,7 @@
                             <th data-column-id="reverse" data-type="string">Domain</th>
                             <th data-column-id="subdomain" data-type="string">Subdomain</th>
                             <th data-column-id="HandleType" data-type="string" data-visible="false">Handle Type</th>
-                            <th data-column-id="HandlePath" data-type="string" data-visible="false">Handle Path</Th>
+                            <th data-column-id="HandlePath" data-type="string" data-visible="false">Handle Path</th>
                             <th data-column-id="ToDomain" data-type="string">Upstream Domain</th>
                             <th data-column-id="ToPort" data-type="string">Upstream Port</th>
                             <th data-column-id="ToPath" data-type="string" data-visible="false">Upstream Path</th>

--- a/www/caddy/src/opnsense/scripts/OPNsense/Caddy/caddy_certs.php
+++ b/www/caddy/src/opnsense/scripts/OPNsense/Caddy/caddy_certs.php
@@ -29,13 +29,11 @@
  */
 
 require_once("config.inc");
-require_once("certs.inc");
-require_once("legacy_bindings.inc");
 
 use OPNsense\Core\Config;
 
 $configObj = Config::getInstance()->object();
-$temp_dir = '/usr/local/etc/caddy/certificates/temp/';
+$temp_dir = '/var/db/caddy/data/caddy/certificates/temp/';
 
 function extract_and_save_certificates($configObj, $temp_dir)
 {

--- a/www/caddy/src/opnsense/scripts/OPNsense/Caddy/caddy_certs.php
+++ b/www/caddy/src/opnsense/scripts/OPNsense/Caddy/caddy_certs.php
@@ -29,8 +29,6 @@
  */
 
 require_once("config.inc");
-require_once("certs.inc");
-require_once("legacy_bindings.inc");
 
 use OPNsense\Core\Config;
 

--- a/www/caddy/src/opnsense/scripts/OPNsense/Caddy/caddy_certs.php
+++ b/www/caddy/src/opnsense/scripts/OPNsense/Caddy/caddy_certs.php
@@ -29,6 +29,8 @@
  */
 
 require_once("config.inc");
+require_once("certs.inc");
+require_once("legacy_bindings.inc");
 
 use OPNsense\Core\Config;
 
@@ -66,9 +68,7 @@ function extract_and_save_certificates($configObj, $temp_dir)
 
         // Save the certificate chain and private key
         file_put_contents($temp_dir . $cert_refid . '.pem', $cert_chain);
-        chmod($temp_dir . $cert_refid . '.pem', 0600);
         file_put_contents($temp_dir . $cert_refid . '.key', $key_content);
-        chmod($temp_dir . $cert_refid . '.key', 0600);
     }
 
     // Traverse through CA certificates and save them
@@ -78,7 +78,6 @@ function extract_and_save_certificates($configObj, $temp_dir)
 
         // Save the CA certificate
         file_put_contents($temp_dir . $ca_refid . '.pem', $ca_content);
-        chmod($temp_dir . $ca_refid . '.pem', 0600);
     }
 }
 

--- a/www/caddy/src/opnsense/scripts/OPNsense/Caddy/setup.sh
+++ b/www/caddy/src/opnsense/scripts/OPNsense/Caddy/setup.sh
@@ -1,29 +1,26 @@
 #!/bin/sh
 
 # Define directories
-CADDY_DIR="/usr/local/etc/caddy"
-CADDY_CERTS_DIR="${CADDY_DIR}/certificates/temp"
+CADDY_CERTS_DIR="/var/db/caddy/data/caddy/certificates/temp"
 CADDY_LOG_DIR="/var/log/caddy/access"
-CADDY_CONF_DIR="${CADDY_DIR}/caddy.d"
+CADDY_CONF_DIR="/usr/local/etc/caddy/caddy.d"
 
-# Create Caddy configuration directories with appropriate permissions
-mkdir -p "${CADDY_DIR}"
-mkdir -p "${CADDY_CERTS_DIR}"
-mkdir -p "${CADDY_CONF_DIR}"
+# Create custom directories with appropriate permissions
+mkdir -p "$CADDY_CERTS_DIR"
+chown -R root:wheel "$CADDY_CERTS_DIR"
+chmod -R 750 "$CADDY_CERTS_DIR"
 
-# Set permissions for Caddy configuration directories
-chown -R root:wheel "${CADDY_DIR}"
-chmod -R 750 "${CADDY_DIR}"
+mkdir -p "$CADDY_LOG_DIR"
+chown -R root:wheel "$CADDY_LOG_DIR"
+chmod -R 750 "$CADDY_LOG_DIR"
 
-# Create Caddy log directory
-mkdir -p "${CADDY_LOG_DIR}"
-
-# Set permissions for Caddy log directory
-chown -R root:wheel "${CADDY_LOG_DIR}"
-chmod -R 750 "${CADDY_LOG_DIR}"
+mkdir -p "$CADDY_CONF_DIR"
+chown -R root:wheel "$CADDY_CONF_DIR"
+chmod -R 750 "$CADDY_CONF_DIR"
 
 # Format and overwrite the Caddyfile
-(cd "${CADDY_DIR}" && /usr/local/bin/caddy fmt --overwrite)
+(cd "/usr/local/etc/caddy" && /usr/local/bin/caddy fmt --overwrite)
 
 # Write custom certs from the OPNsense Trust Store into a directory where Caddy can read them
 /usr/local/opnsense/scripts/OPNsense/Caddy/caddy_certs.php
+

--- a/www/caddy/src/opnsense/scripts/OPNsense/Caddy/setup.sh
+++ b/www/caddy/src/opnsense/scripts/OPNsense/Caddy/setup.sh
@@ -2,19 +2,13 @@
 
 # Define directories
 CADDY_DIR="/usr/local/etc/caddy"
-CADDY_ACME_DIR="${CADDY_DIR}/acme"
 CADDY_CERTS_DIR="${CADDY_DIR}/certificates/temp"
-CADDY_OCSP_DIR="${CADDY_DIR}/ocsp"
-CADDY_LOCKS_DIR="${CADDY_DIR}/locks"
 CADDY_LOG_DIR="/var/log/caddy/access"
 CADDY_CONF_DIR="${CADDY_DIR}/caddy.d"
 
 # Create Caddy configuration directories with appropriate permissions
 mkdir -p "${CADDY_DIR}"
-mkdir -p "${CADDY_ACME_DIR}"
 mkdir -p "${CADDY_CERTS_DIR}"
-mkdir -p "${CADDY_OCSP_DIR}"
-mkdir -p "${CADDY_LOCKS_DIR}"
 mkdir -p "${CADDY_CONF_DIR}"
 
 # Set permissions for Caddy configuration directories
@@ -33,6 +27,3 @@ chmod -R 750 "${CADDY_LOG_DIR}"
 
 # Write custom certs from the OPNsense Trust Store into a directory where Caddy can read them
 /usr/local/opnsense/scripts/OPNsense/Caddy/caddy_certs.php
-
-# Optional Debug message
-# echo "Caddy installation completed. All caddy directories and files created successfully."

--- a/www/caddy/src/opnsense/scripts/OPNsense/Caddy/setup.sh
+++ b/www/caddy/src/opnsense/scripts/OPNsense/Caddy/setup.sh
@@ -4,7 +4,7 @@
 CADDY_DIR="/usr/local/etc/caddy"
 CADDY_CERTS_DIR="/var/db/caddy/data/caddy/certificates/temp"
 CADDY_LOG_DIR="/var/log/caddy/access"
-CADDY_CONF_DIR="$CADDY_DIR/caddy.d"
+CADDY_CONF_DIR="${CADDY_DIR}/caddy.d"
 
 # Create custom directories with appropriate permissions
 mkdir -p "$CADDY_CERTS_DIR"

--- a/www/caddy/src/opnsense/scripts/OPNsense/Caddy/setup.sh
+++ b/www/caddy/src/opnsense/scripts/OPNsense/Caddy/setup.sh
@@ -7,17 +7,17 @@ CADDY_LOG_DIR="/var/log/caddy/access"
 CADDY_CONF_DIR="${CADDY_DIR}/caddy.d"
 
 # Create custom directories with appropriate permissions
-mkdir -p "$CADDY_CERTS_DIR"
-chown -R root:wheel "$CADDY_CERTS_DIR"
-chmod -R 750 "$CADDY_CERTS_DIR"
+mkdir -p "${CADDY_CERTS_DIR}"
+chown -R root:wheel "${CADDY_CERTS_DIR}"
+chmod -R 750 "${CADDY_CERTS_DIR}"
 
-mkdir -p "$CADDY_LOG_DIR"
-chown -R root:wheel "$CADDY_LOG_DIR"
-chmod -R 750 "$CADDY_LOG_DIR"
+mkdir -p "${CADDY_LOG_DIR}"
+chown -R root:wheel "${CADDY_LOG_DIR}"
+chmod -R 750 "${CADDY_LOG_DIR}"
 
-mkdir -p "$CADDY_CONF_DIR"
-chown -R root:wheel "$CADDY_CONF_DIR"
-chmod -R 750 "$CADDY_CONF_DIR"
+mkdir -p "${CADDY_CONF_DIR}"
+chown -R root:wheel "${CADDY_CONF_DIR}"
+chmod -R 750 "${CADDY_CONF_DIR}"
 
 # Format and overwrite the Caddyfile
 (cd "${CADDY_DIR}" && /usr/local/bin/caddy fmt --overwrite)

--- a/www/caddy/src/opnsense/scripts/OPNsense/Caddy/setup.sh
+++ b/www/caddy/src/opnsense/scripts/OPNsense/Caddy/setup.sh
@@ -9,7 +9,7 @@ CADDY_CONF_DIR="${CADDY_DIR}/caddy.d"
 # Create custom directories with appropriate permissions
 mkdir -p "${CADDY_CERTS_DIR}"
 chown -R root:wheel "${CADDY_CERTS_DIR}"
-chmod -R 750 "${CADDY_CERTS_DIR}"
+chmod -R 600 "${CADDY_CERTS_DIR}"
 
 mkdir -p "${CADDY_LOG_DIR}"
 chown -R root:wheel "${CADDY_LOG_DIR}"

--- a/www/caddy/src/opnsense/scripts/OPNsense/Caddy/setup.sh
+++ b/www/caddy/src/opnsense/scripts/OPNsense/Caddy/setup.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
 
 # Define directories
+CADDY_DIR="/usr/local/etc/caddy"
 CADDY_CERTS_DIR="/var/db/caddy/data/caddy/certificates/temp"
 CADDY_LOG_DIR="/var/log/caddy/access"
-CADDY_CONF_DIR="/usr/local/etc/caddy/caddy.d"
+CADDY_CONF_DIR="$CADDY_DIR/caddy.d"
 
 # Create custom directories with appropriate permissions
 mkdir -p "$CADDY_CERTS_DIR"
@@ -19,8 +20,7 @@ chown -R root:wheel "$CADDY_CONF_DIR"
 chmod -R 750 "$CADDY_CONF_DIR"
 
 # Format and overwrite the Caddyfile
-(cd "/usr/local/etc/caddy" && /usr/local/bin/caddy fmt --overwrite)
+(cd "${CADDY_DIR}" && /usr/local/bin/caddy fmt --overwrite)
 
 # Write custom certs from the OPNsense Trust Store into a directory where Caddy can read them
 /usr/local/opnsense/scripts/OPNsense/Caddy/caddy_certs.php
-

--- a/www/caddy/src/opnsense/service/conf/actions.d/actions_caddy.conf
+++ b/www/caddy/src/opnsense/service/conf/actions.d/actions_caddy.conf
@@ -15,6 +15,7 @@ command:/usr/local/opnsense/scripts/OPNsense/Caddy/caddy_control.py restart
 parameters:
 type:script
 message:Reloading Caddy configuration
+description:Restart Caddy service
 
 [validate]
 command:/usr/local/opnsense/scripts/OPNsense/Caddy/caddy_control.py validate

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -219,6 +219,21 @@
 }
 
 # Reverse Proxy Configuration
+
+{% for reverse in helpers.toList('Pischem.caddy.reverseproxy.reverse') %}
+    {% if reverse.enabled|default("0") == "1" and reverse.AcmePassthrough %}
+        # HTTP-01 challenge redirection for domain: "{{ reverse['@uuid'] }}"
+        http://{{ reverse.FromDomain|default("") }} {
+            handle /.well-known/acme-challenge/* {
+                reverse_proxy {{ reverse.AcmePassthrough }}
+            }
+            handle {
+                redir https://{host}{uri} 308
+            }
+        }
+    {% endif %}
+{% endfor %}
+
 {% macro tls_configuration(dnsProvider, dnsApiKey, customCert, dnsChallenge, dnsSecretApiKey, TlsDnsOptionalField1, TlsDnsOptionalField2, TlsDnsOptionalField3, TlsDnsOptionalField4) %}
     {% if dnsChallenge == "1" and dnsProvider and dnsProvider != "none" %}
         {% if dnsProvider in ['duckdns', 'porkbun', 'desec', 'route53', 'acmedns', 'googleclouddns', 'azure', 'ovh', 'namecheap', 'powerdns', 'ddnss', 'linode', 'tencentcloud', 'dinahosting', 'hexonet', 'mailinabox'] %}

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -341,7 +341,7 @@
         {% endif %}
     {% endif %}
     {% if customCert %}
-        tls /usr/local/etc/caddy/certificates/temp/{{ customCert }}.pem /usr/local/etc/caddy/certificates/temp/{{ customCert }}.key
+        tls /var/db/caddy/data/caddy/certificates/temp/{{ customCert }}.pem /var/db/caddy/data/caddy/certificates/temp/{{ customCert }}.key
     {% endif %}
 {% endmacro %}
 
@@ -359,7 +359,7 @@
                     {% else %}
                     tls
                     {% if handle.HttpTlsTrustedCaCerts %}
-                    tls_trusted_ca_certs /usr/local/etc/caddy/certificates/temp/{{ handle.HttpTlsTrustedCaCerts }}.pem
+                    tls_trusted_ca_certs /var/db/caddy/data/caddy/certificates/temp/{{ handle.HttpTlsTrustedCaCerts }}.pem
                     {% endif %}
                     {% if handle.HttpTlsServerName %}
                     tls_server_name {{ handle.HttpTlsServerName }}
@@ -373,7 +373,7 @@
                     {% else %}
                     tls
                     {% if handle.HttpTlsTrustedCaCerts %}
-                    tls_trusted_ca_certs /usr/local/etc/caddy/certificates/temp/{{ handle.HttpTlsTrustedCaCerts }}.pem
+                    tls_trusted_ca_certs /var/db/caddy/data/caddy/certificates/temp/{{ handle.HttpTlsTrustedCaCerts }}.pem
                     {% endif %}
                     {% if handle.HttpTlsServerName %}
                     tls_server_name {{ handle.HttpTlsServerName }}

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -54,8 +54,6 @@
     {% set dnsOptionalField2 = generalSettings.TlsDnsOptionalField2 %}
     {% set dnsOptionalField3 = generalSettings.TlsDnsOptionalField3 %}
     {% set dnsOptionalField4 = generalSettings.TlsDnsOptionalField4 %}
-    {% set dnsOptionalField5 = generalSettings.TlsDnsOptionalField5 %}
-    {% set dnsOptionalField6 = generalSettings.TlsDnsOptionalField6 %}
     {% set dynDnsSimpleHttp = generalSettings.DynDnsSimpleHttp %}
     {% set dynDnsInterface = generalSettings.DynDnsInterface %}
     {% set dynDnsCheckInterval = generalSettings.DynDnsCheckInterval %}
@@ -82,7 +80,7 @@
 
     {% if dnsProvider and dnsProvider != "none" and dnsProvider != "acmedns" and dynDnsDomains|length > 0 %}
         dynamic_dns {
-            {% if dnsProvider in ['porkbun', 'desec', 'route53', 'alidns', 'googleclouddns', 'azure', 'openstack-designate', 'ovh', 'namecheap', 'powerdns', 'ddnss', 'linode', 'tencentcloud', 'dinahosting', 'hexonet', 'mailinabox'] %}
+            {% if dnsProvider in ['porkbun', 'desec', 'route53', 'googleclouddns', 'azure', 'ovh', 'namecheap', 'powerdns', 'ddnss', 'linode', 'tencentcloud', 'dinahosting', 'hexonet', 'mailinabox'] %}
                 provider {{ dnsProvider }} {
                     {% if dnsProvider == 'porkbun' %}
                         {% if dnsApiKey %}api_key {{ dnsApiKey }}
@@ -105,11 +103,6 @@
                         {% endif %}
                         {% if dnsOptionalField4 %}token {{ dnsOptionalField4 }}
                         {% endif %}
-                    {% elif dnsProvider == 'alidns' %}
-                        {% if dnsApiKey %}access_key_id {{ dnsApiKey }}
-                        {% endif %}
-                        {% if dnsSecretApiKey %}access_key_secret {{ dnsSecretApiKey }}
-                        {% endif %}
                     {% elif dnsProvider == 'googleclouddns' %}
                         {% if dnsApiKey %}gcp_project {{ dnsApiKey }}
                         {% endif %}
@@ -123,23 +116,6 @@
                         {% if dnsOptionalField2 %}subscription_id {{ dnsOptionalField2 }}
                         {% endif %}
                         {% if dnsOptionalField3 %}resource_group_name {{ dnsOptionalField3 }}
-                        {% endif %}
-                    {% elif dnsProvider == 'openstack-designate' %}
-                        {% if dnsApiKey %}region_name {{ dnsApiKey }}
-                        {% endif %}
-                        {% if dnsSecretApiKey %}tenant_id {{ dnsSecretApiKey }}
-                        {% endif %}
-                        {% if dnsOptionalField1 %}identity_api_version {{ dnsOptionalField1 }}
-                        {% endif %}
-                        {% if dnsOptionalField2 %}password {{ dnsOptionalField2 }}
-                        {% endif %}
-                        {% if dnsOptionalField3 %}username {{ dnsOptionalField3 }}
-                        {% endif %}
-                        {% if dnsOptionalField4 %}tenant_name {{ dnsOptionalField4 }}
-                        {% endif %}
-                        {% if dnsOptionalField5 %}auth_url {{ dnsOptionalField5 }}
-                        {% endif %}
-                        {% if dnsOptionalField6 %}endpoint_type {{ dnsOptionalField6 }}
                         {% endif %}
                     {% elif dnsProvider == 'ovh' %}
                         {% if dnsApiKey %}endpoint {{ dnsApiKey }}
@@ -201,8 +177,6 @@
                         {% endif %}
                     {% endif %}
                 }
-            {% elif dnsProvider in ['metaname'] %}
-                provider {{ dnsProvider }} {{ dnsApiKey }} {{ dnsSecretApiKey }}
             {% else %}
                 provider {{ dnsProvider }} {{ dnsApiKey }}
             {% endif %}
@@ -245,9 +219,9 @@
 }
 
 # Reverse Proxy Configuration
-{% macro tls_configuration(dnsProvider, dnsApiKey, customCert, dnsChallenge, dnsSecretApiKey, TlsDnsOptionalField1, TlsDnsOptionalField2, TlsDnsOptionalField3, TlsDnsOptionalField4, TlsDnsOptionalField5, TlsDnsOptionalField6) %}
+{% macro tls_configuration(dnsProvider, dnsApiKey, customCert, dnsChallenge, dnsSecretApiKey, TlsDnsOptionalField1, TlsDnsOptionalField2, TlsDnsOptionalField3, TlsDnsOptionalField4) %}
     {% if dnsChallenge == "1" and dnsProvider and dnsProvider != "none" %}
-        {% if dnsProvider in ['duckdns', 'porkbun', 'desec', 'route53', 'acmedns', 'alidns', 'googleclouddns', 'azure', 'openstack-designate', 'ovh', 'namecheap', 'powerdns', 'ddnss', 'linode', 'tencentcloud', 'dinahosting', 'hexonet', 'mailinabox'] %}
+        {% if dnsProvider in ['duckdns', 'porkbun', 'desec', 'route53', 'acmedns', 'googleclouddns', 'azure', 'ovh', 'namecheap', 'powerdns', 'ddnss', 'linode', 'tencentcloud', 'dinahosting', 'hexonet', 'mailinabox'] %}
             tls {
                 dns {{ dnsProvider }} {
                     {% if dnsProvider == 'duckdns' %}
@@ -285,11 +259,6 @@
                         {% endif %}
                         {% if dnsOptionalField2 %}server_url {{ dnsOptionalField2 }}
                         {% endif %}
-                    {% elif dnsProvider == 'alidns' %}
-                        {% if dnsApiKey %}access_key_id {{ dnsApiKey }}
-                        {% endif %}
-                        {% if dnsSecretApiKey %}access_key_secret {{ dnsSecretApiKey }}
-                        {% endif %}
                     {% elif dnsProvider == 'googleclouddns' %}
                         {% if dnsApiKey %}gcp_project {{ dnsApiKey }}
                         {% endif %}
@@ -303,23 +272,6 @@
                         {% if dnsOptionalField2 %}subscription_id {{ dnsOptionalField2 }}
                         {% endif %}
                         {% if dnsOptionalField3 %}resource_group_name {{ dnsOptionalField3 }}
-                        {% endif %}
-                    {% elif dnsProvider == 'openstack-designate' %}
-                        {% if dnsApiKey %}region_name {{ dnsApiKey }}
-                        {% endif %}
-                        {% if dnsSecretApiKey %}tenant_id {{ dnsSecretApiKey }}
-                        {% endif %}
-                        {% if dnsOptionalField1 %}identity_api_version {{ dnsOptionalField1 }}
-                        {% endif %}
-                        {% if dnsOptionalField2 %}password {{ dnsOptionalField2 }}
-                        {% endif %}
-                        {% if dnsOptionalField3 %}username {{ dnsOptionalField3 }}
-                        {% endif %}
-                        {% if dnsOptionalField4 %}tenant_name {{ dnsOptionalField4 }}
-                        {% endif %}
-                        {% if dnsOptionalField5 %}auth_url {{ dnsOptionalField5 }}
-                        {% endif %}
-                        {% if dnsOptionalField6 %}endpoint_type {{ dnsOptionalField6 }}
                         {% endif %}
                     {% elif dnsProvider == 'ovh' %}
                         {% if dnsApiKey %}endpoint {{ dnsApiKey }}
@@ -381,10 +333,6 @@
                         {% endif %}
                     {% endif %}
                 }
-            }
-        {% elif dnsProvider in ['metaname'] %}
-            tls {
-                dns {{ dnsProvider }} {{ dnsApiKey }} {{ dnsSecretApiKey }}
             }
         {% else %}
             tls {
@@ -476,7 +424,7 @@
     {% endif %}
     {% set customCert = reverse.CustomCertificate|default("") %}
     {% set dnsChallenge = reverse.DnsChallenge|default("0") %}
-    {{ tls_configuration(dnsProvider, dnsApiKey, customCert, dnsChallenge, dnsSecretApiKey, TlsDnsOptionalField1, TlsDnsOptionalField2, TlsDnsOptionalField3, TlsDnsOptionalField4, TlsDnsOptionalField5, TlsDnsOptionalField6) }}
+    {{ tls_configuration(dnsProvider, dnsApiKey, customCert, dnsChallenge, dnsSecretApiKey, TlsDnsOptionalField1, TlsDnsOptionalField2, TlsDnsOptionalField3, TlsDnsOptionalField4) }}
 
     {% if not reverse.accesslist %}
         {% set basicauth_uuids = reverse.basicauth %}

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -403,28 +403,36 @@
         rewrite * {{ handle.ToPath }}{uri}
         {% endif %}
         reverse_proxy {{ handle.ToDomain }}{% if handle.ToPort %}:{{ handle.ToPort }}{% endif %} {
-            {% if handle.HttpTls|default("0") == "1" %}
-            {% if handle.HttpNtlm|default("0") == "1" %}
-            transport http_ntlm {
-                tls
-                {% if handle.HttpTlsTrustedCaCerts %}
-                tls_trusted_ca_certs /usr/local/etc/caddy/certificates/temp/{{ handle.HttpTlsTrustedCaCerts }}.pem
+            {% if handle.HttpTls|default("0") == "1" or handle.HttpTlsInsecureSkipVerify|default("0") == "1" %}
+                {% if handle.HttpNtlm|default("0") == "1" %}
+                transport http_ntlm {
+                    {% if handle.HttpTlsInsecureSkipVerify|default("0") == "1" %}
+                    tls_insecure_skip_verify
+                    {% else %}
+                    tls
+                    {% if handle.HttpTlsTrustedCaCerts %}
+                    tls_trusted_ca_certs /usr/local/etc/caddy/certificates/temp/{{ handle.HttpTlsTrustedCaCerts }}.pem
+                    {% endif %}
+                    {% if handle.HttpTlsServerName %}
+                    tls_server_name {{ handle.HttpTlsServerName }}
+                    {% endif %}
+                    {% endif %}
+                }
+                {% else %}
+                transport http {
+                    {% if handle.HttpTlsInsecureSkipVerify|default("0") == "1" %}
+                    tls_insecure_skip_verify
+                    {% else %}
+                    tls
+                    {% if handle.HttpTlsTrustedCaCerts %}
+                    tls_trusted_ca_certs /usr/local/etc/caddy/certificates/temp/{{ handle.HttpTlsTrustedCaCerts }}.pem
+                    {% endif %}
+                    {% if handle.HttpTlsServerName %}
+                    tls_server_name {{ handle.HttpTlsServerName }}
+                    {% endif %}
+                    {% endif %}
+                }
                 {% endif %}
-                {% if handle.HttpTlsServerName %}
-                tls_server_name {{ handle.HttpTlsServerName }}
-                {% endif %}
-            }
-            {% else %}
-            transport http {
-                tls
-                {% if handle.HttpTlsTrustedCaCerts %}
-                tls_trusted_ca_certs /usr/local/etc/caddy/certificates/temp/{{ handle.HttpTlsTrustedCaCerts }}.pem
-                {% endif %}
-                {% if handle.HttpTlsServerName %}
-                tls_server_name {{ handle.HttpTlsServerName }}
-                {% endif %}
-            }
-            {% endif %}
             {% endif %}
         }
     }

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -4,9 +4,6 @@
 
 # Global Options
 {
-    storage file_system {
-        root /usr/local/etc/caddy
-    }
     log {
         {% if generalSettings.LogAccessPlain|default("0") == "0" %}
         {% for reverse in helpers.toList('Pischem.caddy.reverseproxy.reverse') %}


### PR DESCRIPTION
WIP Pull request for next version of os-caddy.

**DONE for v1.5.3:**
- Change from Phalcon Messages to OPNsense Messages - Requires: https://github.com/opnsense/core/commit/c2ea9aa3039eb4d24ba53a7aa2190642150f20eb
- Change default storage location to ```/var/db/caddy/data/caddy/``` (in line with rc.d file), by removing custom storage mount in the Caddyfile
- Refactor setup.sh for new storage location
- Add [tls_insecure_skip_verify](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#tls_insecure_skip_verify) to handlers because a lot of people need it for backwards compatibility with old services, examples would be certificates that only have a CN, weird self signed certs that have expired, old ciphers etc... Not all services allow their cert to be changed (sadly...)
- Change description to the standard "DescriptionField" https://docs.opnsense.org/development/frontend/models_fieldtypes.html#descriptionfield
- Remove unmaintained DNS Providers: dnspod, hetzner, namesilo, vercel, alidns, metaname, openstack-designate
- Change certificate extraction script and template to "/var/db/caddy/data/caddy/certificates/temp/", clean up setup.sh even more.
- Improved UI in forms to clearly label all options, removing excessive use of advanced mode. This guides the user better through the setup without hiding too many options (except really special ones).
- Add option to redirect the HTTP-01 challenge to a upstream destination while also retaining the automatic HTTP to HTTPS redirection. (Compare: https://caddy.community/t/using-certbot-behind-caddy/23295/8)