### PR TITLE
dns/bind: Fix multiple select on Recursion field

### DIFF
--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/general.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/general.xml
@@ -111,7 +111,7 @@
     <field>
         <id>general.recursion</id>
         <label>Recursion</label>
-        <type>dropdown</type>
+        <type>select_multiple</type>
         <help>Define an ACL where you allow which clients can resolve via this service. Usually use your local LAN.</help>
     </field>
     <field>


### PR DESCRIPTION
The Recursion field on the Configuration page does not allow multiple selections. This was added in 1.26 for Transfers and Queries but is broken for Recursion. The model already has `<Multiple>Y</Multiple>` and this PR fixes the controller.