### PR TITLE
net-mgmt/zabbix-proxy: fix syntax error

### DIFF
--- a/net-mgmt/zabbix-proxy/Makefile
+++ b/net-mgmt/zabbix-proxy/Makefile
@@ -1,5 +1,6 @@
 PLUGIN_NAME=		zabbix-proxy
 PLUGIN_VERSION=		1.10
+PLUGIN_REVISION=	1
 PLUGIN_COMMENT=		Zabbix monitoring proxy
 PLUGIN_MAINTAINER=	m.muenz@gmail.com
 PLUGIN_VARIANTS=	zabbix6 zabbix64 zabbix5

--- a/net-mgmt/zabbix-proxy/src/opnsense/service/templates/OPNsense/Zabbixproxy/zabbix_proxy.conf.in
+++ b/net-mgmt/zabbix-proxy/src/opnsense/service/templates/OPNsense/Zabbixproxy/zabbix_proxy.conf.in
@@ -34,7 +34,7 @@ LogFile=/var/log/zabbix/zabbix_proxy.log
 LogFileSize={{OPNsense.zabbixproxy.general.logFileSize}}
 {% endif %}
 {% endif %}
-{% if helpers.exists('OPNsense.zabbixproxy.general.debugLevel')
+{% if helpers.exists('OPNsense.zabbixproxy.general.debugLevel') %}
 DebugLevel={{OPNsense.zabbixproxy.general.debugLevel|replace("val_", "")}}
 {% endif %}
 PidFile=/var/run/zabbix/zabbix_proxy.pid


### PR DESCRIPTION
Closes #3921.
Regression was introduced in 26e6379874d56190e409c07c37cb12a58679c1ff.