### PR TITLE
 dns/bind: Do not add the update-policy if the zone type is secondary

### DIFF
--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
@@ -180,7 +180,7 @@ zone "{{ domain.domainname }}" {
 {%              endfor %}
         };
 {%      endif %}
-{%      if domain.allowrndcupdate is defined and domain.allowrndcupdate == "1" %}
+{%      if domain.allowrndcupdate is defined and domain.allowrndcupdate == "1" and domain.type != 'secondary' %}
         update-policy {
 		grant rndc-key zonesub ANY;
         };


### PR DESCRIPTION
I have a bunch of secondary configured in the BIND Plugin. If I make a change through the web interface, the named.conf file at /usr/local/etc/namedb/named.conf will be regenerated from the /usr/local/opnsense/service/templates/OPNsense/Bind/named.conf template.

/usr/local/bin/named does not allow updates on the secondary zone as they should be done to the primary zone. Hence named throws an error:

`/usr/local/etc/namedb/named.conf:93: option 'update-policy' is not allowed in 'secondary' zone 'xx.xx.xx.in-addr.arpa'
`

In the secondary zone configuration block, 'update-policy' seems not to be allowed - this is a snippet from the generated name.conf file:

```
zone "xx.xx.xx.in-addr.arpa" {
        type secondary;
        primaries { yy.yy.yy.yy key "key.dyn.zz.zz.zz"; };
        file "/usr/local/etc/namedb/secondary/xx.xx.xx.in-addr.arpa.db";
        allow-transfer {
                ns_notify;
        };
        allow-query {
                ns_query;
        };
        update-policy {
                grant rndc-key zonesub ANY;
        };
};

```

Here is the patch that fixes it:

```
Y@Z:/usr/local/opnsense/service/templates/OPNsense/Bind % diff named.conf.org named.conf
183c183
< {%      if domain.allowrndcupdate is defined and domain.allowrndcupdate == "1" %}
---
> {%      if domain.allowrndcupdate is defined and domain.allowrndcupdate == "1" and domain.type != 'secondary' %}

```

