### PR TITLE
www/caddy: Fix type error in configAction of DiagnosticsController.

### DIFF
--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/DiagnosticsController.php
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/Api/DiagnosticsController.php
@@ -61,8 +61,6 @@ class DiagnosticsController extends ApiMutableModelControllerBase
         $this->response->setContentType('application/json', 'UTF-8');
         // Encode and set the content
         $this->response->setContent(json_encode($response, JSON_PRETTY_PRINT));
-
-        return $this->response;
     }
 
     /**


### PR DESCRIPTION
Fixes this:

``
[17-Jun-2024 16:08:31 Etc/UTC] TypeError: Cannot assign OPNsense\Mvc\Response to property OPNsense\Mvc\Dispatcher::$returnedValue of type array|string|null in /usr/local/opnsense/mvc/app/library/OPNsense/Mvc/Dispatcher.php:165
``
