### PR TITLE
www/caddy: Remove port from subdomain since it is unsupported.

### DIFF
--- a/www/caddy/Makefile
+++ b/www/caddy/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		caddy
-PLUGIN_VERSION=		1.5.6
+PLUGIN_VERSION=		1.5.7
 PLUGIN_DEPENDS=		caddy-custom
 PLUGIN_COMMENT=		Easy to configure Reverse Proxy with Automatic HTTPS and Dynamic DNS
 PLUGIN_MAINTAINER=	cedrik@pischem.com

--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -26,6 +26,14 @@ DOC: https://docs.opnsense.org/manual/how-tos/caddy.html
 Plugin Changelog
 ================
 
+1.5.7
+
+* Add: Error message when OPNsense WebGUI settings conflict with Auto HTTPS.
+* Add: Error message when Auto HTTPS is enabled, and ACME email field is empty, for caddy v2.8.0+
+* Cleanup: Fix crash of searchAction when reverseUuids is null
+* Cleanup: basicauth directive is now basic_auth in the Caddyfile template, for caddy v2.8.0+
+* Fix: The subdomain port field has been removed, since it is unsupported. Subdomains track their ports from their parent wildcard domain.
+
 1.5.6
 
 * Fix: Wildcard domains with activated "Dynamic DNS" update their base domain with * instead of @.

--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -28,10 +28,11 @@ Plugin Changelog
 
 1.5.7
 
+* Build: Update to Caddy v2.8.4 + caddy-dns plugins updated to latest upstream versions
 * Add: Error message when OPNsense WebGUI settings conflict with Auto HTTPS.
-* Add: Error message when Auto HTTPS is enabled, and ACME email field is empty, for caddy v2.8.0+
+* Add: Error message when Auto HTTPS is enabled, and ACME email field is empty, for caddy v2.8.4
 * Cleanup: Fix crash of searchAction when reverseUuids is null
-* Cleanup: basicauth directive is now basic_auth in the Caddyfile template, for caddy v2.8.0+
+* Cleanup: basicauth directive is now basic_auth in the Caddyfile template, for caddy v2.8.4
 * Fix: The subdomain port field has been removed, since it is unsupported. Subdomains track their ports from their parent wildcard domain.
 
 1.5.6

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogSubdomain.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogSubdomain.xml
@@ -16,20 +16,13 @@
         <label>Subdomain</label>
         <type>text</type>
         <hint>opn.example.com</hint>
-        <help><![CDATA[Enter a subdomain. For example, "opn.example.com" if the wildcard domain is "*.example.com".]]></help>
-    </field>
-    <field>
-        <id>subdomain.FromPort</id>
-        <label>Port</label>
-        <type>text</type>
-        <hint>443</hint>
-        <help><![CDATA[Leave empty to use ports 80 and 443 with automatic redirection from HTTP to HTTPS or choose a custom port. Do not forget to allow these ports with a Firewall rule.]]></help>
+        <help><![CDATA[Enter a subdomain. For example, "opn.example.com" if the wildcard domain is "*.example.com". All subdomains use the same ports as their parent wildcard domain.]]></help>
     </field>
     <field>
         <id>subdomain.description</id>
         <label>Description</label>
         <type>text</type>
-        <hint>opn.example.com.443</hint>
+        <hint>opn.example.com</hint>
         <help><![CDATA[Enter a description for this subdomain.]]></help>
     </field>
     <field>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
@@ -37,13 +37,12 @@ use OPNsense\Core\Config;
 class Caddy extends BaseModel
 {
     // 1. Check domain-port combinations
-    // 2. Check subdomain-port combinations
     private function checkForUniquePortCombos($items, $messages)
     {
         $combos = [];
         foreach ($items as $item) {
             $key = $item->__reference; // Dynamic key based on item reference
-            $fromDomainOrSubdomain = (string) $item->FromDomain;
+            $fromDomain = (string) $item->FromDomain;
             $fromPort = (string) $item->FromPort;
 
             if ($fromPort === '') {
@@ -53,14 +52,14 @@ class Caddy extends BaseModel
             }
 
             foreach ($defaultPorts as $port) {
-                // Create a unique key for domain/subdomain-port combination
-                $comboKey = $fromDomainOrSubdomain . ':' . $port;
+                // Create a unique key for domain-port combination
+                $comboKey = $fromDomain . ':' . $port;
 
                 // Check for duplicate combinations
                 if (isset($combos[$comboKey])) {
                     // Use dynamic $key for message referencing
                     $messages->appendMessage(new Message(
-                        sprintf(gettext("Duplicate entry: The combination of '%s' and port '%s' is already used. Each combination of domain/subdomain and port must be unique."), $fromDomainOrSubdomain, $port),
+                        sprintf(gettext("Duplicate entry: The combination of '%s' and port '%s' is already used. Each combination of domain and port must be unique."), $fromDomain, $port),
                         $key . ".FromDomain", // Adjusted to use dynamic key
                         "DuplicateDomainPort"
                     ));
@@ -147,8 +146,6 @@ class Caddy extends BaseModel
         $messages = parent::performValidation($validateFullModel);
         // 1. Check domain-port combinations
         $this->checkForUniquePortCombos($this->reverseproxy->reverse->iterateItems(), $messages);
-        // 2. Check subdomain-port combinations
-        $this->checkForUniquePortCombos($this->reverseproxy->subdomain->iterateItems(), $messages);
         // 3. Check that subdomains are under a wildcard or exact domain
         $this->checkSubdomainsAgainstDomains($this->reverseproxy->subdomain->iterateItems(), $this->reverseproxy->reverse->iterateItems(), $messages);
         // 4. Check WebGUI conflicts

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//Pischem/caddy</mount>
     <description>A GUI model for configuring a reverse proxy in the Caddy web server.</description>
-    <version>1.1.9</version>
+    <version>1.2.0</version>
     <items>
         <general>
             <enabled type="BooleanField">
@@ -191,11 +191,6 @@
                     <ValidationMessage>Please enter a valid 'from' Subdomain that is based upon the wildcard domain.</ValidationMessage>
                     <ZoneRootAllowed>N</ZoneRootAllowed>
                 </FromDomain>
-                <FromPort type="PortField">
-                    <ValidationMessage>Please enter a valid 'from' port number.</ValidationMessage>
-                    <EnableWellKnown>Y</EnableWellKnown>
-                    <EnableRanges>N</EnableRanges>
-                </FromPort>
                 <accesslist type="ModelRelationField">
                     <Model>
                         <reverseproxy>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -291,7 +291,6 @@
                             <th data-column-id="enabled" data-width="6em" data-type="boolean" data-formatter="rowtoggle">{{ lang._('Enabled') }}</th>
                             <th data-column-id="reverse" data-type="string">{{ lang._('Domain') }}</th>
                             <th data-column-id="FromDomain" data-type="string">{{ lang._('Subdomain') }}</th>
-                            <th data-column-id="FromPort" data-type="string">{{ lang._('Port') }}</th>
                             <th data-column-id="accesslist" data-type="string" data-visible="false">{{ lang._('Access List') }}</th>
                             <th data-column-id="basicauth" data-type="string" data-visible="false">{{ lang._('Basic Auth') }}</th>
                             <th data-column-id="DynDns" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('Dynamic DNS') }}</th>

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -694,7 +694,7 @@
     {% for subdomain in helpers.toList('Pischem.caddy.reverseproxy.subdomain') %}
     {% if subdomain.enabled|default("0") == "1" and subdomain.reverse == reverse['@uuid'] %}
     @{{ subdomain['@uuid'] }} {
-        host {{ subdomain.FromDomain }}{% if subdomain.FromPort %}:{{ subdomain.FromPort }}{% endif %}
+        host {{ subdomain.FromDomain }}
     }
     handle @{{ subdomain['@uuid'] }} {
 


### PR DESCRIPTION
Fixes: https://github.com/opnsense/plugins/issues/4024

- The subdomain port field has been removed, since it is unsupported. Subdomains track their ports from their parent wildcard domain.
- Filling this field out currently will result in site block that does not work properly, since it will not route requests to the upstream.
