### PR TITLE
www/caddy: Add HTTP version selection. Mark NTLM as deprecated.

### DIFF
--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -99,10 +99,17 @@
         <help><![CDATA[Enable or disable HTTP over TLS (HTTPS) to communicate with the upstream destination. Caddy uses HTTP with the upstream destination by default.]]></help>
     </field>
     <field>
+        <id>handle.HttpVersion</id>
+        <label>HTTP Version</label>
+        <type>dropdown</type>
+        <help><![CDATA[The default versions are highly recommended. Choose a HTTP version for the upstream destination. HTTP/3 (HTTP over QUIC) requires TLS, and only establishes connections to webservers that also support HTTP/3.]]></help>
+    </field>
+    <field>
         <id>handle.HttpNtlm</id>
         <label>NTLM</label>
         <type>checkbox</type>
-        <help><![CDATA[Enable or disable NTLM. Needed to reverse proxy an Exchange Server.]]></help>
+        <help><![CDATA[Enable or disable NTLM. Needed to reverse proxy an Exchange Server. Warning: NTLM has been deprecated by Microsoft. This option will be removed in the future when support for NTLM phases out.]]></help>
+        <advanced>true</advanced>
     </field>
     <field>
         <id>handle.HttpTlsInsecureSkipVerify</id>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -311,6 +311,14 @@
                         </check001>
                     </Constraints>
                 </HttpTls>
+                <HttpVersion type="OptionField">
+                    <BlankDesc>HTTP/1.1, HTTP/2</BlankDesc>
+                    <OptionValues>
+                        <http1>HTTP/1.1</http1>
+                        <http2>HTTP/2</http2>
+                        <http3>HTTP/3</http3>
+                    </OptionValues>
+                </HttpVersion>
                 <HttpNtlm type="BooleanField">
                     <Constraints>
                         <check001>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -335,6 +335,7 @@
                             <th data-column-id="ToPath" data-type="string" data-visible="false">{{ lang._('Upstream Path') }}</th>
                             <th data-column-id="PassiveHealthFailDuration" data-type="string" data-visible="false">{{ lang._('Fail Duration') }}</th>
                             <th data-column-id="HttpTls" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('TLS') }}</th>
+                            <th data-column-id="HttpVersion" data-type="string" data-visible="false">{{ lang._('HTTP Version') }}</th>
                             <th data-column-id="HttpTlsTrustedCaCerts" data-type="string" data-visible="false">{{ lang._('TLS CA') }}</th>
                             <th data-column-id="HttpTlsServerName" data-type="string" data-visible="false">{{ lang._('TLS Server Name') }}</th>
                             <th data-column-id="HttpNtlm" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('NTLM') }}</th>

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -343,6 +343,7 @@
 #       - HttpTlsTrustedCaCerts (string, optional): The config extracted name of a CA certificate.
 #       - HttpTlsServerName (string, optional): Specifies the server name for the TLS handshake.
 #       - PassiveHealthFailDuration (integer, optional): Enables passive health checks when set > 0.
+#       - HttpVersion (string, optional): Choose HTTP version. Empty (default) is 1.1 and 2.
 #}
 {% macro reverse_proxy_configuration(handle) %}
     {{ handle.HandleType }} {{ handle.HandlePath|default("") }} {
@@ -359,7 +360,7 @@
             {% if handle.PassiveHealthFailDuration|default("") %}
             fail_duration {{ handle.PassiveHealthFailDuration }}s
             {% endif %}
-            {% if handle.HttpTls|default("0") == "1" or handle.HttpTlsInsecureSkipVerify|default("0") == "1" or handle.HttpTlsTrustedCaCerts|default("") != "" or handle.HttpTlsServerName|default("") != "" %}
+            {% if handle.HttpTls|default("0") == "1" or handle.HttpTlsInsecureSkipVerify|default("0") == "1" or handle.HttpTlsTrustedCaCerts or handle.HttpTlsServerName or handle.HttpVersion %}
                 {% if handle.HttpNtlm|default("0") == "1" %}
                 transport http_ntlm {
                     {% if handle.HttpTls|default("0") == "1" %}
@@ -377,6 +378,11 @@
                 }
                 {% else %}
                 transport http {
+                    {# The model does not allow to set a single number as option directly, so we have to map them. #}
+                    {% set version_map = {'http1': 1.1, 'http2': 2, 'http3': 3} %}
+                    {% if handle.HttpVersion %}
+                        versions {{ version_map[handle.HttpVersion] }}
+                    {% endif %}
                     {% if handle.HttpTls|default("0") == "1" %}
                     tls
                     {% endif %}


### PR DESCRIPTION
- Theoretically, NTLM only hard codes the transport http to `versions 1.1` as `transport http_ntlm` before the option `versions` in `transport http` existed. So, NTLM could be replaced by setting http `versions 1.1`., since NTLM always requires the full header being sent. HTTP `versions 2` only sends the header one time, and that makes Outlook fail to authenticate.
- At the same time, this also adds support for HTTP/3 `versions 3` to the upstream, which is included in the latest Caddy version 2.8.4 we have rolled out.