### PR TITLE
www/caddy: Diagnostics View

### DIFF
--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/DiagnosticsController.php
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/DiagnosticsController.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ *    Copyright (C) 2024 Cedrik Pischem
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+namespace OPNsense\Caddy\Api;
+
+use OPNsense\Base\ApiMutableModelControllerBase;
+use OPNsense\Core\Backend;
+
+class DiagnosticsController extends ApiMutableModelControllerBase
+{
+    protected static $internalModelName = 'caddy';
+    protected static $internalModelClass = 'OPNsense\Caddy\Caddy';
+
+    /**
+     * Fetch and display the contents of the Caddy configuration.
+     * Ensure that the JSON output is handled correctly.
+     */
+    public function showconfigAction()
+    {
+        $backend = new Backend();
+        $response = $backend->configdRun('caddy showconfig');
+
+        // Decode JSON to PHP array to prevent double encoding issues
+        $responseArray = json_decode($response, true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            // If there's an error in the JSON structure, handle it
+            return ["status" => "failed", "message" => "Invalid JSON format: " . json_last_error_msg()];
+        }
+
+        // Return the response as an array which gets automatically encoded to JSON
+        return ["status" => "success", "content" => $responseArray];
+    }
+}

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/DiagnosticsController.php
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/DiagnosticsController.php
@@ -55,8 +55,14 @@ class DiagnosticsController extends ApiMutableModelControllerBase
             return ["status" => "failed", "message" => $responseArray['message']];
         }
 
-        // Return the response as an array which gets automatically encoded to JSON
-        return ["status" => "success", "content" => $responseArray];
+        // Prepare the response array
+        $response = ['status' => 'success', 'content' => $responseArray];
+        // Set the content type
+        $this->response->setContentType('application/json', 'UTF-8');
+        // Encode and set the content
+        $this->response->setContent(json_encode($response, JSON_PRETTY_PRINT));
+
+        return $this->response;
     }
 
     /**
@@ -75,10 +81,12 @@ class DiagnosticsController extends ApiMutableModelControllerBase
             return ["status" => "failed", "message" => $responseArray['message']];
         }
 
-        // Extract and prepare the Caddyfile content from the response
-        $caddyfileContent = $responseArray['Caddyfile'];
+        // Assuming the response structure is like { "content": "actual Caddyfile content here" }
+        if (!isset($responseArray['content'])) {
+            return ["status" => "failed", "message" => "Caddyfile content not found"];
+        }
 
         // Return the response as an array which gets automatically encoded to JSON
-        return ["status" => "success", "content" => $caddyfileContent];
+        return ["status" => "success", "content" => $responseArray['content']];
     }
 }

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/DiagnosticsController.php
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/DiagnosticsController.php
@@ -58,4 +58,27 @@ class DiagnosticsController extends ApiMutableModelControllerBase
         // Return the response as an array which gets automatically encoded to JSON
         return ["status" => "success", "content" => $responseArray];
     }
+
+    /**
+     * Fetch and display the contents of the Caddyfile as JSON.
+     */
+    public function caddyfileAction()
+    {
+        $backend = new Backend();
+        $response = $backend->configdRun('caddy caddyfile');
+
+        // Decode JSON to PHP array
+        $responseArray = json_decode($response, true);
+
+        if (isset($responseArray['error'])) {
+            // Handle the error
+            return ["status" => "failed", "message" => $responseArray['message']];
+        }
+
+        // Extract and prepare the Caddyfile content from the response
+        $caddyfileContent = $responseArray['Caddyfile'];
+
+        // Return the response as an array which gets automatically encoded to JSON
+        return ["status" => "success", "content" => $caddyfileContent];
+    }
 }

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/DiagnosticsController.php
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/DiagnosticsController.php
@@ -39,19 +39,20 @@ class DiagnosticsController extends ApiMutableModelControllerBase
     protected static $internalModelClass = 'OPNsense\Caddy\Caddy';
 
     /**
-     * Fetch and display the contents of the Caddy configuration.
-     * Ensure that the JSON output is handled correctly.
+     * Fetch and display the contents of the Caddy configuration as JSON.
+     * Any errors are handled by caddy_diagnostics script and passed to this controller as JSON.
      */
-    public function showconfigAction()
+    public function configAction()
     {
         $backend = new Backend();
-        $response = $backend->configdRun('caddy showconfig');
+        $response = $backend->configdRun('caddy config');
 
-        // Decode JSON to PHP array to prevent double encoding issues
+        // Decode JSON to PHP array
         $responseArray = json_decode($response, true);
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            // If there's an error in the JSON structure, handle it
-            return ["status" => "failed", "message" => "Invalid JSON format: " . json_last_error_msg()];
+
+        // Since errors are handled by the caddy_diagnostics script and returned as json, check for an error key in the response
+        if (isset($responseArray['error'])) {
+            return ["status" => "failed", "message" => $responseArray['message']];
         }
 
         // Return the response as an array which gets automatically encoded to JSON

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/DiagnosticsController.php
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/DiagnosticsController.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ *    Copyright (C) 2024 Cedrik Pischem
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+namespace OPNsense\Caddy;
+
+use OPNsense\Base\IndexController;
+
+class DiagnosticsController extends IndexController
+{
+    public function indexAction()
+    {
+        $this->view->pick('OPNsense/Caddy/diagnostics');
+    }
+}

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/ACL/ACL.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/ACL/ACL.xml
@@ -15,4 +15,12 @@
             <pattern>api/caddy/reverse_proxy/*</pattern>
         </patterns>
     </page-caddy-reverse-proxy>
+    <page-caddy-diagnostics>
+        <name>Services: Caddy Web Server: Diagnostics</name>
+        <description>Allow access to Caddy Diagnostics</description>
+        <patterns>
+            <pattern>ui/caddy/diagnostics/*</pattern>
+            <pattern>api/caddy/diagnostics/*</pattern>
+        </patterns>
+    </page-caddy-diagnostics>
 </acl>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Menu/Menu.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Menu/Menu.xml
@@ -3,7 +3,8 @@
         <Caddy VisibleName="Caddy Web Server" cssClass="fa fa-globe fa-fw">
             <General VisibleName="General Settings" order="10" url="/ui/caddy/general"/>
             <ReverseProxy VisibleName="Reverse Proxy" order="20" url="/ui/caddy/reverse_proxy"/>
-            <Log VisibleName="Log File" order="30" url="/ui/diagnostics/log/core/caddy"/>
+            <Diagnostics VisibleName="Diagnostics" order="30" url="/ui/caddy/diagnostics"/>
+            <Log VisibleName="Log File" order="40" url="/ui/diagnostics/log/core/caddy"/>
         </Caddy>
     </Services>
 </menu>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/diagnostics.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/diagnostics.volt
@@ -1,0 +1,74 @@
+{#
+ # Copyright (c) 2024 Cedrik Pischem
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1. Redistributions of source code must retain the above copyright notice,
+ #    this list of conditions and the following disclaimer.
+ #
+ # 2. Redistributions in binary form must reproduce the above copyright notice,
+ #    this list of conditions and the following disclaimer in the documentation
+ #    and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #}
+
+<script type="text/javascript">
+    $(document).ready(function() {
+        $("#downloadCaddyConfig").click(function() {
+            $.ajax({
+                url: "/api/caddy/diagnostics/showconfig",  // Custom API endpoint that shows a validated json configuration
+                type: "GET",
+                success: function(response) {
+                    if (response.status === "success") {
+                        let timestamp = new Date().toISOString().replace(/[-:]/g, '').replace('T', '-').split('.')[0];
+                        let filename = "caddy_autosave_" + timestamp + ".json";
+                        download_content(JSON.stringify(response.content), filename, "application/json");
+                    } else {
+                        alert("Failed to download configuration: " + response.message);
+                    }
+                },
+                error: function() {
+                    alert("Error accessing the API.");
+                }
+            });
+        });
+
+        function download_content(payload, filename, file_type) {
+            let a_tag = $('<a></a>').attr('href', 'data:' + file_type + ';charset=utf-8,' + encodeURIComponent(payload))
+                                    .attr('download', filename)
+                                    .appendTo('body');
+
+            a_tag[0].click();
+            a_tag.remove();
+        }
+    });
+</script>
+
+<section class="page-content-main">
+    <div class="content-box">
+        <div class="col-md-12">
+            <h2>{{ lang._('Caddy configuration file') }}</h2>
+            <ul>
+                <li>{{ lang._('Downloads the current configuration file from:') }} <code>/var/db/caddy/config/caddy/autosave.json</code></li>
+                <li>{{ lang._('The running configuration is adapted from:') }} <code>/usr/local/etc/caddy/Caddyfile</code></li>
+                <li>{{ lang._('Custom imports are included.') }} <code>*.conf</code> {{ lang._('and') }} <code>*.global</code> {{ lang._('from:') }} <code>/usr/local/etc/caddy/caddy.d/</code></li>
+            </ul>
+            <hr/>
+            <button class="btn btn-primary" id="downloadCaddyConfig" type="button">{{ lang._('Download') }}</button>
+            <br/><br/>
+        </div>
+    </div>
+</section>
+

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/diagnostics.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/diagnostics.volt
@@ -27,40 +27,33 @@
 <script type="text/javascript">
     $(document).ready(function() {
         // Fetch and display Caddyfile and JSON configuration
-        fetchAndDisplay('/api/caddy/diagnostics/caddyfile', '#caddyfileDisplay', false);
-        fetchAndDisplay('/api/caddy/diagnostics/config', '#jsonDisplay', true);
+        fetchAndDisplay('/api/caddy/diagnostics/caddyfile', '#caddyfileDisplay');
+        fetchAndDisplay('/api/caddy/diagnostics/config', '#jsonDisplay');
 
         /**
          * Fetches data from the specified URL and displays it within a given element on the page.
-         * The Caddyfile is raw content and will be displayed directly by setting isJson to false.
-         * The JSON configuration is a double encoded JSON which will be stringified and nicely formatted.
+         * The response is expected to be JSON and will be formatted for display.
          *
          * @param {string} url - The URL from which to fetch data.
          * @param {string} displaySelector - jQuery selector for the element where data should be displayed.
-         * @param {boolean} isJson - Flag indicating whether the response should be treated as JSON that needs parsing.
          */
-        function fetchAndDisplay(url, displaySelector, isJson) {
+        function fetchAndDisplay(url, displaySelector) {
             $.ajax({
                 url: url,
                 type: "GET",
                 success: function(response) {
                     if (response.status === "success") {
-                        if (isJson) {
-                            try {
-                                // Assuming response.content is a JSON object containing a stringified JSON in 'config_data'
-                                let parsedContent = JSON.parse(response.content.config_data); // Parse the stringified JSON
-                                let formattedContent = JSON.stringify(parsedContent, null, 2); // Format it nicely
-                                $(displaySelector).text(formattedContent);
-                            } catch (error) {
-                                // If JSON parsing fails, display an error message
-                                $(displaySelector).text("JSON parsing error: " + error.message);
-                            }
+                        let formattedContent;
+                        if (typeof response.content === 'object') {
+                            // If the content is an object, stringify and format it
+                            formattedContent = JSON.stringify(response.content, null, 2);
                         } else {
-                            // If the data is not JSON, directly display the raw content
-                            $(displaySelector).text(response.content);
+                            // If the content is plain text (as with the Caddyfile), just use it directly
+                            formattedContent = response.content;
                         }
+                        $(displaySelector).text(formattedContent);
                     } else {
-                        // If the response status is not 'success', handle it by showing an appropriate message
+                        // If the response status is not 'success', display an error message
                         $(displaySelector).text("Failed to load content: " + response.message || "Unknown error");
                     }
                 },

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/diagnostics.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/diagnostics.volt
@@ -26,6 +26,7 @@
 
 <script type="text/javascript">
     $(document).ready(function() {
+        // Download the json configuration as file with timestamp
         $("#downloadCaddyConfig").click(function() {
             $.ajax({
                 url: "/api/caddy/diagnostics/showconfig",  // Custom API endpoint that shows a validated json configuration
@@ -45,11 +46,15 @@
             });
         });
 
+        // Open the json configuration in a new browser tab
+        $("#openConfigInNewTab").click(function() {
+            window.open('/api/caddy/diagnostics/showconfig', '_blank');
+        });
+
         function download_content(payload, filename, file_type) {
             let a_tag = $('<a></a>').attr('href', 'data:' + file_type + ';charset=utf-8,' + encodeURIComponent(payload))
                                     .attr('download', filename)
                                     .appendTo('body');
-
             a_tag[0].click();
             a_tag.remove();
         }
@@ -67,8 +72,8 @@
             </ul>
             <hr/>
             <button class="btn btn-primary" id="downloadCaddyConfig" type="button">{{ lang._('Download') }}</button>
+            <button class="btn btn-secondary" id="openConfigInNewTab" type="button">{{ lang._('Open in Browser') }}</button>
             <br/><br/>
         </div>
     </div>
 </section>
-

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/diagnostics.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/diagnostics.volt
@@ -51,12 +51,12 @@
                         $(displaySelector).text(formattedContent);
                     } else {
                         // If the response status is not 'success', display an error message
-                        $(displaySelector).text("Failed to load content: " + response.message || "Unknown error");
+                        $(displaySelector).text("{{ lang._('Failed to load content: ') }}" + response.message || "{{ lang._('Unknown error') }}");
                     }
                 },
                 error: function(xhr, status, error) {
                     // Handle errors from the AJAX request itself
-                    $(displaySelector).text("AJAX error accessing the API: " + error);
+                    $(displaySelector).text("{{ lang._('AJAX error accessing the API: ') }}" + error);
                 }
             });
         }
@@ -93,7 +93,7 @@
                 title: title,
                 message: message,
                 buttons: [{
-                    label: 'Close',
+                    label: '{{ lang._('Close') }}',
                     action: function(dialogRef) {
                         dialogRef.close();
                     }
@@ -129,13 +129,13 @@
                 dataType: 'json',
                 success: function(data) {
                     if (data && data['status'].toLowerCase() === 'ok') {
-                        showDialogAlert(BootstrapDialog.TYPE_SUCCESS, "Validation Successful", data['message']);
+                        showDialogAlert(BootstrapDialog.TYPE_SUCCESS, "{{ lang._('Validation Successful') }}", data['message']);
                     } else {
-                        showDialogAlert(BootstrapDialog.TYPE_WARNING, "Validation Error", data['message']);  // Show error message from the API
+                        showDialogAlert(BootstrapDialog.TYPE_WARNING, "{{ lang._('Validation Error') }}", data['message']);  // Show error message from the API
                     }
                 },
                 error: function(xhr, status, error) {
-                    showDialogAlert(BootstrapDialog.TYPE_DANGER, "Validation Request Failed", error);  // Show AJAX error
+                    showDialogAlert(BootstrapDialog.TYPE_DANGER, "{{ lang._('Validation Request Failed') }}", error);  // Show AJAX error
                 }
             });
         });
@@ -166,8 +166,8 @@
 
 <!-- Tab Navigation -->
 <ul class="nav nav-tabs" data-tabs="tabs" id="configTabs">
-    <li class="active"><a data-toggle="tab" href="#caddyfileTab">Caddyfile</a></li>
-    <li><a data-toggle="tab" href="#jsonConfigTab">JSON Configuration</a></li>
+    <li class="active"><a data-toggle="tab" href="#caddyfileTab">{{ lang._('Caddyfile') }}</a></li>
+    <li><a data-toggle="tab" href="#jsonConfigTab">{{ lang._('JSON Configuration') }}</a></li>
 </ul>
 
 <!-- Tab Content -->

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/diagnostics.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/diagnostics.volt
@@ -72,7 +72,7 @@
             </ul>
             <hr/>
             <button class="btn btn-primary" id="downloadCaddyConfig" type="button">{{ lang._('Download') }}</button>
-            <button class="btn btn-secondary" id="openConfigInNewTab" type="button">{{ lang._('Open in Browser') }}</button>
+            <button class="btn btn-secondary" id="openConfigInNewTab" type="button">{{ lang._('Show in browser') }}</button>
             <br/><br/>
         </div>
     </div>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/diagnostics.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/diagnostics.volt
@@ -26,9 +26,6 @@
 
 <script type="text/javascript">
     $(document).ready(function() {
-        // Fetch and display Caddyfile and JSON configuration
-        fetchAndDisplay('/api/caddy/diagnostics/caddyfile', '#caddyfileDisplay');
-        fetchAndDisplay('/api/caddy/diagnostics/config', '#jsonDisplay');
 
         /**
          * Fetches data from the specified URL and displays it within a given element on the page.
@@ -64,20 +61,6 @@
             });
         }
 
-        $("#downloadJSONConfig").click(function() {
-            let content = $("#jsonDisplay").text();
-            let timestamp = new Date().toISOString().replace(/[-:]/g, '').replace('T', '-').split('.')[0];
-            let filename = "caddy_config_" + timestamp + ".json";
-            downloadContent(content, filename, "application/json");
-        });
-
-        $("#downloadCaddyfile").click(function() {
-            let content = $("#caddyfileDisplay").text();
-            let timestamp = new Date().toISOString().replace(/[-:]/g, '').replace('T', '-').split('.')[0];
-            let filename = "Caddyfile_" + timestamp;
-            downloadContent(content, filename, "text/plain");
-        });
-
         /**
          * Initiates a file download directly from the browser using JavaScript. The function dynamically creates
          * an anchor (<a>) element, sets its attributes for downloading and simulates a click to start the download.
@@ -97,25 +80,6 @@
             a_tag.remove();  // Remove the anchor tag
         }
 
-        // Event handler for the Validate Caddyfile button
-        $('#validateCaddyfile').click(function() {
-            $.ajax({
-                url: '/api/caddy/service/validate',
-                type: 'GET',
-                dataType: 'json',
-                success: function(data) {
-                    if (data && data['status'].toLowerCase() === 'ok') {
-                        showDialogAlert(BootstrapDialog.TYPE_SUCCESS, "Validation Successful", data['message']);
-                    } else {
-                        showDialogAlert(BootstrapDialog.TYPE_WARNING, "Validation Error", data['message']);  // Show error message from the API
-                    }
-                },
-                error: function(xhr, status, error) {
-                    showDialogAlert(BootstrapDialog.TYPE_DANGER, "Validation Request Failed", error);  // Show AJAX error
-                }
-            });
-        });
-        
         /**
          * Shows a BootstrapDialog alert with custom settings.
          * 
@@ -136,6 +100,45 @@
                 }]
             });
         }
+
+        // Fetch and display Caddyfile and JSON configuration
+        fetchAndDisplay('/api/caddy/diagnostics/caddyfile', '#caddyfileDisplay');
+        fetchAndDisplay('/api/caddy/diagnostics/config', '#jsonDisplay');
+
+        // Event handler to initiate JSON configuration download
+        $("#downloadJSONConfig").click(function() {
+            let content = $("#jsonDisplay").text();
+            let timestamp = new Date().toISOString().replace(/[-:]/g, '').replace('T', '-').split('.')[0];
+            let filename = "caddy_config_" + timestamp + ".json";
+            downloadContent(content, filename, "application/json");
+        });
+
+        // Event handler to initiate Caddyfile download
+        $("#downloadCaddyfile").click(function() {
+            let content = $("#caddyfileDisplay").text();
+            let timestamp = new Date().toISOString().replace(/[-:]/g, '').replace('T', '-').split('.')[0];
+            let filename = "Caddyfile_" + timestamp;
+            downloadContent(content, filename, "text/plain");
+        });
+
+        // Event handler for the Validate Caddyfile button
+        $('#validateCaddyfile').click(function() {
+            $.ajax({
+                url: '/api/caddy/service/validate',
+                type: 'GET',
+                dataType: 'json',
+                success: function(data) {
+                    if (data && data['status'].toLowerCase() === 'ok') {
+                        showDialogAlert(BootstrapDialog.TYPE_SUCCESS, "Validation Successful", data['message']);
+                    } else {
+                        showDialogAlert(BootstrapDialog.TYPE_WARNING, "Validation Error", data['message']);  // Show error message from the API
+                    }
+                },
+                error: function(xhr, status, error) {
+                    showDialogAlert(BootstrapDialog.TYPE_DANGER, "Validation Request Failed", error);  // Show AJAX error
+                }
+            });
+        });
 
     });
 </script>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/diagnostics.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/diagnostics.volt
@@ -29,7 +29,7 @@
         // Download the json configuration as file with timestamp
         $("#downloadCaddyConfig").click(function() {
             $.ajax({
-                url: "/api/caddy/diagnostics/showconfig",  // Custom API endpoint that shows a validated json configuration
+                url: "/api/caddy/diagnostics/config",  // Custom API endpoint that shows a validated json configuration
                 type: "GET",
                 success: function(response) {
                     if (response.status === "success") {
@@ -48,7 +48,7 @@
 
         // Open the json configuration in a new browser tab
         $("#openConfigInNewTab").click(function() {
-            window.open('/api/caddy/diagnostics/showconfig', '_blank');
+            window.open('/api/caddy/diagnostics/config', '_blank');
         });
 
         function download_content(payload, filename, file_type) {

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/diagnostics.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/diagnostics.volt
@@ -32,7 +32,7 @@
 
         /**
          * Fetches data from the specified URL and displays it within a given element on the page.
-         * The Caddyfile is raw content and will be displayed directly.
+         * The Caddyfile is raw content and will be displayed directly by setting isJson to false.
          * The JSON configuration is a double encoded JSON which will be stringified and nicely formatted.
          *
          * @param {string} url - The URL from which to fetch data.
@@ -112,16 +112,37 @@
                 dataType: 'json',
                 success: function(data) {
                     if (data && data['status'].toLowerCase() === 'ok') {
-                        alert('Validation successful: ' + data['message']);  // Show success message
+                        showDialogAlert(BootstrapDialog.TYPE_SUCCESS, "Validation Successful", data['message']);
                     } else {
-                        alert('Validation error: ' + data['message']);  // Show error message from the API
+                        showDialogAlert(BootstrapDialog.TYPE_WARNING, "Validation Error", data['message']);  // Show error message from the API
                     }
                 },
                 error: function(xhr, status, error) {
-                    alert('Validation request failed: ' + error);  // Show AJAX error
+                    showDialogAlert(BootstrapDialog.TYPE_DANGER, "Validation Request Failed", error);  // Show AJAX error
                 }
             });
         });
+        
+        /**
+         * Shows a BootstrapDialog alert with custom settings.
+         * 
+         * @param {string} type - Type of the dialog based on BootstrapDialog types.
+         * @param {string} title - Title of the dialog.
+         * @param {string} message - Message to be displayed in the dialog.
+         */
+        function showDialogAlert(type, title, message) {
+            BootstrapDialog.show({
+                type: type,
+                title: title,
+                message: message,
+                buttons: [{
+                    label: 'Close',
+                    action: function(dialogRef) {
+                        dialogRef.close();
+                    }
+                }]
+            });
+        }
 
     });
 </script>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/diagnostics.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/diagnostics.volt
@@ -132,18 +132,19 @@
     }
 
     .custom-style .display-area {
-        height: 800px;
         overflow-y: scroll;
-        background-color: #f8f9fa;
-        margin-bottom: 25px; /* Adds bottom margin to separate from the button */
+        /* Dynamic height management using clamp for varying screen sizes */
+        height: clamp(50px, 50vh, 4000px); 
+        margin-bottom: 20px; /* Adds bottom margin to separate from the help text */
     }
 
     .custom-style .help-text {
         margin-top: 10px;
         margin-bottom: 20px;
         line-height: 1.4;
+        /* Adjusting text size for readability on various displays */
+        font-size: clamp(12px, 1.5vw, 16px);
     }
-
 </style>
 
 <!-- Tab Navigation -->
@@ -159,8 +160,8 @@
         <div class="content-box">
             <pre id="caddyfileDisplay" class="display-area"></pre>
             <p class="help-text">{{ lang._("This is the generated configuration located at %sCaddyfile%s. It's the main configuration file to get support with. The validation button triggers a manual check for any configuration errors, which is the same check that is triggered by the Apply buttons automatically.") | format('<code>/usr/local/etc/caddy/', '</code>') }}</p>
-            <button class="btn btn-primary download-btn" id="downloadCaddyfile" type="button">Download</button>
-            <button class="btn btn-secondary" id="validateCaddyfile" type="button">Validate Caddyfile</button>
+            <button class="btn btn-primary download-btn" id="downloadCaddyfile" type="button">{{ lang._('Download') }}</button>
+            <button class="btn btn-secondary" id="validateCaddyfile" type="button">{{ lang._('Validate Caddyfile') }}</button>
             <br/><br/>
         </div>
     </div>
@@ -169,7 +170,7 @@
         <div class="content-box">
             <pre id="jsonDisplay" class="display-area"></pre>
             <p class="help-text">{{ lang._("Shows the running Caddy configuration located in %sautosave.json%s. It is automatically adapted from the Caddyfile and also includes any custom imported configurations from %scaddy.d%s.") | format('<code>/var/db/caddy/config/caddy/', '</code>', '<code>/usr/local/etc/caddy/', '</code>') }}</p>
-            <button class="btn btn-primary download-btn" id="downloadJSONConfig" type="button">Download</button>
+            <button class="btn btn-primary download-btn" id="downloadJSONConfig" type="button">{{ lang._('Download') }}</button>
             <br/><br/>
         </div>
     </div>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/diagnostics.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/diagnostics.volt
@@ -103,6 +103,26 @@
             a_tag[0].click();  // Programmatically click the anchor tag to trigger the download
             a_tag.remove();  // Remove the anchor tag
         }
+
+        // Event handler for the Validate Caddyfile button
+        $('#validateCaddyfile').click(function() {
+            $.ajax({
+                url: '/api/caddy/service/validate',
+                type: 'GET',
+                dataType: 'json',
+                success: function(data) {
+                    if (data && data['status'].toLowerCase() === 'ok') {
+                        alert('Validation successful: ' + data['message']);  // Show success message
+                    } else {
+                        alert('Validation error: ' + data['message']);  // Show error message from the API
+                    }
+                },
+                error: function(xhr, status, error) {
+                    alert('Validation request failed: ' + error);  // Show AJAX error
+                }
+            });
+        });
+
     });
 </script>
 
@@ -117,6 +137,13 @@
         background-color: #f8f9fa;
         margin-bottom: 25px; /* Adds bottom margin to separate from the button */
     }
+
+    .custom-style .help-text {
+        margin-top: 10px;
+        margin-bottom: 20px;
+        line-height: 1.4;
+    }
+
 </style>
 
 <!-- Tab Navigation -->
@@ -131,7 +158,9 @@
     <div id="caddyfileTab" class="tab-pane fade in active">
         <div class="content-box">
             <pre id="caddyfileDisplay" class="display-area"></pre>
+            <p class="help-text">{{ lang._("This is the generated configuration located at %sCaddyfile%s. It's the main configuration file to get support with. The validation button triggers a manual check for any configuration errors, which is the same check that is triggered by the Apply buttons automatically.") | format('<code>/usr/local/etc/caddy/', '</code>') }}</p>
             <button class="btn btn-primary download-btn" id="downloadCaddyfile" type="button">Download</button>
+            <button class="btn btn-secondary" id="validateCaddyfile" type="button">Validate Caddyfile</button>
             <br/><br/>
         </div>
     </div>
@@ -139,6 +168,7 @@
     <div id="jsonConfigTab" class="tab-pane fade">
         <div class="content-box">
             <pre id="jsonDisplay" class="display-area"></pre>
+            <p class="help-text">{{ lang._("Shows the running Caddy configuration located in %sautosave.json%s. It is automatically adapted from the Caddyfile and also includes any custom imported configurations from %scaddy.d%s.") | format('<code>/var/db/caddy/config/caddy/', '</code>', '<code>/usr/local/etc/caddy/', '</code>') }}</p>
             <button class="btn btn-primary download-btn" id="downloadJSONConfig" type="button">Download</button>
             <br/><br/>
         </div>

--- a/www/caddy/src/opnsense/scripts/OPNsense/Caddy/caddy_diagnostics.py
+++ b/www/caddy/src/opnsense/scripts/OPNsense/Caddy/caddy_diagnostics.py
@@ -28,7 +28,6 @@
 
 import sys
 import json
-import os
 
 # Function to show the Caddy configuration from a JSON file
 def show_caddy_config():

--- a/www/caddy/src/opnsense/scripts/OPNsense/Caddy/caddy_diagnostics.py
+++ b/www/caddy/src/opnsense/scripts/OPNsense/Caddy/caddy_diagnostics.py
@@ -34,15 +34,12 @@ def show_caddy_config():
     config_path = "/var/db/caddy/config/caddy/autosave.json"
 
     try:
-        # Open and read the JSON configuration file
+        # Open and read the JSON configuration file directly into a Python dictionary
         with open(config_path, "r") as file:
-            config_data = file.read()  # Read the file as raw text
+            config_data = json.load(file)  # Load the JSON directly
 
-        # Attempt to decode the JSON to validate its integrity
-        json.loads(config_data)  # This line is just to validate JSON
-
-        # Print the valid JSON to stdout
-        print(json.dumps({"config_data": config_data}))
+        # Print the JSON to stdout using json.dumps to ensure it's a JSON string and nicely formatted
+        print(json.dumps(config_data))  # Output the JSON directly
         # Output error details in JSON format so that the API can consume them
     except FileNotFoundError:
         print(json.dumps({"error": "File not found", "message": "Caddy autosave.json configuration file not found"}))
@@ -51,14 +48,14 @@ def show_caddy_config():
     except Exception as e:
         print(json.dumps({"error": "General Error", "message": str(e)}))
 
-# Function to show the main Caddyfile content
 def show_caddyfile():
     caddyfile_path = "/usr/local/etc/caddy/Caddyfile"
 
     try:
         with open(caddyfile_path, "r") as file:
             caddyfile_data = file.read()
-        print(json.dumps({"Caddyfile": caddyfile_data}))
+        # Output the Caddyfile data directly as a JSON object with a generic key like "content"
+        print(json.dumps({"content": caddyfile_data}))
     except FileNotFoundError:
         print(json.dumps({"error": "Caddyfile not found", "message": "Caddyfile not found"}))
     except Exception as e:

--- a/www/caddy/src/opnsense/scripts/OPNsense/Caddy/caddy_diagnostics.py
+++ b/www/caddy/src/opnsense/scripts/OPNsense/Caddy/caddy_diagnostics.py
@@ -28,7 +28,9 @@
 
 import sys
 import json
+import os
 
+# Function to show the Caddy configuration from a JSON file
 def show_caddy_config():
     config_path = "/var/db/caddy/config/caddy/autosave.json"
 
@@ -41,18 +43,33 @@ def show_caddy_config():
         json.loads(config_data)  # This line is just to validate JSON
 
         # Print the valid JSON to stdout
-        print(config_data)
-    except FileNotFoundError:
+        print(json.dumps({"config_data": config_data}))
         # Output error details in JSON format so that the API can consume them
+    except FileNotFoundError:
         print(json.dumps({"error": "File not found", "message": "Caddy autosave.json configuration file not found"}))
     except json.JSONDecodeError:
         print(json.dumps({"error": "Invalid JSON", "message": "Error decoding the Caddy autosave.json, the file is not valid JSON"}))
     except Exception as e:
         print(json.dumps({"error": "General Error", "message": str(e)}))
 
+# Function to show the main Caddyfile content
+def show_caddyfile():
+    caddyfile_path = "/usr/local/etc/caddy/Caddyfile"
+
+    try:
+        with open(caddyfile_path, "r") as file:
+            caddyfile_data = file.read()
+        print(json.dumps({"Caddyfile": caddyfile_data}))
+    except FileNotFoundError:
+        print(json.dumps({"error": "Caddyfile not found", "message": "Caddyfile not found"}))
+    except Exception as e:
+        print(json.dumps({"error": "General Error", "message": str(e)}))
+
+# Action handler
 def perform_action(action):
     actions = {
-        "config": show_caddy_config
+        "config": show_caddy_config,
+        "caddyfile": show_caddyfile
         # Additional actions can be added here in the same format.
     }
 

--- a/www/caddy/src/opnsense/scripts/OPNsense/Caddy/caddy_diagnostics.py
+++ b/www/caddy/src/opnsense/scripts/OPNsense/Caddy/caddy_diagnostics.py
@@ -40,33 +40,34 @@ def show_caddy_config():
         # Attempt to decode the JSON to validate its integrity
         json.loads(config_data)  # This line is just to validate JSON
 
-        # If the file is valid JSON, return it as raw string
-        return config_data
+        # Print the valid JSON to stdout
+        print(config_data)
     except FileNotFoundError:
-        sys.exit("Caddy autosave configuration file not found.")
+        # Output error details in JSON format so that the API can consume them
+        print(json.dumps({"error": "File not found", "message": "Caddy autosave.json configuration file not found"}))
     except json.JSONDecodeError:
-        sys.exit("Error decoding the Caddy configuration JSON. The file is not valid JSON.")
+        print(json.dumps({"error": "Invalid JSON", "message": "Error decoding the Caddy autosave.json, the file is not valid JSON"}))
     except Exception as e:
-        sys.exit(f"An error occurred: {str(e)}")
+        print(json.dumps({"error": "General Error", "message": str(e)}))
 
 def perform_action(action):
     actions = {
-        "showconfig": show_caddy_config
+        "config": show_caddy_config
         # Additional actions can be added here in the same format.
     }
 
     action_func = actions.get(action)
     if action_func:
-        return action_func()
+        action_func()
     else:
-        return f"Unknown action: {action}"
+        # Output error details in JSON format if action is unknown
+        print(json.dumps({"error": "Unknown Action", "message": f"Unknown action: {action}"}))
 
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         action = sys.argv[1]
-        result = perform_action(action)
-        if result:
-            print(result)
+        perform_action(action)
     else:
-        print("No action specified.")
+        # Output error details in JSON format if no action is specified
+        print(json.dumps({"error": "No Action Specified", "message": "No action specified"}))
 

--- a/www/caddy/src/opnsense/scripts/OPNsense/Caddy/caddy_diagnostics.py
+++ b/www/caddy/src/opnsense/scripts/OPNsense/Caddy/caddy_diagnostics.py
@@ -1,0 +1,72 @@
+#!/usr/local/bin/python3
+
+#
+# Copyright (c) 2024 Cedrik Pischem
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+# AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+# OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+import sys
+import json
+
+def show_caddy_config():
+    config_path = "/var/db/caddy/config/caddy/autosave.json"
+
+    try:
+        # Open and read the JSON configuration file
+        with open(config_path, "r") as file:
+            config_data = file.read()  # Read the file as raw text
+
+        # Attempt to decode the JSON to validate its integrity
+        json.loads(config_data)  # This line is just to validate JSON
+
+        # If the file is valid JSON, return it as raw string
+        return config_data
+    except FileNotFoundError:
+        sys.exit("Caddy autosave configuration file not found.")
+    except json.JSONDecodeError:
+        sys.exit("Error decoding the Caddy configuration JSON. The file is not valid JSON.")
+    except Exception as e:
+        sys.exit(f"An error occurred: {str(e)}")
+
+def perform_action(action):
+    actions = {
+        "showconfig": show_caddy_config
+        # Additional actions can be added here in the same format.
+    }
+
+    action_func = actions.get(action)
+    if action_func:
+        return action_func()
+    else:
+        return f"Unknown action: {action}"
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        action = sys.argv[1]
+        result = perform_action(action)
+        if result:
+            print(result)
+    else:
+        print("No action specified.")
+

--- a/www/caddy/src/opnsense/service/conf/actions.d/actions_caddy.conf
+++ b/www/caddy/src/opnsense/service/conf/actions.d/actions_caddy.conf
@@ -36,8 +36,8 @@ parameters:
 type:script_output
 message:Request Caddy status
 
-[showconfig]
-command:/usr/local/opnsense/scripts/OPNsense/Caddy/caddy_diagnostics.py showconfig
+[config]
+command:/usr/local/opnsense/scripts/OPNsense/Caddy/caddy_diagnostics.py config
 parameters:
 type:script_output
-message:Request Caddyfile
+message:Request Caddy configuration

--- a/www/caddy/src/opnsense/service/conf/actions.d/actions_caddy.conf
+++ b/www/caddy/src/opnsense/service/conf/actions.d/actions_caddy.conf
@@ -35,3 +35,9 @@ command:/usr/local/sbin/pluginctl -s caddy status
 parameters:
 type:script_output
 message:Request Caddy status
+
+[showconfig]
+command:/usr/local/opnsense/scripts/OPNsense/Caddy/caddy_diagnostics.py showconfig
+parameters:
+type:script_output
+message:Request Caddyfile

--- a/www/caddy/src/opnsense/service/conf/actions.d/actions_caddy.conf
+++ b/www/caddy/src/opnsense/service/conf/actions.d/actions_caddy.conf
@@ -40,4 +40,10 @@ message:Request Caddy status
 command:/usr/local/opnsense/scripts/OPNsense/Caddy/caddy_diagnostics.py config
 parameters:
 type:script_output
-message:Request Caddy configuration
+message:Request Caddy JSON configuration
+
+[caddyfile]
+command:/usr/local/opnsense/scripts/OPNsense/Caddy/caddy_diagnostics.py caddyfile
+parameters:
+type:script_output
+message:Request Caddyfile


### PR DESCRIPTION
Adds a new Diagnostics view in which a download button can download the latest caddy configuration with timestamp.

The autosave.json file is used, since it's json, which makes it easy to validate that it is indeed valid json. Also, it includes all custom imports which users might have dropped into the filesystem, unlike the raw Caddyfile would.

The new API endpoint /api/caddy/diagnostics/showconfig can also be invoked, to show the json configuration in the Browser in real time. There is no view for that, to keep it simple. The API is only used for the Download button, and with a button that shows the json configuration in the browser.