### PR TITLE
dns/bind: Fix handling of multiple ACLs in allow-query/allow-transfer

### DIFF
--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
@@ -58,7 +58,7 @@ options {
 
 {% if helpers.exists('OPNsense.bind.general.allowtransfer') and OPNsense.bind.general.allowtransfer != '' %}
         allow-transfer {
-{%              for acl in helpers.toList('OPNsense.bind.general.allowtransfer') %}
+{%              for acl in OPNsense.bind.general.allowtransfer.split(',') %}
 {%              set transfer_acl = helpers.getUUID(acl) %}
                 {{ transfer_acl.name }};
 {%              endfor %}
@@ -67,7 +67,7 @@ options {
 
 {% if helpers.exists('OPNsense.bind.general.allowquery') and OPNsense.bind.general.allowquery != '' %}
         allow-query {
-{%              for acl in helpers.toList('OPNsense.bind.general.allowquery') %}
+{%              for acl in OPNsense.bind.general.allowquery.split(',') %}
 {%              set query_acl = helpers.getUUID(acl) %}
                 {{ query_acl.name }};
 {%              endfor %}


### PR DESCRIPTION
Selecting multiple ACLs under the General tab currently results in invalid config:

```
        allow-transfer {
                ;
        };

        allow-query {
                ;
        };
```

This corrects the behaviour:

```
        allow-recursion {
                LAN;
                VPN;
        };


        allow-query {
                LAN;
                VPN;
        };
```
