### PR TITLE
www/caddy: basicauth becomes basic_auth in Caddy 2.8.0 onward

### DIFF
--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -590,7 +590,7 @@
 #}
 {% macro basicauth_configuration(basicauth_uuids) %}
     {% if basicauth_uuids %}
-    basicauth {
+    basic_auth {
         {% for uuid in basicauth_uuids.split(',') %}
             {% set basicauth = helpers.toList('Pischem.caddy.reverseproxy.basicauth') | selectattr('@uuid', 'equalto', uuid) | first %}
             {% if basicauth %}


### PR DESCRIPTION
Closes: https://github.com/opnsense/plugins/issues/3951

Draft for now since upstream has to serve the new version first when it releases fully.
