### PR TITLE
www/caddy: Change TTL of DNS Records set by dynamic DNS from hours to seconds

### DIFF
--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -33,6 +33,7 @@ Plugin Changelog
 * Add: Error message when Auto HTTPS is enabled, and ACME email field is empty, for caddy v2.8.4
 * Cleanup: Fix crash of searchAction when reverseUuids is null
 * Cleanup: basicauth directive is now basic_auth in the Caddyfile template, for caddy v2.8.4
+* Change: Dynamic DNS TTL has been changed from hours to seconds. Existing values have been reset to use the defaults of the implementation.
 * Fix: The subdomain port field has been removed, since it is unsupported. Subdomains track their ports from their parent wildcard domain.
 * Add: DNS Providers: dnsmadeeasy, bunny, civo, scaleway, acmeproxy, inwx, namedotcom, easydns, infomaniak, directadmin, hosttech, vultr
 * Remove: DNS Providers: godaddy

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dynamicdns.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dynamicdns.xml
@@ -15,7 +15,7 @@
         <id>caddy.general.DynDnsTTL</id>
         <label>DynDns TTL</label>
         <type>text</type>
-        <help><![CDATA[Set the TTL (Time to Live) for DNS records. The default is 1 hour. Values can range from 1 to 24 hours.]]></help>
+        <help><![CDATA[Set the TTL (Time to Live) for DNS records in seconds. Can be left empty to use the defaults of the dynamicdns module. If set, values should be as defined in rfc2181 section 8.]]></help>
     </field>
     <field>
         <type>header</type>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//Pischem/caddy</mount>
     <description>A GUI model for configuring a reverse proxy in the Caddy web server.</description>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
     <items>
         <general>
             <enabled type="BooleanField">
@@ -122,13 +122,7 @@
                     <ipv6>IPv6 only</ipv6>
                 </OptionValues>
             </DynDnsIpVersions>
-            <DynDnsTTL type="IntegerField">
-                <Default>1</Default>
-                <MinimumValue>1</MinimumValue>
-                <MaximumValue>24</MaximumValue>
-                <ValidationMessage>Please enter a valid number from 1 to 24 hours.</ValidationMessage>
-                <Required>Y</Required>
-            </DynDnsTTL>
+            <DynDnsTtl type="IntegerField"/>
         </general>
         <reverseproxy>
             <reverse type="ArrayField">

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -117,7 +117,7 @@
     {% set dynDnsInterface = generalSettings.DynDnsInterface %}
     {% set dynDnsCheckInterval = generalSettings.DynDnsCheckInterval %}
     {% set dynDnsIpVersions = generalSettings.DynDnsIpVersions %}
-    {% set dynDnsTTL = generalSettings.DynDnsTTL %}
+    {% set dynDnsTtl = generalSettings.DynDnsTtl %}
     {% set dynDnsDomains = [] %}
 
     {% for reverse in helpers.toList('Pischem.caddy.reverseproxy.reverse') %}
@@ -335,8 +335,8 @@
         {% if dynDnsIpVersions %}
         versions {{ dynDnsIpVersions }}
         {% endif %}
-        {% if dynDnsTTL %}
-        ttl {{ dynDnsTTL }}h
+        {% if dynDnsTtl %}
+        ttl {{ dynDnsTtl }}s
         {% endif %}
     }
     {% endif %}


### PR DESCRIPTION
This change makes use of the default migration by changing the field name.

The default of the old field was 1 hour, which is way too high for dynamic dns. I doubt anybody would choose a higher value than 1 hour.

So, this change changes the field name to a new one, making it empty with the default migration. It can be left empty, the template won't render the field and it will use the defaults of the dynamicDNS module.

Anybody else who defines a TTL, will be able to do so in seconds. There is no explicit validation of the integer range, because it is a non required field, and the https://www.rfc-editor.org/rfc/rfc2181#section-8 defines it between 0 and a very high integer. If there is a user error here it will be caught by the Caddyfile validation.

This change fixes the problem with minimal breakage for existing users, without having to use a custom migration, keeping the code clean.

Fixes: https://github.com/opnsense/plugins/issues/4037