### PR TITLE
net/freeradius: Using fallback VLAN with Mikrotik specific attributes

### DIFF
--- a/net/freeradius/Makefile
+++ b/net/freeradius/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		freeradius
-PLUGIN_VERSION=		1.9.23
+PLUGIN_VERSION=		1.9.24
 PLUGIN_COMMENT=		RADIUS Authentication, Authorization and Accounting Server
 PLUGIN_DEPENDS=		freeradius3
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net/freeradius/pkg-descr
+++ b/net/freeradius/pkg-descr
@@ -15,6 +15,10 @@ The server is fast, feature-rich, modular, and scalable.
 Plugin Changelog
 ================
 
+1.9.24
+
+* Using Mikrotik attributes in fallback VLAN when both settings are activated
+
 1.9.23
 
 * Support NT hash of user password (contributed by Stuart McLaren)

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/users
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/users
@@ -29,9 +29,6 @@
        Tunnel-Type = VLAN,
        Tunnel-Medium-Type = IEEE-802,
        Tunnel-Private-Group-Id = {{ user_list.vlan }},
-       Mikrotik-Wireless-VLANID := {{ user_list.vlan }},
-       Mikrotik-Wireless-VLANID-Type := 0,
-       Mikrotik-Wireless-Comment = "unknown"
 {%         endif %}
 {%       endif %}
 {%       if helpers.exists('OPNsense.freeradius.general.exos') and OPNsense.freeradius.general.exos == '1' %}
@@ -107,6 +104,14 @@ DEFAULT Auth-Type := Accept
        Tunnel-Type = VLAN,
        Tunnel-Medium-Type = IEEE-802,
        Tunnel-Private-Group-Id = {{ OPNsense.freeradius.general.fallbackvlan_id }},
+
+{%        if helpers.exists('OPNsense.freeradius.general.mikrotik') and OPNsense.freeradius.general.mikrotik == '1' %}
+       Mikrotik-Wireless-VLANID := {{ OPNsense.freeradius.general.fallbackvlan_id }},
+       Mikrotik-Wireless-VLANID-Type := 0,
+       Mikrotik-Wireless-Comment = "unknown",
+{%       endif %}
+
        Framed-Protocol = PPP
+
 {%  endif %}
 {% endif %}

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/users
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/users
@@ -29,6 +29,9 @@
        Tunnel-Type = VLAN,
        Tunnel-Medium-Type = IEEE-802,
        Tunnel-Private-Group-Id = {{ user_list.vlan }},
+       Mikrotik-Wireless-VLANID := {{ user_list.vlan }},
+       Mikrotik-Wireless-VLANID-Type := 0,
+       Mikrotik-Wireless-Comment = "unknown"
 {%         endif %}
 {%       endif %}
 {%       if helpers.exists('OPNsense.freeradius.general.exos') and OPNsense.freeradius.general.exos == '1' %}


### PR DESCRIPTION
When both settings are enabled and configured (Fallback VLAN and Mikrotik Attributes) the Mikrotik attributes are written to the VLAN fallback section in users configuration file for users