### PR TITLE
security/acme-client: Update Syslog Debug Levels to match acme.sh

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeCommon.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeCommon.php
@@ -219,13 +219,13 @@ abstract class LeCommon
                 $this->debug = true;
                 break;
             case 'debug2':
-                $this->acme_args[] = '--syslog 7';
+                $this->acme_args[] = '--syslog 8';
                 $this->acme_args[] = '--debug 2';
                 $this->acme_syslog = 7;
                 $this->debug = true;
                 break;
             case 'debug3':
-                $this->acme_args[] = '--syslog 7';
+                $this->acme_args[] = '--syslog 9';
                 $this->acme_args[] = '--debug 3';
                 $this->acme_syslog = 7;
                 $this->debug = true;


### PR DESCRIPTION
Match acme.sh settings where debug 2 should have corresponding syslog = 8, and debug 3 should have corresponding syslog = 9. Refer to levels as defined in [acme.sh line 133](https://github.com/acmesh-official/acme.sh/blob/master/acme.sh#L133)

Fixes: https://github.com/opnsense/plugins/issues/3933