### PR TITLE
www/caddy: template fix tls_server_name option

### DIFF
--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -290,8 +290,24 @@
                     <MaximumValue>100</MaximumValue>
                     <ValidationMessage>Please enter a value between 1 to 100.</ValidationMessage>
                 </PassiveHealthFailDuration>
-                <HttpTls type="BooleanField"/>
-                <HttpNtlm type="BooleanField"/>
+                <HttpTls type="BooleanField">
+                    <Constraints>
+                        <check001>
+                            <ValidationMessage>TLS and NTLM must be enabled at the same time.</ValidationMessage>
+                            <type>DependConstraint</type>
+                            <addFields>
+                                <field1>HttpNtlm</field1>
+                            </addFields>
+                        </check001>
+                    </Constraints>
+                </HttpTls>
+                <HttpNtlm type="BooleanField">
+                    <Constraints>
+                        <check001>
+                            <reference>HttpNtlm.check001</reference>
+                        </check001>
+                    </Constraints>
+                </HttpNtlm>
                 <HttpTlsInsecureSkipVerify type="BooleanField"/>
                 <HttpTlsTrustedCaCerts type="CertificateField">
                     <Type>ca</Type>

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -523,33 +523,35 @@
             {% if handle.PassiveHealthFailDuration|default("") %}
             fail_duration {{ handle.PassiveHealthFailDuration }}s
             {% endif %}
-            {% if handle.HttpTls|default("0") == "1" or handle.HttpTlsInsecureSkipVerify|default("0") == "1" %}
+            {% if handle.HttpTls|default("0") == "1" or handle.HttpTlsInsecureSkipVerify|default("0") == "1" or handle.HttpTlsTrustedCaCerts|default("") != "" or handle.HttpTlsServerName|default("") != "" %}
                 {% if handle.HttpNtlm|default("0") == "1" %}
                 transport http_ntlm {
+                    {% if handle.HttpTls|default("0") == "1" %}
+                    tls
+                    {% endif %}
                     {% if handle.HttpTlsInsecureSkipVerify|default("0") == "1" %}
                     tls_insecure_skip_verify
-                    {% else %}
-                    tls
+                    {% endif %}
                     {% if handle.HttpTlsTrustedCaCerts %}
                     tls_trusted_ca_certs /var/db/caddy/data/caddy/certificates/temp/{{ handle.HttpTlsTrustedCaCerts }}.pem
                     {% endif %}
                     {% if handle.HttpTlsServerName %}
                     tls_server_name {{ handle.HttpTlsServerName }}
-                    {% endif %}
                     {% endif %}
                 }
                 {% else %}
                 transport http {
+                    {% if handle.HttpTls|default("0") == "1" %}
+                    tls
+                    {% endif %}
                     {% if handle.HttpTlsInsecureSkipVerify|default("0") == "1" %}
                     tls_insecure_skip_verify
-                    {% else %}
-                    tls
+                    {% endif %}
                     {% if handle.HttpTlsTrustedCaCerts %}
                     tls_trusted_ca_certs /var/db/caddy/data/caddy/certificates/temp/{{ handle.HttpTlsTrustedCaCerts }}.pem
                     {% endif %}
                     {% if handle.HttpTlsServerName %}
                     tls_server_name {{ handle.HttpTlsServerName }}
-                    {% endif %}
                     {% endif %}
                 }
                 {% endif %}


### PR DESCRIPTION
It is valid to use the `tls_server_name` option, and most other options, inside a `transport_http` or `transport_ntlm` block without having an invalid configuration. For some configurations, it seems to be required to only have `tls_server_name` inside `transport_http`.

At the same time, a constraint was added to `tls` and `ntlm` because they depend on each other, also in the template.

Fixes: https://forum.opnsense.org/index.php?topic=39951.msg197303#msg197303