### PR TITLE
security/acme-client: fix EasyDNS variable assignment

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -1471,7 +1471,7 @@
     </field>
     <field>
         <id>validation.dns_easydns_apikey</id>
-        <label>Api Key</label>
+        <label>API Key</label>
         <type>password</type>
     </field>
     <field>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsEasydns.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsEasydns.php
@@ -1,8 +1,8 @@
 <?php
 
 /*
- * Copyright (C) 2023 mleinart,
- *               2024 txr13
+ * Copyright (C) 2023 mleinart
+ * Copyright (C) 2024 txr13
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsEasydns.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsEasydns.php
@@ -1,7 +1,8 @@
 <?php
 
 /*
- * Copyright (C) 2023 mleinart
+ * Copyright (C) 2023 mleinart,
+ *               2024 txr13
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -39,7 +40,7 @@ class DnsEasydns extends Base implements LeValidationInterface
 {
     public function prepare()
     {
-        $this->acme_env[EASYDNS_Key] = (string)$this->config->dns_easydns_apikey;
-        $this->acme_env[EASYDNS_Token] = (string)$this->config->dns_easydns_apitoken;
+        $this->acme_env['EASYDNS_Key'] = (string)$this->config->dns_easydns_apikey;
+        $this->acme_env['EASYDNS_Token'] = (string)$this->config->dns_easydns_apitoken;
     }
 }


### PR DESCRIPTION
Changes an undeclared constant to a quoted string. Also fixes some (very minor) capitalization.

Fixes #4067