### PR TITLE
www/caddy: Add forward_auth functionality, auth provider Authelia added.

### DIFF
--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/GeneralController.php
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/GeneralController.php
@@ -42,6 +42,7 @@ class GeneralController extends IndexController
         $this->view->generalForm = $this->getForm("general");
         $this->view->dnsproviderForm = $this->getForm("dnsprovider");
         $this->view->dynamicdnsForm = $this->getForm("dynamicdns");
+        $this->view->authproviderForm = $this->getForm("authprovider");
         $this->view->logsettingsForm = $this->getForm("logsettings");
     }
 }

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/authprovider.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/authprovider.xml
@@ -1,0 +1,32 @@
+<form>
+    <field>
+        <id>caddy.general.AuthProvider</id>
+        <label>Forward Auth Provider</label>
+        <type>dropdown</type>
+        <help><![CDATA[Select a Forward Auth Provider. It can be added inside a "Handler" by enabling the "Forward Auth" checkbox. For Authelia only the basic subdomain example is supported. More information: https://www.authelia.com/integration/proxies/caddy/#basic-examples]]></help>
+    </field>
+    <field>
+        <id>caddy.general.AuthToDomain</id>
+        <label>Forward Auth Domain</label>
+        <type>text</type>
+        <help><![CDATA[Enter the domain name or IP address of the chosen Forward Auth Provider.]]></help>
+    </field>
+    <field>
+        <id>caddy.general.AuthToPort</id>
+        <label>Forward Auth Port</label>
+        <type>text</type>
+        <help><![CDATA[Enter the listen port of the chosen Forward Auth Provider.]]></help>
+    </field>
+    <field>
+        <id>caddy.general.AuthToTls</id>
+        <label>TLS</label>
+        <type>checkbox</type>
+        <help><![CDATA[Enable or disable HTTP over TLS (HTTPS) to communicate with the Forward Auth Provider.]]></help>
+    </field>
+    <field>
+        <id>caddy.general.AuthToUri</id>
+        <label>Forward Auth URI</label>
+        <type>text</type>
+        <help><![CDATA[Enter the URI of the authz api endpoint.]]></help>
+    </field>
+</form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -38,6 +38,17 @@
     </field>
     <field>
         <type>header</type>
+        <label>Access</label>
+        <collapse>true</collapse>
+    </field>
+    <field>
+        <id>handle.ForwardAuth</id>
+        <label>Forward Auth</label>
+        <type>checkbox</type>
+        <help><![CDATA[Enable or disable Forward Auth. Requires an "Auth Provider" in "General Settings". Headers are set automatically to the standard of the chosen provider. Enabling this option will additionally generate the forward_auth directive in front of the reverse_proxy directive inside the scope of this handler.]]></help>
+    </field>
+    <field>
+        <type>header</type>
         <label>Header</label>
         <collapse>true</collapse>
     </field>
@@ -86,17 +97,6 @@
         <label>Upstream Fail Duration</label>
         <type>text</type>
         <help><![CDATA[Enables a passive health check when multiple destinations in "Upstream Domain" are set. "Fail Duration" is a value that defines how long to remember a failed request. A duration of 1 or more seconds enables passive health checking; the default is empty (off). A reasonable starting point might be 30s to balance error rates with responsiveness when bringing an unhealthy upstream back online.]]></help>
-    </field>
-    <field>
-        <type>header</type>
-        <label>Access</label>
-        <collapse>true</collapse>
-    </field>
-    <field>
-        <id>handle.ForwardAuth</id>
-        <label>Forward Auth</label>
-        <type>checkbox</type>
-        <help><![CDATA[Enable or disable Forward Auth. Requires an "Auth Provider" in "General Settings". Headers are set automatically to the standard of the chosen provider.]]></help>
     </field>
     <field>
         <type>header</type>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -89,6 +89,17 @@
     </field>
     <field>
         <type>header</type>
+        <label>Access</label>
+        <collapse>true</collapse>
+    </field>
+    <field>
+        <id>handle.ForwardAuth</id>
+        <label>Forward Auth</label>
+        <type>checkbox</type>
+        <help><![CDATA[Enable or disable Forward Auth. Requires an "Auth Provider" in "General Settings". Headers are set automatically to the standard of the chosen provider.]]></help>
+    </field>
+    <field>
+        <type>header</type>
         <label>Trust</label>
         <collapse>true</collapse>
     </field>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -132,17 +132,9 @@
                     <authelia>Authelia</authelia>
                 </OptionValues>
             </AuthProvider>
-            <AuthToDomain type="HostnameField">
-                <ValidationMessage>Please enter a valid 'to' domain.</ValidationMessage>
-                <IpAllowed>Y</IpAllowed>
-                <HostWildcardAllowed>N</HostWildcardAllowed>
-                <FqdnWildcardAllowed>N</FqdnWildcardAllowed>
-                <ZoneRootAllowed>N</ZoneRootAllowed>
-            </AuthToDomain>
+            <AuthToDomain type="HostnameField"/>
             <AuthToPort type="PortField">
-                <ValidationMessage>Please enter a valid 'to' port number.</ValidationMessage>
                 <EnableWellKnown>Y</EnableWellKnown>
-                <EnableRanges>N</EnableRanges>
             </AuthToPort>
             <AuthToTls type="BooleanField"/>
             <AuthToUri type="TextField">

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -133,9 +133,7 @@
                 </OptionValues>
             </AuthProvider>
             <AuthToDomain type="HostnameField"/>
-            <AuthToPort type="PortField">
-                <EnableWellKnown>Y</EnableWellKnown>
-            </AuthToPort>
+            <AuthToPort type="PortField"/>
             <AuthToTls type="BooleanField"/>
             <AuthToUri type="TextField">
                 <Mask>/^(\/.*)?$/u</Mask>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -349,8 +349,8 @@
                 <HttpTlsServerName type="HostnameField">
                     <ValidationMessage>Please enter a valid hostname or IP address.</ValidationMessage>
                     <IpAllowed>Y</IpAllowed>
-                    <HostWildcardAllowed>Y</HostWildcardAllowed>
-                    <FqdnWildcardAllowed>Y</FqdnWildcardAllowed>
+                    <HostWildcardAllowed>N</HostWildcardAllowed>
+                    <FqdnWildcardAllowed>N</FqdnWildcardAllowed>
                     <ZoneRootAllowed>N</ZoneRootAllowed>
                 </HttpTlsServerName>
                 <description type="DescriptionField">

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -126,6 +126,29 @@
                 <ValidationMessage>Please enter a valid number from 0 to 2147483647 seconds or leave empty for default.</ValidationMessage>
             </DynDnsTtl>
             <DynDnsUpdateOnly type="BooleanField"/>
+            <AuthProvider type="OptionField">
+                <BlankDesc>None (default)</BlankDesc>
+                <OptionValues>
+                    <authelia>Authelia</authelia>
+                </OptionValues>
+            </AuthProvider>
+            <AuthToDomain type="HostnameField">
+                <ValidationMessage>Please enter a valid 'to' domain.</ValidationMessage>
+                <IpAllowed>Y</IpAllowed>
+                <HostWildcardAllowed>Y</HostWildcardAllowed>
+                <FqdnWildcardAllowed>Y</FqdnWildcardAllowed>
+                <ZoneRootAllowed>N</ZoneRootAllowed>
+            </AuthToDomain>
+            <AuthToPort type="PortField">
+                <ValidationMessage>Please enter a valid 'to' port number.</ValidationMessage>
+                <EnableWellKnown>Y</EnableWellKnown>
+                <EnableRanges>N</EnableRanges>
+            </AuthToPort>
+            <AuthToTls type="BooleanField"/>
+            <AuthToUri type="TextField">
+                <Mask>/^(\/.*)?$/u</Mask>
+                <ValidationMessage>Please enter a valid 'URI' that starts with '/'.</ValidationMessage>
+            </AuthToUri>
         </general>
         <reverseproxy>
             <reverse type="ArrayField">
@@ -300,6 +323,7 @@
                     <MaximumValue>100</MaximumValue>
                     <ValidationMessage>Please enter a value between 1 to 100.</ValidationMessage>
                 </PassiveHealthFailDuration>
+                <ForwardAuth type="BooleanField"/>
                 <HttpTls type="BooleanField">
                     <Constraints>
                         <check001>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -135,8 +135,8 @@
             <AuthToDomain type="HostnameField">
                 <ValidationMessage>Please enter a valid 'to' domain.</ValidationMessage>
                 <IpAllowed>Y</IpAllowed>
-                <HostWildcardAllowed>Y</HostWildcardAllowed>
-                <FqdnWildcardAllowed>Y</FqdnWildcardAllowed>
+                <HostWildcardAllowed>N</HostWildcardAllowed>
+                <FqdnWildcardAllowed>N</FqdnWildcardAllowed>
                 <ZoneRootAllowed>N</ZoneRootAllowed>
             </AuthToDomain>
             <AuthToPort type="PortField">
@@ -349,8 +349,8 @@
                 <HttpTlsServerName type="HostnameField">
                     <ValidationMessage>Please enter a valid hostname or IP address.</ValidationMessage>
                     <IpAllowed>Y</IpAllowed>
-                    <HostWildcardAllowed>N</HostWildcardAllowed>
-                    <FqdnWildcardAllowed>N</FqdnWildcardAllowed>
+                    <HostWildcardAllowed>Y</HostWildcardAllowed>
+                    <FqdnWildcardAllowed>Y</FqdnWildcardAllowed>
                     <ZoneRootAllowed>N</ZoneRootAllowed>
                 </HttpTlsServerName>
                 <description type="DescriptionField">

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/general.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/general.volt
@@ -137,6 +137,7 @@
     <li class="active"><a data-toggle="tab" href="#generalTab">{{ lang._('General') }}</a></li>
     <li><a data-toggle="tab" href="#dnsProviderTab">{{ lang._('DNS Provider') }}</a></li>
     <li><a data-toggle="tab" href="#dynamicDnsTab">{{ lang._('Dynamic DNS') }}</a></li>
+    <li><a data-toggle="tab" href="#authProviderTab">{{ lang._('Auth Provider') }}</a></li>
     <li><a data-toggle="tab" href="#logSettingsTab">{{ lang._('Log Settings') }}</a></li>
 </ul>
 
@@ -153,6 +154,10 @@
     <!-- Dynamic DNS Tab -->
     <div id="dynamicDnsTab" class="tab-pane fade">
         {{ partial("layout_partials/base_form", ['fields': dynamicdnsForm, 'action': '/ui/caddy/general', 'id': 'frm_GeneralSettings']) }}
+    </div>
+    <!-- Auth Provider Tab -->
+    <div id="authProviderTab" class="tab-pane fade">
+        {{ partial("layout_partials/base_form", ['fields': authproviderForm, 'action': '/ui/caddy/general', 'id': 'frm_GeneralSettings']) }}
     </div>
     <!-- Log Settings Tab -->
     <div id="logSettingsTab" class="tab-pane fade">

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -334,6 +334,7 @@
                             <th data-column-id="ToPort" data-type="string">{{ lang._('Upstream Port') }}</th>
                             <th data-column-id="ToPath" data-type="string" data-visible="false">{{ lang._('Upstream Path') }}</th>
                             <th data-column-id="PassiveHealthFailDuration" data-type="string" data-visible="false">{{ lang._('Fail Duration') }}</th>
+                            <th data-column-id="ForwardAuth" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('Forward Auth') }}</th>
                             <th data-column-id="HttpTls" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('TLS') }}</th>
                             <th data-column-id="HttpTlsTrustedCaCerts" data-type="string" data-visible="false">{{ lang._('TLS CA') }}</th>
                             <th data-column-id="HttpTlsServerName" data-type="string" data-visible="false">{{ lang._('TLS Server Name') }}</th>

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -346,6 +346,9 @@
 #}
 {% macro reverse_proxy_configuration(handle) %}
     {{ handle.HandleType }} {{ handle.HandlePath|default("") }} {
+        {% if handle.ForwardAuth|default("0") == "1" %}
+            {% include "OPNsense/Caddy/includeAuthProvider" %}
+        {% endif %}
         {% if handle.ToPath|default("") != "" %}
         rewrite * {{ handle.ToPath }}{uri}
         {% endif %}

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/includeAuthProvider
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/includeAuthProvider
@@ -3,7 +3,9 @@
 # - Section: Reverse Proxy Configurations
 #}
 {% if generalSettings.AuthProvider == 'authelia' %}
-    forward_auth {% if generalSettings.AuthToTls|default("0") == "1" %}https://{% endif %}{{ generalSettings.AuthToDomain|default("") }}{% if generalSettings.AuthToPort %}:{{ generalSettings.AuthToPort }}{% endif %} {
+    {# Check if the domain is IPv6 and wrap in square brackets if necessary #}
+    {% set is_ipv6 = (':' in generalSettings.AuthToDomain and generalSettings.AuthToDomain.count(':') >= 2) %}
+    forward_auth {% if generalSettings.AuthToTls|default("0") == "1" %}https://{% endif %}{{ '[' if is_ipv6 else '' }}{{ generalSettings.AuthToDomain|default("") }}{{ ']' if is_ipv6 else '' }}{% if generalSettings.AuthToPort %}:{{ generalSettings.AuthToPort }}{% endif %} {
     {% if generalSettings.AuthToUri %}uri {{ generalSettings.AuthToUri|default("") }}{% endif %}
 
     copy_headers Remote-User Remote-Groups Remote-Name Remote-Email

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/includeAuthProvider
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/includeAuthProvider
@@ -1,0 +1,11 @@
+{#
+# This file gets imported to configure forward auth in handlers.
+# - Section: Reverse Proxy Configurations
+#}
+{% if generalSettings.AuthProvider == 'authelia' %}
+    forward_auth {% if generalSettings.AuthToTls|default("0") == "1" %}https://{% endif %}{{ generalSettings.AuthToDomain|default("") }}{% if generalSettings.AuthToPort %}:{{ generalSettings.AuthToPort }}{% endif %} {
+    {% if generalSettings.AuthToUri %}uri {{ generalSettings.AuthToUri|default("") }}{% endif %}
+
+    copy_headers Remote-User Remote-Groups Remote-Name Remote-Email
+    }
+{% endif %}


### PR DESCRIPTION
Fixes: https://github.com/opnsense/plugins/issues/4056

This adds a generic and standard approach to forward_auth: https://caddyserver.com/docs/caddyfile/directives/forward_auth.

This implementation generates the default configuration for Authelia based on the documentation: https://caddyserver.com/docs/caddyfile/directives/forward_auth#authelia

Authelia is open source and a partner of Caddy, so this configuration is standardized. https://www.authelia.com/

Users can customize ```domain```, ```port```,```tls```, and the ```uri```. Only one Auth Provider can be serialized to the config.
```copy_headers``` are added automatically as per documentation standard without customization options.

To use it, the Forward Auth Provider has to be configured in "General Settings - Auth Provider". Afterwards, in any ```handle``` the tab "Access" has the option ```Forward Auth```. Enabling this checkbox will prepend the ```forward_auth``` directive before the ```reverse_proxy``` directive.

This should work with both ```domains```, and ```subdomains```.

An example generated config:

```
# Reverse Proxy Domain: "d5d05c2d-3f3a-4cd7-b6bf-0755cbbeb42b"
abc.example.com {
	handle {
		forward_auth https://authelia:9001 {
			uri /api/verify?rd=https://auth.example.com
			copy_headers Remote-User Remote-Groups Remote-Name Remote-Email
		}
		reverse_proxy 192.168.1.1:81 {
		}
	}
}
```