### PR TITLE
Fix bug introduced in PR#3891, auto_https should never be set to `on`

### DIFF
--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -273,8 +273,14 @@
     {% if emailValue %}
     email {{ emailValue }}
     {% endif %}
+
+    {#
+    #   Upstream docs: https://caddyserver.com/docs/caddyfile/options#auto-https
+    #   Note: if value is `on`, do not emit directive to caddyfile. `on` is default, and
+    #         should be omitted if that effect is desired.
+    #}
     {% set autoHttpsValue = helpers.toList('Pischem.caddy.general.TlsAutoHttps') | first %}
-    {% if autoHttpsValue %}
+    {% if autoHttpsValue != 'on' %}
     auto_https {{ autoHttpsValue }}
     {% endif %}
     import /usr/local/etc/caddy/caddy.d/*.global


### PR DESCRIPTION
upstream docs: https://caddyserver.com/docs/caddyfile/options#auto-https

For some reason, the caddy directive `auto_https` cannot take a value of `on`, but instead just shouldn't be called.

Bug was introduced here: https://github.com/opnsense/plugins/pull/3891/files?w=1#diff-c905c5709a75510121b03ead89789a33e45e9514b7e7facd591d8bcdf503263bL215-R277

The `auto_https` directive is quite confusing, so I also added a comment explaining why this fix should remain, so that it's not accidentally undone in the future.