### PR TITLE
www/caddy: basicauth becomes basic_auth, for caddy v2.8.0+

### DIFF
--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -590,7 +590,7 @@
 #}
 {% macro basicauth_configuration(basicauth_uuids) %}
     {% if basicauth_uuids %}
-    basicauth {
+    basic_auth {
         {% for uuid in basicauth_uuids.split(',') %}
             {% set basicauth = helpers.toList('Pischem.caddy.reverseproxy.basicauth') | selectattr('@uuid', 'equalto', uuid) | first %}
             {% if basicauth %}


### PR DESCRIPTION
https://github.com/caddyserver/caddy/pull/6092

`basicauth` would still work, but spawns errors in the logs. So we change it to `basic_auth` now for compliance with caddy >=v2.8.0 upstream.