### PR TITLE
www/caddy: Change ACME E-Mail to required field

### DIFF
--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
@@ -10,7 +10,7 @@
         <label>ACME Email</label>
         <type>text</type>
         <hint>info@example.com</hint>
-        <help><![CDATA[Enter the email address for certificate notifications.]]></help>
+        <help><![CDATA[Enter the email address for certificate notifications. This is required to receive automatic certificates from Let's Encrypt and ZeroSSL.]]></help>
     </field>
     <field>
         <id>caddy.general.TlsAutoHttps</id>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -10,6 +10,7 @@
             </enabled>
             <TlsEmail type="EmailField">
                 <ValidationMessage>Please enter a valid email address.</ValidationMessage>
+                <Required>Y</Required>
             </TlsEmail>
             <TlsAutoHttps type="OptionField">
                 <BlankDesc>On (default)</BlankDesc>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -10,7 +10,6 @@
             </enabled>
             <TlsEmail type="EmailField">
                 <ValidationMessage>Please enter a valid email address.</ValidationMessage>
-                <Required>Y</Required>
             </TlsEmail>
             <TlsAutoHttps type="OptionField">
                 <BlankDesc>On (default)</BlankDesc>


### PR DESCRIPTION
In the upcoming Caddy Version 2.8.x, there were changes with ZeroSSL that now demand the ACME E-Mail to be filled out with a valid E-Mail address to create the ACME account.

So the field has been changed to required.

Please note that this change needs the updated general.volt from this pull request to properly display validation errors, since that has been a bug: https://github.com/opnsense/plugins/pull/3957

Reference: https://github.com/opnsense/plugins/issues/3951