### PR TITLE
www/nginx: 1.34

### DIFF
--- a/www/nginx/Makefile
+++ b/www/nginx/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		nginx
-PLUGIN_VERSION=		1.33
+PLUGIN_VERSION=		1.34
 PLUGIN_COMMENT=		Nginx HTTP server and reverse proxy
 PLUGIN_DEPENDS=		nginx
 PLUGIN_MAINTAINER=	franz.fabian.94@gmail.com

--- a/www/nginx/pkg-descr
+++ b/www/nginx/pkg-descr
@@ -10,6 +10,12 @@ WWW: https://nginx.org/
 Plugin Changelog
 ================
 
+1.34
+
+* Add the option to not log TLS handshakes
+* Remove obsolete http2_push_preload directive
+* Migrate from the deprecated 'listen … http2' directive to the 'http2' directive
+
 1.33
 
 * Add the "resolver" directive support

--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/httpserver.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/httpserver.xml
@@ -143,6 +143,13 @@
     <advanced>true</advanced>
   </field>
   <field>
+    <id>httpserver.log_handshakes</id>
+    <label>Enable TLS handshakes logging</label>
+    <type>checkbox</type>
+    <help>Log TLS handshakes to fill the User Agent fingerprint database and detect MITM attacks.</help>
+    <advanced>true</advanced>
+  </field>
+  <field>
     <id>httpserver.enable_acme_support</id>
     <label>Enable Let's Encrypt Plugin Support</label>
     <type>checkbox</type>

--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/location.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/location.xml
@@ -207,12 +207,6 @@
     <help>If the request scheme is not HTTPS, redirect to use HTTPS for this location.</help>
   </field>
   <field>
-    <id>location.http2_push_preload</id>
-    <label>Enable HTTP/2 Preloading</label>
-    <type>checkbox</type>
-    <help>If you check this box, you can use the link header to send resources to the client before they are requested. You can boost your performance with this setting. This requires that your application sets the "Link" header correctly.</help>
-  </field>
-  <field>
     <id>location.php_enable</id>
     <label>Pass Request To Local PHP Interpreter / Threat Upstream As FastCGI</label>
     <type>checkbox</type>

--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
@@ -515,10 +515,6 @@
         <Required>N</Required>
         <minValue>1</minValue>
       </proxy_send_timeout>
-      <http2_push_preload type="BooleanField">
-        <Required>Y</Required>
-        <default>0</default>
-      </http2_push_preload>
       <ip_acl type="ModelRelationField">
         <Model>
           <template>

--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
@@ -1,6 +1,6 @@
 <model>
   <mount>//OPNsense/Nginx</mount>
-  <version>1.33</version>
+  <version>1.34</version>
   <description>nginx web server, reverse proxy and waf</description>
   <items>
     <general>
@@ -863,6 +863,10 @@
         <Required>Y</Required>
         <default>error</default>
       </error_log_level>
+      <log_handshakes type="BooleanField">
+        <default>1</default>
+        <Required>Y</Required>
+      </log_handshakes>
       <enable_acme_support type="BooleanField">
         <Required>Y</Required>
         <default>1</default>

--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/http.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/http.conf
@@ -115,9 +115,9 @@ server {
 
 {%   if server.listen_https_address is defined and server.listen_https_address != '' %}
 {%     for listen_address in server.listen_https_address.split(',') %}
-    listen {{ listen_address }} http2 ssl{% if server.proxy_protocol is defined and server.proxy_protocol == '1' %} proxy_protocol{% endif %}{% if server.default_server is defined and server.default_server == '1' %} default_server{% endif %};
+    listen {{ listen_address }} ssl{% if server.proxy_protocol is defined and server.proxy_protocol == '1' %} proxy_protocol{% endif %}{% if server.default_server is defined and server.default_server == '1' %} default_server{% endif %};
 {%     endfor %}
-
+    http2 on;
 {%     if server.tls_reject_handshake is defined and server.tls_reject_handshake == '1'%}
     ssl_reject_handshake on;
 {%     endif %}

--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/http.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/http.conf
@@ -197,7 +197,9 @@ server {
 {%   set syslog_targets = server.syslog_targets.split(',') %}
 {%   include "OPNsense/Nginx/syslog_targets.conf" %}
 {% endif %}
+{% if server.log_handshakes|default("1") == "1" %}
     access_log  /var/log/nginx/tls_handshake.log handshake;
+{% endif %}
     error_log  /var/log/nginx/{{ server.servername }}.error.log{% if server.error_log_level is defined %} {{ server.error_log_level }}{% endif %};
 {% if server.root is defined and server.root != '' %}
     root "{{server.root}}";

--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/location.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/location.conf
@@ -88,7 +88,6 @@ location {{ location.matchtype }} {{ location.urlpattern }} {
     auth_request /opnsense-auth-request;
 {%   endif %}
 {% endif %}
-    http2_push_preload {% if location.http2_push_preload is defined and location.http2_push_preload == '1' %}on{% else %}off{% endif %};
 {% if location.php_enable is defined and location.php_enable == '1' %}
     fastcgi_split_path_info ^(.+\.php)(/.+)$;
     include        fastcgi_params;

--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/webgui.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/webgui.conf
@@ -27,7 +27,6 @@ server {
 {% endif %}
 
   autoindex off;
-  http2_push_preload on;
 
   # gzip compression
   gzip_static on;

--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/webgui.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/webgui.conf
@@ -9,7 +9,8 @@ server {
       return 302 https://$host$request_uri;
   }
   listen 80 default_server; # if redirect is enabled
-  listen {% if system.webgui.port is defined and system.webgui.port != '' %}{{ system.webgui.port }}{% else %}443{% endif %} ssl http2 default_server;
+  listen {% if system.webgui.port is defined and system.webgui.port != '' %}{{ system.webgui.port }}{% else %}443{% endif %} ssl default_server;
+  http2 on;
   ## TLS configuration
   ssl_dhparam /usr/local/opnsense/data/OPNsense/Nginx/dh-parameters.4096.rfc7919;
   ssl_ecdh_curve secp384r1;


### PR DESCRIPTION
Hi!
more quick fixes than anything new, but still )
* Add the option to not log TLS handshakes
* Remove obsolete http2_push_preload directive
* Migrate from the deprecated 'listen … http2' directive to the 'http2' directive

ref.:
https://github.com/opnsense/plugins/issues/3854
https://forum.opnsense.org/index.php?topic=41415.0
https://nginx.org/en/CHANGES (1.25.1 version changes)
@fabianfrz please take a look when you have time

Thanks!