### PR TITLE
www/caddy: Small style fix for new selectpicker "Select by Domain"

### DIFF
--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -224,9 +224,6 @@
         padding: 0 15px;  // Align with the tables
     }
 
-    #reverseFilter {
-        width: 100% !important;  // Ensure it fills the container
-    }
 </style>
 
 <ul class="nav nav-tabs" data-tabs="tabs" id="maintabs">
@@ -240,7 +237,7 @@
 
     <!-- Selectpicker for filter by domain -->
     <div class="form-group common-filter">
-        <select id="reverseFilter" class="selectpicker form-control" multiple data-live-search="true" data-width="340px" data-size="7" title="Filter by Domain">
+        <select id="reverseFilter" class="selectpicker form-control" multiple data-live-search="true" data-width="330px" data-size="7" title="Filter by Domain">
             <!-- Options will be populated dynamically using JavaScript/Ajax -->
         </select>
     </div>


### PR DESCRIPTION
The style for reverseFilter was messing with the reverse proxy page on mobile phones, dropping it is the best choice.

Now everything stays aligned even on small displays.