### PR TITLE
www/caddy: Add more dns providers for os-caddy-1.5.7

### DIFF
--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -34,6 +34,8 @@ Plugin Changelog
 * Cleanup: Fix crash of searchAction when reverseUuids is null
 * Cleanup: basicauth directive is now basic_auth in the Caddyfile template, for caddy v2.8.4
 * Fix: The subdomain port field has been removed, since it is unsupported. Subdomains track their ports from their parent wildcard domain.
+* Add: DNS Providers: dnsmadeeasy, bunny, civo, scaleway, acmeproxy, inwx, namedotcom, easydns, infomaniak, directadmin, hosttech, vultr
+* Remove: DNS Providers: godaddy
 
 1.5.6
 

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dnsprovider.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dnsprovider.xml
@@ -9,7 +9,7 @@
         <id>caddy.general.TlsDnsApiKey</id>
         <label>DNS API Standard Field</label>
         <type>text</type>
-        <help><![CDATA[This is the standard field for the API Key. Field can be left empty if optional: Cloudflare "api_token", Duckdns "api_token", DigitalOcean "auth_token", Godaddy "api_token", Gandi "bearer_token", IONOS "api_token", deSEC "token", Route53 "access_key_id", Porkbun "api_key", ACME-DNS "username", Netlify "personal_access_token", Njalla "api_token", Google Cloud DNS "gcp_project", Azure "tenant_id", OVH "endpoint", Namecheap "api_key", PowerDNS "server_url", DDNSS "api_token", Linode "api_token", Tencent Cloud "secret_id", Dinahosting "username", Hexonet "username", Mail-in-a-Box "api_url", Netcup "customer_number", RFC2136 "key_name".]]></help>
+        <help><![CDATA[This is the standard field for the API Key. Field can be left empty if optional: Cloudflare "api_token", Duckdns "api_token", DigitalOcean "auth_token", Godaddy "api_token", Gandi "bearer_token", IONOS "api_token", deSEC "token", Route53 "access_key_id", Porkbun "api_key", ACME-DNS "username", Netlify "personal_access_token", Njalla "api_token", Google Cloud DNS "gcp_project", Azure "tenant_id", OVH "endpoint", Namecheap "api_key", PowerDNS "server_url", DDNSS "api_token", Linode "api_token", Tencent Cloud "secret_id", Dinahosting "username", Hexonet "username", Mail-in-a-Box "api_url", DNS Made Easy "api_key", Bunny "access_key", Civo "api_token", Scaleway "secret_key", ACME Proxy "username", INWX "username", Netcup "customer_number", RFC2136 "key_name", Name.com "token", EasyDNS "api_token", Infomaniak "api_token", DirectAdmin "host", Hosttech "api_token", Vultr "api_token"]]></help>
     </field>
     <field>
         <type>header</type>
@@ -20,19 +20,19 @@
         <id>caddy.general.TlsDnsSecretApiKey</id>
         <label>DNS API Additional Field 1</label>
         <type>text</type>
-        <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: Duckdns "override_domain", Route53 "secret_access_key", Porkbun "api_secret_key", ACME-DNS "password", Azure "client_id", OVH "application_key", Namecheap "user", PowerDNS "api_token", DDNSS "username", Linode "api_url", Tencent Cloud "secret_key", Dinahosting "password", Hexonet "password", Mail-in-a-Box "email_address", Netcup "api_key", RFC2136 "key_alg".]]></help>
+        <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: Duckdns "override_domain", Route53 "secret_access_key", Porkbun "api_secret_key", ACME-DNS "password", Azure "client_id", OVH "application_key", Namecheap "user", PowerDNS "api_token", DDNSS "username", Linode "api_url", Tencent Cloud "secret_key", Dinahosting "password", Hexonet "password", Mail-in-a-Box "email_address", DNS Made Easy "secret_key", Scaleway "organization_id", ACME Proxy "password", INWX "password", Netcup "api_key", RFC2136 "key_alg", Name.com "server", EasyDNS "api_key", DirectAdmin "user".]]></help>
     </field>
     <field>
         <id>caddy.general.TlsDnsOptionalField1</id>
         <label>DNS API Additional Field 2</label>
         <type>text</type>
-        <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: Route53 "max_retries", ACME-DNS "subdomain", Azure "client_secret", OVH "application_secret", Namecheap "api_endpoint", DDNSS "password", Linode "api_version", Mail-in-a-Box "password", Netcup "api_password", RFC2136 "key".]]></help>
+        <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: Route53 "max_retries", ACME-DNS "subdomain", Azure "client_secret", OVH "application_secret", Namecheap "api_endpoint", DDNSS "password", Linode "api_version", Mail-in-a-Box "password", DNS Made Easy "api_endpoint", ACME Proxy "endpoint", INWX "shared_secret", Netcup "api_password", Name.com "user", EasyDNS "api_url", DirectAdmin "login_key", RFC2136 "key".]]></help>
     </field>
     <field>
         <id>caddy.general.TlsDnsOptionalField2</id>
         <label>DNS API Additional Field 3</label>
         <type>text</type>
-        <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: Route53 "aws_profile", ACME-DNS "server_url", Azure "subscription_id", OVH "consumer_key", Namecheap "client_ip", DDNS "password", RFC2136 "server".]]></help>
+        <help><![CDATA[Leave empty if your DNS Provider isn't specified here. Field can be left empty if optional: Route53 "aws_profile", ACME-DNS "server_url", Azure "subscription_id", OVH "consumer_key", Namecheap "client_ip", DDNS "password", INWX "endpoint_url", DirectAdmin "insecure_requests", RFC2136 "server".]]></help>
     </field>
     <field>
         <id>caddy.general.TlsDnsOptionalField3</id>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//Pischem/caddy</mount>
     <description>A GUI model for configuring a reverse proxy in the Caddy web server.</description>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
     <items>
         <general>
             <enabled type="BooleanField">
@@ -26,7 +26,6 @@
                     <cloudflare>Cloudflare</cloudflare>
                     <duckdns>Duck DNS</duckdns>
                     <digitalocean>DigitalOcean</digitalocean>
-                    <godaddy>GoDaddy</godaddy>
                     <gandi>Gandi</gandi>
                     <ionos>IONOS</ionos>
                     <desec>Desec</desec>
@@ -48,6 +47,19 @@
                     <mailinabox>Mail-in-a-Box</mailinabox>
                     <netcup>Netcup</netcup>
                     <rfc2136>RFC2136</rfc2136>
+                    <dnsmadeeasy>DNS Made Easy</dnsmadeeasy>
+                    <bunny>Bunny</bunny>
+                    <civo>Civo</civo>
+                    <scaleway>Scaleway</scaleway>
+                    <acmeproxy>ACME Proxy</acmeproxy>
+                    <inwx>INWX</inwx>
+                    <netcup>Netcup</netcup>
+                    <namedotcom>Name.com</namedotcom>
+                    <easydns>EasyDNS</easydns>
+                    <infomaniak>Infomaniak</infomaniak>
+                    <directadmin>DirectAdmin</directadmin>
+                    <hosttech>Hosttech</hosttech>
+                    <vultr>Vultr</vultr>
                 </OptionValues>
             </TlsDnsProvider>
             <TlsDnsApiKey type="TextField"/>

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -143,7 +143,7 @@
 
     {% if dnsProvider and dnsProvider != "acmedns" and dynDnsDomains|length > 0 %}
         dynamic_dns {
-            {% if dnsProvider in ['porkbun', 'desec', 'route53', 'googleclouddns', 'azure', 'ovh', 'namecheap', 'powerdns', 'ddnss', 'linode', 'tencentcloud', 'dinahosting', 'hexonet', 'mailinabox', 'netcup', 'rfc2136'] %}
+            {% if dnsProvider in ['porkbun', 'desec', 'route53', 'googleclouddns', 'azure', 'ovh', 'namecheap', 'powerdns', 'ddnss', 'linode', 'tencentcloud', 'dinahosting', 'hexonet', 'mailinabox', 'netcup', 'rfc2136', 'dnsmadeeasy', 'civo', 'scaleway', 'acmeproxy', 'inwx', 'netcup', 'namedotcom', 'easydns', 'directadmin'] %}
                 provider {{ dnsProvider }} {
                     {% if dnsProvider == 'porkbun' %}
                         {% if dnsApiKey %}api_key {{ dnsApiKey }}
@@ -254,9 +254,64 @@
                         {% endif %}
                         {% if dnsOptionalField2 %}server {{ dnsOptionalField2 }}
                         {% endif %}
+                    {% elif dnsProvider == 'dnsmadeeasy' %}
+                        {% if dnsApiKey %}api_key {{ dnsApiKey }}
+                        {% endif %}
+                        {% if dnsSecretApiKey %}secret_key {{ dnsSecretApiKey }}
+                        {% endif %}
+                        {% if dnsOptionalField1 %}api_endpoint {{ dnsOptionalField1 }}
+                        {% endif %}
+                    {% elif dnsProvider == 'civo' %}
+                        {% if dnsApiKey %}api_token {{ dnsApiKey }}
+                        {% endif %}
+                    {% elif dnsProvider == 'scaleway' %}
+                        {% if dnsApiKey %}secret_key {{ dnsApiKey }}
+                        {% endif %}
+                        {% if dnsSecretApiKey %}organization_id {{ dnsSecretApiKey }}
+                        {% endif %}
+                    {% elif dnsProvider == 'acmeproxy' %}
+                        {% if dnsApiKey %}username {{ dnsApiKey }}
+                        {% endif %}
+                        {% if dnsSecretApiKey %}password {{ dnsSecretApiKey }}
+                        {% endif %}
+                        {% if dnsOptionalField1 %}endpoint {{ dnsOptionalField1 }}
+                        {% endif %}
+                    {% elif dnsProvider == 'inwx' %}
+                        {% if dnsApiKey %}username {{ dnsApiKey }}
+                        {% endif %}
+                        {% if dnsSecretApiKey %}password {{ dnsSecretApiKey }}
+                        {% endif %}
+                        {% if dnsOptionalField1 %}shared_secret {{ dnsOptionalField1 }}
+                        {% endif %}
+                        {% if dnsOptionalField2 %}endpoint_url {{ dnsOptionalField2 }}
+                        {% endif %}
+                    {% elif dnsProvider == 'namedotcom' %}
+                        {% if dnsApiKey %}token {{ dnsApiKey }}
+                        {% endif %}
+                        {% if dnsSecretApiKey %}server {{ dnsSecretApiKey }}
+                        {% endif %}
+                        {% if dnsOptionalField1 %}user {{ dnsOptionalField1 }}
+                        {% endif %}
+                    {% elif dnsProvider == 'easydns' %}
+                        {% if dnsApiKey %}api_token {{ dnsApiKey }}
+                        {% endif %}
+                        {% if dnsSecretApiKey %}api_key {{ dnsSecretApiKey }}
+                        {% endif %}
+                        {% if dnsOptionalField1 %}api_url {{ dnsOptionalField1 }}
+                        {% endif %}
+                    {% elif dnsProvider == 'directadmin' %}
+                        {% if dnsApiKey %}host {{ dnsApiKey }}
+                        {% endif %}
+                        {% if dnsSecretApiKey %}user {{ dnsSecretApiKey }}
+                        {% endif %}
+                        {% if dnsOptionalField1 %}login_key {{ dnsOptionalField1 }}
+                        {% endif %}
+                        {% if dnsOptionalField2 %}insecure_requests {{ dnsOptionalField2 }}
+                        {% endif %}
                     {% endif %}
                 }
             {% else %}
+                {# Other DNS Providers fall under this default #}
                 provider {{ dnsProvider }} {{ dnsApiKey }}
             {% endif %}
             domains {
@@ -358,7 +413,7 @@
 #}
 {% macro tls_configuration(dnsProvider, dnsApiKey, customCert, dnsChallenge, dnsSecretApiKey, TlsDnsOptionalField1, TlsDnsOptionalField2, TlsDnsOptionalField3, TlsDnsOptionalField4) %}
     {% if dnsChallenge == "1" and dnsProvider %}
-        {% if dnsProvider in ['duckdns', 'porkbun', 'desec', 'route53', 'acmedns', 'googleclouddns', 'azure', 'ovh', 'namecheap', 'powerdns', 'ddnss', 'linode', 'tencentcloud', 'dinahosting', 'hexonet', 'mailinabox', 'netcup', 'rfc2136'] %}
+        {% if dnsProvider in ['duckdns', 'porkbun', 'desec', 'route53', 'acmedns', 'googleclouddns', 'azure', 'ovh', 'namecheap', 'powerdns', 'ddnss', 'linode', 'tencentcloud', 'dinahosting', 'hexonet', 'mailinabox', 'netcup', 'rfc2136', 'dnsmadeeasy', 'civo', 'scaleway', 'acmeproxy', 'inwx', 'netcup', 'namedotcom', 'easydns', 'directadmin'] %}
             tls {
                 dns {{ dnsProvider }} {
                     {% if dnsProvider == 'duckdns' %}
@@ -484,11 +539,66 @@
                         {% endif %}
                         {% if dnsOptionalField2 %}server {{ dnsOptionalField2 }}
                         {% endif %}
+                    {% elif dnsProvider == 'dnsmadeeasy' %}
+                        {% if dnsApiKey %}api_key {{ dnsApiKey }}
+                        {% endif %}
+                        {% if dnsSecretApiKey %}secret_key {{ dnsSecretApiKey }}
+                        {% endif %}
+                        {% if dnsOptionalField1 %}api_endpoint {{ dnsOptionalField1 }}
+                        {% endif %}
+                    {% elif dnsProvider == 'civo' %}
+                        {% if dnsApiKey %}api_token {{ dnsApiKey }}
+                        {% endif %}
+                    {% elif dnsProvider == 'scaleway' %}
+                        {% if dnsApiKey %}secret_key {{ dnsApiKey }}
+                        {% endif %}
+                        {% if dnsSecretApiKey %}organization_id {{ dnsSecretApiKey }}
+                        {% endif %}
+                    {% elif dnsProvider == 'acmeproxy' %}
+                        {% if dnsApiKey %}username {{ dnsApiKey }}
+                        {% endif %}
+                        {% if dnsSecretApiKey %}password {{ dnsSecretApiKey }}
+                        {% endif %}
+                        {% if dnsOptionalField1 %}endpoint {{ dnsOptionalField1 }}
+                        {% endif %}
+                    {% elif dnsProvider == 'inwx' %}
+                        {% if dnsApiKey %}username {{ dnsApiKey }}
+                        {% endif %}
+                        {% if dnsSecretApiKey %}password {{ dnsSecretApiKey }}
+                        {% endif %}
+                        {% if dnsOptionalField1 %}shared_secret {{ dnsOptionalField1 }}
+                        {% endif %}
+                        {% if dnsOptionalField2 %}endpoint_url {{ dnsOptionalField2 }}
+                        {% endif %}
+                    {% elif dnsProvider == 'namedotcom' %}
+                        {% if dnsApiKey %}token {{ dnsApiKey }}
+                        {% endif %}
+                        {% if dnsSecretApiKey %}server {{ dnsSecretApiKey }}
+                        {% endif %}
+                        {% if dnsOptionalField1 %}user {{ dnsOptionalField1 }}
+                        {% endif %}
+                    {% elif dnsProvider == 'easydns' %}
+                        {% if dnsApiKey %}api_token {{ dnsApiKey }}
+                        {% endif %}
+                        {% if dnsSecretApiKey %}api_key {{ dnsSecretApiKey }}
+                        {% endif %}
+                        {% if dnsOptionalField1 %}api_url {{ dnsOptionalField1 }}
+                        {% endif %}
+                    {% elif dnsProvider == 'directadmin' %}
+                        {% if dnsApiKey %}host {{ dnsApiKey }}
+                        {% endif %}
+                        {% if dnsSecretApiKey %}user {{ dnsSecretApiKey }}
+                        {% endif %}
+                        {% if dnsOptionalField1 %}login_key {{ dnsOptionalField1 }}
+                        {% endif %}
+                        {% if dnsOptionalField2 %}insecure_requests {{ dnsOptionalField2 }}
+                        {% endif %}
                     {% endif %}
                 }
             }
         {% else %}
             tls {
+                {# Other DNS Providers fall under this default #}
                 dns {{ dnsProvider }} {{ dnsApiKey }}
             }
         {% endif %}


### PR DESCRIPTION
Requires: https://github.com/opnsense/tools/pull/415

* Add dns providers: dnsmadeeasy, bunny, civo, scaleway, acmeproxy, inwx, namedotcom, easydns, infomaniak, directadmin, hosttech, vultr, 
* Remove dns providers: godaddy (Changes in their API policy makes the API only usable if you own 50 or more domains with them, making it pretty much unusable, doubt the plugin is going to be maintained now. If this changes it will be re-added, or upon request.)