### PR TITLE
WIP: net/haproxy: add SNI support in mapfile-based backend selection

### DIFF
--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogAction.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogAction.xml
@@ -446,13 +446,13 @@
         <id>action.map_use_backend_default</id>
         <label>Default backend pool</label>
         <type>dropdown</type>
-        <help><![CDATA[HAProxy will use this backend pool if no match is found in the map file.]]></help>
+        <help><![CDATA[HAProxy will use this backend pool if no match is found in the map file by Host header.]]></help>
     </field>
     <field>
         <id>action.map_use_backend_file_matchtype</id>
 	<label>Match type</label>
         <type>dropdown</type>
-	<help><![CDATA[HAProxy will match the hostname against the map file using the selected matching method.]]></help>
+	<help><![CDATA[HAProxy will match the hostname against the map file using the selected matching method. See HAProxy documentation for Map files for details.]]></help>
     </field>
     <field>
         <id>action.map_use_backend_file_snisupport</id>

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogAction.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogAction.xml
@@ -449,6 +449,18 @@
         <help><![CDATA[HAProxy will use this backend pool if no match is found in the map file.]]></help>
     </field>
     <field>
+        <id>action.map_use_backend_file_matchtype</id>
+	<label>Match type</label>
+        <type>dropdown</type>
+	<help><![CDATA[HAProxy will match the hostname against the map file using the selected matching method.]]></help>
+    </field>
+    <field>
+        <id>action.map_use_backend_file_snisupport</id>
+	<label>Hostname reference</label>
+        <type>dropdown</type>
+	<help><![CDATA[HAProxy will use SNI and/or Host header as hostname according to the selected sequence.]]></help>
+    </field>
+    <field>
         <label>Parameters</label>
         <type>header</type>
         <style>type_table table_fcgi_pass_header</style>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -2542,6 +2542,23 @@
                     <Multiple>N</Multiple>
                     <Required>N</Required>
                 </map_use_backend_file>
+                <map_use_backend_file_matchtype type="OptionField">
+                    <Required>Y</Required>
+                    <default>dom</default>
+                    <OptionValues>
+                        <dom>Match domain exactly</dom>
+                        <reg>Match domain by regular expression</reg>
+                    </OptionValues>
+                </map_use_backend_file_matchtype>
+                <map_use_backend_file_snisupport type="OptionField">
+                    <Required>Y</Required>
+                    <default>hostonly</default>
+                    <OptionValues>
+                        <hostonly>Match Host header only</hostonly>
+                        <sniandhost>Match SNI and fallback to Host header</sniandhost>
+                        <snionly>Match SNI only</snionly>
+                    </OptionValues>
+                </map_use_backend_file_snisupport>
                 <map_use_backend_default type="ModelRelationField">
                     <Model>
                         <template>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -2546,8 +2546,12 @@
                     <Required>Y</Required>
                     <default>dom</default>
                     <OptionValues>
-                        <dom>Match domain exactly</dom>
+                        <str>Match domain exactly</str>
+                        <dom>Match domain and subdomains</dom>
                         <reg>Match domain by regular expression</reg>
+                        <beg>Match string prefix</beg>
+                        <end>Match string suffix</end>
+                        <sub>Match substring</sub>
                     </OptionValues>
                 </map_use_backend_file_matchtype>
                 <map_use_backend_file_snisupport type="OptionField">

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -475,27 +475,15 @@
 {%               do action_options.append('tcp-request content accept if { req.ssl_hello_type 1 }\n   ') %}
 {%               set backend_file_options_set = true %}
 {%             endif %}
-{%             if proxy.mode in ("http", "ssl") %}
-{%               if backend_file_hostname_snisupport == "snionly" %}
-{%                 if proxy.ssl_enabled is defined and proxy.ssl_enabled == "1" %}
-{%                   do action_options.append('use_backend %[ssl_fc_sni,lower,' ~ backend_file_matchtype_func ~ '(' ~ mapfile_path ~ ')]') %}
-{%                 else %}
-{%                   do action_options.append('use_backend %[req.ssl_sni,lower,' ~ backend_file_matchtype_func ~ '(' ~ mapfile_path ~ ')]') %}
-{%                 endif %}
-{%               elif backend_file_hostname_snisupport == "sniandhost" %}
-{%                 if proxy.ssl_enabled is defined and proxy.ssl_enabled == "1" %}
-{%                   do action_options.append('use_backend %[ssl_fc_sni,lower,' ~ backend_file_matchtype_func ~ '(' ~ mapfile_path ~ ')]' ~ '\n   ') %}
-{%                 else %}
-{%                   do action_options.append('use_backend %[req.ssl_sni,lower,' ~ backend_file_matchtype_func ~ '(' ~ mapfile_path ~ ')]' ~ '\n   ') %}
-{%                 endif %}
-{%                 do action_options.append('use_backend %[req.hdr(host),lower,' ~ backend_file_matchtype_func ~ '(' ~ mapfile_path ~ defaultbackend_option ~ ')]') %}
-{%               elif backend_file_hostname_snisupport == "hostonly" %}
-{%                 do action_options.append('use_backend %[req.hdr(host),lower,' ~ backend_file_matchtype_func ~ '(' ~ mapfile_path ~ defaultbackend_option ~ ')]') %}
-{%               endif %}
-{%             elif proxy.mode == "tcp" %}
-{%               if backend_file_hostname_snisupport in ("sniandhost", "snionly") %}
+{%             if backend_file_hostname_snisupport in ("sniandhost", "snionly") %}
+{%               if proxy.ssl_enabled is defined and proxy.ssl_enabled == "1" %}
+{%                 do action_options.append('use_backend %[ssl_fc_sni,lower,' ~ backend_file_matchtype_func ~ '(' ~ mapfile_path ~ ')]') %}
+{%               else %}
 {%                 do action_options.append('use_backend %[req.ssl_sni,lower,' ~ backend_file_matchtype_func ~ '(' ~ mapfile_path ~ ')]') %}
 {%               endif %}
+{%             endif %}
+{%             if backend_file_hostname_snisupport in ("hostonly", "sniandhost") %}
+{%               do action_options.append('use_backend %[req.hdr(host),lower,' ~ backend_file_matchtype_func ~ '(' ~ mapfile_path ~ defaultbackend_option ~ ')]') %}
 {%             endif %}
 {%           else %}
 {%             set action_enabled = '0' %}

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -45,7 +45,6 @@
 {#     # remember all ACLs to avoid duplicate declarations #}
 {%     set acls_seen = [] %}
 {%     set global_action_options = [] %}
-{%     set backend_file_options_set = false %}
 {%     for action in linkedData.split(",") %}
 {%       set action_data = helpers.getUUID(action) %}
 {#       # collect ACLs for this action #}
@@ -471,10 +470,9 @@
 {#             # Finally add map file to config #}
 {%             set backend_file_hostname_snisupport = action_data.map_use_backend_file_snisupport|default("hostonly") %}
 {%             if backend_file_hostname_snisupport in ("sniandhost", "snionly") %}
-{%               if not backend_file_options_set %}
-{%                 do action_options.append('tcp-request inspect-delay 200ms\n   ') %}
-{%                 do action_options.append('tcp-request content accept if { req.ssl_hello_type 1 }\n   ') %}
-{%                 set backend_file_options_set = true %}
+{%               set backend_file_global_options = ['# NOTE: Map files SNI support', 'tcp-request inspect-delay 200ms', 'tcp-request content accept if { req.ssl_hello_type 1 }', ''] %}
+{%               if backend_file_global_options[0] not in global_action_options %}
+{%                 do global_action_options.extend(backend_file_global_options) %}
 {%               endif %}
 {%               if proxy.ssl_enabled is defined and proxy.ssl_enabled == "1" %}
 {%                 do action_options.append('use_backend %[ssl_fc_sni,lower,' ~ backend_file_matchtype_func ~ '(' ~ mapfile_path ~ ')]') %}

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -45,6 +45,7 @@
 {#     # remember all ACLs to avoid duplicate declarations #}
 {%     set acls_seen = [] %}
 {%     set global_action_options = [] %}
+{%     set backend_file_options_set = false %}
 {%     for action in linkedData.split(",") %}
 {%       set action_data = helpers.getUUID(action) %}
 {#       # collect ACLs for this action #}
@@ -460,20 +461,26 @@
 {%             else %}
 {%               set defaultbackend_option = '' %}
 {%             endif %}
+{#             # Store match function from configured match type #}
 {%             set backend_file_matchtype = action_data.map_use_backend_file_matchtype|default("dom") %}
-{%             if backend_file_matchtype in ("dom", "reg") %}
+{%             if backend_file_matchtype in ("str", "dom", "reg", "beg", "end", "sub") %}
 {%               set backend_file_matchtype_func = "map_" ~ backend_file_matchtype %}
 {%             else %}
 {%               set backend_file_matchtype_func = "map_dom" %}
 {%             endif %}
 {#             # Finally add map file to config #}
 {%             set backend_file_hostname_snisupport = action_data.map_use_backend_file_snisupport|default("hostonly") %}
-{%             if proxy.mode == "http" %}
+{%             if not backend_file_options_set %}
+{%               do action_options.append('tcp-request inspect-delay 200ms\n   ') %}
+{%               do action_options.append('tcp-request content accept if { req.ssl_hello_type 1 }\n   ') %}
+{%               set backend_file_options_set = true %}
+{%             endif %}
+{%             if proxy.mode in ("http", "ssl") %}
 {%               if backend_file_hostname_snisupport == "snionly" %}
 {%                 if proxy.ssl_enabled is defined and proxy.ssl_enabled == "1" %}
-{%                   do action_options.append('use_backend %[ssl_fc_sni,lower,' ~ backend_file_matchtype_func ~ '(' ~ mapfile_path ~ defaultbackend_option ~ ')]') %}
+{%                   do action_options.append('use_backend %[ssl_fc_sni,lower,' ~ backend_file_matchtype_func ~ '(' ~ mapfile_path ~ ')]') %}
 {%                 else %}
-{%                   do action_options.append('use_backend %[req.ssl_sni,lower,' ~ backend_file_matchtype_func ~ '(' ~ mapfile_path ~ defaultbackend_option ~ ')]') %}
+{%                   do action_options.append('use_backend %[req.ssl_sni,lower,' ~ backend_file_matchtype_func ~ '(' ~ mapfile_path ~ ')]') %}
 {%                 endif %}
 {%               elif backend_file_hostname_snisupport == "sniandhost" %}
 {%                 if proxy.ssl_enabled is defined and proxy.ssl_enabled == "1" %}
@@ -485,9 +492,9 @@
 {%               elif backend_file_hostname_snisupport == "hostonly" %}
 {%                 do action_options.append('use_backend %[req.hdr(host),lower,' ~ backend_file_matchtype_func ~ '(' ~ mapfile_path ~ defaultbackend_option ~ ')]') %}
 {%               endif %}
-{%             elif proxy.mode == "ssl" %}
+{%             elif proxy.mode == "tcp" %}
 {%               if backend_file_hostname_snisupport in ("sniandhost", "snionly") %}
-{%                 do action_options.append('use_backend %[req.ssl_sni,lower,' ~ backend_file_matchtype_func ~ '(' ~ mapfile_path ~ defaultbackend_option ~ ')]') %}
+{%                 do action_options.append('use_backend %[req.ssl_sni,lower,' ~ backend_file_matchtype_func ~ '(' ~ mapfile_path ~ ')]') %}
 {%               endif %}
 {%             endif %}
 {%           else %}
@@ -1028,6 +1035,7 @@ global
 {% if helpers.exists('OPNsense.HAProxy.general.tuning.maxDHSize') %}
     tune.ssl.default-dh-param   {{OPNsense.HAProxy.general.tuning.maxDHSize}}
 {% endif %}
+    tune.ssl.capture-buffer-size 512
 {% if helpers.exists('OPNsense.HAProxy.general.tuning.sslServerVerify') %}
 {%     if OPNsense.HAProxy.general.tuning.sslServerVerify|default("") != 'ignore' %}
     ssl-server-verify           {{OPNsense.HAProxy.general.tuning.sslServerVerify}}

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -39,8 +39,9 @@
 {%- endmacro -%}
 
 {# Macro expects a CSV list of Actions and validates them. #}
-{%- macro AclsAndActions(linkedData) -%}
-{%   if linkedData is defined %}
+{%- macro AclsAndActions(proxy) -%}
+{%   if proxy.linkedActions is defined %}
+{%     set linkedData = proxy.linkedActions %}
 {#     # remember all ACLs to avoid duplicate declarations #}
 {%     set acls_seen = [] %}
 {%     set global_action_options = [] %}
@@ -459,8 +460,36 @@
 {%             else %}
 {%               set defaultbackend_option = '' %}
 {%             endif %}
+{%             set backend_file_matchtype = action_data.map_use_backend_file_matchtype|default("dom") %}
+{%             if backend_file_matchtype in ("dom", "reg") %}
+{%               set backend_file_matchtype_func = "map_" ~ backend_file_matchtype %}
+{%             else %}
+{%               set backend_file_matchtype_func = "map_dom" %}
+{%             endif %}
 {#             # Finally add map file to config #}
-{%             do action_options.append('use_backend %[req.hdr(host),lower,map_dom(' ~ mapfile_path ~ defaultbackend_option ~ ')]') %}
+{%             set backend_file_hostname_snisupport = action_data.map_use_backend_file_snisupport|default("hostonly") %}
+{%             if proxy.mode == "http" %}
+{%               if backend_file_hostname_snisupport == "snionly" %}
+{%                 if proxy.ssl_enabled is defined and proxy.ssl_enabled == "1" %}
+{%                   do action_options.append('use_backend %[ssl_fc_sni,lower,' ~ backend_file_matchtype_func ~ '(' ~ mapfile_path ~ defaultbackend_option ~ ')]') %}
+{%                 else %}
+{%                   do action_options.append('use_backend %[req.ssl_sni,lower,' ~ backend_file_matchtype_func ~ '(' ~ mapfile_path ~ defaultbackend_option ~ ')]') %}
+{%                 endif %}
+{%               elif backend_file_hostname_snisupport == "sniandhost" %}
+{%                 if proxy.ssl_enabled is defined and proxy.ssl_enabled == "1" %}
+{%                   do action_options.append('use_backend %[ssl_fc_sni,lower,' ~ backend_file_matchtype_func ~ '(' ~ mapfile_path ~ ')]' ~ '\n   ') %}
+{%                 else %}
+{%                   do action_options.append('use_backend %[req.ssl_sni,lower,' ~ backend_file_matchtype_func ~ '(' ~ mapfile_path ~ ')]' ~ '\n   ') %}
+{%                 endif %}
+{%                 do action_options.append('use_backend %[req.hdr(host),lower,' ~ backend_file_matchtype_func ~ '(' ~ mapfile_path ~ defaultbackend_option ~ ')]') %}
+{%               elif backend_file_hostname_snisupport == "hostonly" %}
+{%                 do action_options.append('use_backend %[req.hdr(host),lower,' ~ backend_file_matchtype_func ~ '(' ~ mapfile_path ~ defaultbackend_option ~ ')]') %}
+{%               endif %}
+{%             elif proxy.mode == "ssl" %}
+{%               if backend_file_hostname_snisupport in ("sniandhost", "snionly") %}
+{%                 do action_options.append('use_backend %[req.ssl_sni,lower,' ~ backend_file_matchtype_func ~ '(' ~ mapfile_path ~ defaultbackend_option ~ ')]') %}
+{%               endif %}
+{%             endif %}
 {%           else %}
 {%             set action_enabled = '0' %}
     # ERROR: missing parameters
@@ -1497,7 +1526,7 @@ frontend {{frontend.name}}
 {#       # action and ACL configuration #}
 {%       if frontend.linkedActions|default("") != "" -%}
 {#         # call macro to evaluate ACLs and actions #}
-{{         AclsAndActions(frontend.linkedActions) }}
+{{         AclsAndActions(frontend) }}
 {%-      endif %}
 {#       # error files #}
 {%       if frontend.linkedErrorfiles|default("") != "" %}
@@ -1696,7 +1725,7 @@ backend {{backend.name}}
 {#       # action and ACL configuration #}
 {%       if backend.linkedActions|default("") != "" -%}
 {#         # call macro to evaluate ACLs and actions #}
-{{         AclsAndActions(backend.linkedActions) }}
+{{         AclsAndActions(backend) }}
 {%-      endif %}
 {#       # error files #}
 {%       if backend.linkedErrorfiles|default("") != "" %}
@@ -1993,7 +2022,7 @@ fcgi-app {{fcgi.name}}
 {#        # action and ACL configuration #}
 {%       if fcgi.linkedActions|default("") != "" -%}
 {#         # call macro to evaluate ACLs and actions #}
-{{         AclsAndActions(fcgi.linkedActions) }}
+{{         AclsAndActions(fcgi) }}
 {%-      endif %}
 
 {%     else %}

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -470,12 +470,12 @@
 {%             endif %}
 {#             # Finally add map file to config #}
 {%             set backend_file_hostname_snisupport = action_data.map_use_backend_file_snisupport|default("hostonly") %}
-{%             if not backend_file_options_set %}
-{%               do action_options.append('tcp-request inspect-delay 200ms\n   ') %}
-{%               do action_options.append('tcp-request content accept if { req.ssl_hello_type 1 }\n   ') %}
-{%               set backend_file_options_set = true %}
-{%             endif %}
 {%             if backend_file_hostname_snisupport in ("sniandhost", "snionly") %}
+{%               if not backend_file_options_set %}
+{%                 do action_options.append('tcp-request inspect-delay 200ms\n   ') %}
+{%                 do action_options.append('tcp-request content accept if { req.ssl_hello_type 1 }\n   ') %}
+{%                 set backend_file_options_set = true %}
+{%               endif %}
 {%               if proxy.ssl_enabled is defined and proxy.ssl_enabled == "1" %}
 {%                 do action_options.append('use_backend %[ssl_fc_sni,lower,' ~ backend_file_matchtype_func ~ '(' ~ mapfile_path ~ ')]') %}
 {%               else %}

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -474,14 +474,29 @@
 {%               if backend_file_global_options[0] not in global_action_options %}
 {%                 do global_action_options.extend(backend_file_global_options) %}
 {%               endif %}
+{#               # What follows is a HACK. I have to synthesize ACLs which do not exist in the user config,                    #}
+{#               # and I can't see how this could be accomplished in this template.  The method below emits ACLs in-place,     #}
+{#               # but this ONLY works when if further code won't add another 'if acl_xY' afterwards.                          #}
 {%               if proxy.ssl_enabled is defined and proxy.ssl_enabled == "1" %}
+{%                 if not defaultbackend_option %}
+{%                   do action_options.append('acl acl_' ~ mapfile_data.id ~ '.mapfile_match ssl_fc_sni,lower,' ~ backend_file_matchtype_func ~ '(' ~ mapfile_path ~ ') -m found\n   ') %}
+{%                 endif %}
 {%                 do action_options.append('use_backend %[ssl_fc_sni,lower,' ~ backend_file_matchtype_func ~ '(' ~ mapfile_path ~ ')]') %}
+{%                 if not defaultbackend_option %}{% do action_options.append('if acl_' ~ mapfile_data.id ~ '.mapfile_match') %}{% endif %}{# This is a HACK (see note above) #}
 {%               else %}
+{%                 if not defaultbackend_option %}
+{%                   do action_options.append('acl acl_' ~ mapfile_data.id ~ '.mapfile_match req.ssl_sni,lower,' ~ backend_file_matchtype_func ~ '(' ~ mapfile_path ~ ') -m found\n   ') %}
+{%                 endif %}
 {%                 do action_options.append('use_backend %[req.ssl_sni,lower,' ~ backend_file_matchtype_func ~ '(' ~ mapfile_path ~ ')]') %}
+{%                 if not defaultbackend_option %}{% do action_options.append('if acl_' ~ mapfile_data.id ~ '.mapfile_match') %}{% endif %}{# This is a HACK (see note above) #}
 {%               endif %}
 {%             endif %}
 {%             if backend_file_hostname_snisupport in ("hostonly", "sniandhost") %}
+{%               if not defaultbackend_option %}
+{%                 do action_options.append('acl acl_' ~ mapfile_data.id ~ '.mapfile_match req.hdr(host),lower,' ~ backend_file_matchtype_func ~ '(' ~ mapfile_path ~ ') -m found\n   ') %}
+{%               endif %}
 {%               do action_options.append('use_backend %[req.hdr(host),lower,' ~ backend_file_matchtype_func ~ '(' ~ mapfile_path ~ defaultbackend_option ~ ')]') %}
+{%               if not defaultbackend_option %}{% do action_options.append('if acl_' ~ mapfile_data.id ~ '.mapfile_match') %}{% endif %}{# This is a HACK (see note above) #}
 {%             endif %}
 {%           else %}
 {%             set action_enabled = '0' %}


### PR DESCRIPTION
This adds two options to the "Map domains to backend pools using a map file".
One of the options is addressing https://github.com/opnsense/plugins/issues/3641.

The first option adds all map_dom, map_str, map_beg, map_end and map_reg (regex) support.
![2024-06-04_11h33_26](https://github.com/opnsense/plugins/assets/870386/5d34da1a-f4a4-4afd-a2f9-0a52d195a722)

The second option adds SNI support.

![2024-06-01_19h38_18](https://github.com/opnsense/plugins/assets/870386/63c8e2f9-9ea1-42ea-9c8a-cc07a1d5e3c8)

Defaults are chosen such that existing setups don't change behavior.

___

I am currently testing this in our lab, but the more testing this gets the better.