### PR TITLE
www/caddy: Restructure and format helptext

### DIFF
--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogAccessList.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogAccessList.xml
@@ -3,7 +3,7 @@
         <id>accesslist.accesslistName</id>
         <label>Access List Name</label>
         <type>text</type>
-        <help><![CDATA[Enter a name for this access list.]]></help>
+        <help><![CDATA[<strong>Enter a name for this access list.</strong>]]></help>
     </field>
     <field>
         <id>accesslist.clientIps</id>
@@ -11,34 +11,32 @@
         <type>select_multiple</type>
         <style>tokenize</style>
         <allownew>true</allownew>
-        <help><![CDATA[Enter the client IP addresses or networks for this access list. Accepts multiple IPv4/IPv6 addresses or networks.]]></help>
+        <help><![CDATA[<strong>Enter the client IP addresses or networks</strong> for this access list. Accepts multiple IPv4/IPv6 addresses or networks.]]></help>
     </field>
     <field>
         <id>accesslist.accesslistInvert</id>
         <label>Invert List</label>
         <type>checkbox</type>
-        <help><![CDATA[If checked, the access list logic will be inverted (i.e., the listed IPs will be blocked instead of allowed).]]></help>
+        <help><![CDATA[<strong>If checked, the access list logic will be inverted</strong> (i.e., the listed IPs will be blocked instead of allowed).]]></help>
     </field>
     <field>
         <id>accesslist.HttpResponseCode</id>
         <label>HTTP Response Code</label>
         <type>text</type>
         <hint>403</hint>
-        <help><![CDATA[Set a custom HTTP response code that should be returned to the requesting client when the access list doesn't match. Setting this will replace "Abort Connections", all clients will stay connected but will receive the response code.]]></help>
-        <advanced>true</advanced>
+        <help><![CDATA[<strong>Set a custom HTTP response code</strong> that should be returned to the requesting client when the access list doesn't match. Setting this will replace <code>Abort Connections</code> only for this access list. All clients will stay connected but will receive the response code.]]></help>
     </field>
     <field>
         <id>accesslist.HttpResponseMessage</id>
         <label>HTTP Response Message</label>
         <type>text</type>
         <hint>Forbidden</hint>
-        <help><![CDATA[Set a custom HTTP response message in addition to the HTTP response code.]]></help>
-        <advanced>true</advanced>
+        <help><![CDATA[<strong>Set a custom HTTP response message</strong> in addition to the HTTP response code.]]></help>
     </field>
     <field>
         <id>accesslist.description</id>
         <label>Description</label>
         <type>text</type>
-        <help><![CDATA[Enter a description for this access list.]]></help>
+        <help><![CDATA[<strong>Enter a description for this access list.</strong>]]></help>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogAccessList.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogAccessList.xml
@@ -24,7 +24,7 @@
         <label>HTTP Response Code</label>
         <type>text</type>
         <hint>403</hint>
-        <help><![CDATA[Set a custom HTTP response code that should be returned to the requesting client when the access list doesn't match. Setting this will replace "Abort Connections" only for this access list. All clients will stay connected but will receive the response code.]]></help>
+        <help><![CDATA[Set a custom HTTP response code that should be returned to the requesting client when the access list does not match. Setting this will replace "Abort Connections" only for this access list. All clients will stay connected but will receive the response code.]]></help>
     </field>
     <field>
         <id>accesslist.HttpResponseMessage</id>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogAccessList.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogAccessList.xml
@@ -3,7 +3,7 @@
         <id>accesslist.accesslistName</id>
         <label>Access List Name</label>
         <type>text</type>
-        <help><![CDATA[<strong>Enter a name for this access list.</strong>]]></help>
+        <help><![CDATA[Enter a name for this access list.]]></help>
     </field>
     <field>
         <id>accesslist.clientIps</id>
@@ -11,32 +11,32 @@
         <type>select_multiple</type>
         <style>tokenize</style>
         <allownew>true</allownew>
-        <help><![CDATA[<strong>Enter the client IP addresses or networks</strong> for this access list. Accepts multiple IPv4/IPv6 addresses or networks.]]></help>
+        <help><![CDATA[Enter the client IP addresses or networks for this access list. Accepts multiple IPv4/IPv6 addresses or networks.]]></help>
     </field>
     <field>
         <id>accesslist.accesslistInvert</id>
         <label>Invert List</label>
         <type>checkbox</type>
-        <help><![CDATA[<strong>If checked, the access list logic will be inverted</strong> (i.e., the listed IPs will be blocked instead of allowed).]]></help>
+        <help><![CDATA[If checked, the access list logic will be inverted (i.e., the listed IPs will be blocked instead of allowed).]]></help>
     </field>
     <field>
         <id>accesslist.HttpResponseCode</id>
         <label>HTTP Response Code</label>
         <type>text</type>
         <hint>403</hint>
-        <help><![CDATA[<strong>Set a custom HTTP response code</strong> that should be returned to the requesting client when the access list doesn't match. Setting this will replace <code>Abort Connections</code> only for this access list. All clients will stay connected but will receive the response code.]]></help>
+        <help><![CDATA[Set a custom HTTP response code that should be returned to the requesting client when the access list doesn't match. Setting this will replace "Abort Connections" only for this access list. All clients will stay connected but will receive the response code.]]></help>
     </field>
     <field>
         <id>accesslist.HttpResponseMessage</id>
         <label>HTTP Response Message</label>
         <type>text</type>
         <hint>Forbidden</hint>
-        <help><![CDATA[<strong>Set a custom HTTP response message</strong> in addition to the HTTP response code.]]></help>
+        <help><![CDATA[Set a custom HTTP response message in addition to the HTTP response code.]]></help>
     </field>
     <field>
         <id>accesslist.description</id>
         <label>Description</label>
         <type>text</type>
-        <help><![CDATA[<strong>Enter a description for this access list.</strong>]]></help>
+        <help><![CDATA[Enter a description for this access list.]]></help>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogBasicAuth.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogBasicAuth.xml
@@ -3,18 +3,18 @@
         <id>basicauth.basicauthuser</id>
         <label>User</label>
         <type>text</type>
-        <help><![CDATA[Enter a username. Afterwards, you can select it in Reverse Proxy Domains or Subdomains to restrict access with basic auth.]]></help>
+        <help><![CDATA[<strong>Enter a username.</strong> Afterwards, select it in a <code>Domain</code> or <code>Subdomain</code> to restrict access with basic auth.]]></help>
     </field>
     <field>
         <id>basicauth.basicauthpass</id>
         <label>Password</label>
         <type>text</type>
-        <help><![CDATA[Enter a password. It will be hashed with bcrypt. It can only be set and changed but won't be visible anymore.]]></help>
+        <help><![CDATA[<strong>Enter a password.</strong> It will be hashed with bcrypt. It can only be set and changed but won't be visible anymore.]]></help>
     </field>
     <field>
         <id>basicauth.description</id>
         <label>Description</label>
         <type>text</type>
-        <help><![CDATA[Enter a description for this user.]]></help>
+        <help><![CDATA[<strong>Enter a description for this user.</strong>]]></help>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogBasicAuth.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogBasicAuth.xml
@@ -9,7 +9,7 @@
         <id>basicauth.basicauthpass</id>
         <label>Password</label>
         <type>text</type>
-        <help><![CDATA[Enter a password. It will be hashed with bcrypt. It can only be set and changed but won't be visible anymore.]]></help>
+        <help><![CDATA[Enter a password. It will be hashed with bcrypt. It can only be set and changed but will not be visible anymore.]]></help>
     </field>
     <field>
         <id>basicauth.description</id>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogBasicAuth.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogBasicAuth.xml
@@ -3,18 +3,18 @@
         <id>basicauth.basicauthuser</id>
         <label>User</label>
         <type>text</type>
-        <help><![CDATA[<strong>Enter a username.</strong> Afterwards, select it in a <code>Domain</code> or <code>Subdomain</code> to restrict access with basic auth.]]></help>
+        <help><![CDATA[Enter a username. Afterwards, select it in a "Domain" or "Subdomain" to restrict access with basic auth.]]></help>
     </field>
     <field>
         <id>basicauth.basicauthpass</id>
         <label>Password</label>
         <type>text</type>
-        <help><![CDATA[<strong>Enter a password.</strong> It will be hashed with bcrypt. It can only be set and changed but won't be visible anymore.]]></help>
+        <help><![CDATA[Enter a password. It will be hashed with bcrypt. It can only be set and changed but won't be visible anymore.]]></help>
     </field>
     <field>
         <id>basicauth.description</id>
         <label>Description</label>
         <type>text</type>
-        <help><![CDATA[<strong>Enter a description for this user.</strong>]]></help>
+        <help><![CDATA[Enter a description for this user.]]></help>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -67,7 +67,7 @@
         <label>Upstream Port</label>
         <type>text</type>
         <hint>80</hint>
-        <help><![CDATA[Leave empty to use port 80 or choose a custom port for the upstream destination.]]></help>
+        <help><![CDATA[Leave empty to use the default port or choose a custom port for the upstream destination.]]></help>
     </field>
     <field>
         <id>handle.ToPath</id>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -1,40 +1,40 @@
 <form>
     <field>
         <id>handle.enabled</id>
-        <label>enabled</label>
+        <label>Enabled</label>
         <type>checkbox</type>
-        <help><![CDATA[Enable this handler.]]></help>
+        <help><![CDATA[<strong>Enable or disable this handler.</strong>]]></help>
     </field>
     <field>
         <id>handle.reverse</id>
         <label>Domain</label>
         <type>dropdown</type>
-        <help><![CDATA[Select a reverse proxy domain to which this handler should be added.]]></help>
+        <help><![CDATA[<strong>Select a domain to handle.</strong>]]></help>
     </field>
     <field>
         <id>handle.subdomain</id>
         <label>Subdomain</label>
         <type>dropdown</type>
-        <help><![CDATA[Optionally, select a reverse proxy subdomain to which this handler should be added. If not using subdomains, leaving this as "None" will be the best choice.]]></help>
+        <help><![CDATA[<strong>Select a subdomain to handle</strong>. Make sure to additionaly choose a wildcard domain as <code>Domain</code>. Leave unset, if not using subdomains.]]></help>
     </field>
     <field>
         <id>handle.HandleType</id>
         <label>Handle Type</label>
         <type>dropdown</type>
-        <help><![CDATA[In most cases, leaving this as "handle" will be the best choice.]]></help>
+        <help><![CDATA[<strong>Choose a handling directive.</strong> <code>handle</code> (default) will keep the URI of <code>Handle URI</code> in all requests. <code>handle_path</code> will strip the URI of <code>Handle URI</code> from all requests.]]></help>
         <advanced>true</advanced>
     </field>
     <field>
         <id>handle.HandlePath</id>
-        <label>Handle Path</label>
+        <label>Handle URI</label>
         <type>text</type>
-        <help><![CDATA[Enter a handler like '/*' or '/example/*', or leave blank for a catch-all handler (recommended). Any request matching this handler will be reverse proxied to the upstream destination.]]></help>
+        <help><![CDATA[<strong>Enter an URI to handle.</strong> Choose a pattern like <code>/*</code> or <code>/example/*</code>. <strong>Leave empty to catch all URIs (recommended)</strong>. Any request matching this pattern will be handled.]]></help>
     </field>
     <field>
         <id>handle.description</id>
         <label>Description</label>
         <type>text</type>
-        <help><![CDATA[Enter a description for this handler.]]></help>
+        <help><![CDATA[<strong>Enter a description for this handler.</strong>]]></help>
     </field>
     <field>
         <type>header</type>
@@ -47,7 +47,7 @@
         <type>dropdown</type>
         <type>select_multiple</type>
         <size>5</size>
-        <help><![CDATA[Select one or multiple header manipulations. These will be set to this handler. Generally this is not needed. Setting a wrong configuration can be a security risk or break functionality.]]></help>
+        <help><![CDATA[<strong>Select one or multiple header manipulations.</strong> Caddy sets <code>X-Forwarded-For</code>, <code>X-Forwarded-Proto</code> and <code>X-Forwarded-Host</code> by default, adding them here is not needed. <strong>Setting a wrong configuration can be a security risk or break functionality.</strong>]]></help>
     </field>
     <field>
         <type>header</type>
@@ -60,28 +60,32 @@
         <style>tokenize</style>
         <allownew>true</allownew>
         <hint>192.168.1.1</hint>
-        <help><![CDATA[Enter the internal domain name or IP address of the upstream destination for this handler. If multiple upstream destinations are chosen, they will be load balanced with the default random policy.]]></help>
+        <help><![CDATA[<strong>Enter a domain name or IP address of the upstream destination.</strong> If multiple are chosen, they will be load balanced with the default random policy. A health check can be set in <em>Load Balancing</em>]]></help>
     </field>
     <field>
         <id>handle.ToPort</id>
         <label>Upstream Port</label>
         <type>text</type>
         <hint>80</hint>
-        <help><![CDATA[Enter the port number of the upstream destination. Leave this empty to use port 80.]]></help>
+        <help><![CDATA[<strong>Leave empty to use port 80</strong> or choose a custom port of the upstream destination.]]></help>
     </field>
     <field>
         <id>handle.ToPath</id>
         <label>Upstream Path</label>
         <type>text</type>
-        <help><![CDATA[Enter a path prefix like '/guacamole' that should be prepended to the upstream request because the application demands it.]]></help>
+        <help><![CDATA[<strong>Enter a path prefix</strong> like <code>/guacamole</code> that should be prepended to the upstream request because the application demands it.]]></help>
         <advanced>true</advanced>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Load Balancing</label>
+        <collapse>true</collapse>
     </field>
     <field>
         <id>handle.PassiveHealthFailDuration</id>
         <label>Upstream Fail Duration</label>
         <type>text</type>
-        <help><![CDATA[Enables a passive health check when multiple upstream destinations have been defined for load balancing. "fail_duration" is a duration value that defines how long to remember a failed request. A duration of 1 or more seconds enables passive health checking; the default is empty (off). A reasonable starting point might be 30s to balance error rates with responsiveness when bringing an unhealthy upstream back online.]]></help>
-        <advanced>true</advanced>
+        <help><![CDATA[<strong>Enables a passive health check</strong> when multiple destinations in <code>Upstream Domain</code> are set. <code>Fail Duration</code> is a value that defines how long to remember a failed request. A duration of 1 or more seconds enables passive health checking; the default is empty (off). A reasonable starting point might be 30s to balance error rates with responsiveness when bringing an unhealthy upstream back online.]]></help>
     </field>
     <field>
         <type>header</type>
@@ -92,32 +96,30 @@
         <id>handle.HttpTls</id>
         <label>TLS</label>
         <type>checkbox</type>
-        <help><![CDATA[Use HTTP over TLS (HTTPS) to communicate with the upstream destination. In most cases, leaving this unchecked will be the best choice. Caddy uses HTTP for communication with the upstream destination by default.]]></help>
+        <help><![CDATA[<strong>Enable or disable HTTP over TLS (HTTPS)</strong> to communicate with the upstream destination. Caddy uses HTTP with the upstream destination by default.]]></help>
     </field>
     <field>
         <id>handle.HttpNtlm</id>
         <label>NTLM</label>
         <type>checkbox</type>
-        <help><![CDATA[If "TLS" has been checked, check "NTLM" in addition for reverse proxying an Exchange Server. In most other cases, leaving this unchecked will be the best choice.]]></help>
-        <advanced>true</advanced>
+        <help><![CDATA[<strong>Enable or disable NTLM.</strong> Needed to reverse proxy an Exchange Server.]]></help>
     </field>
     <field>
         <id>handle.HttpTlsInsecureSkipVerify</id>
         <label>TLS Insecure Skip Verify</label>
         <type>checkbox</type>
-        <help><![CDATA[Turns off TLS handshake verification, making the connection insecure and vulnerable to man-in-the-middle attacks. Do not use in production.]]></help>
-        <advanced>true</advanced>
+        <help><![CDATA[<strong>Disable the TLS handshake verification</strong>, making the connection insecure and vulnerable to man-in-the-middle attacks. <strong>Do not use in production if possible.</strong> When having issues with an upstream that only accepts TLS connections, enabling this option can mitigate them.]]></help>
     </field>
     <field>
         <id>handle.HttpTlsTrustedCaCerts</id>
         <label>TLS Trusted CA Certificate</label>
         <type>dropdown</type>
-        <help><![CDATA[Optionally, if TLS is enabled, choose a CA certificate or self-signed certificate to trust from "System - Trust - Authorities".]]></help>
+        <help><![CDATA[<strong>Choose a CA or self-signed certificate to trust</strong> from <em>System - Trust - Authorities</em>. Useful if the upstream destination only accepts TLS connections and offers a self signed certificate. Adding that certificate here will allow for the encrypted connection to succeed.]]></help>
     </field>
     <field>
         <id>handle.HttpTlsServerName</id>
         <label>TLS Server Name</label>
         <type>text</type>
-        <help><![CDATA[Optionally, specify a hostname or IP address that matches the SAN of the "TLS Trusted CA Certificate". Please note that only SAN certificates are supported; CN will not work.]]></help>
+        <help><![CDATA[<strong>Enter a hostname or IP address</strong> that matches the SAN <em>Subject Alternative Name</em> of the offered upstream certificate. This will change the SNI <em>Server Name Indication</em> of Caddy. Setting an IP address as <code>Upstream Domain</code>, enabling <code>TLS</code> and selecting a <code>TLS Trusted CA Certificate</code>, would make the SAN of the offered upstream certificate not match with the SNI of Caddy, since it will be an IP address instead of a hostname. Setting the hostname of the certificate here, fixes this issue. Please note that only SAN certificates are supported; CN <em>Common Name</em> will not work.]]></help>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -3,7 +3,7 @@
         <id>handle.enabled</id>
         <label>Enabled</label>
         <type>checkbox</type>
-        <help><![CDATA[Enable or disable this handler.]]></help>
+        <help><![CDATA[Enable this handler.]]></help>
     </field>
     <field>
         <id>handle.reverse</id>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -3,38 +3,38 @@
         <id>handle.enabled</id>
         <label>Enabled</label>
         <type>checkbox</type>
-        <help><![CDATA[<strong>Enable or disable this handler.</strong>]]></help>
+        <help><![CDATA[Enable or disable this handler.]]></help>
     </field>
     <field>
         <id>handle.reverse</id>
         <label>Domain</label>
         <type>dropdown</type>
-        <help><![CDATA[<strong>Select a domain to handle.</strong>]]></help>
+        <help><![CDATA[Select a domain to handle.]]></help>
     </field>
     <field>
         <id>handle.subdomain</id>
         <label>Subdomain</label>
         <type>dropdown</type>
-        <help><![CDATA[<strong>Select a subdomain to handle</strong>. Make sure to additionaly choose a wildcard domain as <code>Domain</code>. Leave unset, if not using subdomains.]]></help>
+        <help><![CDATA[Select a subdomain to handle. Make sure to additionaly choose a wildcard domain as "Domain". Leave unset, if not using subdomains.]]></help>
     </field>
     <field>
         <id>handle.HandleType</id>
         <label>Handle Type</label>
         <type>dropdown</type>
-        <help><![CDATA[<strong>Choose a handling directive.</strong> <code>handle</code> (default) will keep the URI of <code>Handle URI</code> in all requests. <code>handle_path</code> will strip the URI of <code>Handle URI</code> from all requests.]]></help>
+        <help><![CDATA[Choose a handling directive. "handle" (default) will keep the URI of "Handle URI" in all requests. "handle_path" will strip the URI of "Handle URI" from all requests.]]></help>
         <advanced>true</advanced>
     </field>
     <field>
         <id>handle.HandlePath</id>
         <label>Handle URI</label>
         <type>text</type>
-        <help><![CDATA[<strong>Enter an URI to handle.</strong> Choose a pattern like <code>/*</code> or <code>/example/*</code>. <strong>Leave empty to catch all URIs (recommended)</strong>. Any request matching this pattern will be handled.]]></help>
+        <help><![CDATA[Enter an URI to handle. Choose a pattern like "/*" or "/example/*". Leave empty to catch all URIs (recommended). Any request matching this pattern will be handled.]]></help>
     </field>
     <field>
         <id>handle.description</id>
         <label>Description</label>
         <type>text</type>
-        <help><![CDATA[<strong>Enter a description for this handler.</strong>]]></help>
+        <help><![CDATA[Enter a description for this handler.]]></help>
     </field>
     <field>
         <type>header</type>
@@ -47,7 +47,7 @@
         <type>dropdown</type>
         <type>select_multiple</type>
         <size>5</size>
-        <help><![CDATA[<strong>Select one or multiple header manipulations.</strong> Caddy sets <code>X-Forwarded-For</code>, <code>X-Forwarded-Proto</code> and <code>X-Forwarded-Host</code> by default, adding them here is not needed. <strong>Setting a wrong configuration can be a security risk or break functionality.</strong>]]></help>
+        <help><![CDATA[Select one or multiple header manipulations. Caddy sets "X-Forwarded-For", "X-Forwarded-Proto" and "X-Forwarded-Host" by default, adding them here is not needed. Setting a wrong configuration can be a security risk or break functionality.]]></help>
     </field>
     <field>
         <type>header</type>
@@ -60,20 +60,20 @@
         <style>tokenize</style>
         <allownew>true</allownew>
         <hint>192.168.1.1</hint>
-        <help><![CDATA[<strong>Enter a domain name or IP address of the upstream destination.</strong> If multiple are chosen, they will be load balanced with the default random policy. A health check can be set in <em>Load Balancing</em>]]></help>
+        <help><![CDATA[Enter a domain name or IP address of the upstream destination. If multiple are chosen, they will be load balanced with the default random policy. A health check can be set in "Load Balancing"]]></help>
     </field>
     <field>
         <id>handle.ToPort</id>
         <label>Upstream Port</label>
         <type>text</type>
         <hint>80</hint>
-        <help><![CDATA[<strong>Leave empty to use port 80</strong> or choose a custom port of the upstream destination.]]></help>
+        <help><![CDATA[Leave empty to use port 80 or choose a custom port for the upstream destination.]]></help>
     </field>
     <field>
         <id>handle.ToPath</id>
         <label>Upstream Path</label>
         <type>text</type>
-        <help><![CDATA[<strong>Enter a path prefix</strong> like <code>/guacamole</code> that should be prepended to the upstream request because the application demands it.]]></help>
+        <help><![CDATA[Enter a path prefix like "/guacamole" that should be prepended to the upstream request because the application demands it.]]></help>
         <advanced>true</advanced>
     </field>
     <field>
@@ -85,7 +85,7 @@
         <id>handle.PassiveHealthFailDuration</id>
         <label>Upstream Fail Duration</label>
         <type>text</type>
-        <help><![CDATA[<strong>Enables a passive health check</strong> when multiple destinations in <code>Upstream Domain</code> are set. <code>Fail Duration</code> is a value that defines how long to remember a failed request. A duration of 1 or more seconds enables passive health checking; the default is empty (off). A reasonable starting point might be 30s to balance error rates with responsiveness when bringing an unhealthy upstream back online.]]></help>
+        <help><![CDATA[Enables a passive health check when multiple destinations in "Upstream Domain" are set. "Fail Duration" is a value that defines how long to remember a failed request. A duration of 1 or more seconds enables passive health checking; the default is empty (off). A reasonable starting point might be 30s to balance error rates with responsiveness when bringing an unhealthy upstream back online.]]></help>
     </field>
     <field>
         <type>header</type>
@@ -96,30 +96,30 @@
         <id>handle.HttpTls</id>
         <label>TLS</label>
         <type>checkbox</type>
-        <help><![CDATA[<strong>Enable or disable HTTP over TLS (HTTPS)</strong> to communicate with the upstream destination. Caddy uses HTTP with the upstream destination by default.]]></help>
+        <help><![CDATA[Enable or disable HTTP over TLS (HTTPS) to communicate with the upstream destination. Caddy uses HTTP with the upstream destination by default.]]></help>
     </field>
     <field>
         <id>handle.HttpNtlm</id>
         <label>NTLM</label>
         <type>checkbox</type>
-        <help><![CDATA[<strong>Enable or disable NTLM.</strong> Needed to reverse proxy an Exchange Server.]]></help>
+        <help><![CDATA[Enable or disable NTLM. Needed to reverse proxy an Exchange Server.]]></help>
     </field>
     <field>
         <id>handle.HttpTlsInsecureSkipVerify</id>
         <label>TLS Insecure Skip Verify</label>
         <type>checkbox</type>
-        <help><![CDATA[<strong>Disable the TLS handshake verification</strong>, making the connection insecure and vulnerable to man-in-the-middle attacks. <strong>Do not use in production if possible.</strong> When having issues with an upstream that only accepts TLS connections, enabling this option can mitigate them.]]></help>
+        <help><![CDATA[Disable the TLS handshake verification, making the connection insecure and vulnerable to man-in-the-middle attacks. Do not use in production if possible. When having issues with an upstream that only accepts TLS connections, enabling this option can mitigate them.]]></help>
     </field>
     <field>
         <id>handle.HttpTlsTrustedCaCerts</id>
         <label>TLS Trusted CA Certificate</label>
         <type>dropdown</type>
-        <help><![CDATA[<strong>Choose a CA or self-signed certificate to trust</strong> from <em>System - Trust - Authorities</em>. Useful if the upstream destination only accepts TLS connections and offers a self signed certificate. Adding that certificate here will allow for the encrypted connection to succeed.]]></help>
+        <help><![CDATA[Choose a CA or self-signed certificate to trust from "System - Trust - Authorities". Useful if the upstream destination only accepts TLS connections and offers a self signed certificate. Adding that certificate here will allow for the encrypted connection to succeed.]]></help>
     </field>
     <field>
         <id>handle.HttpTlsServerName</id>
         <label>TLS Server Name</label>
         <type>text</type>
-        <help><![CDATA[<strong>Enter a hostname or IP address</strong> that matches the SAN <em>Subject Alternative Name</em> of the offered upstream certificate. This will change the SNI <em>Server Name Indication</em> of Caddy. Setting an IP address as <code>Upstream Domain</code>, enabling <code>TLS</code> and selecting a <code>TLS Trusted CA Certificate</code>, would make the SAN of the offered upstream certificate not match with the SNI of Caddy, since it will be an IP address instead of a hostname. Setting the hostname of the certificate here, fixes this issue. Please note that only SAN certificates are supported; CN <em>Common Name</em> will not work.]]></help>
+        <help><![CDATA[Enter a hostname or IP address that matches the SAN "Subject Alternative Name" of the offered upstream certificate. This will change the SNI "Server Name Indication" of Caddy. Setting an IP address as "Upstream Domain", enabling "TLS" and selecting a "TLS Trusted CA Certificate", would make the SAN of the offered upstream certificate not match with the SNI of Caddy, since it will be an IP address instead of a hostname. Setting the hostname of the certificate here, fixes this issue. Please note that only SAN certificates are supported; CN "Common Name" will not work.]]></help>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHeader.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHeader.xml
@@ -3,32 +3,32 @@
         <id>header.HeaderUpDown</id>
         <label>Header</label>
         <type>dropdown</type>
-        <help><![CDATA[header_up sets, adds (with the + prefix), deletes (with the - prefix), or performs a replacement (by using two arguments, a search and replacement) in a request header going upstream to the backend. header_down sets, adds (with the + prefix), deletes (with the - prefix), or performs a replacement (by using two arguments, a search and replacement) in a response header coming downstream from the backend. For more information: https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#headers]]></help>
+        <help><![CDATA[<strong>header_up</strong> sets, adds (with the <code>+</code> prefix), deletes (with the <code>-</code> prefix), or performs a replacement (by using two arguments, a search and replacement) in a request header going upstream to the backend. <strong>header_down</strong> sets, adds (with the <code>+</code> prefix), deletes (with the <code>-</code> prefix), or performs a replacement (by using two arguments, a search and replacement) in a response header coming downstream from the backend. For more information: <a href="https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#headers">Caddy Documentation on Headers</a>.]]></help>
     </field>
     <field>
         <id>header.HeaderType</id>
         <label>Header Type</label>
         <hint>Host</hint>
         <type>text</type>
-        <help><![CDATA[Enter a header, for example "Host". Use the + or - prefix to add or remove this header, for example "-Host" or "+Host". A suffix match like "-Host-*" is also supported. To replace a header, use "Some-Header" without + or -.]]></help>
+        <help><![CDATA[<strong>Enter a header,</strong> for example <code>Host</code>. Use the <code>+</code> or <code>-</code> prefix to add or remove this header, for example <code>-Host</code> or <code>+Host</code>. A suffix match like <code>-Host-*</code> is also supported. To replace a header, use <code>Host</code> without <code>+</code> or <code>-</code>.]]></help>
     </field>
     <field>
         <id>header.HeaderValue</id>
         <label>Header Value</label>
         <hint>{upstream_hostport}</hint>
         <type>text</type>
-        <help><![CDATA[Enter a value for the above header. One of the most common options is "{upstream_hostport}". It's also possible to use a regular expression to search for a specific value in a header. For example: "^prefix-([A-Za-z0-9]*)$" which uses the regular expression language RE2 included in Go.]]></help>
+        <help><![CDATA[<strong>Enter a value for the selected header.</strong> One of the most common options is <code>{upstream_hostport}</code>. It's also possible to use a regular expression to search for a specific value in a header. For example: <code>^prefix-([A-Za-z0-9]*)$</code> which uses the regular expression language RE2 included in Go.]]></help>
     </field>
     <field>
         <id>header.HeaderReplace</id>
         <label>Header Replace</label>
         <type>text</type>
-        <help><![CDATA[If a regular expression is used to search for a Header Value, here the replacement string can be set. For example: "replaced-$1-suffix" which expands the replacement string, allowing the use of captured values, $1 being the first capture group.]]></help>
+        <help><![CDATA[If a regular expression is used to search for a Header Value, the replacement string can be set here. For example: <code>replaced-$1-suffix</code> which expands the replacement string, allowing the use of captured values, <code>$1</code> being the first capture group.]]></help>
     </field>
     <field>
         <id>header.description</id>
         <label>Description</label>
         <type>text</type>
-        <help><![CDATA[Enter a description for this header.]]></help>
+        <help><![CDATA[<strong>Enter a description for this header.</strong>]]></help>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHeader.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHeader.xml
@@ -17,7 +17,7 @@
         <label>Header Value</label>
         <hint>{upstream_hostport}</hint>
         <type>text</type>
-        <help><![CDATA[Enter a value for the selected header. One of the most common options is "{upstream_hostport}". It's also possible to use a regular expression to search for a specific value in a header. For example: "^prefix-([A-Za-z0-9]*)$" which uses the regular expression language RE2 included in Go.]]></help>
+        <help><![CDATA[Enter a value for the selected header. One of the most common options is "{upstream_hostport}". It is also possible to use a regular expression to search for a specific value in a header. For example: "^prefix-([A-Za-z0-9]*)$" which uses the regular expression language RE2 included in Go.]]></help>
     </field>
     <field>
         <id>header.HeaderReplace</id>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHeader.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHeader.xml
@@ -3,32 +3,32 @@
         <id>header.HeaderUpDown</id>
         <label>Header</label>
         <type>dropdown</type>
-        <help><![CDATA[<strong>header_up</strong> sets, adds (with the <code>+</code> prefix), deletes (with the <code>-</code> prefix), or performs a replacement (by using two arguments, a search and replacement) in a request header going upstream to the backend. <strong>header_down</strong> sets, adds (with the <code>+</code> prefix), deletes (with the <code>-</code> prefix), or performs a replacement (by using two arguments, a search and replacement) in a response header coming downstream from the backend. For more information: <a href="https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#headers">Caddy Documentation on Headers</a>.]]></help>
+        <help><![CDATA["header_up" sets, adds (with the "+" prefix), deletes (with the "-" prefix), or performs a replacement (by using two arguments, a search and replacement) in a request header going upstream to the backend. "header_down" sets, adds (with the "+" prefix), deletes (with the "-" prefix), or performs a replacement (by using two arguments, a search and replacement) in a response header coming downstream from the backend. For more information: https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#headers]]></help>
     </field>
     <field>
         <id>header.HeaderType</id>
         <label>Header Type</label>
         <hint>Host</hint>
         <type>text</type>
-        <help><![CDATA[<strong>Enter a header,</strong> for example <code>Host</code>. Use the <code>+</code> or <code>-</code> prefix to add or remove this header, for example <code>-Host</code> or <code>+Host</code>. A suffix match like <code>-Host-*</code> is also supported. To replace a header, use <code>Host</code> without <code>+</code> or <code>-</code>.]]></help>
+        <help><![CDATA[Enter a header, for example "Host". Use the "+" or "-" prefix to add or remove this header, for example "-Host" or "+Host". A suffix match like "-Host-*" is also supported. To replace a header, use "Host" without "+" or "-".]]></help>
     </field>
     <field>
         <id>header.HeaderValue</id>
         <label>Header Value</label>
         <hint>{upstream_hostport}</hint>
         <type>text</type>
-        <help><![CDATA[<strong>Enter a value for the selected header.</strong> One of the most common options is <code>{upstream_hostport}</code>. It's also possible to use a regular expression to search for a specific value in a header. For example: <code>^prefix-([A-Za-z0-9]*)$</code> which uses the regular expression language RE2 included in Go.]]></help>
+        <help><![CDATA[Enter a value for the selected header. One of the most common options is "{upstream_hostport}". It's also possible to use a regular expression to search for a specific value in a header. For example: "^prefix-([A-Za-z0-9]*)$" which uses the regular expression language RE2 included in Go.]]></help>
     </field>
     <field>
         <id>header.HeaderReplace</id>
         <label>Header Replace</label>
         <type>text</type>
-        <help><![CDATA[If a regular expression is used to search for a Header Value, the replacement string can be set here. For example: <code>replaced-$1-suffix</code> which expands the replacement string, allowing the use of captured values, <code>$1</code> being the first capture group.]]></help>
+        <help><![CDATA[If a regular expression is used to search for a Header Value, the replacement string can be set here. For example: "replaced-$1-suffix" which expands the replacement string, allowing the use of captured values, "$1" being the first capture group.]]></help>
     </field>
     <field>
         <id>header.description</id>
         <label>Description</label>
         <type>text</type>
-        <help><![CDATA[<strong>Enter a description for this header.</strong>]]></help>
+        <help><![CDATA[Enter a description for this header.]]></help>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
@@ -3,28 +3,28 @@
         <id>reverse.enabled</id>
         <label>Enabled</label>
         <type>checkbox</type>
-        <help><![CDATA[<strong>Enable or disable this domain.</strong>]]></help>
+        <help><![CDATA[Enable or disable this domain.]]></help>
     </field>
     <field>
         <id>reverse.FromDomain</id>
         <label>Domain</label>
         <type>text</type>
         <hint>example.com</hint>
-        <help><![CDATA[<strong>Enter a domain name or IP address.</strong> For a base domain, use <code>example.com</code> or <code>opn.example.com</code>. Using a base domain enables automatic <em>Let's Encrypt</em> and <em>ZeroSSL</em> certificates by default. For a wildcard domain, use <code>*.example.com</code>. Only use wildcard domains with wildcard certificates, which require a DNS Provider.</strong>]]></help>
+        <help><![CDATA[Enter a domain name or IP address. For a base domain, use "example.com" or "opn.example.com". Using a base domain enables automatic "Let's Encrypt" and "ZeroSSL" certificates by default. For a wildcard domain, use "*.example.com". Only use wildcard domains with wildcard certificates, which require a DNS Provider.]]></help>
     </field>
     <field>
         <id>reverse.FromPort</id>
         <label>Port</label>
         <type>text</type>
         <hint>443</hint>
-        <help><![CDATA[<strong>Leave empty to use ports 80 and 443 with automatic redirection from HTTP to HTTPS</strong> or choose a custom port. Don't forget to allow these ports with a Firewall rule.]]></help>
+        <help><![CDATA[Leave empty to use ports 80 and 443 with automatic redirection from HTTP to HTTPS or choose a custom port. Don't forget to allow these ports with a Firewall rule.]]></help>
     </field>
     <field>
         <id>reverse.description</id>
         <label>Description</label>
         <type>text</type>
         <hint>example.com.443</hint>
-        <help><![CDATA[<strong>Enter a description for this domain.</strong>]]></help>
+        <help><![CDATA[Enter a description for this domain.]]></help>
     </field>
     <field>
         <type>header</type>
@@ -35,7 +35,7 @@
         <id>reverse.DynDns</id>
         <label>Dynamic DNS</label>
         <type>checkbox</type>
-        <help><![CDATA[<strong>Enable or disable Dynamic DNS.</strong> Requires a <code>DNS Provider</code> in <em>General Settings</em>. The DNS records of this domain will be automatically updated.]]></help>
+        <help><![CDATA[Enable or disable Dynamic DNS. Requires a "DNS Provider" in "General Settings". The DNS records of this domain will be automatically updated.]]></help>
     </field>
     <field>
         <type>header</type>
@@ -46,19 +46,19 @@
         <id>reverse.DnsChallenge</id>
         <label>DNS-01 Challenge</label>
         <type>checkbox</type>
-        <help><![CDATA[<strong>Enable or disable the DNS-01 challenge for this domain.</strong> Requires a <code>DNS Provider</code> in <em>General Settings</em>. This is mostly only needed for wildcard domains, or when the HTTP-01 and TLS-ALPN-01 challenge can't be used due to restrictive firewall policies.]]></help>
+        <help><![CDATA[Enable or disable the DNS-01 challenge for this domain. Requires a "DNS Provider" in "General Settings". This is mostly only needed for wildcard domains, or when the HTTP-01 and TLS-ALPN-01 challenge can't be used due to restrictive firewall policies.]]></help>
     </field>
     <field>
         <id>reverse.AcmePassthrough</id>
         <label>HTTP-01 Challenge Redirection</label>
         <type>text</type>
-        <help><![CDATA[<strong>Enter a domain name or IP address. The HTTP-01 challenge will be redirected to that destination</strong>. This enables an ACME Client behind Caddy to serve "/.well-known/acme-challenge/" on port 80. Caddy will reverse proxy the HTTP-01 challenge for this domain, and will still issue a certificate using the TLS-ALPN-01 challenge or DNS-01 challenge for itself. <strong>This option can be used for High Availability when using Caddy with a master and backup OPNsense.</strong>]]></help>
+        <help><![CDATA[Enter a domain name or IP address. The HTTP-01 challenge will be redirected to that destination. This enables an ACME Client behind Caddy to serve "/.well-known/acme-challenge/" on port 80. Caddy will reverse proxy the HTTP-01 challenge for this domain, and will still issue a certificate using the TLS-ALPN-01 challenge or DNS-01 challenge for itself. This option can be used for High Availability when using Caddy with a master and backup OPNsense.]]></help>
     </field>
     <field>
         <id>reverse.CustomCertificate</id>
         <label>Custom Certificate</label>
         <type>dropdown</type>
-        <help><![CDATA[<strong>Choose a custom certificate from <em>System - Trust - Certificates</em> for this domain.</strong> Make sure the full chain has been imported.]]></help>
+        <help><![CDATA[Choose a custom certificate from "System - Trust - Certificates" for this domain. Make sure the full chain has been imported.]]></help>
     </field>
     <field>
         <type>header</type>
@@ -69,19 +69,19 @@
         <id>reverse.accesslist</id>
         <label>Access List</label>
         <type>dropdown</type>
-        <help><![CDATA[<strong>Select an Access List to restrict access to this domain.</strong> If unset, any local or remote client is allowed access.]]></help>
+        <help><![CDATA[Select an Access List to restrict access to this domain. If unset, any local or remote client is allowed access.]]></help>
     </field>
     <field>
         <id>reverse.basicauth</id>
         <label>Basic Auth</label>
         <type>select_multiple</type>
         <size>5</size>
-        <help><![CDATA[<strong>Select Users to restrict access to this domain.</strong> Basic Auth matches after Access Lists. If unset, any user is allowed access. When using CrowdSec, authorization failures will result in automatic bans.]]></help>
+        <help><![CDATA[Select Users to restrict access to this domain. Basic Auth matches after Access Lists. If unset, any user is allowed access. When using CrowdSec, authorization failures will result in automatic bans.]]></help>
     </field>
     <field>
         <id>reverse.AccessLog</id>
         <label>HTTP Access Log</label>
         <type>checkbox</type>
-        <help><![CDATA[<strong>Enable HTTP request logging for this domain and its subdomains</strong>. This option is mostly used for troubleshooting, audits and CrowdSec. It will log every single request.]]></help>
+        <help><![CDATA[Enable HTTP request logging for this domain and its subdomains. This option is mostly used for troubleshooting, audits and CrowdSec. It will log every single request.]]></help>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
@@ -1,30 +1,30 @@
 <form>
     <field>
         <id>reverse.enabled</id>
-        <label>enabled</label>
+        <label>Enabled</label>
         <type>checkbox</type>
-        <help><![CDATA[Enable this reverse proxy domain.]]></help>
+        <help><![CDATA[<strong>Enable or disable this domain.</strong>]]></help>
     </field>
     <field>
         <id>reverse.FromDomain</id>
         <label>Domain</label>
         <type>text</type>
         <hint>example.com</hint>
-        <help><![CDATA[Enter a domain name or IP address. For a wildcard domain, use *.example.com. Only use wildcard domains with a wildcard certificate. Don't forget to create a firewall rule that allows port 80 and 443 to "This Firewall".]]></help>
+        <help><![CDATA[<strong>Enter a domain name or IP address.</strong> For a base domain, use <code>example.com</code> or <code>opn.example.com</code>. Using a base domain enables automatic <em>Let's Encrypt</em> and <em>ZeroSSL</em> certificates by default. For a wildcard domain, use <code>*.example.com</code>. Only use wildcard domains with wildcard certificates, which require a DNS Provider.</strong>]]></help>
     </field>
     <field>
         <id>reverse.FromPort</id>
         <label>Port</label>
         <type>text</type>
         <hint>443</hint>
-        <help><![CDATA[Enter the port number. Leave this empty to bind to port 80 and 443 with automatic redirection. Don't forget to create a firewall rule that allows this port to "This Firewall".]]></help>
+        <help><![CDATA[<strong>Leave empty to use ports 80 and 443 with automatic redirection from HTTP to HTTPS</strong> or choose a custom port. Don't forget to allow these ports with a Firewall rule.]]></help>
     </field>
     <field>
         <id>reverse.description</id>
         <label>Description</label>
         <type>text</type>
         <hint>example.com.443</hint>
-        <help><![CDATA[Enter a description for this reverse proxy domain.]]></help>
+        <help><![CDATA[<strong>Enter a description for this domain.</strong>]]></help>
     </field>
     <field>
         <type>header</type>
@@ -35,8 +35,7 @@
         <id>reverse.DynDns</id>
         <label>Dynamic DNS</label>
         <type>checkbox</type>
-        <help><![CDATA[Enable Dynamic DNS, please configure DNS Provider and API Key in General Settings. The DNS Records of this domain wi
-ll be automatically updated with your DNS Provider.]]></help>
+        <help><![CDATA[<strong>Enable or disable Dynamic DNS.</strong> Requires a <code>DNS Provider</code> in <em>General Settings</em>. The DNS records of this domain will be automatically updated.]]></help>
     </field>
     <field>
         <type>header</type>
@@ -45,21 +44,21 @@ ll be automatically updated with your DNS Provider.]]></help>
     </field>
     <field>
         <id>reverse.DnsChallenge</id>
-        <label>DNS-01 challenge</label>
+        <label>DNS-01 Challenge</label>
         <type>checkbox</type>
-        <help><![CDATA[Enable DNS-01 challenge for ACME, please configure DNS Provider and API Key in General Settings. In most cases, leaving this option unchecked will be the best choice. The automatic Let's Encrypt HTTP challenge will be used if this option is unchecked, which needs no further configuration.]]></help>
+        <help><![CDATA[<strong>Enable or disable the DNS-01 challenge for this domain.</strong> Requires a <code>DNS Provider</code> in <em>General Settings</em>. This is mostly only needed for wildcard domains, or when the HTTP-01 and TLS-ALPN-01 challenge can't be used due to restrictive firewall policies.]]></help>
     </field>
     <field>
         <id>reverse.AcmePassthrough</id>
-        <label>HTTP-01 challenge redirection</label>
+        <label>HTTP-01 Challenge Redirection</label>
         <type>text</type>
-        <help><![CDATA[Enter a domain name or IP address. The HTTP-01 challenge will be redirected to that destination. This enables a server behind Caddy to serve "/.well-known/acme-challenge/". Caddy will issue a certificate for the same domain using the TLS-ALPN-01 challenge or DNS-01 challenge instead. Setting this option on a wildcard domain will pass the challenge of all subdomains to a single server behind Caddy. For finer control, use this option in subdomains instead of their wildcard domain.]]></help>
+        <help><![CDATA[<strong>Enter a domain name or IP address. The HTTP-01 challenge will be redirected to that destination</strong>. This enables an ACME Client behind Caddy to serve "/.well-known/acme-challenge/" on port 80. Caddy will reverse proxy the HTTP-01 challenge for this domain, and will still issue a certificate using the TLS-ALPN-01 challenge or DNS-01 challenge for itself. <strong>This option can be used for High Availability when using Caddy with a master and backup OPNsense.</Strong>]]></help>
     </field>
     <field>
         <id>reverse.CustomCertificate</id>
         <label>Custom Certificate</label>
         <type>dropdown</type>
-        <help><![CDATA[Choose your own certificate from System Trust Certificates. Make sure you have imported the full chain. In most cases, leaving this as "None" will be the best choice.]]></help>
+        <help><![CDATA[<strong>Choose a custom certificate from <em>System - Trust - Certificates</em> for this domain.</strong> Make sure the full chain has been imported.]]></help>
     </field>
     <field>
         <type>header</type>
@@ -70,19 +69,19 @@ ll be automatically updated with your DNS Provider.]]></help>
         <id>reverse.accesslist</id>
         <label>Access List</label>
         <type>dropdown</type>
-        <help><![CDATA[Optionally, select an Access List to restrict access to this domain. If left as "None", any local or remote client is allowed access. In most cases, leaving this as "None" will be the best choice.]]></help>
+        <help><![CDATA[<strong>Select an Access List to restrict access to this domain.</strong> If unset, any local or remote client is allowed access.]]></help>
     </field>
     <field>
         <id>reverse.basicauth</id>
         <label>Basic Auth</label>
         <type>select_multiple</type>
         <size>5</size>
-        <help><![CDATA[Optionally, select Users to restrict access to this domain. Basic Auth matches after Access Lists. If left as "None", any client is allowed access. In most cases, leaving this as "None" will be the best choice.]]></help>
+        <help><![CDATA[<strong>Select Users to restrict access to this domain.</strong> Basic Auth matches after Access Lists. If unset, any user is allowed access. When using CrowdSec, authorization failures will result in automatic bans.]]></help>
     </field>
     <field>
         <id>reverse.AccessLog</id>
         <label>HTTP Access Log</label>
         <type>checkbox</type>
-        <help><![CDATA[Enable the HTTP request logging for this domain and its subdomains. This option is mostly for troubleshooting since it will log every single request.]]></help>
+        <help><![CDATA[<strong>Enable HTTP request logging for this domain and its subdomains</strong>. This option is mostly used for troubleshooting, audits and CrowdSec. It will log every single request.]]></help>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
@@ -3,7 +3,7 @@
         <id>reverse.enabled</id>
         <label>Enabled</label>
         <type>checkbox</type>
-        <help><![CDATA[Enable or disable this domain.]]></help>
+        <help><![CDATA[Enable this domain.]]></help>
     </field>
     <field>
         <id>reverse.FromDomain</id>
@@ -46,7 +46,7 @@
         <id>reverse.DnsChallenge</id>
         <label>DNS-01 Challenge</label>
         <type>checkbox</type>
-        <help><![CDATA[Enable or disable the DNS-01 challenge for this domain. Requires a "DNS Provider" in "General Settings". This is mostly only needed for wildcard domains, or when the HTTP-01 and TLS-ALPN-01 challenge can't be used due to restrictive firewall policies.]]></help>
+        <help><![CDATA[Enable the DNS-01 challenge for this domain. Requires a "DNS Provider" in "General Settings". This is mostly only needed for wildcard domains, or when the HTTP-01 and TLS-ALPN-01 challenge can not be used due to restrictive firewall policies.]]></help>
     </field>
     <field>
         <id>reverse.AcmePassthrough</id>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
@@ -52,7 +52,7 @@
         <id>reverse.AcmePassthrough</id>
         <label>HTTP-01 Challenge Redirection</label>
         <type>text</type>
-        <help><![CDATA[<strong>Enter a domain name or IP address. The HTTP-01 challenge will be redirected to that destination</strong>. This enables an ACME Client behind Caddy to serve "/.well-known/acme-challenge/" on port 80. Caddy will reverse proxy the HTTP-01 challenge for this domain, and will still issue a certificate using the TLS-ALPN-01 challenge or DNS-01 challenge for itself. <strong>This option can be used for High Availability when using Caddy with a master and backup OPNsense.</Strong>]]></help>
+        <help><![CDATA[<strong>Enter a domain name or IP address. The HTTP-01 challenge will be redirected to that destination</strong>. This enables an ACME Client behind Caddy to serve "/.well-known/acme-challenge/" on port 80. Caddy will reverse proxy the HTTP-01 challenge for this domain, and will still issue a certificate using the TLS-ALPN-01 challenge or DNS-01 challenge for itself. <strong>This option can be used for High Availability when using Caddy with a master and backup OPNsense.</strong>]]></help>
     </field>
     <field>
         <id>reverse.CustomCertificate</id>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogSubdomain.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogSubdomain.xml
@@ -3,34 +3,34 @@
         <id>subdomain.enabled</id>
         <label>Enabled</label>
         <type>checkbox</type>
-        <help><![CDATA[<strong>Enable or disable this subdomain.</strong>]]></help>
+        <help><![CDATA[Enable or disable this subdomain.]]></help>
     </field>
     <field>
         <id>subdomain.reverse</id>
         <label>Domain</label>
         <type>dropdown</type>
-        <help><![CDATA[<strong>Select a wildcard domain for this subdomain.</strong>]]></help>
+        <help><![CDATA[Select a wildcard domain for this subdomain.]]></help>
     </field>
     <field>
         <id>subdomain.FromDomain</id>
         <label>Subdomain</label>
         <type>text</type>
         <hint>opn.example.com</hint>
-        <help><![CDATA[<strong>Enter a subdomain.</strong> For example, <code>opn.example.com</code> if the wildcard domain is <code>*.example.com</code>.]]></help>
+        <help><![CDATA[Enter a subdomain. For example, "opn.example.com" if the wildcard domain is "*.example.com".]]></help>
     </field>
     <field>
         <id>subdomain.FromPort</id>
         <label>Port</label>
         <type>text</type>
         <hint>443</hint>
-        <help><![CDATA[<strong>Leave empty to use ports 80 and 443 with automatic redirection from HTTP to HTTPS</strong> or choose a custom port. Don't forget to allow these ports with a Firewall rule.]]></help>
+        <help><![CDATA[Leave empty to use ports 80 and 443 with automatic redirection from HTTP to HTTPS or choose a custom port. Don't forget to allow these ports with a Firewall rule.]]></help>
     </field>
     <field>
         <id>subdomain.description</id>
         <label>Description</label>
         <type>text</type>
         <hint>opn.example.com.443</hint>
-        <help><![CDATA[<strong>Enter a description for this subdomain.</strong>]]></help>
+        <help><![CDATA[Enter a description for this subdomain.]]></help>
     </field>
     <field>
         <type>header</type>
@@ -41,7 +41,7 @@
         <id>subdomain.DynDns</id>
         <label>Dynamic DNS</label>
         <type>checkbox</type>
-        <help><![CDATA[<strong>Enable or disable Dynamic DNS.</strong> Requires a <code>DNS Provider</code> in <em>General Settings</em>. The DNS records of this subdomain will be automatically updated.]]></help>
+        <help><![CDATA[Enable or disable Dynamic DNS. Requires a "DNS Provider" in "General Settings". The DNS records of this subdomain will be automatically updated.]]></help>
     </field>
     <field>
         <type>header</type>
@@ -52,7 +52,7 @@
         <id>subdomain.AcmePassthrough</id>
         <label>HTTP-01 Challenge Redirection</label>
         <type>text</type>
-        <help><![CDATA[<strong>Enter a domain name or IP address. The HTTP-01 challenge will be redirected to that destination</strong>. This enables an ACME Client behind Caddy to serve "/.well-known/acme-challenge/" on port 80. Caddy will reverse proxy the HTTP-01 challenge for this subdomain.]]></help>
+        <help><![CDATA[Enter a domain name or IP address. The HTTP-01 challenge will be redirected to that destination. This enables an ACME Client behind Caddy to serve "/.well-known/acme-challenge/" on port 80. Caddy will reverse proxy the HTTP-01 challenge for this subdomain.]]></help>
     </field>
     <field>
         <type>header</type>
@@ -63,13 +63,13 @@
         <id>subdomain.accesslist</id>
         <label>Access List</label>
         <type>dropdown</type>
-        <help><![CDATA[<strong>Select an Access List to restrict access to this subdomain.</strong> If unset, any local or remote client is allowed access.]]></help>
+        <help><![CDATA[Select an Access List to restrict access to this subdomain. If unset, any local or remote client is allowed access.]]></help>
     </field>
     <field>
         <id>subdomain.basicauth</id>
         <label>Basic Auth</label>
         <type>select_multiple</type>
         <size>5</size>
-        <help><![CDATA[<strong>Select Users to restrict access to this subdomain.</strong> Basic Auth matches after Access Lists. If unset, any user is allowed access.]]></help>
+        <help><![CDATA[Select Users to restrict access to this subdomain. Basic Auth matches after Access Lists. If unset, any user is allowed access.]]></help>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogSubdomain.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogSubdomain.xml
@@ -3,7 +3,7 @@
         <id>subdomain.enabled</id>
         <label>Enabled</label>
         <type>checkbox</type>
-        <help><![CDATA[Enable or disable this subdomain.]]></help>
+        <help><![CDATA[Enable this subdomain.]]></help>
     </field>
     <field>
         <id>subdomain.reverse</id>
@@ -23,7 +23,7 @@
         <label>Port</label>
         <type>text</type>
         <hint>443</hint>
-        <help><![CDATA[Leave empty to use ports 80 and 443 with automatic redirection from HTTP to HTTPS or choose a custom port. Don't forget to allow these ports with a Firewall rule.]]></help>
+        <help><![CDATA[Leave empty to use ports 80 and 443 with automatic redirection from HTTP to HTTPS or choose a custom port. Do not forget to allow these ports with a Firewall rule.]]></help>
     </field>
     <field>
         <id>subdomain.description</id>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogSubdomain.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogSubdomain.xml
@@ -1,36 +1,36 @@
 <form>
     <field>
         <id>subdomain.enabled</id>
-        <label>enabled</label>
+        <label>Enabled</label>
         <type>checkbox</type>
-        <help><![CDATA[Enable this reverse proxy subdomain.]]></help>
+        <help><![CDATA[<strong>Enable or disable this subdomain.</strong>]]></help>
     </field>
     <field>
         <id>subdomain.reverse</id>
         <label>Domain</label>
         <type>dropdown</type>
-        <help><![CDATA[Select a domain, to which this subdomain should be added.]]></help>
+        <help><![CDATA[<strong>Select a wildcard domain for this subdomain.</strong>]]></help>
     </field>
     <field>
         <id>subdomain.FromDomain</id>
         <label>Subdomain</label>
         <type>text</type>
         <hint>opn.example.com</hint>
-        <help><![CDATA[Enter the subdomain name (e.g., 'opn.example.com' if your wildcard domain is '*.example.com').]]></help>
+        <help><![CDATA[<strong>Enter a subdomain.</strong> For example, <code>opn.example.com</code> if the wildcard domain is <code>*.example.com</code>.]]></help>
     </field>
     <field>
         <id>subdomain.FromPort</id>
         <label>Port</label>
         <type>text</type>
         <hint>443</hint>
-        <help><![CDATA[Enter the port number. Leave this empty to bind to port 80 and 443 with automatic redirection. Don't forget to create a firewall rule that allows this destination port to "This Firewall".]]></help>
+        <help><![CDATA[<strong>Leave empty to use ports 80 and 443 with automatic redirection from HTTP to HTTPS</strong> or choose a custom port. Don't forget to allow these ports with a Firewall rule.]]></help>
     </field>
     <field>
         <id>subdomain.description</id>
         <label>Description</label>
         <type>text</type>
         <hint>opn.example.com.443</hint>
-        <help><![CDATA[Enter a description for this reverse proxy subdomain.]]></help>
+        <help><![CDATA[<strong>Enter a description for this subdomain.</strong>]]></help>
     </field>
     <field>
         <type>header</type>
@@ -41,7 +41,7 @@
         <id>subdomain.DynDns</id>
         <label>Dynamic DNS</label>
         <type>checkbox</type>
-        <help><![CDATA[Enable Dynamic DNS, please configure DNS Provider and API Key in General Settings. The DNS Records of this subdomain will be automatically updated with your DNS Provider.]]></help>
+        <help><![CDATA[<strong>Enable or disable Dynamic DNS.</strong> Requires a <code>DNS Provider</code> in <em>General Settings</em>. The DNS records of this subdomain will be automatically updated.]]></help>
     </field>
     <field>
         <type>header</type>
@@ -50,9 +50,9 @@
     </field>
     <field>
         <id>subdomain.AcmePassthrough</id>
-        <label>HTTP-01 challenge redirection</label>
+        <label>HTTP-01 Challenge Redirection</label>
         <type>text</type>
-        <help><![CDATA[Enter a domain name or IP address. The HTTP-01 challenge will be redirected to that destination. This enables a server behind Caddy to serve "/.well-known/acme-challenge/".]]></help>
+        <help><![CDATA[<strong>Enter a domain name or IP address. The HTTP-01 challenge will be redirected to that destination</strong>. This enables an ACME Client behind Caddy to serve "/.well-known/acme-challenge/" on port 80. Caddy will reverse proxy the HTTP-01 challenge for this subdomain.]]></help>
     </field>
     <field>
         <type>header</type>
@@ -63,13 +63,13 @@
         <id>subdomain.accesslist</id>
         <label>Access List</label>
         <type>dropdown</type>
-        <help><![CDATA[Optionally, select an Access List to restrict access to this subdomain. If left as "None", any local or remote client is allowed access. In most cases, leaving this as "None" will be the best choice.]]></help>
+        <help><![CDATA[<strong>Select an Access List to restrict access to this subdomain.</strong> If unset, any local or remote client is allowed access.]]></help>
     </field>
     <field>
         <id>subdomain.basicauth</id>
         <label>Basic Auth</label>
         <type>select_multiple</type>
         <size>5</size>
-        <help><![CDATA[Optionally, select Users to restrict access to this subdomain. Basic Auth matches after Access Lists. If left as "None", any client is allowed access. In most cases, leaving this as "None" will be the best choice.]]></help>
+        <help><![CDATA[<strong>Select Users to restrict access to this subdomain.</strong> Basic Auth matches after Access Lists. If unset, any user is allowed access.]]></help>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dnsprovider.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dnsprovider.xml
@@ -3,13 +3,14 @@
         <id>caddy.general.TlsDnsProvider</id>
         <label>DNS Provider</label>
         <type>dropdown</type>
-        <help><![CDATA[<strong>Select the DNS provider for the DNS-01 Challenge and Dynamic DNS.</strong> This is mostly needed for Wildcard Certificates, and for Dynamic DNS. To use, <strong>enable the checkbox</strong> in a <code>Domain</code> or <code>Subdomain</code>. For more information, visit <a href="https://github.com/caddy-dns">Caddy DNS</a>. Each module is community maintained.]]></help>
+        <help><![CDATA[Select the DNS provider for the DNS-01 Challenge and Dynamic DNS. This is mostly needed for Wildcard Certificates, and for Dynamic DNS. To use, enable the checkbox in a "Domain" or "Subdomain". For more information, visit https://github.com/caddy-dns where each module is community maintained.]]></help>
+    </field>
     </field>
     <field>
         <id>caddy.general.TlsDnsApiKey</id>
         <label>DNS API Standard Field</label>
         <type>text</type>
-        <help><![CDATA[This is the standard field for the API Key. The field can be left empty if optional. Specify according to the selected DNS provider, e.g., <strong>Cloudflare</strong> <code>api_token</code>, <strong>Duckdns</strong> <code>api_token</code>, <strong>DigitalOcean</strong> <code>auth_token</code>, <strong>Godaddy</strong> <code>api_token</code>, <strong>Gandi</strong> <code>bearer_token</code>, <strong>IONOS</strong> <code>api_token</code>, <strong>deSEC</strong> <code>token</code>, <strong>Route53</strong> <code>access_key_id</code>, <strong>Porkbun</strong> <code>api_key</code>, <strong>ACME-DNS</strong> <code>username</code>, <strong>Netlify</strong> <code>personal_access_token</code>, <strong>Njalla</strong> <code>api_token</code>, <strong>Google Cloud DNS</strong> <code>gcp_project</code>, <strong>Azure</strong> <code>tenant_id</code>, <strong>OVH</strong> <code>endpoint</code>, <strong>Namecheap</strong> <code>api_key</code>, <strong>PowerDNS</strong> <code>server_url</code>, <strong>DDNSS</strong> <code>api_token</code>, <strong>Linode</strong> <code>api_token</code>, <strong>Tencent Cloud</strong> <code>secret_id</code>, <strong>Dinahosting</strong> <code>username</code>, <strong>Hexonet</strong> <code>username</code>, <strong>Mail-in-a-Box</strong> <code>api_url</code>.]]></help>
+        <help><![CDATA[This is the standard field for the API Key. Field can be left empty if optional: Cloudflare "api_token", Duckdns "api_token", DigitalOcean "auth_token", Godaddy "api_token", Gandi "bearer_token", IONOS "api_token", deSEC "token", Route53 "access_key_id", Porkbun "api_key", ACME-DNS "username", Netlify "personal_access_token", Njalla "api_token", Google Cloud DNS "gcp_project", Azure "tenant_id", OVH "endpoint", Namecheap "api_key", PowerDNS "server_url", DDNSS "api_token", Linode "api_token", Tencent Cloud "secret_id", Dinahosting "username", Hexonet "username", Mail-in-a-Box "api_url".]]></help>
     </field>
     <field>
         <type>header</type>
@@ -20,30 +21,30 @@
         <id>caddy.general.TlsDnsSecretApiKey</id>
         <label>DNS API Additional Field 1</label>
         <type>text</type>
-        <help><![CDATA[Leave empty if the selected DNS Provider isn't specified here. Specify additional optional fields as needed, e.g., <strong>Duckdns</strong> <code>override_domain</code>, <strong>Route53</strong> <code>secret_access_key</code>, <strong>Porkbun</strong> <code>api_secret_key</code>, <strong>ACME-DNS</strong> <code>password</code>, <strong>Azure</strong> <code>client_id</code>, <strong>OVH</strong> <code>application_key</code>, <strong>Namecheap</strong> <code>user</code>, <strong>PowerDNS</strong> <code>api_token</code>, <strong>DDNSS</strong> <code>username</code>, <strong>Linode</strong> <code>api_url</code>, <strong>Tencent Cloud</strong> <code>secret_key</code>, <strong>Dinahosting</strong> <code>password</code>, <strong>Hexonet</strong> <code>password</code>, <strong>Mail-in-a-Box</strong> <code>email_address</code>.]]></help>
+        <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: Duckdns "override_domain", Route53 "secret_access_key", Porkbun "api_secret_key", ACME-DNS "password", Azure "client_id", OVH "application_key", Namecheap "user", PowerDNS "api_token", DDNSS "username", Linode "api_url", Tencent Cloud "secret_key", Dinahosting "password", Hexonet "password", Mail-in-a-Box "email_address".]]></help>
     </field>
     <field>
         <id>caddy.general.TlsDnsOptionalField1</id>
         <label>DNS API Additional Field 2</label>
         <type>text</type>
-        <help><![CDATA[Leave empty if the selected DNS Provider isn't specified here. Specify additional optional fields as needed, e.g., <strong>Route53</strong> <code>max_retries</code>, <strong>ACME-DNS</strong> <code>subdomain</code>, <strong>Azure</strong> <code>client_secret</code>, <strong>OVH</strong> <code>application_secret</code>, <strong>Namecheap</strong> <code>api_endpoint</code>, <strong>DDNSS</strong> <code>password</code>, <strong>Linode</strong> <code>api_version</code>, <strong>Mail-in-a-Box</strong> <code>password</code>.]]></help>
+        <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: Route53 "max_retries", ACME-DNS "subdomain", Azure "client_secret", OVH "application_secret", Namecheap "api_endpoint", DDNSS "password", Linode "api_version", Mail-in-a-Box "password".]]></help>
     </field>
     <field>
         <id>caddy.general.TlsDnsOptionalField2</id>
         <label>DNS API Additional Field 3</label>
         <type>text</type>
-        <help><![CDATA[Leave empty if the selected DNS Provider isn't specified here. Specify additional optional fields as needed, e.g., <strong>Route53</strong> <code>aws_profile</code>, <strong>ACME-DNS</strong> <code>server_url</code>, <strong>Azure</strong> <code>subscription_id</code>, <strong>OVH</strong> <code>consumer_key</code>, <strong>Namecheap</strong> <code>client_ip</code>, <strong>DDNS</strong> <code>password</code>.]]></help>
+        <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: Route53 "aws_profile", ACME-DNS "server_url", Azure "subscription_id", OVH "consumer_key", Namecheap "client_ip", DDNS "password".]]></help>
     </field>
     <field>
         <id>caddy.general.TlsDnsOptionalField3</id>
         <label>DNS API Additional Field 4</label>
         <type>text</type>
-        <help><![CDATA[Leave empty if the selected DNS Provider isn't specified here. Specify additional optional fields as needed, e.g., <strong>Route53</strong> <code>region</code>, <strong>Azure</strong> <code>resource_group_name</code>.]]></help>
+        <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: Route53 "region", Azure "resource_group_name".]]></help>
     </field>
     <field>
         <id>caddy.general.TlsDnsOptionalField4</id>
         <label>DNS API Additional Field 5</label>
         <type>text</type>
-        <help><![CDATA[Leave empty if the selected DNS Provider isn't specified here. Specify additional optional fields as needed, e.g., <strong>Route53</strong> <code>token</code>.]]></help>
+        <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: Route53 "token".]]></help>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dnsprovider.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dnsprovider.xml
@@ -3,13 +3,13 @@
         <id>caddy.general.TlsDnsProvider</id>
         <label>DNS Provider</label>
         <type>dropdown</type>
-        <help><![CDATA[Select the DNS provider for the DNS-01 Challenge and Dynamic DNS. This is optional, since certificates will be requested from Let's Encrypt via HTTP Challenge when this option is unset. You mostly need this for Wildcard Certificates, and for Dynamic DNS. To use the DNS-01 Challenge and Dynamic DNS, enable the checkbox in a Reverse Proxy Domain or Subdomain. For more information: https://github.com/caddy-dns]]></help>
+        <help><![CDATA[<strong>Select the DNS provider for the DNS-01 Challenge and Dynamic DNS.</strong> This is mostly needed for Wildcard Certificates, and for Dynamic DNS. To use, <strong>enable the checkbox</strong> in a <code>Domain</code> or <code>Subdomain</code>. For more information, visit <a href="https://github.com/caddy-dns">Caddy DNS</a>. Each module is community maintained.]]></help>
     </field>
     <field>
         <id>caddy.general.TlsDnsApiKey</id>
         <label>DNS API Standard Field</label>
         <type>text</type>
-        <help><![CDATA[This is the standard field for the API Key. Field can be left empty if optional: Cloudflare "api_token", Duckdns "api_token", DigitalOcean "auth_token", Godaddy "api_token", Gandi "bearer_token", IONOS "api_token", deSEC "token", Route53 "access_key_id", Porkbun "api_key", ACME-DNS "username", Netlify "personal_access_token", Njalla "api_token", Google Cloud DNS "gcp_project", Azure "tenant_id", OVH "endpoint", Namecheap "api_key", PowerDNS "server_url", DDNSS "api_token", Linode "api_token", Tencent Cloud "secret_id", Dinahosting "username", Hexonet "username", Mail-in-a-Box "api_url".]]></help>
+        <help><![CDATA[This is the standard field for the API Key. The field can be left empty if optional. Specify according to the selected DNS provider, e.g., <strong>Cloudflare</strong> <code>api_token</code>, <strong>Duckdns</strong> <code>api_token</code>, <strong>DigitalOcean</strong> <code>auth_token</code>, <strong>Godaddy</strong> <code>api_token</code>, <strong>Gandi</strong> <code>bearer_token</code>, <strong>IONOS</strong> <code>api_token</code>, <strong>deSEC</strong> <code>token</code>, <strong>Route53</strong> <code>access_key_id</code>, <strong>Porkbun</strong> <code>api_key</code>, <strong>ACME-DNS</strong> <code>username</code>, <strong>Netlify</strong> <code>personal_access_token</code>, <strong>Njalla</strong> <code>api_token</code>, <strong>Google Cloud DNS</strong> <code>gcp_project</code>, <strong>Azure</strong> <code>tenant_id</code>, <strong>OVH</strong> <code>endpoint</code>, <strong>Namecheap</strong> <code>api_key</code>, <strong>PowerDNS</strong> <code>server_url</code>, <strong>DDNSS</strong> <code>api_token</code>, <strong>Linode</strong> <code>api_token</code>, <strong>Tencent Cloud</strong> <code>secret_id</code>, <strong>Dinahosting</strong> <code>username</code>, <strong>Hexonet</strong> <code>username</code>, <strong>Mail-in-a-Box</strong> <code>api_url</code>.]]></help>
     </field>
     <field>
         <type>header</type>
@@ -20,30 +20,30 @@
         <id>caddy.general.TlsDnsSecretApiKey</id>
         <label>DNS API Additional Field 1</label>
         <type>text</type>
-        <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: Duckdns "override_domain", Route53 "secret_access_key", Porkbun "api_secret_key", ACME-DNS "password", Azure "client_id", OVH "application_key", Namecheap "user", PowerDNS "api_token", DDNSS "username", Linode "api_url", Tencent Cloud "secret_key", Dinahosting "password", Hexonet "password", Mail-in-a-Box "email_address".]]></help>
+        <help><![CDATA[Leave empty if the selected DNS Provider isn't specified here. Specify additional optional fields as needed, e.g., <strong>Duckdns</strong> <code>override_domain</code>, <strong>Route53</strong> <code>secret_access_key</code>, <strong>Porkbun</strong> <code>api_secret_key</code>, <strong>ACME-DNS</strong> <code>password</code>, <strong>Azure</strong> <code>client_id</code>, <strong>OVH</strong> <code>application_key</code>, <strong>Namecheap</strong> <code>user</code>, <strong>PowerDNS</strong> <code>api_token</code>, <strong>DDNSS</strong> <code>username</code>, <strong>Linode</strong> <code>api_url</code>, <strong>Tencent Cloud</strong> <code>secret_key</code>, <strong>Dinahosting</strong> <code>password</code>, <strong>Hexonet</strong> <code>password</code>, <strong>Mail-in-a-Box</strong> <code>email_address</code>.]]></help>
     </field>
     <field>
         <id>caddy.general.TlsDnsOptionalField1</id>
         <label>DNS API Additional Field 2</label>
         <type>text</type>
-        <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: Route53 "max_retries", ACME-DNS "subdomain", Azure "client_secret", OVH "application_secret", Namecheap "api_endpoint", DDNSS "password", Linode "api_version", Mail-in-a-Box "password".]]></help>
+        <help><![CDATA[Leave empty if the selected DNS Provider isn't specified here. Specify additional optional fields as needed, e.g., <strong>Route53</strong> <code>max_retries</code>, <strong>ACME-DNS</strong> <code>subdomain</code>, <strong>Azure</strong> <code>client_secret</code>, <strong>OVH</strong> <code>application_secret</code>, <strong>Namecheap</strong> <code>api_endpoint</code>, <strong>DDNSS</strong> <code>password</code>, <strong>Linode</strong> <code>api_version</code>, <strong>Mail-in-a-Box</strong> <code>password</code>.]]></help>
     </field>
     <field>
         <id>caddy.general.TlsDnsOptionalField2</id>
         <label>DNS API Additional Field 3</label>
         <type>text</type>
-        <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: Route53 "aws_profile", ACME-DNS "server_url", Azure "subscription_id", OVH "consumer_key", Namecheap "client_ip", DDNS "password".]]></help>
+        <help><![CDATA[Leave empty if the selected DNS Provider isn't specified here. Specify additional optional fields as needed, e.g., <strong>Route53</strong> <code>aws_profile</code>, <strong>ACME-DNS</strong> <code>server_url</code>, <strong>Azure</strong> <code>subscription_id</code>, <strong>OVH</strong> <code>consumer_key</code>, <strong>Namecheap</strong> <code>client_ip</code>, <strong>DDNS</strong> <code>password</code>.]]></help>
     </field>
     <field>
         <id>caddy.general.TlsDnsOptionalField3</id>
         <label>DNS API Additional Field 4</label>
         <type>text</type>
-        <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: Route53 "region", Azure "resource_group_name".]]></help>
+        <help><![CDATA[Leave empty if the selected DNS Provider isn't specified here. Specify additional optional fields as needed, e.g., <strong>Route53</strong> <code>region</code>, <strong>Azure</strong> <code>resource_group_name</code>.]]></help>
     </field>
     <field>
         <id>caddy.general.TlsDnsOptionalField4</id>
         <label>DNS API Additional Field 5</label>
         <type>text</type>
-        <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: Route53 "token".]]></help>
+        <help><![CDATA[Leave empty if the selected DNS Provider isn't specified here. Specify additional optional fields as needed, e.g., <strong>Route53</strong> <code>token</code>.]]></help>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dynamicdns.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dynamicdns.xml
@@ -3,19 +3,19 @@
         <id>caddy.general.DynDnsIpVersions</id>
         <label>DynDns IP Version</label>
         <type>dropdown</type>
-        <help><![CDATA[Select "IPv4+IPv6" to set IPv4 A-Records and IPv6 AAAA-Records, "IPv4 only" for only A-Records, "IPv6 only" for only AAAA-Records.]]></help>
+        <help><![CDATA[<strong>Select the DynDns IP Version:</strong> <code>IPv4+IPv6</code> to set IPv4 A-Records and IPv6 AAAA-Records, <code>IPv4 only</code> for only A-Records, <code>IPv6 only</code> for only AAAA-Records.]]></help>
     </field>
     <field>
         <id>caddy.general.DynDnsCheckInterval</id>
         <label>DynDns Check Interval</label>
         <type>text</type>
-        <help><![CDATA[Interval to poll for changes of the IP address. The default is 5 minutes. Can be a number between 1 to 1440 minutes.]]></help>
+        <help><![CDATA[<strong>Set the interval to poll for changes in the IP address.</strong> The default is 5 minutes. Values can range from 1 to 1440 minutes.]]></help>
     </field>
     <field>
         <id>caddy.general.DynDnsTTL</id>
         <label>DynDns TTL</label>
         <type>text</type>
-        <help><![CDATA[Set the TTL (time to live) for DNS Records. The default is 1 hour. Can be a number between 1 to 24 hours.]]></help>
+        <help><![CDATA[<strong>Set the TTL (Time to Live) for DNS records.</strong> The default is 1 hour. Values can range from 1 to 24 hours.]]></help>
     </field>
     <field>
         <type>header</type>
@@ -26,12 +26,12 @@
         <id>caddy.general.DynDnsSimpleHttp</id>
         <label>DynDns Check Http</label>
         <type>text</type>
-        <help><![CDATA[Optionally, enter a URL to test the current IP address of the firewall via HTTP protocol. Generally, this is not needed. Caddy uses default providers to test the current IP addresses. If you'd rather use your own, enter the https:// link to an IP address testing website.]]></help>
+        <help><![CDATA[<strong>Enter a URL to test the current IP address of the firewall via the HTTP protocol.</strong> <em>This is generally not needed</em> as Caddy uses default providers to test the current IP addresses. If a custom provider is preferred, enter the <code>https://</code> link to an IP address testing website.]]></help>
     </field>
     <field>
         <id>caddy.general.DynDnsInterface</id>
         <label>DynDns Check Interface</label>
         <type>dropdown</type>
-        <help><![CDATA[Optionally, select an interface to extract the current IP addresses of the firewall. At most, one IPv6 Global Unicast Address and one IPv4 non-RFC1918 Address will be extracted. This depends on the DynDns IP Version that's specified.]]></help>
+        <help><![CDATA[<strong>Select an interface to extract the current IP addresses of the firewall</strong>. <em>This is generally not needed</em> as Caddy uses default providers to test the current IP addresses. Depending on the specified DynDns IP Version, at most one IPv6 Global Unicast Address and one IPv4 non-RFC1918 Address will be extracted.]]></help>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dynamicdns.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dynamicdns.xml
@@ -3,19 +3,19 @@
         <id>caddy.general.DynDnsIpVersions</id>
         <label>DynDns IP Version</label>
         <type>dropdown</type>
-        <help><![CDATA[<strong>Select the DynDns IP Version:</strong> <code>IPv4+IPv6</code> to set IPv4 A-Records and IPv6 AAAA-Records, <code>IPv4 only</code> for only A-Records, <code>IPv6 only</code> for only AAAA-Records.]]></help>
+        <help><![CDATA[Select the DynDns IP Version: "IPv4+IPv6" to set IPv4 A-Records and IPv6 AAAA-Records, "IPv4 only" for only A-Records, "IPv6 only" for only AAAA-Records.]]></help>
     </field>
     <field>
         <id>caddy.general.DynDnsCheckInterval</id>
         <label>DynDns Check Interval</label>
         <type>text</type>
-        <help><![CDATA[<strong>Set the interval to poll for changes in the IP address.</strong> The default is 5 minutes. Values can range from 1 to 1440 minutes.]]></help>
+        <help><![CDATA[Set the interval to poll for changes in the IP address. The default is 5 minutes. Values can range from 1 to 1440 minutes.]]></help>
     </field>
     <field>
         <id>caddy.general.DynDnsTTL</id>
         <label>DynDns TTL</label>
         <type>text</type>
-        <help><![CDATA[<strong>Set the TTL (Time to Live) for DNS records.</strong> The default is 1 hour. Values can range from 1 to 24 hours.]]></help>
+        <help><![CDATA[Set the TTL (Time to Live) for DNS records. The default is 1 hour. Values can range from 1 to 24 hours.]]></help>
     </field>
     <field>
         <type>header</type>
@@ -26,12 +26,12 @@
         <id>caddy.general.DynDnsSimpleHttp</id>
         <label>DynDns Check Http</label>
         <type>text</type>
-        <help><![CDATA[<strong>Enter a URL to test the current IP address of the firewall via the HTTP protocol.</strong> <em>This is generally not needed</em> as Caddy uses default providers to test the current IP addresses. If a custom provider is preferred, enter the <code>https://</code> link to an IP address testing website.]]></help>
+        <help><![CDATA[Enter a URL to test the current IP address of the firewall via the HTTP protocol. This is generally not needed as Caddy uses default providers to test the current IP addresses. If a custom provider is preferred, enter the "https://" link to an IP address testing website.]]></help>
     </field>
     <field>
         <id>caddy.general.DynDnsInterface</id>
         <label>DynDns Check Interface</label>
         <type>dropdown</type>
-        <help><![CDATA[<strong>Select an interface to extract the current IP addresses of the firewall</strong>. <em>This is generally not needed</em> as Caddy uses default providers to test the current IP addresses. Depending on the specified DynDns IP Version, at most one IPv6 Global Unicast Address and one IPv4 non-RFC1918 Address will be extracted.]]></help>
+        <help><![CDATA[Select an interface to extract the current IP addresses of the firewall. This is generally not needed as Caddy uses default providers to test the current IP addresses. Depending on the specified DynDns IP Version, at most one IPv6 Global Unicast Address and one IPv4 non-RFC1918 Address will be extracted.]]></help>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
@@ -3,38 +3,38 @@
         <id>caddy.general.enabled</id>
         <label>Enabled</label>
         <type>checkbox</type>
-        <help><![CDATA[Enable or disable the Caddy web server.]]></help>
+        <help><![CDATA[<strong>Enable or disable the Caddy web server.</strong>]]></help>
     </field>
     <field>
         <id>caddy.general.TlsEmail</id>
         <label>ACME Email</label>
         <type>text</type>
         <hint>info@example.com</hint>
-        <help><![CDATA[Enter the email address for certificate notifications. This is required to receive automatic certificates from Let's Encrypt and ZeroSSL.]]></help>
+        <help><![CDATA[<strong>Enter the email address for certificate notifications.</strong> This is <strong>required</strong> to receive automatic certificates from <em>Let's Encrypt</em> and <em>ZeroSSL</em>.]]></help>
     </field>
     <field>
         <id>caddy.general.TlsAutoHttps</id>
         <label>Auto HTTPS</label>
         <type>dropdown</type>
-        <help><![CDATA[Select the auto HTTPS option. "On" (default) creates automatic certificates using Let's Encrypt or ZeroSSL without needing any configuration.]]></help>
+        <help><![CDATA[<strong>Select the Auto HTTPS option.</strong> <code>On (default)</code> creates automatic certificates using <em>Let's Encrypt</em> or <em>ZeroSSL</em>. <code>Off</code> turns all automatic certificate requests off.]]></help>
     </field>
     <field>
         <id>caddy.general.accesslist</id>
         <label>Trusted Proxies</label>
         <type>dropdown</type>
-        <help><![CDATA[Select an Access List of Trusted Proxies. If Caddy is not the first server being connected to by your clients (for example when a CDN is in front of Caddy), you may configure trusted_proxies with a list of IP ranges (CIDRs) from which incoming requests are trusted to have sent good values for these headers. Additionally, set the same Access List to the Domains your Trusted Proxy connects to.]]></help>
+        <help><![CDATA[<strong>Select an Access List to set IP ranges of Trusted Proxies.</strong> If Caddy is not the first server being connected to by clients (for example, when a <em>CDN</em> is in front of Caddy), configure <code>Trusted Proxies</code> with a list of IP ranges (CIDRs) from which incoming requests are trusted to have sent good values for these headers. Additionally, set the same <code>Access List</code> to the domains the <code>Trusted Proxies</code> connect to.]]></help>
     </field>
     <field>
         <id>caddy.general.abort</id>
         <label>Abort Connections</label>
         <type>checkbox</type>
-        <help><![CDATA[Abort all connections that don't have a matching handle or access list. This option doesn't conflict with Let's Encrypt. Disable it for troubleshooting purposes, e.g., testing if the Reverse Proxy Domain works and the Certificate has been installed. For production use, enabling this option is recommended.]]></help>
+        <help><![CDATA[<strong>Abort all connections that don't have a matching Handle or Access List.</strong> This option does not conflict with <em>Let's Encrypt or ZeroSSL</em>. Disable it for troubleshooting purposes, e.g., testing if the <code>Domain</code> works and the automatic certificate has been installed. <strong>For production use, enabling this option is recommended.</strong>]]></help>
     </field>
     <field>
         <id>caddy.general.GracePeriod</id>
         <label>Grace Period</label>
         <type>text</type>
         <hint>10</hint>
-        <help><![CDATA[Defines the grace period for shutting down HTTP servers (i.e. during config changes or when Caddy is stopping) in seconds. During the grace period, no new connections are accepted, idle connections are closed, and active connections are impatiently waited upon to finish their requests. If clients do not finish their requests within the grace period, the server will be forcefully terminated to allow the reload to complete and free up resources. This can influence how long "Apply" of new configurations take, since Caddy waits for all open connections to close.]]></help>
+        <help><![CDATA[<strong>Defines the grace period for shutting down Caddy during a reload in seconds.</strong> During the grace period, no new connections are accepted, idle connections are closed, and active connections are <em>impatiently waited upon</em> to finish their requests. If clients do not finish their requests within the grace period, the server will be <strong>forcefully terminated</strong> to allow the reload to complete and free up resources. This can influence how long <code>Apply</code> of new configurations take, since Caddy waits for all open connections to close.]]></help>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
@@ -3,38 +3,38 @@
         <id>caddy.general.enabled</id>
         <label>Enabled</label>
         <type>checkbox</type>
-        <help><![CDATA[<strong>Enable or disable the Caddy web server.</strong>]]></help>
+        <help><![CDATA[Enable or disable the Caddy web server.]]></help>
     </field>
     <field>
         <id>caddy.general.TlsEmail</id>
         <label>ACME Email</label>
         <type>text</type>
         <hint>info@example.com</hint>
-        <help><![CDATA[<strong>Enter the email address for certificate notifications.</strong> This is <strong>required</strong> to receive automatic certificates from <em>Let's Encrypt</em> and <em>ZeroSSL</em>.]]></help>
+        <help><![CDATA[Enter the email address for certificate notifications. This is required to receive automatic certificates from "Let's Encrypt" and "ZeroSSL".]]></help>
     </field>
     <field>
         <id>caddy.general.TlsAutoHttps</id>
         <label>Auto HTTPS</label>
         <type>dropdown</type>
-        <help><![CDATA[<strong>Select the Auto HTTPS option.</strong> <code>On (default)</code> creates automatic certificates using <em>Let's Encrypt</em> or <em>ZeroSSL</em>. <code>Off</code> turns all automatic certificate requests off.]]></help>
+        <help><![CDATA[Select the Auto HTTPS option. "On (default)" creates automatic certificates using "Let's Encrypt" or "ZeroSSL". "Off" turns all automatic certificate requests off.]]></help>
     </field>
     <field>
         <id>caddy.general.accesslist</id>
         <label>Trusted Proxies</label>
         <type>dropdown</type>
-        <help><![CDATA[<strong>Select an Access List to set IP ranges of Trusted Proxies.</strong> If Caddy is not the first server being connected to by clients (for example, when a <em>CDN</em> is in front of Caddy), configure <code>Trusted Proxies</code> with a list of IP ranges (CIDRs) from which incoming requests are trusted to have sent good values for these headers. Additionally, set the same <code>Access List</code> to the domains the <code>Trusted Proxies</code> connect to.]]></help>
+        <help><![CDATA[Select an Access List to set IP ranges of Trusted Proxies. If Caddy is not the first server being connected to by clients (for example, when a "CDN" is in front of Caddy), configure "Trusted Proxies" with a list of IP ranges (CIDRs) from which incoming requests are trusted to have sent good values for these headers. Additionally, set the same Access List to the domains the Trusted Proxies connect to.]]></help>
     </field>
     <field>
         <id>caddy.general.abort</id>
         <label>Abort Connections</label>
         <type>checkbox</type>
-        <help><![CDATA[<strong>Abort all connections that don't have a matching Handle or Access List.</strong> This option does not conflict with <em>Let's Encrypt or ZeroSSL</em>. Disable it for troubleshooting purposes, e.g., testing if the <code>Domain</code> works and the automatic certificate has been installed. <strong>For production use, enabling this option is recommended.</strong>]]></help>
+        <help><![CDATA[Abort all connections that don't have a matching Handle or Access List. This option does not conflict with "Let's Encrypt" or "ZeroSSL". Disable it for troubleshooting purposes, e.g., testing if the "Domain" works and the automatic certificate has been installed. For production use, enabling this option is recommended.]]></help>
     </field>
     <field>
         <id>caddy.general.GracePeriod</id>
         <label>Grace Period</label>
         <type>text</type>
         <hint>10</hint>
-        <help><![CDATA[<strong>Defines the grace period for shutting down Caddy during a reload in seconds.</strong> During the grace period, no new connections are accepted, idle connections are closed, and active connections are <em>impatiently waited upon</em> to finish their requests. If clients do not finish their requests within the grace period, the server will be <strong>forcefully terminated</strong> to allow the reload to complete and free up resources. This can influence how long <code>Apply</code> of new configurations take, since Caddy waits for all open connections to close.]]></help>
+        <help><![CDATA[Defines the grace period for shutting down Caddy during a reload in seconds. During the grace period, no new connections are accepted, idle connections are closed, and active connections are impatiently waited upon to finish their requests. If clients do not finish their requests within the grace period, the server will be forcefully terminated to allow the reload to complete and free up resources. This can influence how long "Apply" of new configurations take, since Caddy waits for all open connections to close.]]></help>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/logsettings.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/logsettings.xml
@@ -3,25 +3,25 @@
         <id>caddy.general.LogLevel</id>
         <label>Log Level</label>
         <type>dropdown</type>
-        <help><![CDATA[<strong>Select the minimum global Log Level.</strong> <code>INFO</code> is the default and should not be changed without a reason, as it displays the ACME Client messages for automatic certificates. This setting does not influence the HTTP Access logs; they always use <code>INFO</code>, which is their lowest supported Log Level.]]></help>
+        <help><![CDATA[Select the minimum global Log Level. "INFO" is the default and should not be changed without a reason, as it displays the ACME Client messages for automatic certificates. This setting does not influence the HTTP Access logs; they always use "INFO", which is their lowest supported Log Level.]]></help>
     </field>
     <field>
         <id>caddy.general.LogCredentials</id>
         <label>Log Credentials</label>
         <type>checkbox</type>
-        <help><![CDATA[<strong>Log all cookies and authorization in HTTP request logging</strong>. Use this option combined with <code>HTTP Access Log</code> in a <code>Domain</code>. <strong>Enable this option only for troubleshooting.</strong>]]></help>
+        <help><![CDATA[Log all cookies and authorization in HTTP request logging. Use this option combined with "HTTP Access Log" in a "Domain". Enable this option only for troubleshooting.]]></help>
     </field>
     <field>
         <id>caddy.general.LogAccessPlain</id>
         <label>Log HTTP Access in JSON Format</label>
         <type>checkbox</type>
-        <help><![CDATA[<strong>Log HTTP access in a standard JSON logfile per domain</strong>, e.g., for processing by <em>CrowdSec</em>. Use this option combined with <code>HTTP Access Log</code> in a <code>Domain</code>. Enabling this will make the HTTP Access Log disappear from the standard Log File. Logs can be found in the filesystem at <code>/var/log/caddy/access/</code>.]]></help>
+        <help><![CDATA[Log HTTP access in a standard JSON logfile per domain, e.g., for processing by CrowdSec. Use this option combined with "HTTP Access Log" in a "Domain". Enabling this will make the HTTP Access Log disappear from the standard Log File. Logs can be found in the filesystem at "/var/log/caddy/access/".]]></help>
     </field>
     <field>
         <id>caddy.general.LogAccessPlainKeep</id>
         <label>Keep HTTP Access JSON Logs for (days)</label>
         <hint>10</hint>
         <type>text</type>
-        <help><![CDATA[<strong>Specify how many days to keep the JSON access logs.</strong>]]></help>
+        <help><![CDATA[Specify how many days to keep the JSON access logs.]]></help>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/logsettings.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/logsettings.xml
@@ -3,25 +3,25 @@
         <id>caddy.general.LogLevel</id>
         <label>Log Level</label>
         <type>dropdown</type>
-        <help><![CDATA[Select the minimum global Log Level. "INFO" is the default and shouldn't be changed without a reason, since that level displays the ACME Client messages for automatic certificates. This setting doesn't influence the HTTP Access logs, they're always using INFO, which is their lowest supported Log Level.]]></help>
+        <help><![CDATA[<strong>Select the minimum global Log Level.</strong> <code>INFO</code> is the default and should not be changed without a reason, as it displays the ACME Client messages for automatic certificates. This setting does not influence the HTTP Access logs; they always use <code>INFO</code>, which is their lowest supported Log Level.]]></help>
     </field>
     <field>
         <id>caddy.general.LogCredentials</id>
         <label>Log Credentials</label>
         <type>checkbox</type>
-        <help><![CDATA[Log all Cookies and Authorization in HTTP request logging. Use combined with HTTP Access Log in the Reverse Proxy Domain. Enable this option only for troubleshooting.]]></help>
+        <help><![CDATA[<strong>Log all cookies and authorization in HTTP request logging</strong>. Use this option combined with <code>HTTP Access Log</code> in a <code>Domain</code>. <strong>Enable this option only for troubleshooting.</strong>]]></help>
     </field>
     <field>
         <id>caddy.general.LogAccessPlain</id>
         <label>Log HTTP Access in JSON Format</label>
         <type>checkbox</type>
-        <help><![CDATA[Log HTTP access in a standard JSON logfile per domain, e.g for processing by CrowdSec. Use combined with HTTP Access Log in the Reverse Proxy Domain. Enabling this will make the HTTP Access Log dissappear from the standard "Log File" in the GUI. They can be found in the filesystem "/var/log/caddy/access/"]]></help>
+        <help><![CDATA[<strong>Log HTTP access in a standard JSON logfile per domain</strong>, e.g., for processing by <em>CrowdSec</em>. Use this option combined with <code>HTTP Access Log</code> in a <code>Domain</code>. Enabling this will make the HTTP Access Log disappear from the standard Log File. Logs can be found in the filesystem at <code>/var/log/caddy/access/</code>.]]></help>
     </field>
     <field>
         <id>caddy.general.LogAccessPlainKeep</id>
         <label>Keep HTTP Access JSON Logs for (days)</label>
         <hint>10</hint>
         <type>text</type>
-        <help><![CDATA[How many days to keep the JSON access logs.]]></help>
+        <help><![CDATA[<strong>Specify how many days to keep the JSON access logs.</strong>]]></help>
     </field>
 </form>


### PR DESCRIPTION
Most help text was incrementally written. Mistakes have been fixed, and everything has been explained more clearly. Some of the more convoluted options were given bigger help texts.

This PR aims to improve the help text (a lot). Every option is clearly labeled and none of the vital options are hidden in advanced mode anymore.

This cleanup was long overdue and took a few hours. :D