### PR TITLE
dns/bind: adjust log severity levels

### DIFF
--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/General.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/General.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/bind/general</mount>
     <description>BIND configuration</description>
-    <version>1.0.11</version>
+    <version>1.0.12</version>
     <items>
         <enabled type="BooleanField">
             <default>0</default>
@@ -78,14 +78,13 @@
         </logsize>
         <general_log_level type="OptionField">
             <OptionValues>
-                <emerg value="emerg">Emergency</emerg>
-                <alert value="alert">Alert</alert>
-                <crit value="crit">Critical</crit>
+                <crit value="critical">Critical</crit>
                 <error value="error">Error</error>
-                <warn value="warn">Warning</warn>
+                <warn value="warning">Warning</warn>
                 <notice value="notice">Notice</notice>
                 <info value="info">Informational</info>
                 <debug value="debug">Debug</debug>
+                <dynamic value="dynamic">Dynamic</dynamic>
             </OptionValues>
             <Required>Y</Required>
             <default>info</default>


### PR DESCRIPTION
Hi!
adjust log severity levels: remove not supported, rename deprecated, add 'dynamic'.
closes https://github.com/opnsense/plugins/issues/3876
Thanks!