### PR TITLE
www/caddy: Fix CaddyCertificate.js not loading

### DIFF
--- a/www/caddy/src/opnsense/www/js/widgets/CaddyCertificate.js
+++ b/www/caddy/src/opnsense/www/js/widgets/CaddyCertificate.js
@@ -59,7 +59,7 @@ export default class CaddyCertificate extends BaseTableWidget {
         }
 
         // Fetch the certificate details
-        const response = await this.ajaxGet('/api/caddy/diagnostics/certificate');
+        const response = await this.ajaxCall('/api/caddy/diagnostics/certificate');
         if (response.status !== "success") {
             this.displayError(`${this.translations.nocerts}`);
             return;


### PR DESCRIPTION
There were two ajaxGet, and I forgot to rename one into ajaxCall.