### PR TITLE
www/caddy: Allow bind to non standard ports

### DIFF
--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
@@ -22,13 +22,6 @@
         <advanced>true</advanced>
     </field>
     <field>
-        <id>caddy.general.Loopback</id>
-        <label>Bind to Loopback</label>
-        <type>checkbox</type>
-        <help><![CDATA[Instead of binding to all interfaces (default), enable this checkbox to bind Caddy to 127.0.0.1 and ::1 instead. Use Port Forwarding to route traffic to Caddy. This option can be combined with custom ports for HTTP and HTTPS.]]></help>
-        <advanced>true</advanced>
-    </field>
-    <field>
         <id>caddy.general.TlsEmail</id>
         <label>ACME Email</label>
         <type>text</type>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
@@ -6,6 +6,29 @@
         <help><![CDATA[Enable or disable the Caddy web server.]]></help>
     </field>
     <field>
+        <id>caddy.general.HttpPort</id>
+        <label>HTTP Port</label>
+        <type>text</type>
+        <hint>80</hint>
+        <help><![CDATA[If the default HTTP port is changed to e.g. 8080, then a port forward from port 80 to 8080 is necessary to issue automatic certificates with the HTTP-01 challenge and serve clients the reverse proxied resources.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>caddy.general.HttpsPort</id>
+        <label>HTTPS Port</label>
+        <type>text</type>
+        <hint>443</hint>
+        <help><![CDATA[If the default HTTPS port is changed to e.g. 8443, then a port forward from port 443 to 8443 is necessary to issue automatic certificates with the TLS-ALPN-01 challenge and serve clients the reverse proxied resources.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>caddy.general.Loopback</id>
+        <label>Bind to Loopback</label>
+        <type>checkbox</type>
+        <help><![CDATA[Instead of binding to all interfaces (default), enable this checkbox to bind Caddy to 127.0.0.1 and ::1 instead. Use Port Forwarding to route traffic to Caddy. This option can be combined with custom ports for HTTP and HTTPS.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
         <id>caddy.general.TlsEmail</id>
         <label>ACME Email</label>
         <type>text</type>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
@@ -129,18 +129,18 @@ class Caddy extends BaseModel
 
     private function checkWebGuiSettings($messages)
     {
-        $overlap = array_intersect($this->getWebGuiPorts(), ['80', '443']);
+        // Get custom caddy ports if set. If empty, default to 80 and 443.
+        $httpPort = !empty((string)$this->general->HttpPort) ? (string)$this->general->HttpPort : '80';
+        $httpsPort = !empty((string)$this->general->HttpsPort) ? (string)$this->general->HttpsPort : '443';
         $tlsAutoHttpsSetting = (string)$this->general->TlsAutoHttps;
 
-        // If these following variables are set, the validation should not happen since it should only catch the default usecase.
-        $Loopback = (string)$this->general->Loopback;
-        $httpPort = (string)$this->general->HttpPort;
-        $httpsPort = (string)$this->general->HttpPort;
+        // Check for conflicts
+        $overlap = array_intersect($this->getWebGuiPorts(), [$httpPort, $httpsPort]);
 
-        if (!empty($overlap) && $tlsAutoHttpsSetting !== 'off' && $Loopback === '0' && empty($httpPort) && empty($httpsPort)) {
+        if (!empty($overlap) && $tlsAutoHttpsSetting !== 'off') {
             $portOverlap = implode(', ', $overlap);
             $messages->appendMessage(new Message(
-                sprintf(gettext('To use "Auto HTTPS", resolve these conflicting ports (%s) that are currently configured for the OPNsense WebGUI. Go to "System - Settings - Administration". To release port 80, enable "Disable web GUI redirect rule". To release port 443, change "TCP port" to a non-standard port, e.g., 8443.'), $portOverlap),
+                sprintf(gettext('To use "Auto HTTPS", resolve these conflicting ports (%s) that are currently configured for the OPNsense WebGUI. Go to "System - Settings - Administration". To release port 80, enable "Disable web GUI redirect rule". To release port %s, change "TCP port" to a non-standard port, e.g., 8443.'), $portOverlap, $httpsPort),
                 "general.TlsAutoHttps"
             ));
         }

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
@@ -132,7 +132,12 @@ class Caddy extends BaseModel
         $overlap = array_intersect($this->getWebGuiPorts(), ['80', '443']);
         $tlsAutoHttpsSetting = (string)$this->general->TlsAutoHttps;
 
-        if (!empty($overlap) && $tlsAutoHttpsSetting !== 'off') {
+        // If these following variables are set, the validation should not happen since it should only catch the default usecase.
+        $Loopback = (string)$this->general->Loopback;
+        $httpPort = (string)$this->general->HttpPort;
+        $httpsPort = (string)$this->general->HttpPort;
+
+        if (!empty($overlap) && $tlsAutoHttpsSetting !== 'off' && $Loopback === '0' && empty($httpPort) && empty($httpsPort)) {
             $portOverlap = implode(', ', $overlap);
             $messages->appendMessage(new Message(
                 sprintf(gettext('To use "Auto HTTPS", resolve these conflicting ports (%s) that are currently configured for the OPNsense WebGUI. Go to "System - Settings - Administration". To release port 80, enable "Disable web GUI redirect rule". To release port 443, change "TCP port" to a non-standard port, e.g., 8443.'), $portOverlap),

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -9,14 +9,10 @@
                 <Required>Y</Required>
             </enabled>
             <HttpPort type="PortField">
-                <ValidationMessage>Please enter a valid HTTP port number.</ValidationMessage>
                 <EnableWellKnown>Y</EnableWellKnown>
-                <EnableRanges>N</EnableRanges>
             </HttpPort>
             <HttpsPort type="PortField">
-                <ValidationMessage>Please enter a valid HTTPS port number.</ValidationMessage>
                 <EnableWellKnown>Y</EnableWellKnown>
-                <EnableRanges>N</EnableRanges>
             </HttpsPort>
             <TlsEmail type="EmailField">
                 <ValidationMessage>Please enter a valid email address.</ValidationMessage>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -8,6 +8,17 @@
                 <Default>0</Default>
                 <Required>Y</Required>
             </enabled>
+            <HttpPort type="PortField">
+                <ValidationMessage>Please enter a valid HTTP port number.</ValidationMessage>
+                <EnableWellKnown>Y</EnableWellKnown>
+                <EnableRanges>N</EnableRanges>
+            </HttpPort>
+            <HttpsPort type="PortField">
+                <ValidationMessage>Please enter a valid HTTPS port number.</ValidationMessage>
+                <EnableWellKnown>Y</EnableWellKnown>
+                <EnableRanges>N</EnableRanges>
+            </HttpsPort>
+            <Loopback type="BooleanField"/>
             <TlsEmail type="EmailField">
                 <ValidationMessage>Please enter a valid email address.</ValidationMessage>
             </TlsEmail>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -18,7 +18,6 @@
                 <EnableWellKnown>Y</EnableWellKnown>
                 <EnableRanges>N</EnableRanges>
             </HttpsPort>
-            <Loopback type="BooleanField"/>
             <TlsEmail type="EmailField">
                 <ValidationMessage>Please enter a valid email address.</ValidationMessage>
             </TlsEmail>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -8,12 +8,8 @@
                 <Default>0</Default>
                 <Required>Y</Required>
             </enabled>
-            <HttpPort type="PortField">
-                <EnableWellKnown>Y</EnableWellKnown>
-            </HttpPort>
-            <HttpsPort type="PortField">
-                <EnableWellKnown>Y</EnableWellKnown>
-            </HttpsPort>
+            <HttpPort type="PortField"/>
+            <HttpsPort type="PortField"/>
             <TlsEmail type="EmailField">
                 <ValidationMessage>Please enter a valid email address.</ValidationMessage>
             </TlsEmail>

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -53,6 +53,21 @@
         {% endif %}
     }
 
+    {# Change default bind and default ports on demand. #}
+    {% set loopback = generalSettings.Loopback %}
+    {% set httpPort = generalSettings.HttpPort %}
+    {% set httpsPort = generalSettings.HttpsPort %}
+
+    {% if loopback|default("0") == "1" %}
+        default_bind 127.0.0.1 [::1]
+    {% endif %}
+    {% if httpPort %}
+        http_port {{ httpPort }}
+    {% endif %}
+    {% if httpsPort %}
+        https_port {{ httpsPort }}
+    {% endif %}
+
     {#
     #   Section: Global Trusted Proxy and Credential Logging
     #   Purpose: The trusted proxy section is important when using CDNs so that headers are trusted.
@@ -215,6 +230,14 @@
 }
 
 # Reverse Proxy Configuration
+
+{# Set up a http site block when default_bind is used, otherwise Caddy will not bind http to the loopback interfaces. #}
+{% if loopback|default("0") == "1" %}
+    http:// {
+    bind 127.0.0.1 [::1]
+    }
+{% endif %}
+
 
 {#
 #   Section: HTTP-01 Challenge Redirection

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -53,14 +53,10 @@
         {% endif %}
     }
 
-    {# Change default bind and default ports on demand. #}
-    {% set loopback = generalSettings.Loopback %}
+    {# Change default ports on demand #}
     {% set httpPort = generalSettings.HttpPort %}
     {% set httpsPort = generalSettings.HttpsPort %}
 
-    {% if loopback|default("0") == "1" %}
-        default_bind 127.0.0.1 [::1]
-    {% endif %}
     {% if httpPort %}
         http_port {{ httpPort }}
     {% endif %}
@@ -230,14 +226,6 @@
 }
 
 # Reverse Proxy Configuration
-
-{# Set up a http site block when default_bind is used, otherwise Caddy will not bind http to the loopback interfaces. #}
-{% if loopback|default("0") == "1" %}
-    http:// {
-    bind 127.0.0.1 [::1]
-    }
-{% endif %}
-
 
 {#
 #   Section: HTTP-01 Challenge Redirection


### PR DESCRIPTION
Fixes: https://github.com/opnsense/plugins/issues/4065

Adds following options:

- `http_port`: https://caddyserver.com/docs/caddyfile/options#http-port
- `https_port`: https://caddyserver.com/docs/caddyfile/options#https-port

`http_port` and `https_port` can be chosen freely. The validation catches errors when there are conflicts with the WebGUI ports.

This should satisfy advanced usecases without causing regressions.