### PR TITLE
www/caddy: Change display of domain and port combination in Model Relation Field

### DIFF
--- a/www/caddy/Makefile
+++ b/www/caddy/Makefile
@@ -1,5 +1,6 @@
 PLUGIN_NAME=		caddy
 PLUGIN_VERSION=		1.5.4
+PLUGIN_REVISION=	1
 PLUGIN_DEPENDS=		caddy-custom
 PLUGIN_COMMENT=		Easy to configure Reverse Proxy with Automatic HTTPS and Dynamic DNS
 PLUGIN_MAINTAINER=	cedrik@pischem.com

--- a/www/caddy/Makefile
+++ b/www/caddy/Makefile
@@ -1,6 +1,5 @@
 PLUGIN_NAME=		caddy
 PLUGIN_VERSION=		1.5.4
-PLUGIN_REVISION=	1
 PLUGIN_DEPENDS=		caddy-custom
 PLUGIN_COMMENT=		Easy to configure Reverse Proxy with Automatic HTTPS and Dynamic DNS
 PLUGIN_MAINTAINER=	cedrik@pischem.com

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -163,7 +163,7 @@
                             <source>OPNsense.Caddy.Caddy</source>
                             <items>reverseproxy.reverse</items>
                             <display>FromDomain,FromPort</display>
-                            <display_format>%s:%s</display_format>
+                            <display_format>%s.%s</display_format>
                         </reverseproxy>
                     </Model>
                 </reverse>
@@ -215,7 +215,7 @@
                             <source>OPNsense.Caddy.Caddy</source>
                             <items>reverseproxy.reverse</items>
                             <display>FromDomain,FromPort</display>
-                            <display_format>%s:%s</display_format>
+                            <display_format>%s.%s</display_format>
                         </reverseproxy>
                     </Model>
                 </reverse>
@@ -225,7 +225,7 @@
                             <source>OPNsense.Caddy.Caddy</source>
                             <items>reverseproxy.subdomain</items>
                             <display>FromDomain,FromPort</display>
-                            <display_format>%s:%s</display_format>
+                            <display_format>%s.%s</display_format>
                         </reverseproxy>
                     </Model>
                 </subdomain>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -163,7 +163,7 @@
                             <source>OPNsense.Caddy.Caddy</source>
                             <items>reverseproxy.reverse</items>
                             <display>FromDomain,FromPort</display>
-                            <display_format>%s.%s</display_format>
+                            <display_format>%s %s</display_format>
                         </reverseproxy>
                     </Model>
                 </reverse>
@@ -215,7 +215,7 @@
                             <source>OPNsense.Caddy.Caddy</source>
                             <items>reverseproxy.reverse</items>
                             <display>FromDomain,FromPort</display>
-                            <display_format>%s.%s</display_format>
+                            <display_format>%s %s</display_format>
                         </reverseproxy>
                     </Model>
                 </reverse>
@@ -225,7 +225,7 @@
                             <source>OPNsense.Caddy.Caddy</source>
                             <items>reverseproxy.subdomain</items>
                             <display>FromDomain,FromPort</display>
-                            <display_format>%s.%s</display_format>
+                            <display_format>%s %s</display_format>
                         </reverseproxy>
                     </Model>
                 </subdomain>


### PR DESCRIPTION
Since a stray ":" when leaving the port empty could cause confusion, I have opted to replace it with a "space".

**Old display:**
example.com:
example.com:443

**Fixed display:**

example.com
example.com 443

(Compare to: https://github.com/opnsense/plugins/issues/3917#issuecomment-2064230068 )