### PR TITLE
net/freeradius: Allow `:` in user and password

### DIFF
--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/dialogEditFreeRADIUSUser.xml
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/dialogEditFreeRADIUSUser.xml
@@ -9,13 +9,13 @@
         <id>user.username</id>
         <label>Username</label>
         <type>text</type>
-        <help>Set the unique username for the user. Allowed characters are 0-9, a-z, A-Z, and ._-@/</help>
+        <help>Set the unique username for the user. Allowed characters are 0-9, a-z, A-Z, and ._-@/:</help>
     </field>
     <field>
         <id>user.password</id>
         <label>Password</label>
         <type>password</type>
-        <help>Set the password for the user. Allowed characters are 0-9, a-z, A-Z, and ,._-!$%/()+#= with up to 128 characters.</help>
+        <help>Set the password for the user. Allowed characters are 0-9, a-z, A-Z, and ,._-!$%/()+#=: with up to 128 characters.</help>
     </field>
     <field>
         <id>user.passwordencryption</id>

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/User.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/User.xml
@@ -11,11 +11,11 @@
                 </enabled>
                 <username type="TextField">
                     <Required>Y</Required>
-                    <mask>/^([0-9a-zA-Z@._\-\/]){1,128}$/u</mask>
+                    <mask>/^([0-9a-zA-Z@._\-\/:]){1,128}$/u</mask>
                 </username>
                 <password type="TextField">
                     <Required>Y</Required>
-                    <mask>/^([0-9a-zA-Z._\-\!\$\%\/\(\)\+\#\=\{\}]){1,128}$/u</mask>
+                    <mask>/^([0-9a-zA-Z._\-\!\$\%\/\(\)\+\#\=\{\}:]){1,128}$/u</mask>
                 </password>
                 <passwordencryption type="OptionField">
                     <default>Cleartext-Password</default>


### PR DESCRIPTION
Fixes #3975 

FreeRADIUS allows a `:` character in the username and password. This update is especially useful for MAC-based authentication where you might want to copy-paste a MAC address for the username and password.

```
# opnsense-patch -a chelming -c plugins 1207358
Fetched 1207358 via https://github.com/chelming/plugins
Hmm...  Looks like a unified diff to me...
The text leading up to this was:
--------------------------
|From 120735808a1bdcdfec7a85897a252d0e9b8dcfa4 Mon Sep 17 00:00:00 2001
|From: Chris Helming <chris.helming@gmail.com>
|Date: Mon, 13 May 2024 10:21:33 -0400
|Subject: [PATCH] allow : in FreeRADIUS user and password
|
|---
| .../OPNsense/Freeradius/forms/dialogEditFreeRADIUSUser.xml    | 4 ++--
| .../src/opnsense/mvc/app/models/OPNsense/Freeradius/User.xml  | 4 ++--
| 2 files changed, 4 insertions(+), 4 deletions(-)
|
|diff --git a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/dialogEditFreeRADIUSUser.xml b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/dialogEditFreeRADIUSUser.xml
|index e6fc8d7484..e025a865a5 100644
|--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/dialogEditFreeRADIUSUser.xml
|+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/dialogEditFreeRADIUSUser.xml
--------------------------
Patching file opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/dialogEditFreeRADIUSUser.xml using Plan A...
Hunk #1 succeeded at 9 with fuzz 1.
Hmm...  The next patch looks like a unified diff to me...
The text leading up to this was:
--------------------------
|diff --git a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/User.xml b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/User.xml
|index 506ab2d3f9..589798ce4a 100644
|--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/User.xml
|+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/User.xml
--------------------------
Patching file opnsense/mvc/app/models/OPNsense/Freeradius/User.xml using Plan A...
Hunk #1 succeeded at 11 with fuzz 2.
done
All patches have been applied successfully.  Have a nice day.
```
```
# radtest 11:22:33:44:55:66 11:22:33:44:55:66 127.0.0.1 1812 abcd
Sent Access-Request Id 59 from 0.0.0.0:8d5b to 127.0.0.1:1812 length 103
        User-Name = "11:22:33:44:55:66"
        User-Password = "11:22:33:44:55:66"
        NAS-IP-Address = 192.168.0.1
        NAS-Port = 1812
        Message-Authenticator = 0x00
        Cleartext-Password = "11:22:33:44:55:66"
Received Access-Accept Id 59 from 127.0.0.1:714 to 127.0.0.1:36187 length 42
        Tunnel-Type:0 = VLAN
        Tunnel-Medium-Type:0 = IEEE-802
        Tunnel-Private-Group-Id:0 = "20"
        Framed-Protocol = PPP
```

![image](https://github.com/opnsense/plugins/assets/7746625/262433a0-6d31-4670-9947-41993543a790)

