### PR TITLE
www/caddy: Create Migration script that fixes issue with Caddy not being able to start. (Regression in 1.5.4)

### DIFF
--- a/www/caddy/Makefile
+++ b/www/caddy/Makefile
@@ -1,5 +1,6 @@
 PLUGIN_NAME=		caddy
 PLUGIN_VERSION=		1.5.4
+PLUGIN_REVISION=	1
 PLUGIN_DEPENDS=		caddy-custom
 PLUGIN_COMMENT=		Easy to configure Reverse Proxy with Automatic HTTPS and Dynamic DNS
 PLUGIN_MAINTAINER=	cedrik@pischem.com

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//Pischem/caddy</mount>
     <description>A GUI model for configuring a reverse proxy in the Caddy web server.</description>
-    <version>1.1.7</version>
+    <version>1.1.8</version>
     <items>
         <general>
             <enabled type="BooleanField">

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Migrations/M1_1_7.php
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Migrations/M1_1_7.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ *    Copyright (C) 2024 Cedrik Pischem
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Caddy\Migrations;
+
+use OPNsense\Base\BaseModelMigration;
+use OPNsense\Core\Config;
+
+class M1_1_7 extends BaseModelMigration
+{
+    public function run($model)
+    {
+        // Load the current system configuration
+        $config = Config::getInstance()->object();
+
+        // Read and migrate TlsAutoHttps setting if necessary
+        if (!empty($config->Pischem->caddy->general->TlsAutoHttps)) {
+            $tlsAutoHttpsValue = (string)$config->Pischem->caddy->general->TlsAutoHttps;
+            // Check if the current value is 'on' and needs to be migrated
+            if ($tlsAutoHttpsValue === 'on') {
+                // Locate the corresponding node in the model
+                $modelNode = $model->getNodeByReference('general.TlsAutoHttps');
+                if ($modelNode != null) {
+                    // Set to empty value in the model, migration from 'on' to ''
+                    $modelNode->setValue('');
+                }
+            }
+        }
+
+        // Read and migrate TlsDnsProvider setting if necessary
+        if (!empty($config->Pischem->caddy->general->TlsDnsProvider)) {
+            $tlsDnsProviderValue = (string)$config->Pischem->caddy->general->TlsDnsProvider;
+            // Check if the current value is 'none' and needs to be migrated
+            if ($tlsDnsProviderValue === 'none') {
+                // Locate the corresponding node in the model
+                $modelNode = $model->getNodeByReference('general.TlsDnsProvider');
+                if ($modelNode != null) {
+                    // Set to empty value in the model, migration from 'none' to ''
+                    $modelNode->setValue('');
+                }
+            }
+        }
+
+        // Model is saved by 'run_migrations.php'
+    }
+}

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Migrations/M1_1_8.php
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Migrations/M1_1_8.php
@@ -31,7 +31,7 @@ namespace OPNsense\Caddy\Migrations;
 use OPNsense\Base\BaseModelMigration;
 use OPNsense\Core\Config;
 
-class M1_1_7 extends BaseModelMigration
+class M1_1_8 extends BaseModelMigration
 {
     public function run($model)
     {


### PR DESCRIPTION
This migration script empties out "on" and "none" options that were replaced with empty values by the referenced commit in os-caddy-1.5.4. It fixes the regression that Caddy will refuse to start because invalid values for AutoHttps and DnsProvider will remain stored in the config without a manual config change from the user.

Compare to commit that caused regression: https://github.com/opnsense/plugins/commit/a628ebfc0682c0f27ec59b6a605dbeff8bd52765

Issue was tracked multiple times:
https://forum.opnsense.org/index.php?topic=40075.0 
https://github.com/opnsense/plugins/pull/3930
https://github.com/opnsense/plugins/issues/3917#issuecomment-2064230068