### PR TITLE
www/caddy: Fix IPv6 address + Port combination in Caddyfile template

### DIFF
--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
@@ -10,7 +10,7 @@
         <label>Domain</label>
         <type>text</type>
         <hint>example.com</hint>
-        <help><![CDATA[Enter a domain name or IP address. For a base domain, use "example.com" or "opn.example.com". Using a base domain enables automatic "Let's Encrypt" and "ZeroSSL" certificates by default. For a wildcard domain, use "*.example.com". Only use wildcard domains with wildcard certificates, which require a DNS Provider.]]></help>
+        <help><![CDATA[Enter a domain name. For a base domain, use "example.com" or "opn.example.com". Using a base domain enables automatic "Let's Encrypt" and "ZeroSSL" certificates by default. For a wildcard domain, use "*.example.com". Only use wildcard domains with wildcard certificates, which require a DNS Provider.]]></help>
     </field>
     <field>
         <id>reverse.FromPort</id>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -136,6 +136,7 @@
                 <FromDomain type="HostnameField">
                     <Required>Y</Required>
                     <ValidationMessage>Please enter a valid 'from' domain.</ValidationMessage>
+                    <IpAllowed>N</IpAllowed>
                     <HostWildcardAllowed>Y</HostWildcardAllowed>
                     <FqdnWildcardAllowed>Y</FqdnWildcardAllowed>
                     <ZoneRootAllowed>N</ZoneRootAllowed>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -135,8 +135,7 @@
                 </enabled>
                 <FromDomain type="HostnameField">
                     <Required>Y</Required>
-                    <ValidationMessage>Please enter a valid 'from' domain or IP address.</ValidationMessage>
-                    <IpAllowed>Y</IpAllowed>
+                    <ValidationMessage>Please enter a valid 'from' domain.</ValidationMessage>
                     <HostWildcardAllowed>Y</HostWildcardAllowed>
                     <FqdnWildcardAllowed>Y</FqdnWildcardAllowed>
                     <ZoneRootAllowed>N</ZoneRootAllowed>

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -350,9 +350,11 @@
         rewrite * {{ handle.ToPath }}{uri}
         {% endif %}
         reverse_proxy {% for domain in handle.ToDomain.split(',') %}
+            {# Check if the domain is IPv6 and wrap in square brackets if necessary #}
+            {% set is_ipv6 = (':' in domain and domain.count(':') >= 2) %}
             {# For each domain/IP, append the port if it's specified, followed by a space #}
-            {{- domain -}}{% if handle.ToPort %}:{{ handle.ToPort }}{% endif %}{% if not loop.last %} {% endif %}
-        {% endfor %}{
+            {{- '[' if is_ipv6 else '' -}}{{ domain }}{{ ']' if is_ipv6 else '' -}}{% if handle.ToPort %}:{{ handle.ToPort }}{% endif %}{% if not loop.last %} {% endif %}
+        {% endfor %} {
             {{ header_manipulation(handle) }}
             {% if handle.PassiveHealthFailDuration|default("") %}
             fail_duration {{ handle.PassiveHealthFailDuration }}s


### PR DESCRIPTION
Fixes: https://forum.opnsense.org/index.php?topic=41203

- IPv6 will be detected and put into square brackets. 
- Additionally removed that IP addresses are valid in the frontend domain, since that would break some template sections like dyndns and certificate generation, so it is unsupported in the scope of the GUI.

Before the fix:

```
handle @66b595d6-ed36-458b-83a4-b48fecb89416 {
		handle {
			reverse_proxy 192.168.1.1:81 2003::1:81 example.com:81 fd00:00::1:81 {
			}
		}
	}
```

After the fix:

```
handle @66b595d6-ed36-458b-83a4-b48fecb89416 {
		handle {
			reverse_proxy 192.168.1.1:81 [2003::1]:81 example.com:81 [fd00:00::1]:81 {
			}
		}
	}
```