### PR TITLE
ProxySSO (kerberos) split REALM by default

### DIFF
--- a/www/web-proxy-sso/src/opnsense/service/templates/OPNsense/ProxySSO/kerberos.sso.conf
+++ b/www/web-proxy-sso/src/opnsense/service/templates/OPNsense/ProxySSO/kerberos.sso.conf
@@ -11,7 +11,7 @@
 {%          endif %}
 {%      endfor %}
 {%      if ldap_method|length > 0 and helpers.exists('OPNsense.ProxySSO.EnableSSO') and OPNsense.ProxySSO.EnableSSO == '1' %}
-auth_param negotiate program /usr/local/libexec/squid/negotiate_kerberos_auth -i -s HTTP/{{system.hostname}}.{{system.domain}}@{{system.domain|upper}}
+auth_param negotiate program /usr/local/libexec/squid/negotiate_kerberos_auth -r -i -s HTTP/{{system.hostname}}.{{system.domain}}@{{system.domain|upper}}
 auth_param negotiate keep_alive on
 {%          if helpers.exists('OPNsense.proxy.forward.authentication.children') %}
 auth_param negotiate children {{OPNsense.proxy.forward.authentication.children}}


### PR DESCRIPTION
The purpose of this pull request is to enable the ProxySSO plugin  (os-web-proxy-sso) to default strip the user domain/realm from kerberos authentication.

What's the benefits of doing it? squid proxy alone does not allow grouping users to give permissions. But it will be needed when using squidGuard alone or the os-web-filter plugin / tier2. 
