### PR TITLE
www/caddy: Fix reload/stop of caddy being infinite when websocket streams of clients are open

### DIFF
--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
@@ -30,4 +30,11 @@
         <type>checkbox</type>
         <help><![CDATA[Abort all connections that don't have a matching handle or access list. This option doesn't conflict with Let's Encrypt. Disable it for troubleshooting purposes, e.g., testing if the Reverse Proxy Domain works and the Certificate has been installed. For production use, enabling this option is recommended.]]></help>
     </field>
+    <field>
+        <id>caddy.general.GracePeriod</id>
+        <label>Grace Period</label>
+        <type>text</type>
+        <hint>10</hint>
+        <help><![CDATA[Defines the grace period for shutting down HTTP servers (i.e. during config changes or when Caddy is stopping) in seconds. During the grace period, no new connections are accepted, idle connections are closed, and active connections are impatiently waited upon to finish their requests. If clients do not finish their requests within the grace period, the server will be forcefully terminated to allow the reload to complete and free up resources. This can influence how long "Apply" of new configurations take, since Caddy waits for all open connections to close.]]></help>
+    </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//Pischem/caddy</mount>
     <description>A GUI model for configuring a reverse proxy in the Caddy web server.</description>
-    <version>1.1.8</version>
+    <version>1.1.9</version>
     <items>
         <general>
             <enabled type="BooleanField">

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -65,6 +65,13 @@
                 </Model>
             </accesslist>
             <abort type="BooleanField"/>
+            <GracePeriod type="IntegerField">
+                <Default>10</Default>
+                <MinimumValue>1</MinimumValue>
+                <MaximumValue>3600</MaximumValue>
+                <ValidationMessage>Please enter a valid Grace Period between 1 and 3600 seconds.</ValidationMessage>
+                <Required>Y</Required>
+            </GracePeriod>
             <LogCredentials type="BooleanField"/>
             <LogAccessPlain type="BooleanField"/>
             <LogAccessPlainKeep type="IntegerField">

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -281,9 +281,8 @@
     # Important: Grace Period influences how fast the server can finish reloads with open connections, by forcing termination.
     # Default of Caddy is to wait for all connections to close before allowing reload, meaning the higher the value, the longer applies take.
     #}
-    {% set gracePeriodValue = helpers.toList('Pischem.caddy.general.GracePeriod') | first %}
-    {% if gracePeriodValue %}
-    grace_period {{ gracePeriodValue }}s
+    {% if Pischem.caddy.general.GracePeriod %}
+    grace_period {{ Pischem.caddy.general.GracePeriod }}s
     {% endif %}
     import /usr/local/etc/caddy/caddy.d/*.global
 }

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -281,9 +281,7 @@
     # Important: Grace Period influences how fast the server can finish reloads with open connections, by forcing termination.
     # Default of Caddy is to wait for all connections to close before allowing reload, meaning the higher the value, the longer applies take.
     #}
-    {% if generalSettings.GracePeriod %}
     grace_period {{ generalSettings.GracePeriod }}s
-    {% endif %}
     import /usr/local/etc/caddy/caddy.d/*.global
 }
 

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -281,8 +281,8 @@
     # Important: Grace Period influences how fast the server can finish reloads with open connections, by forcing termination.
     # Default of Caddy is to wait for all connections to close before allowing reload, meaning the higher the value, the longer applies take.
     #}
-    {% if Pischem.caddy.general.GracePeriod %}
-    grace_period {{ Pischem.caddy.general.GracePeriod }}s
+    {% if generalSettings.GracePeriod %}
+    grace_period {{ generalSettings.GracePeriod }}s
     {% endif %}
     import /usr/local/etc/caddy/caddy.d/*.global
 }

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -277,6 +277,14 @@
     {% if autoHttpsValue %}
     auto_https {{ autoHttpsValue }}
     {% endif %}
+    {# 
+    # Important: Grace Period influences how fast the server can finish reloads with open connections, by forcing termination.
+    # Default of Caddy is to wait for all connections to close before allowing reload, meaning the higher the value, the longer applies take.
+    #}
+    {% set gracePeriodValue = helpers.toList('Pischem.caddy.general.GracePeriod') | first %}
+    {% if gracePeriodValue %}
+    grace_period {{ gracePeriodValue }}s
+    {% endif %}
     import /usr/local/etc/caddy/caddy.d/*.global
 }
 


### PR DESCRIPTION
Fixes: https://github.com/opnsense/plugins/issues/3929

This one can cause a lot of pain. It took almost two months to track this down. I had this issue too and didn't understand for quite a while why it was happening.

I had a chat with Francis Lavoie (one of the Caddy contributers and devs) and he pointed me to the way Caddy handles open connections and streams. (but it was not straight forward that it was exactly this option at first)

Caddy, by default, tries to keep all connections and streams open, and waits for clients to close them gracefully. This means, it can wait **indefinitely** when a reload, or stop action happens. Which makes Caddy seem frozen, and the apply in the GUI hang forever.

https://caddyserver.com/docs/caddyfile/options#grace-period