### PR TITLE
Add zone to DNSExit provider

### DIFF
--- a/dns/ddclient/pkg-descr
+++ b/dns/ddclient/pkg-descr
@@ -6,6 +6,8 @@ WWW: https://github.com/ddclient/ddclient
 Plugin Changelog
 ================
 
+* Add zone support to DNSExit provider
+
 1.21
 
 * Add Netcup support (contributed by Ingo Lafrenz)

--- a/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/dialogAccount.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/dialogAccount.xml
@@ -62,7 +62,7 @@
         <id>account.zone</id>
         <label>Zone</label>
         <type>text</type>
-        <style>optional_setting service_aws service_zoneedit1 service_cloudflare service_nsupdate service_gandi service_godaddy service_nfsn service_hetzner service_digitalocean</style>
+        <style>optional_setting service_aws service_zoneedit1 service_cloudflare service_nsupdate service_gandi service_godaddy service_nfsn service_hetzner service_digitalocean service_dnsexit2</style>
         <help>Zone containing the host entry.</help>
     </field>
     <field>

--- a/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
+++ b/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
@@ -36,7 +36,7 @@ use=cmd, cmd="/usr/local/opnsense/scripts/ddclient/checkip -t {{account.force_ss
 {%      if account.service == 'custom' %}
 protocol={{account.protocol}}, \
 server={{account.server}}, \
-{%      elif account.service in ['cloudflare', 'digitalocean'] %}
+{%      elif account.service in ['cloudflare', 'digitalocean', 'dnsexit2', 'gandi', 'godaddy', 'hetzner'] %}
 protocol={{account.service}}, \
 zone={{account.zone}}, \
 {%      elif account.service == 'cloudns' %}
@@ -44,21 +44,12 @@ protocol={{account.service}}, \
 dynurl=https://ipv4.cloudns.net/api/dynamicURL/?q={{account.password}}, \
 {%      elif account.service == 'hosting1984' %}
 protocol=1984, \
-{%      elif account.service == 'godaddy' %}
-protocol={{account.service}}, \
-zone={{account.zone}}, \
-{%      elif account.service == 'hetzner' %}
-protocol={{account.service}}, \
-zone={{account.zone}}, \
 {%      elif account.service == 'dns-o-matic' %}
 protocol=dyndns2, \
 server=updates.dnsomatic.com, \
 {%      elif account.service == 'dynu' %}
 protocol=dyndns2, \
 server=api.dynu.com, \
-{%      elif account.service == 'gandi' %}
-protocol={{account.service}}, \
-zone={{account.zone}}, \
 {%      elif account.service == 'he-net' %}
 protocol=dyndns2, \
 server=dyn.dns.he.net, \


### PR DESCRIPTION
ddclient: Adding `zone` config field to DNSExit provider.
For #3712.

Could it be as trivial as this? Note I have no experience with the OPNSense plugin / mvc system.
