### PR TITLE
www/caddy: Implement gettext() function for localization in php controllers and model

### DIFF
--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/DiagnosticsController.php
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/DiagnosticsController.php
@@ -52,7 +52,7 @@ class DiagnosticsController extends ApiMutableModelControllerBase
 
         // Since errors are handled by the caddy_diagnostics script and returned as json, check for an error key in the response
         if (isset($responseArray['error'])) {
-            return ["status" => "failed", "message" => _($responseArray['message'])];
+            return ["status" => "failed", "message" => $responseArray['message']];
         }
 
         // Prepare the response array
@@ -78,7 +78,7 @@ class DiagnosticsController extends ApiMutableModelControllerBase
 
         // Since errors are handled by the caddy_diagnostics script and returned as json, check for an error key in the response
         if (isset($responseArray['error'])) {
-            return ["status" => "failed", "message" => _($responseArray['message'])];
+            return ["status" => "failed", "message" => ($responseArray['message']];
         }
 
         // Return the response as an array which gets automatically encoded to JSON

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/DiagnosticsController.php
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/DiagnosticsController.php
@@ -76,8 +76,8 @@ class DiagnosticsController extends ApiMutableModelControllerBase
         // Decode JSON to PHP array
         $responseArray = json_decode($response, true);
 
+        // Since errors are handled by the caddy_diagnostics script and returned as json, check for an error key in the response
         if (isset($responseArray['error'])) {
-            // Handle the error
             return ["status" => "failed", "message" => _($responseArray['message'])];
         }
 

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/DiagnosticsController.php
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/DiagnosticsController.php
@@ -78,7 +78,7 @@ class DiagnosticsController extends ApiMutableModelControllerBase
 
         // Since errors are handled by the caddy_diagnostics script and returned as json, check for an error key in the response
         if (isset($responseArray['error'])) {
-            return ["status" => "failed", "message" => ($responseArray['message']];
+            return ["status" => "failed", "message" => $responseArray['message']];
         }
 
         // Return the response as an array which gets automatically encoded to JSON

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/DiagnosticsController.php
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/DiagnosticsController.php
@@ -52,7 +52,7 @@ class DiagnosticsController extends ApiMutableModelControllerBase
 
         // Since errors are handled by the caddy_diagnostics script and returned as json, check for an error key in the response
         if (isset($responseArray['error'])) {
-            return ["status" => "failed", "message" => $responseArray['message']];
+            return ["status" => "failed", "message" => _($responseArray['message'])];
         }
 
         // Prepare the response array
@@ -78,12 +78,7 @@ class DiagnosticsController extends ApiMutableModelControllerBase
 
         if (isset($responseArray['error'])) {
             // Handle the error
-            return ["status" => "failed", "message" => $responseArray['message']];
-        }
-
-        // Assuming the response structure is like { "content": "actual Caddyfile content here" }
-        if (!isset($responseArray['content'])) {
-            return ["status" => "failed", "message" => "Caddyfile content not found"];
+            return ["status" => "failed", "message" => _($responseArray['message'])];
         }
 
         // Return the response as an array which gets automatically encoded to JSON

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/ServiceController.php
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/ServiceController.php
@@ -63,11 +63,11 @@ class ServiceController extends ApiMutableServiceControllerBase
             $result = json_decode($jsonOutput, true);
 
             if (is_array($result) && isset($result['status'])) {
-                return ["status" => $result['status'], "message" => _($result['message'])];
+                return ["status" => $result['status'], "message" => $result['message']];
             }
         }
 
         // If unable to parse the expected JSON output, return a generic error message
-        return ["status" => "failed", "message" => _("Unable to parse the validation result.")];
+        return ["status" => "failed", "message" => gettext("Unable to parse the validation result.")];
     }
 }

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/ServiceController.php
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/ServiceController.php
@@ -63,11 +63,11 @@ class ServiceController extends ApiMutableServiceControllerBase
             $result = json_decode($jsonOutput, true);
 
             if (is_array($result) && isset($result['status'])) {
-                return ["status" => $result['status'], "message" => $result['message']];
+                return ["status" => $result['status'], "message" => _($result['message'])];
             }
         }
 
         // If unable to parse the expected JSON output, return a generic error message
-        return ["status" => "failed", "message" => "Unable to parse the validation result."];
+        return ["status" => "failed", "message" => _("Unable to parse the validation result.")];
     }
 }

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
@@ -59,7 +59,7 @@ class Caddy extends BaseModel
                 if (isset($combos[$comboKey])) {
                     // Use dynamic $key for message referencing
                     $messages->appendMessage(new Message(
-                        _("Duplicate entry: The combination of ") . $type . _(" '") . $fromDomainOrSubdomain . _("' and port '") . $port . _("' is already used. Each ") . $type . _(" and port pairing must be unique."),
+                        sprintf(gettext("Duplicate entry: The combination of %1\$s '%2\$s' and port '%3\$s' is already used. Each %1\$s and port pairing must be unique."), $type, $fromDomainOrSubdomain, $port),
                         $type === 'domain' ? $key . ".FromDomain" : $key . ".FromDomain", // Adjusted to use dynamic key
                         "Duplicate" . ucfirst($type) . "Port"
                     ));
@@ -98,7 +98,7 @@ class Caddy extends BaseModel
                 if (!$isValid) {
                     $key = $subdomain->__reference; // Dynamic key based on subdomain reference
                     $messages->appendMessage(new Message(
-                        _("Invalid subdomain configuration: '") . $subdomainName . _("' does not fall under any configured wildcard domain."),
+                        sprintf(gettext("Invalid subdomain configuration: '%1\$s' does not fall under any configured wildcard domain."), $subdomainName),
                         $key . ".FromDomain", // Use dynamic key for message referencing
                         "InvalidSubdomain"
                     ));

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
@@ -59,7 +59,7 @@ class Caddy extends BaseModel
                 if (isset($combos[$comboKey])) {
                     // Use dynamic $key for message referencing
                     $messages->appendMessage(new Message(
-                        "Duplicate entry: The combination of $type '$fromDomainOrSubdomain' and port '$port' is already used. Each $type and port pairing must be unique.",
+                        _("Duplicate entry: The combination of ") . $type . _(" '") . $fromDomainOrSubdomain . _("' and port '") . $port . _("' is already used. Each ") . $type . _(" and port pairing must be unique."),
                         $type === 'domain' ? $key . ".FromDomain" : $key . ".FromDomain", // Adjusted to use dynamic key
                         "Duplicate" . ucfirst($type) . "Port"
                     ));
@@ -98,7 +98,7 @@ class Caddy extends BaseModel
                 if (!$isValid) {
                     $key = $subdomain->__reference; // Dynamic key based on subdomain reference
                     $messages->appendMessage(new Message(
-                        "Invalid subdomain configuration: '$subdomainName' does not fall under any configured wildcard domain.",
+                        _("Invalid subdomain configuration: '") . $subdomainName . _("' does not fall under any configured wildcard domain."),
                         $key . ".FromDomain", // Use dynamic key for message referencing
                         "InvalidSubdomain"
                     ));

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
@@ -37,7 +37,7 @@ class Caddy extends BaseModel
 {
     // 1. Check domain-port combinations
     // 2. Check subdomain-port combinations
-    private function checkForUniquePortCombos($items, $messages, $type = 'domain')
+    private function checkForUniquePortCombos($items, $messages)
     {
         $combos = [];
         foreach ($items as $item) {
@@ -59,9 +59,9 @@ class Caddy extends BaseModel
                 if (isset($combos[$comboKey])) {
                     // Use dynamic $key for message referencing
                     $messages->appendMessage(new Message(
-                        sprintf(gettext("Duplicate entry: The combination of %1\$s '%2\$s' and port '%3\$s' is already used. Each %1\$s and port pairing must be unique."), $type, $fromDomainOrSubdomain, $port),
-                        $type === 'domain' ? $key . ".FromDomain" : $key . ".FromDomain", // Adjusted to use dynamic key
-                        "Duplicate" . ucfirst($type) . "Port"
+                        sprintf(gettext("Duplicate entry: The combination of '%s' and port '%s' is already used. Each combination of domain/subdomain and port must be unique."), $fromDomainOrSubdomain, $port),
+                        $key . ".FromDomain", // Adjusted to use dynamic key
+                        "DuplicateDomainPort"
                     ));
                 } else {
                     $combos[$comboKey] = true;
@@ -112,9 +112,9 @@ class Caddy extends BaseModel
     {
         $messages = parent::performValidation($validateFullModel);
         // 1. Check domain-port combinations
-        $this->checkForUniquePortCombos($this->reverseproxy->reverse->iterateItems(), $messages, 'domain');
+        $this->checkForUniquePortCombos($this->reverseproxy->reverse->iterateItems(), $messages);
         // 2. Check subdomain-port combinations
-        $this->checkForUniquePortCombos($this->reverseproxy->subdomain->iterateItems(), $messages, 'subdomain');
+        $this->checkForUniquePortCombos($this->reverseproxy->subdomain->iterateItems(), $messages);
         // 3. Check that subdomains are under a wildcard or exact domain
         $this->checkSubdomainsAgainstDomains($this->reverseproxy->subdomain->iterateItems(), $this->reverseproxy->reverse->iterateItems(), $messages);
 

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
@@ -98,7 +98,7 @@ class Caddy extends BaseModel
                 if (!$isValid) {
                     $key = $subdomain->__reference; // Dynamic key based on subdomain reference
                     $messages->appendMessage(new Message(
-                        sprintf(gettext("Invalid subdomain configuration: '%1\$s' does not fall under any configured wildcard domain."), $subdomainName),
+                        sprintf(gettext("Invalid subdomain configuration: '%s' does not fall under any configured wildcard domain."), $subdomainName),
                         $key . ".FromDomain", // Use dynamic key for message referencing
                         "InvalidSubdomain"
                     ));


### PR DESCRIPTION
Implement gettext _() function for localization in php controllers and model.

The last few parts where text is emitted to the user have been wrapped into short versions of the gettext() function. _()