### PR TITLE
www/caddy: Selectpicker that can filter the Domain, Subdomain and Handlers by selected Domain

### DIFF
--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/ReverseProxyController.php
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/ReverseProxyController.php
@@ -41,9 +41,22 @@ class ReverseProxyController extends ApiMutableModelControllerBase
 
     /*ReverseProxy Section*/
 
+    /*Search Function adjusted for the search filter dropdown*/
     public function searchReverseProxyAction($add_empty = '0')
     {
-        return $this->searchBase("reverseproxy.reverse", null, 'description');
+        // Get a comma-separated list of UUIDs from the request
+        $reverseUuids = $this->request->get('reverseUuids');
+        $uuidArray = !empty($reverseUuids) ? explode(',', $reverseUuids) : [];
+
+        // Define the filter function to handle multiple UUIDs
+        $filterFunction = function ($modelItem) use ($uuidArray) {
+            $itemUuid = (string)$modelItem->getAttributes()['uuid'];
+            // Include the item if no UUIDs are provided (empty array) or if it's in the array of UUIDs
+            return empty($uuidArray) || in_array($itemUuid, $uuidArray, true);
+        };
+
+        // Return the search results filtered by the provided UUIDs, if any
+        return $this->searchBase("reverseproxy.reverse", null, 'description', $filterFunction);
     }
 
     public function setReverseProxyAction($uuid)

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/ReverseProxyController.php
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/ReverseProxyController.php
@@ -100,9 +100,18 @@ class ReverseProxyController extends ApiMutableModelControllerBase
 
     /*Subdomain Section*/
 
+    /*Search Function adjusted for the search filter dropdown*/
     public function searchSubdomainAction($add_empty = '0')
     {
-        return $this->searchBase("reverseproxy.subdomain", null, 'description');
+        $reverseUuids = $this->request->get('reverseUuids');
+        $uuidArray = !empty($reverseUuids) ? explode(',', $reverseUuids) : [];
+
+        $filterFunction = function ($modelItem) use ($uuidArray) {
+            // Filtering on domain UUIDs referenced by subdomains
+            return empty($uuidArray) || in_array((string)$modelItem->reverse, $uuidArray, true);
+        };
+
+        return $this->searchBase("reverseproxy.subdomain", null, 'description', $filterFunction);
     }
 
     public function setSubdomainAction($uuid)
@@ -133,7 +142,7 @@ class ReverseProxyController extends ApiMutableModelControllerBase
 
     /*Handler Section*/
     
-    /*Function adjusted for the search filter dropdown*/
+    /*Search Function adjusted for the search filter dropdown*/
     public function searchHandleAction($add_empty = '0')
     {
         $reverseUuids = $this->request->get('reverseUuids');

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/ReverseProxyController.php
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/ReverseProxyController.php
@@ -42,7 +42,7 @@ class ReverseProxyController extends ApiMutableModelControllerBase
     /*ReverseProxy Section*/
 
     /*Search Function adjusted for the search filter dropdown*/
-    public function searchReverseProxyAction($add_empty = '0')
+    public function searchReverseProxyAction()
     {
         // Get a comma-separated list of UUIDs from the request
         $reverseUuids = $this->request->get('reverseUuids');
@@ -91,7 +91,7 @@ class ReverseProxyController extends ApiMutableModelControllerBase
         $result = array("rows" => array());
 
         $mdlCaddy = new \OPNsense\Caddy\Caddy();
-        $reverseNodes = $mdlCaddy->getNodeByReference('reverseproxy.reverse')->iterateItems();
+        $reverseNodes = $mdlCaddy->reverseproxy->reverse->iterateItems();
 
         foreach ($reverseNodes as $item) {
             if (!empty($item->FromDomain)) {
@@ -114,7 +114,7 @@ class ReverseProxyController extends ApiMutableModelControllerBase
     /*Subdomain Section*/
 
     /*Search Function adjusted for the search filter dropdown*/
-    public function searchSubdomainAction($add_empty = '0')
+    public function searchSubdomainAction()
     {
         $reverseUuids = $this->request->get('reverseUuids');
         $uuidArray = !empty($reverseUuids) ? explode(',', $reverseUuids) : [];
@@ -156,7 +156,7 @@ class ReverseProxyController extends ApiMutableModelControllerBase
     /*Handler Section*/
     
     /*Search Function adjusted for the search filter dropdown*/
-    public function searchHandleAction($add_empty = '0')
+    public function searchHandleAction()
     {
         $reverseUuids = $this->request->get('reverseUuids');
         $uuidArray = explode(',', $reverseUuids);
@@ -203,7 +203,7 @@ class ReverseProxyController extends ApiMutableModelControllerBase
 
     /* AccessList Section */
 
-    public function searchAccessListAction($add_empty = '0')
+    public function searchAccessListAction()
     {
         return $this->searchBase("reverseproxy.accesslist", null, 'description');
     }
@@ -231,7 +231,7 @@ class ReverseProxyController extends ApiMutableModelControllerBase
 
     /* BasicAuth Section */
 
-    public function searchBasicAuthAction($add_empty = '0')
+    public function searchBasicAuthAction()
     {
         return $this->searchBase("reverseproxy.basicauth", null, 'description');
     }
@@ -279,7 +279,7 @@ class ReverseProxyController extends ApiMutableModelControllerBase
 
     /* Header Section */
 
-    public function searchHeaderAction($add_empty = '0')
+    public function searchHeaderAction()
     {
         return $this->searchBase("reverseproxy.header", null, 'description');
     }

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -220,7 +220,7 @@
     .common-filter {
         text-align: right;
         margin-top: 20px;
-        margin-bottom: 20px;
+        margin-right: 5px;
         padding: 0 15px;  // Align with the tables
     }
 
@@ -240,7 +240,7 @@
 
     <!-- Selectpicker for filter by domain -->
     <div class="form-group common-filter">
-        <select id="reverseFilter" class="selectpicker form-control" multiple data-live-search="true" data-width="400px" data-size="7" title="Filter by Domain">
+        <select id="reverseFilter" class="selectpicker form-control" multiple data-live-search="true" data-width="330px" data-size="7" title="Filter by Domain">
             <!-- Options will be populated dynamically using JavaScript/Ajax -->
         </select>
     </div>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -26,6 +26,17 @@
 
 <script>
     $(document).ready(function() {
+    
+        // Function to handle the search filter request modification
+        function addDomainFilterToRequest(request) {
+            var selectedDomains = $('#reverseFilter').val();
+            if (selectedDomains && selectedDomains.length > 0) {
+                request['reverseUuids'] = selectedDomains.join(',');
+            }
+            return request;
+        }
+    
+        // Bootgrid Setup
         $("#reverseProxyGrid").UIBootgrid({
             search:'/api/caddy/ReverseProxy/searchReverseProxy/',
             get:'/api/caddy/ReverseProxy/getReverseProxy/',
@@ -33,6 +44,9 @@
             add:'/api/caddy/ReverseProxy/addReverseProxy/',
             del:'/api/caddy/ReverseProxy/delReverseProxy/',
             toggle:'/api/caddy/ReverseProxy/toggleReverseProxy/',
+            options: {
+                requestHandler: addDomainFilterToRequest
+            }
         });
 
         $("#reverseSubdomainGrid").UIBootgrid({
@@ -42,6 +56,9 @@
             add:'/api/caddy/ReverseProxy/addSubdomain/',
             del:'/api/caddy/ReverseProxy/delSubdomain/',
             toggle:'/api/caddy/ReverseProxy/toggleSubdomain/',
+            options: {
+                requestHandler: addDomainFilterToRequest
+            }
         });
 
         $("#reverseHandleGrid").UIBootgrid({
@@ -52,13 +69,7 @@
             del:'/api/caddy/ReverseProxy/delHandle/',
             toggle:'/api/caddy/ReverseProxy/toggleHandle/',
             options: {
-                requestHandler: function(request) {
-                    var selectedDomains = $('#reverseFilter').val();
-                    if (selectedDomains && selectedDomains.length > 0) {
-                        request['reverseUuids'] = selectedDomains.join(',');
-                    }
-                    return request;
-                }
+                requestHandler: addDomainFilterToRequest
             }
         });
 
@@ -177,7 +188,9 @@
         loadDomainFilters();
         
         // Reload Bootgrid on filter change
-        $('#reverseFilter').on('changed.bs.select', function (e, clickedIndex, isSelected, previousValue) {
+        $('#reverseFilter').on('changed.bs.select', function() {
+            $("#reverseProxyGrid").bootgrid("reload");
+            $("#reverseSubdomainGrid").bootgrid("reload");
             $("#reverseHandleGrid").bootgrid("reload");
         });
         

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -224,7 +224,7 @@
         padding: 0 15px;  // Align with the tables
     }
 
-    .selectpicker {
+    #reverseFilter {
         width: 100% !important;  // Ensure it fills the container
     }
 </style>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -240,7 +240,7 @@
 
     <!-- Selectpicker for filter by domain -->
     <div class="form-group common-filter">
-        <select id="reverseFilter" class="selectpicker form-control" multiple data-live-search="true" data-width="330px" data-size="7" title="Filter by Domain">
+        <select id="reverseFilter" class="selectpicker form-control" multiple data-live-search="true" data-width="340px" data-size="7" title="Filter by Domain">
             <!-- Options will be populated dynamically using JavaScript/Ajax -->
         </select>
     </div>


### PR DESCRIPTION
Having a big configuration is hard, the items all reference each other, but each bootgrid has multiple domains, subdomains, handlers... it's hard to get an overview of a single item.

This new filter selectpicker solves it.

It shows up conditionally in the Domain/Subdomain Tab, and Handler Tab. It is shared between them. Selecting one or multiple domains manipulates the output of the Search Function to only show items that have the selected domains "reverse" UUIDs referenced.

When nothing is selected, all items are returned.

![screen00001](https://github.com/opnsense/plugins/assets/79600909/793f6faa-3724-47d9-b70d-03444cbf5f3c)
![screen000002](https://github.com/opnsense/plugins/assets/79600909/33a57615-dacf-4a15-a2c5-4f91901eefad)

