### PR TITLE
www/caddy: Add HTTP keepalive to handler, revert NTLM deprecation.

### DIFF
--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -33,7 +33,6 @@ Plugin Changelog
 * Add: Default HTTP and HTTPS ports can be changed in general settings.
 * Add: Introduce HTTP version to handler. HTTP/1.1, HTTP/2 and HTTP/3 can be chosen.
 * Add: HTTP Keepalive can be set in a handler.
-* Change: NTLM is now deprecated and moved to advanced mode, though the option will stay for as long as the optional module works.
 * Change: Option "tls_trusted_ca_certs" is now "tls_trust_pool".
 
 1.5.7

--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -32,7 +32,8 @@ Plugin Changelog
 * Add: forward_auth directive with Authelia as Authz Provider.
 * Add: Default HTTP and HTTPS ports can be changed in general settings.
 * Add: Introduce HTTP version to handler. HTTP/1.1, HTTP/2 and HTTP/3 can be chosen.
-* Change: NTLM is now deprecated, though the option will stay for a while longer.
+* Add: HTTP Keepalive can be set in a handler.
+* Change: NTLM is now deprecated and moved to advanced mode, though the option will stay for as long as the optional module works.
 * Change: Option "tls_trusted_ca_certs" is now "tls_trust_pool".
 
 1.5.7

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -109,7 +109,7 @@
         <label>HTTP Keepalive</label>
         <type>text</type>
         <hint>120</hint>
-        <help><![CDATA[Keepalive is either 0 (off) or a duration value that specifies how long to keep connections open (timeout) in seconds.]]></help>
+        <help><![CDATA[Leave empty to use default. Keepalive is either 0 (off) or a duration value that specifies how long to keep connections open (timeout) in seconds.]]></help>
     </field>
     <field>
         <type>header</type>
@@ -126,8 +126,7 @@
         <id>handle.HttpNtlm</id>
         <label>NTLM</label>
         <type>checkbox</type>
-        <help><![CDATA[Enable or disable NTLM. Needed to reverse proxy an Exchange Server. Warning: NTLM has been deprecated by Microsoft. This option will be removed in the future when support for NTLM phases out.]]></help>
-        <advanced>true</advanced>
+        <help><![CDATA[Enable or disable NTLM. Needed to reverse proxy an Exchange Server. Warning: NTLM has been deprecated by Microsoft. This option will stay for as long as the optional http.reverse_proxy.transport.http_ntlm module can be compiled without errors.]]></help>
     </field>
     <field>
         <id>handle.HttpTlsInsecureSkipVerify</id>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -38,7 +38,7 @@
     </field>
     <field>
         <type>header</type>
-        <label>Access</label>
+        <label>Forward Auth</label>
         <collapse>true</collapse>
     </field>
     <field>
@@ -88,11 +88,6 @@
         <advanced>true</advanced>
     </field>
     <field>
-        <type>header</type>
-        <label>Load Balancing</label>
-        <collapse>true</collapse>
-    </field>
-    <field>
         <id>handle.PassiveHealthFailDuration</id>
         <label>Upstream Fail Duration</label>
         <type>text</type>
@@ -100,20 +95,27 @@
     </field>
     <field>
         <type>header</type>
-        <label>Trust</label>
+        <label>HTTP Transport</label>
         <collapse>true</collapse>
-    </field>
-    <field>
-        <id>handle.HttpTls</id>
-        <label>TLS</label>
-        <type>checkbox</type>
-        <help><![CDATA[Enable or disable HTTP over TLS (HTTPS) to communicate with the upstream destination. Caddy uses HTTP with the upstream destination by default.]]></help>
     </field>
     <field>
         <id>handle.HttpVersion</id>
         <label>HTTP Version</label>
         <type>dropdown</type>
         <help><![CDATA[The default versions are highly recommended. Choose a HTTP version for the upstream destination. HTTP/3 (HTTP over QUIC) requires TLS, and only establishes connections to webservers that also support HTTP/3.]]></help>
+    </field>
+    <field>
+        <id>handle.HttpKeepalive</id>
+        <label>HTTP Keepalive</label>
+        <type>text</type>
+        <hint>120</hint>
+        <help><![CDATA[Keepalive is either 0 (off) or a duration value that specifies how long to keep connections open (timeout) in seconds. Use Keepalive 0 combined with HTTP Version HTTP/1.1 to replace the deprecated NTLM checkbox.]]></help>
+    </field>
+    <field>
+        <id>handle.HttpTls</id>
+        <label>TLS</label>
+        <type>checkbox</type>
+        <help><![CDATA[Enable or disable HTTP over TLS (HTTPS) to communicate with the upstream destination. Caddy uses HTTP with the upstream destination by default.]]></help>
     </field>
     <field>
         <id>handle.HttpNtlm</id>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -38,7 +38,7 @@
     </field>
     <field>
         <type>header</type>
-        <label>Forward Auth</label>
+        <label>Access</label>
         <collapse>true</collapse>
     </field>
     <field>
@@ -109,7 +109,12 @@
         <label>HTTP Keepalive</label>
         <type>text</type>
         <hint>120</hint>
-        <help><![CDATA[Keepalive is either 0 (off) or a duration value that specifies how long to keep connections open (timeout) in seconds. Use Keepalive 0 combined with HTTP Version HTTP/1.1 to replace the deprecated NTLM checkbox.]]></help>
+        <help><![CDATA[Keepalive is either 0 (off) or a duration value that specifies how long to keep connections open (timeout) in seconds.]]></help>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Trust</label>
+        <collapse>true</collapse>
     </field>
     <field>
         <id>handle.HttpTls</id>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -335,6 +335,10 @@
                         <http3>HTTP/3</http3>
                     </OptionValues>
                 </HttpVersion>
+                <HttpKeepalive type="IntegerField">
+                    <MinimumValue>0</MinimumValue>
+                    <MaximumValue>86400</MaximumValue>
+                </HttpKeepalive>
                 <HttpNtlm type="BooleanField">
                     <Constraints>
                         <check001>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -337,6 +337,7 @@
                             <th data-column-id="ForwardAuth" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('Forward Auth') }}</th>
                             <th data-column-id="HttpTls" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('TLS') }}</th>
                             <th data-column-id="HttpVersion" data-type="string" data-visible="false">{{ lang._('HTTP Version') }}</th>
+                            <th data-column-id="HttpKeepalive" data-type="string" data-visible="false">{{ lang._('HTTP Keepalive') }}</th>
                             <th data-column-id="HttpTlsTrustedCaCerts" data-type="string" data-visible="false">{{ lang._('TLS CA') }}</th>
                             <th data-column-id="HttpTlsServerName" data-type="string" data-visible="false">{{ lang._('TLS Server Name') }}</th>
                             <th data-column-id="HttpNtlm" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('NTLM') }}</th>

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -355,6 +355,7 @@
 #       - HttpTlsServerName (string, optional): Specifies the server name for the TLS handshake.
 #       - PassiveHealthFailDuration (integer, optional): Enables passive health checks when set > 0.
 #       - HttpVersion (string, optional): Choose HTTP version. Empty (default) is 1.1 and 2.
+#       - HttpKeepalive (string, optional): Keeaplive is either off (0) or a value. Empty (default) 120s.
 #}
 {% macro reverse_proxy_configuration(handle) %}
     {{ handle.HandleType }} {{ handle.HandlePath|default("") }} {
@@ -374,7 +375,7 @@
             {% if handle.PassiveHealthFailDuration|default("") %}
             fail_duration {{ handle.PassiveHealthFailDuration }}s
             {% endif %}
-            {% if handle.HttpTls|default("0") == "1" or handle.HttpTlsInsecureSkipVerify|default("0") == "1" or handle.HttpTlsTrustedCaCerts or handle.HttpTlsServerName or handle.HttpVersion %}
+            {% if handle.HttpTls|default("0") == "1" or handle.HttpTlsInsecureSkipVerify|default("0") == "1" or handle.HttpTlsTrustedCaCerts or handle.HttpTlsServerName or handle.HttpVersion or handle.HttpKeepalive %}
                 {% if handle.HttpNtlm|default("0") == "1" %}
                 transport http_ntlm {
                     {% if handle.HttpTls|default("0") == "1" %}
@@ -396,6 +397,13 @@
                     {% set version_map = {'http1': 1.1, 'http2': 2, 'http3': 3} %}
                     {% if handle.HttpVersion %}
                         versions {{ version_map[handle.HttpVersion] }}
+                    {% endif %}
+                    {% if handle.HttpKeepalive %}
+                        {% if handle.HttpKeepalive == "0" %}
+                            keepalive off
+                        {% else %}
+                            keepalive {{ handle.HttpKeepalive }}s
+                        {% endif %}
                     {% endif %}
                     {% if handle.HttpTls|default("0") == "1" %}
                     tls

--- a/www/caddy/src/opnsense/www/js/widgets/CaddyCertificate.js
+++ b/www/caddy/src/opnsense/www/js/widgets/CaddyCertificate.js
@@ -51,26 +51,22 @@ export default class CaddyCertificate extends BaseTableWidget {
     }
 
     async onWidgetTick() {
-        try {
-            // Check if Caddy is enabled
-            const caddyStatus = await ajaxGet('/api/caddy/reverse_proxy/get', {});
-            if (!caddyStatus.caddy.general || caddyStatus.caddy.general.enabled === "0") {
-                this.displayError(`${this.translations.unconfigured}`);
-                return;
-            }
-
-            // Fetch the certificate details
-            const response = await ajaxGet('/api/caddy/diagnostics/certificate', {});
-            if (response.status !== "success") {
-                this.displayError(`${this.translations.nocerts}`);
-                return;
-            }
-
-            // Process certificates if the response is successful
-            this.processCertificates(response.content);
-        } catch (error) {
-            this.displayError(`${this.translations.error}`);
+        // Check if Caddy is enabled
+        const caddyStatus = await this.ajaxGet('/api/caddy/reverse_proxy/get');
+        if (!caddyStatus.caddy.general || caddyStatus.caddy.general.enabled === "0") {
+            this.displayError(`${this.translations.unconfigured}`);
+            return;
         }
+
+        // Fetch the certificate details
+        const response = await this.ajaxGet('/api/caddy/diagnostics/certificate');
+        if (response.status !== "success") {
+            this.displayError(`${this.translations.nocerts}`);
+            return;
+        }
+
+        // Process certificates if the response is successful
+        this.processCertificates(response.content);
     }
 
     // Utility function to display errors within the widget

--- a/www/caddy/src/opnsense/www/js/widgets/CaddyCertificate.js
+++ b/www/caddy/src/opnsense/www/js/widgets/CaddyCertificate.js
@@ -30,7 +30,7 @@ export default class CaddyCertificate extends BaseTableWidget {
     constructor() {
         super();
         this.resizeHandles = "e, w";
-        this.tickTimeout = 30000;
+        this.tickTimeout = 30;
     }
 
     getGridOptions() {

--- a/www/caddy/src/opnsense/www/js/widgets/CaddyDomain.js
+++ b/www/caddy/src/opnsense/www/js/widgets/CaddyDomain.js
@@ -50,21 +50,16 @@ export default class CaddyDomain extends BaseTableWidget {
     }
 
     async onWidgetTick() {
-        try {
-            // Check if caddy is enabled
-            const data = await ajaxGet('/api/caddy/reverse_proxy/get', {});
-            if (!data.caddy.general || data.caddy.general.enabled === "0") {
-                this.displayError(`${this.translations.unconfigured}`);
-                return;
-            }
-
-            // Process domains if caddy is enabled
-            let domains = { ...data.caddy.reverseproxy.reverse, ...data.caddy.reverseproxy.subdomain };
-            this.processDomains(domains);
-
-        } catch (error) {
-            this.displayError(`${this.translations.error}`);
+        // Check if caddy is enabled
+        const data = await this.ajaxGet('/api/caddy/reverse_proxy/get');
+        if (!data.caddy.general || data.caddy.general.enabled === "0") {
+            this.displayError(`${this.translations.unconfigured}`);
+            return;
         }
+
+        // Process domains if caddy is enabled
+        let domains = { ...data.caddy.reverseproxy.reverse, ...data.caddy.reverseproxy.subdomain };
+        this.processDomains(domains);
     }
 
     // Utility function to display errors within the widget


### PR DESCRIPTION
Some applications need a longer keepalive or the keepalive turned off. (Also known as connection timeout)

(e.g. Exchange Active Sync, other Microsoft services.)

`keepalive` https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#keepalive

This only changes `transport http`. In `transport http_ntlm` the keepalive is turned off automatically, so this setting won't be rendered there.

NTLM is moved back to standard options since it can't be replaced.
