### PR TITLE
www/caddy: HTTP-01 challenge redirection subdomain fix

### DIFF
--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
@@ -54,7 +54,6 @@ ll be automatically updated with your DNS Provider.]]></help>
         <label>HTTP-01 challenge redirection</label>
         <type>text</type>
         <help><![CDATA[Enter a domain name or IP address. The HTTP-01 challenge will be redirected to that destination. This enables a server behind Caddy to serve "/.well-known/acme-challenge/". Caddy will issue a certificate for the same domain using the TLS-ALPN-01 challenge or DNS-01 challenge instead.]]></help>
-        <advanced>true</advanced>
     </field>
     <field>
         <id>reverse.CustomCertificate</id>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
@@ -53,7 +53,7 @@ ll be automatically updated with your DNS Provider.]]></help>
         <id>reverse.AcmePassthrough</id>
         <label>HTTP-01 challenge redirection</label>
         <type>text</type>
-        <help><![CDATA[Enter a domain name or IP address. The HTTP-01 challenge will be redirected to that destination. This enables a server behind Caddy to serve "/.well-known/acme-challenge/". Caddy will issue a certificate for the same domain using the TLS-ALPN-01 challenge or DNS-01 challenge instead.]]></help>
+        <help><![CDATA[Enter a domain name or IP address. The HTTP-01 challenge will be redirected to that destination. This enables a server behind Caddy to serve "/.well-known/acme-challenge/". Caddy will issue a certificate for the same domain using the TLS-ALPN-01 challenge or DNS-01 challenge instead. Setting this option on a wildcard domain will pass the challenge of all subdomains to a single server behind Caddy. For finer control, use this option in subdomains instead of their wildcard domain.]]></help>
     </field>
     <field>
         <id>reverse.CustomCertificate</id>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogSubdomain.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogSubdomain.xml
@@ -45,6 +45,17 @@
     </field>
     <field>
         <type>header</type>
+        <label>Trust</label>
+        <collapse>true</collapse>
+    </field>
+    <field>
+        <id>subdomain.AcmePassthrough</id>
+        <label>HTTP-01 challenge redirection</label>
+        <type>text</type>
+        <help><![CDATA[Enter a domain name or IP address. The HTTP-01 challenge will be redirected to that destination. This enables a server behind Caddy to serve "/.well-known/acme-challenge/". Caddy will issue a certificate for the same domain using the TLS-ALPN-01 challenge or DNS-01 challenge instead.]]></help>
+    </field>
+    <field>
+        <type>header</type>
         <label>Access</label>
         <collapse>true</collapse>
     </field>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogSubdomain.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogSubdomain.xml
@@ -52,7 +52,7 @@
         <id>subdomain.AcmePassthrough</id>
         <label>HTTP-01 challenge redirection</label>
         <type>text</type>
-        <help><![CDATA[Enter a domain name or IP address. The HTTP-01 challenge will be redirected to that destination. This enables a server behind Caddy to serve "/.well-known/acme-challenge/". Caddy will issue a certificate for the same domain using the TLS-ALPN-01 challenge or DNS-01 challenge instead.]]></help>
+        <help><![CDATA[Enter a domain name or IP address. The HTTP-01 challenge will be redirected to that destination. This enables a server behind Caddy to serve "/.well-known/acme-challenge/".]]></help>
     </field>
     <field>
         <type>header</type>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -219,6 +219,10 @@
                     <Required>Y</Required>
                 </description>
                 <DynDns type="BooleanField"/>
+                <AcmePassthrough type="HostnameField">
+                    <ValidationMessage>Please enter a valid 'to' domain or IP address.</ValidationMessage>
+                    <IpAllowed>Y</IpAllowed>
+                </AcmePassthrough>
             </subdomain>
             <handle type="ArrayField">
                 <enabled type="BooleanField">

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -257,7 +257,7 @@
                             <th data-column-id="FromPort" data-type="string">Port</th>
                             <th data-column-id="accesslist" data-type="string" data-visible="false">Access List</th>
                             <th data-column-id="basicauth" data-type="string" data-visible="false">Basic Auth</th>
-                            <th data-column-id="DnsChallenge" data-type="boolean" data-formatter="boolean" data-visible="false">DNS-01</th>
+                            <th data-column-id="DnsChallenge" data-type="boolean" data-formatter="boolean" data-visible="false">DNS-01 challenge</th>
                             <th data-column-id="DynDns" data-type="boolean" data-formatter="boolean" data-visible="false">Dynamic DNS</th>
                             <th data-column-id="AccessLog" data-type="boolean" data-formatter="boolean" data-visible="false">HTTP Access Log</th>
                             <th data-column-id="CustomCertificate" data-type="string" data-visible="false">Custom Certificate</th>
@@ -295,6 +295,7 @@
                             <th data-column-id="accesslist" data-type="string" data-visible="false">Access List</th>
                             <th data-column-id="basicauth" data-type="string" data-visible="false">Basic Auth</th>
                             <th data-column-id="DynDns" data-type="boolean" data-formatter="boolean" data-visible="false">Dynamic DNS</th>
+                            <th data-column-id="AcmePassthrough" data-type="string" data-visible="false">HTTP-01 redirection</th>
                             <th data-column-id="description" data-type="string">Description</th>
                             <th data-column-id="commands" data-width="7em" data-formatter="commands" data-sortable="false">Commands</th>
                         </tr>

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -308,6 +308,20 @@
         }
     {% endif %}
 {% endfor %}
+{# Process redirection for subdomains afterwards, since a redirection of a wildcard domain has to match before them. #}
+{% for subdomain in helpers.toList('Pischem.caddy.reverseproxy.subdomain') %}
+    {% if subdomain.enabled|default("0") == "1" and subdomain.AcmePassthrough %}
+        # HTTP-01 challenge redirection for subdomain: "{{ subdomain['@uuid'] }}"
+        http://{{ subdomain.FromDomain|default("") }} {
+            handle /.well-known/acme-challenge/* {
+                reverse_proxy {{ subdomain.AcmePassthrough }}
+            }
+            handle {
+                redir https://{host}{uri} 308
+            }
+        }
+    {% endif %}
+{% endfor %}
 
 {#
 #   Macro: tls_configuration


### PR DESCRIPTION
I forgot to allow the acme redirection option for subdomains. I recently needed it and I saw it was not there. So, now it is added.

Also it's not an advanced option anymore since it's tested thoroughly, and also needed for proper HA.