### PR TITLE
www/caddy: Caddy dyndns wildcard domain fix

### DIFF
--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -26,6 +26,10 @@ DOC: https://docs.opnsense.org/manual/how-tos/caddy.html
 Plugin Changelog
 ================
 
+1.5.6
+
+* Fix: Wildcard domains with activated "Dynamic DNS" update their base domain with * instead of @.
+
 1.5.5
 
 * Fix: "Apply" could hang when websockets are in use by clients. A grace period of 10s has been added in General Settings that forces to close all connections on config changes.

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -123,7 +123,11 @@
     {% for reverse in helpers.toList('Pischem.caddy.reverseproxy.reverse') %}
         {% if reverse.enabled|default("0") == "1" and reverse.DynDns|default("0") == "1" %}
             {% set cleanedDomain = reverse.FromDomain | replace("*.","") %}
-            {% do dynDnsDomains.append(cleanedDomain + " @") %}
+            {% if reverse.FromDomain.startswith("*.") %}
+                {% do dynDnsDomains.append(cleanedDomain + " *") %}
+            {% else %}
+                {% do dynDnsDomains.append(cleanedDomain + " @") %}
+            {% endif %}
         {% endif %}
 
         {% for subdomain in helpers.toList('Pischem.caddy.reverseproxy.subdomain') %}


### PR DESCRIPTION
Implements this:

```
	dynamic_dns {
		provider cloudflare
		domains {
			example.com *
			example.com opn
			example.com @
		}
	}
```

Wildcard domains will use "*", base domains will use "@". Subdomains continue to function as before.
Since wildcard domains don't include the base domain, separating it in the template will not cause any regressions.

Fixes: https://forum.opnsense.org/index.php?topic=38714.msg198983#msg198983