### PR TITLE
dns/rfc2136: Use routed_address6 instead of primary_address6 to prevent link-local address in nsupdate command

### DIFF
--- a/dns/rfc2136/src/etc/inc/plugins.inc.d/rfc2136.inc
+++ b/dns/rfc2136/src/etc/inc/plugins.inc.d/rfc2136.inc
@@ -178,7 +178,7 @@ function rfc2136_configure_do($verbose = false, $int = '', $updatehost = '', $fo
             if (isset($dnsupdate['usepublicip'])) {
                 $wanipv6 = get_rfc2136_ip_address($dnsupdate['interface'], 6);
             } else {
-                list ($wanipv6) = interfaces_primary_address6($dnsupdate['interface']);
+                list ($wanipv6) = interfaces_routed_address6($dnsupdate['interface']);
             }
             if (is_ipaddrv6($wanipv6)) {
                 if (($wanipv6 != $cachedipv6) || (($currentTime - $cacheTimev6) > $maxCacheAgeSecs) || $forced) {
@@ -216,7 +216,7 @@ function rfc2136_configure_do($verbose = false, $int = '', $updatehost = '', $fo
 
 function get_rfc2136_ip_address($int, $ipver = 4)
 {
-    list ($ip_address) = $ipver == 6 ? interfaces_primary_address6($int) : interfaces_primary_address($int);
+    list ($ip_address) = $ipver == 6 ? interfaces_routed_address6($int) : interfaces_primary_address($int);
     if (empty($ip_address)) {
         log_error("Aborted IPv{$ipver} detection: no address for {$int}");
         return 'down';


### PR DESCRIPTION
Currently if _Record Type_ in the edit UI of os-rfc2136 is set to _All_ nsupdate fails because it adds incompatible link-local address to _$upinst_.

```
> root@firewall:~ # /usr/local/bin/nsupdate -k /var/etc/nsupdatekey0 /var/etc/nsupdatecmds0
07-Apr-2024 14:47:23.361 dns_rdata_fromtext: buffer-0x835758e40:1: near 'fe80::1234%igb0': bad IPv6 address
invalid rdata format: bad IPv6 address
syntax error
```

This is because function [interfaces_primary_address6](https://github.com/opnsense/core/blob/a8e329b90529bac6ac3682d92fd6d7dec89b3cae/src/etc/inc/interfaces.inc#L4199) may return a link-local address including the interface specifier (e.g. _fe80::1234%igb0_). 
Using [interfaces_routed_address6](https://github.com/opnsense/core/blob/a8e329b90529bac6ac3682d92fd6d7dec89b3cae/src/etc/inc/interfaces.inc#L4187) we ensure that a valid public IPv6 address is used.