### PR TITLE
dns/rfc2136: delete cache files if nsupdate failed

### DIFF
--- a/dns/rfc2136/src/etc/inc/plugins.inc.d/rfc2136.inc
+++ b/dns/rfc2136/src/etc/inc/plugins.inc.d/rfc2136.inc
@@ -200,14 +200,26 @@ function rfc2136_configure_do($verbose = false, $int = '', $updatehost = '', $fo
         if ($need_update) {
             @file_put_contents("/var/etc/nsupdatecmds{$i}", $upinst);
             unset($upinst);
+
             /* invoke nsupdate */
             $cmd = "/usr/local/bin/nsupdate -k {$keyfile}";
             if (isset($dnsupdate['usetcp'])) {
                 $cmd .= " -v";
             }
+
             $cmd .= " /var/etc/nsupdatecmds{$i}";
-            mwexec_bg($cmd);
-            unset($cmd);
+
+            //mwexec_bg($cmd);
+            $out = shell_exec($cmd." 2>&1; echo $?");
+            $status = ((int)trim(end(explode("\n", trim($out)))));
+
+            if ($status > 0) {
+                @unlink($cacheFile);
+                @unlink($cacheFile6);
+                log_error("Dynamic DNS: update failed, delete cache files");
+            }
+
+            unset($cmd, $status);
         }
     }
 


### PR DESCRIPTION
See #4055.

> Similar to #2752, updating my DynDNS Domain via the rfc2136 plugin does not work. I added some log lines to the plugin code and it looks like the update fails at rc.bootup because the internet connection is not established yet. Later on rc.newwanip the plugin reports the IP was not changed and the nsupdate call is skipped.

> My workaround is to delete the cache files when the exit code of the nsupdate command is not zero.