### PR TITLE
www/caddy: When Auto HTTPS is enabled, ACME email is required, for caddy v2.8.0+

### DIFF
--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
@@ -141,6 +141,19 @@ class Caddy extends BaseModel
         }
     }
 
+    // 5. Check for ACME Email being required when Auto HTTPS on
+    private function checkAcmeEmailAutoHttps($messages) {
+        $tlsAutoHttpsSetting = (string)$this->general->TlsAutoHttps;
+        $tlsEmail = (string)$this->general->TlsEmail;
+
+        if (empty($tlsEmail) && $tlsAutoHttpsSetting !== 'off') {
+            $messages->appendMessage(new Message(
+                gettext('To use "Auto HTTPS", an email address is required.'),
+                "general.TlsEmail"
+            ));
+        }
+    }
+
     // Perform the actual validation
     public function performValidation($validateFullModel = false)
     {
@@ -153,6 +166,8 @@ class Caddy extends BaseModel
         $this->checkSubdomainsAgainstDomains($this->reverseproxy->subdomain->iterateItems(), $this->reverseproxy->reverse->iterateItems(), $messages);
         // 4. Check WebGUI conflicts
         $this->checkWebGuiSettings($messages);
+        // 5. Check for ACME Email requirement
+        $this->checkAcmeEmailAutoHttps($messages);
 
         return $messages;
     }


### PR DESCRIPTION
Validation: When Auto HTTPS is enabled, ACME email is required since caddy v2.8.0+
Otherwise ZeroSSL will stop to work due to API policy changes on their side
When Auto HTTPS is turned off, the constraint doesn't apply