### PR TITLE
Added Gandi support to ddclient native backend.

### DIFF
--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/gandi.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/gandi.py
@@ -31,8 +31,6 @@ from . import BaseAccount
 
 
 class Gandi(BaseAccount):
-    _priority = 65535
-
     _services = {
         'gandi': 'api.gandi.net'
     }

--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/gandi.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/gandi.py
@@ -1,6 +1,6 @@
 """
-    Copyright (c) 2023 Thomas Cekal <thomas@cekal.org>
-    Copyright (c) 2023 Ad Schellevis <ad@opnsense.org>
+    Copyright (c) 2024 Thomas Cekal <thomas@cekal.org>
+    Copyright (c) 2024 Ad Schellevis <ad@opnsense.org>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without
@@ -51,13 +51,7 @@ class Gandi(BaseAccount):
     def execute(self):
         if super().execute():
             # IPv4/IPv6
-            recordType = None
-            if str(self.current_address).find(':') > 1:
-                #IPv6
-                recordType = "AAAA"
-            else:
-                #IPv4
-                recordType = "A"
+            recordType = "AAAA" if str(self.current_address).find(':') > 1 else "A"
 
             # Use bearer (api key) authentication
             url = "https://api.gandi.net/v5/livedns/domains/" + self.settings.get('zone') + "/records/" + self.settings.get('hostnames') + "/" + recordType

--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/gandi.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/gandi.py
@@ -1,0 +1,89 @@
+"""
+    Copyright (c) 2023 Thomas Cekal <thomas@cekal.org>
+    Copyright (c) 2023 Ad Schellevis <ad@opnsense.org>
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+"""
+import json
+import syslog
+import requests
+from . import BaseAccount
+
+
+class Gandi(BaseAccount):
+    _priority = 65535
+
+    _services = {
+        'gandi': 'api.gandi.net'
+    }
+
+    def __init__(self, account: dict):
+        super().__init__(account)
+
+    @staticmethod
+    def known_services():
+        return  Gandi._services.keys()
+
+    @staticmethod
+    def match(account):
+        return account.get('service') in Gandi._services
+
+    def execute(self):
+        if super().execute():
+            # IPv4/IPv6
+            recordType = None
+            if str(self.current_address).find(':') > 1:
+                #IPv6
+                recordType = "AAAA"
+            else:
+                #IPv4
+                recordType = "A"
+
+            # Use bearer (api key) authentication
+            url = "https://api.gandi.net/v5/livedns/domains/" + self.settings.get('zone') + "/records/" + self.settings.get('hostnames') + "/" + recordType
+            payload = "{\"rrset_values\":[\"" + self.current_address + "\"],\"rrset_ttl\":300}"
+            headers = {
+                'authorization': "Bearer " + self.settings.get('password'),
+                'content-type': "application/json",
+                'User-Agent': 'OPNsense-dyndns'
+            }
+            # Send IP address update
+            req = requests.request("PUT", url, data=payload, headers=headers)
+            if 200 <= req.status_code < 300:
+                if self.is_verbose:
+                    syslog.syslog(
+                        syslog.LOG_NOTICE,
+                        "Account %s set new ip %s [%s]" % (self.description, self.current_address, req.text.strip())
+                    )
+
+                self.update_state(address=self.current_address, status=req.text.split()[0] if req.text else '')
+                return True
+            else:
+                syslog.syslog(
+                    syslog.LOG_ERR,
+                    "Account %s failed to set new ip %s [%d - %s]" % (
+                        self.description, self.current_address, req.status_code, req.text.replace('\n', '')
+                    )
+                )
+
+        return False


### PR DESCRIPTION
Adding Gandi LiveDNS native backend support to the DDclient plugin.

Problem: while the ddclient plugin supports Gandi when using the ddclient backend, support is absent from the native backend.

I used the cloudflare.py and dyndns2.py files as a template for gandi.py.

What needs to be configured in the plugin web interface for it to work:
Password (API key / personal access token), zone, hostname (host only, not the FQDN), check IP method.

Possible issues:
Not all fields in the opnsense web interface are used. Specifically username, resource ID, and force SSL.
Gandi appears in the bottom of the service list, instead of being sorted alphabetically. I'm unsure how to fix this.
I only check for a 2xx response to determine success or failure. This could be improved by something as simple as writing the http response body to the log when there's an error (non-200 response code).