### PR TITLE
www/caddy: add support for changing host headers

### DIFF
--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/ReverseProxyController.php
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/ReverseProxyController.php
@@ -109,7 +109,7 @@ class ReverseProxyController extends ApiMutableModelControllerBase
 
     public function searchHandleAction()
     {
-        return $this->searchBase("reverseproxy.handle", ['enabled', 'reverse', 'subdomain', 'HandleType', 'HandlePath', 'ToDomain', 'ToPort', 'ToPath', 'HttpTls', 'HttpTlsTrustedCaCerts', 'HttpTlsServerName', 'HttpNtlm', 'HttpTlsInsecureSkipVerify', 'description']);
+        return $this->searchBase("reverseproxy.handle", ['enabled', 'reverse', 'subdomain', 'HandleType', 'HandlePath', 'ToDomain', 'ToPort', 'ToPath', 'ChangeHostHeader', 'HttpTls', 'HttpTlsTrustedCaCerts', 'HttpTlsServerName', 'HttpNtlm', 'HttpTlsInsecureSkipVerify', 'description']);
     }
 
     public function setHandleAction($uuid)

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -62,6 +62,12 @@
         <advanced>true</advanced>
     </field>
     <field>
+        <id>handle.ChangeHostHeader</id>
+        <label>Change Host Header</label>
+        <type>checkbox</type>
+        <help><![CDATA[Override the Host header with the configured upstream address. Useful if you proxy to virtual hosts or HTTPS.]]></help>
+    </field>
+    <field>
         <type>header</type>
         <label>Trust</label>
         <collapse>true</collapse>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -248,6 +248,7 @@
                     <Mask>/^(\/.*)?$/u</Mask>
                     <ValidationMessage>Please enter a valid 'Backend Path' that starts with '/'.</ValidationMessage>
                 </ToPath>
+                <ChangeHostHeader type="BooleanField"/>
                 <HttpTls type="BooleanField"/>
                 <HttpNtlm type="BooleanField"/>
                 <HttpTlsInsecureSkipVerify type="BooleanField"/>

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -366,6 +366,9 @@
         rewrite * {{ handle.ToPath }}{uri}
         {% endif %}
         reverse_proxy {{ handle.ToDomain }}{% if handle.ToPort %}:{{ handle.ToPort }}{% endif %} {
+            {% if handle.ChangeHostHeader|default("0") == "1" %}
+            header_up Host {upstream_hostport}
+            {% endif %}
             {% if handle.HttpTls|default("0") == "1" or handle.HttpTlsInsecureSkipVerify|default("0") == "1" %}
                 {% if handle.HttpNtlm|default("0") == "1" %}
                 transport http_ntlm {


### PR DESCRIPTION
Since (most) headers retain their original value when being proxied, it is often necessary to override the Host header with the configured upstream address when proxying to HTTPS, such that the Host header matches the TLS ServerName value. It is also useful when proxying to virtual hosts that are served from the same instance.