### PR TITLE
www/caddy: Change reload action to reloadssl

### DIFF
--- a/www/caddy/src/opnsense/scripts/OPNsense/Caddy/caddy_control.py
+++ b/www/caddy/src/opnsense/scripts/OPNsense/Caddy/caddy_control.py
@@ -67,7 +67,7 @@ actions = {
     "start": "start",
     "stop": "stop",
     "restart": "restart",
-    "reload": "reload",
+    "reload": "reloadssl", # Forces the reload even if the config in the Caddyfile is unchanged, using an extra command of the rc.d script, forcing certificates in the filesystem to reload.
     "validate": "validate"  # Validate action
 }
 


### PR DESCRIPTION
Forces the reload even if the config in the Caddyfile is unchanged, using an extra command of the rc.d script, forcing certificates in the filesystem to reload.

Fixes: {"info","ts":"2024-04-26T06:13:06Z","msg":"config is unchanged"}

Otherwise, if the config is unchanged, and the certificates are replaced, the names of the certificates in the Caddyfile stay the same, thus implying the config has been unchanged.

As reference, these are the extra commands available in the rc.d script:
https://github.com/opnsense/ports/blob/31b0d3f1d237014192beccdb6e66a1089335ad6d/www/caddy-custom/files/caddy.in#L101-L105