### PR TITLE
www/caddy: Select global log level

### DIFF
--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/logsettings.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/logsettings.xml
@@ -1,5 +1,11 @@
 <form>
     <field>
+        <id>caddy.general.LogLevel</id>
+        <label>Log Level</label>
+        <type>dropdown</type>
+        <help><![CDATA[Select the minimum global Log Level. "INFO" is the default and shouldn't be changed without a reason, since that level displays the ACME Client messages for automatic certificates. This setting doesn't influence the HTTP Access logs, they're always using INFO, which is their lowest supported Log Level.]]></help>
+    </field>
+    <field>
         <id>caddy.general.LogCredentials</id>
         <label>Log Credentials</label>
         <type>checkbox</type>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -76,11 +76,11 @@
             <LogLevel type="OptionField">
                 <BlankDesc>INFO</BlankDesc>
                 <OptionValues>
-                    <DEBUG>Cloudflare</DEBUG>
-                    <WARN>Duck DNS</WARN>
-                    <ERROR>DigitalOcean</ERROR>
-                    <PANIC>GoDaddy</PANIC>
-                    <FATAL>Gandi</FATAL>
+                    <DEBUG>DEBUG</DEBUG>
+                    <WARN>WARN</WARN>
+                    <ERROR>ERROR</ERROR>
+                    <PANIC>PANIC</PANIC>
+                    <FATAL>FATAL</FATAL>
                 </OptionValues>
             </LogLevel>
             <DynDnsSimpleHttp type="UrlField">

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -73,6 +73,16 @@
                 <ValidationMessage>Please enter a valid number of 1 or larger.</ValidationMessage>
                 <Required>Y</Required>
             </LogAccessPlainKeep>
+            <LogLevel type="OptionField">
+                <BlankDesc>INFO</BlankDesc>
+                <OptionValues>
+                    <DEBUG>Cloudflare</DEBUG>
+                    <WARN>Duck DNS</WARN>
+                    <ERROR>DigitalOcean</ERROR>
+                    <PANIC>GoDaddy</PANIC>
+                    <FATAL>Gandi</FATAL>
+                </OptionValues>
+            </LogLevel>
             <DynDnsSimpleHttp type="UrlField">
                 <ValidationMessage>Please enter a valid URL, starting with http or https.</ValidationMessage>
             </DynDnsSimpleHttp>

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -48,6 +48,9 @@
         format json {
             time_format rfc3339
         }
+        {% if generalSettings.LogLevel %}
+        level {{ generalSettings.LogLevel }}
+        {% endif %}
     }
 
     {#


### PR DESCRIPTION
Sometimes it is necessary to enable the debug logs for troubleshooting purposes.