### PR TITLE
security/acme-client: Add support for dnshome DNS API

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -387,7 +387,7 @@
         <type>text</type>
     </field>
     <field>
-        <label>DNS Home</label>
+        <label>dnsHome</label>
         <type>header</type>
         <style>table_dns table_dns_dnshome</style>
     </field>

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -387,6 +387,21 @@
         <type>text</type>
     </field>
     <field>
+        <label>DNS Home</label>
+        <type>header</type>
+        <style>table_dns table_dns_dnshome</style>
+    </field>
+    <field>
+        <id>validation.dns_dnshome_password</id>
+        <label>Password</label>
+        <type>password</type>
+    </field>
+    <field>
+        <id>validation.dns_dnshome_subdomain</id>
+        <label>Subdomain</label>
+        <type>text</type>
+    </field>
+    <field>
         <label>DNSimple</label>
         <type>header</type>
         <style>table_dns table_dns_dnsimple</style>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsDnshome.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsDnshome.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Copyright (C) 2020 Frank Wall
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\AcmeClient\LeValidation;
+
+use OPNsense\AcmeClient\LeValidationInterface;
+use OPNsense\Core\Config;
+
+/**
+ * DnsHome API
+ * @package OPNsense\AcmeClient
+ */
+class DnsDnshome extends Base implements LeValidationInterface
+{
+    public function prepare()
+    {
+        $this->acme_env['DNSHOME_SubdomainPassword'] = (string)$this->config->dns_dnshome_password;
+        $this->acme_env['DNSHOME_Subdomain'] = (string)$this->config->dns_dnshome_subdomain;
+    }
+}

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsDnshome.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsDnshome.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright (C) 2020 Frank Wall
+ * Copyright (C) 2024 realizelol
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -635,8 +635,10 @@
                 </dns_dnsexit_api>
                 <dns_dnshome_password type="TextField">
                     <Required>N</Required>
+                </dns_dnshome_password>
                 <dns_dnshome_subdomain type="TextField">
                     <Required>N</Required>
+                </dns_dnshome_subdomain>
                 <dns_dnsimple_token type="TextField">
                     <Required>N</Required>
                 </dns_dnsimple_token>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -444,7 +444,7 @@
                         <dns_dgon>DigitalOcean</dns_dgon>
                         <dns_da>DirectAdmin</dns_da>
                         <dns_dnsexit>DNSExit</dns_dnsexit>
-                        <dns_dnshome>DNSHome</dns_dnshome>
+                        <dns_dnshome>dnsHome</dns_dnshome>
                         <dns_dnsimple>DNSimple</dns_dnsimple>
                         <dns_dnsservices>DNS.Services</dns_dnsservices>
                         <dns_domeneshop>Domeneshop</dns_domeneshop>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -444,6 +444,7 @@
                         <dns_dgon>DigitalOcean</dns_dgon>
                         <dns_da>DirectAdmin</dns_da>
                         <dns_dnsexit>DNSExit</dns_dnsexit>
+                        <dns_dnshome>DNSHome</dns_dnshome>
                         <dns_dnsimple>DNSimple</dns_dnsimple>
                         <dns_dnsservices>DNS.Services</dns_dnsservices>
                         <dns_domeneshop>Domeneshop</dns_domeneshop>
@@ -632,6 +633,10 @@
                 <dns_dnsexit_api type="TextField">
                     <Required>N</Required>
                 </dns_dnsexit_api>
+                <dns_dnshome_password type="TextField">
+                    <Required>N</Required>
+                <dns_dnshome_subdomain type="TextField">
+                    <Required>N</Required>
                 <dns_dnsimple_token type="TextField">
                     <Required>N</Required>
                 </dns_dnsimple_token>


### PR DESCRIPTION
Hi OPNsense-Team,

would you please add my changes to support DnsHome @ AcmeClient (os-acme-client plugin):
DnsHome which is maintained by @Bodenhaltung is supported but not exposed to the webUI:
https://github.com/opnsense/ports/blob/master/security/acme.sh/pkg-plist#L73
which will be this file => https://github.com/acmesh-official/acme.sh/blob/master/dnsapi/dns_dnshome.sh
Or on Firewall => `/usr/local/share/examples/acme.sh/dnsapi/dns_dnshome.sh`

This changes are working without any constraints by myself.
But is there anything else that needs to be in consideration?

My Syslog:
```log
2024-04-03T09:25:06	opnsense	AcmeClient: imported ACME X.509 certificate: ***mypersonalid***.dnshome.de
2024-04-03T09:25:06	opnsense	AcmeClient: importing ACME CA: R3
2024-04-03T09:25:06	opnsense	AcmeClient: successfully issued/renewed certificate: ***mypersonalid***.dnshome.de
2024-04-03T09:25:06	opnsense	/usr/local/opnsense/scripts/OPNsense/AcmeClient/lecert.php: AcmeClient: The shell command returned exit code '0': '/usr/local/sbin/acme.sh --issue --syslog 7 --debug 3 --server 'letsencrypt' --dns 'dns_dnshome' --home '/var/etc/acme-client/home' --cert-home '/var/etc/acme-client/cert-home/***mypathid***' --certpath '/var/etc/acme-client/certs/***mypathid***/cert.pem' --keypath '/var/etc/acme-client/keys/***mypathid***/private.key' --capath '/var/etc/acme-client/certs/***mypathid***/chain.pem' --fullchainpath '/var/etc/acme-client/certs/***mypathid***/fullchain.pem' --domain '***mypersonalid***.dnshome.de' --days '1' --force --keylength '2048' --accountconf '/var/etc/acme-client/accounts/***myotherpathid***/account.conf''
2024-04-03T09:19:36	opnsense	AcmeClient: running acme.sh command: /usr/local/sbin/acme.sh --issue --syslog 7 --debug 3 --server 'letsencrypt' --dns 'dns_dnshome' --home '/var/etc/acme-client/home' --cert-home '/var/etc/acme-client/cert-home/***mypathid***' --certpath '/var/etc/acme-client/certs/***mypathid***/cert.pem' --keypath '/var/etc/acme-client/keys/***mypathid***/private.key' --capath '/var/etc/acme-client/certs/***mypathid***/chain.pem' --fullchainpath '/var/etc/acme-client/certs/***mypathid***/fullchain.pem' --domain '***mypersonalid***.dnshome.de' --days '1' --force --keylength '2048' --accountconf '/var/etc/acme-client/accounts/***myotherpathid***/account.conf'
2024-04-03T09:19:36	opnsense	AcmeClient: using challenge type: _acme-challenge.***mypersonalid***.dnshome.de
2024-04-03T09:19:36	opnsense	AcmeClient: account is registered: ***mypersonalid***.dnshome.de
2024-04-03T09:19:36	opnsense	AcmeClient: using CA: letsencrypt
2024-04-03T09:19:36	opnsense	AcmeClient: issue certificate: ***mypersonalid***.dnshome.de
2024-04-03T09:19:36	opnsense	AcmeClient: certificate must be issued/renewed: ***mypersonalid***.dnshome.de
```