### PR TITLE
www/caddy: Fix input validation - allow wildcard domains and base domains at the same time

### DIFF
--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -37,6 +37,7 @@ Plugin Changelog
 * Fix: Move selectpicker empty option to model in general.volt, using BlankDesc. This fixes the option IPv4+IPv6 not appearing in Dynamic DNS. 
 * Add: Simple Load Balancing support with the default random policy, by allowing to add multiple Upstream Domains in Handlers.
 * Add: Passive Health check for load balancing (Upstream Fail Duration) in Handlers.
+* Fix: Input validation so a base domain like "example.com" and a wildcard domain like "*.example.com" can now be created at the same time in domains.
 
 1.5.3
 

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
@@ -107,41 +107,6 @@ class Caddy extends BaseModel
         }
     }
 
-    // 4. Check for conflicts between wildcard and base domains
-    private function checkForWildcardAndBaseDomainConflicts($domains, $messages)
-    {
-        $domainList = [];
-        foreach ($domains as $domain) {
-            if ((string) $domain->enabled === '1') {
-                $domainName = (string) $domain->FromDomain;
-                $domainList[$domainName] = true;
-
-                // Check for wildcard or base domain conflict
-                if (str_starts_with($domainName, '*.')) {
-                    $baseDomain = substr($domainName, 2);
-                    if (isset($domainList[$baseDomain])) {
-                        $key = $domain->__reference; // Dynamic key based on domain reference
-                        $messages->appendMessage(new Message(
-                            "Invalid domain configuration: Cannot create wildcard domain '$domainName' because base domain '$baseDomain' exists.",
-                            $key . ".FromDomain", // Use dynamic key for message referencing
-                            "WildcardBaseConflict"
-                        ));
-                    }
-                } else {
-                    $wildcardDomain = '*.' . $domainName;
-                    if (isset($domainList[$wildcardDomain])) {
-                        $key = $domain->__reference; // Dynamic key based on domain reference
-                        $messages->appendMessage(new Message(
-                            "Invalid domain configuration: Cannot create base domain '$domainName' because wildcard domain '$wildcardDomain' exists.",
-                            $key . ".FromDomain", // Use dynamic key for message referencing
-                            "BaseWildcardConflict"
-                        ));
-                    }
-                }
-            }
-        }
-    }
-
     // Perform the actual validation
     public function performValidation($validateFullModel = false)
     {
@@ -152,8 +117,6 @@ class Caddy extends BaseModel
         $this->checkForUniquePortCombos($this->reverseproxy->subdomain->iterateItems(), $messages, 'subdomain');
         // 3. Check that subdomains are under a wildcard or exact domain
         $this->checkSubdomainsAgainstDomains($this->reverseproxy->subdomain->iterateItems(), $this->reverseproxy->reverse->iterateItems(), $messages);
-        // 4. Check for conflicts between wildcard and base domains
-        $this->checkForWildcardAndBaseDomainConflicts($this->reverseproxy->reverse->iterateItems(), $messages);
 
         return $messages;
     }


### PR DESCRIPTION
A small fix that addresses too strict input validation.

PR: https://forum.opnsense.org/index.php?topic=40019.0
Reference: https://caddy.community/t/create-wildcard-cert-with-other-sans-too/16322

The input validation prevented the creation of ```example.com``` at the same time as ```*.example.com```

I thought that was necessary when I created the validation model, but it prevents this valid configuration that will be needed in some circumstances.

