### PR TITLE
www/caddy: Fix that the setup.sh script is not executed with reloadssl

### DIFF
--- a/www/caddy/Makefile
+++ b/www/caddy/Makefile
@@ -1,5 +1,6 @@
 PLUGIN_NAME=		caddy
 PLUGIN_VERSION=		1.5.5
+PLUGIN_REVISION=	1
 PLUGIN_DEPENDS=		caddy-custom
 PLUGIN_COMMENT=		Easy to configure Reverse Proxy with Automatic HTTPS and Dynamic DNS
 PLUGIN_MAINTAINER=	cedrik@pischem.com

--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -26,6 +26,10 @@ DOC: https://docs.opnsense.org/manual/how-tos/caddy.html
 Plugin Changelog
 ================
 
+1.5.5_1
+
+* Fix: The newly introduced "configctl caddy reload" action, which calls the "service caddy reloadssl" command, will now also trigger the setup.sh script.
+
 1.5.5
 
 * Fix: "Apply" could hang when websockets are in use by clients. A grace period of 10s has been added in General Settings that forces to close all connections on config changes.
@@ -37,6 +41,9 @@ Plugin Changelog
 * Cleanup: Javascript variables have been changed from var to let to reduce scope.
 * Fix: Template has been fixed to allow any TLS option in Handlers to appear independant when filled out. This increases flexibility with the "tls_server_name" option.
 * Add: Diagnostics view added where the current Caddyfile and JSON configuration can be displayed, validated and downloaded.
+* Add: HTTP-01 Challenge Redirection can also be configured for subdomains.
+* Cleanup: lang() and gettext() functions added for translations.
+* Cleanup: Rewritten most help texts in forms for consistency.
 
 1.5.4
 

--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -26,10 +26,6 @@ DOC: https://docs.opnsense.org/manual/how-tos/caddy.html
 Plugin Changelog
 ================
 
-1.5.5_1
-
-* Fix: The newly introduced "configctl caddy reload" action, which calls the "service caddy reloadssl" command, will now also trigger the setup.sh script.
-
 1.5.5
 
 * Fix: "Apply" could hang when websockets are in use by clients. A grace period of 10s has been added in General Settings that forces to close all connections on config changes.
@@ -44,6 +40,7 @@ Plugin Changelog
 * Add: HTTP-01 Challenge Redirection can also be configured for subdomains.
 * Cleanup: lang() and gettext() functions added for translations.
 * Cleanup: Rewritten most help texts in forms for consistency.
+* Fix: The newly introduced "configctl caddy reload" action, which calls the "service caddy reloadssl" command, will now also trigger the setup.sh script.
 
 1.5.4
 

--- a/www/caddy/src/opnsense/scripts/OPNsense/Caddy/caddy_control.py
+++ b/www/caddy/src/opnsense/scripts/OPNsense/Caddy/caddy_control.py
@@ -75,11 +75,11 @@ if __name__ == "__main__":
         service_action = actions[action]
         message = f"{action.capitalize()}ing Caddy service" if action != "validate" else "Validating Caddy configuration"
 
-        # Call setup script for 'validate' and 'reload' actions
+        # Call setup script for 'validate' and 'reloadssl' actions
         # This is needed because the setup script triggers the caddy_certs.php script, which exports all certificates into the filesystem.
         # Caddy reloads certificates when reloadssl is used. Because it is a non standard command, the caddy_setup script will not be triggered in /etc/rc.conf.d/caddy.
         # The validate command needs it to make sure all certificates are in the filesystem, because otherwise the validation fails.
-        if action in ["validate", "reload"]:
+        if service_action in ["validate", "reloadssl"]:
             subprocess.run(["/usr/local/opnsense/scripts/OPNsense/Caddy/setup.sh"], check=True)
 
         # Continue with the service action


### PR DESCRIPTION
Fix that the setup.sh script is not executed with reloadssl.

It is now triggered in the overlay script ``caddy_control.py`` that maps the ``reload`` action to the ``reloadssl`` extra command of the upstream caddy rc.d script. For other actions like start/stop/restart, the setup script is still executed by /etc/rc.conf.d/caddy.

Fixes: 
* Certificates not being updated in the filesystem on config changes when a reload is triggered
* Caddyfile not being properly formatted on config changes when a reload is triggered

Who does this bug impact:
* Anybody who uses custom certificates in os-caddy-1.5.5 and triggers ``configctl caddy reload`` without pressing the ``Apply`` button.
* Anybody who uses the new ``Diagnostics`` page and sees a weirdly formatted ``Caddyfile``.

Current impact of the bug:
* Pressing the ``Apply`` button will still export certificates from ``System - Trust``, since the custom ``validate`` action triggers the ``setup.sh`` script too. The following ``reconfigureAct`` will reload the template again without reformatting the Caddyfile, making it not very beautiful to read, yet functionally still working.
* Calling ``configctl caddy reload`` directly won't export certificates and won't reformat the Caddyfile.
* Calling ``service caddy reloadssl`` directly won't export certificates and won't reformat the Caddyfile. -> This will not change and this command should NOT be called directly.

