### PR TITLE
www/caddy: Description Fields are optional now

### DIFF
--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -29,6 +29,7 @@ Plugin Changelog
 
 Add: Run Caddy as "www" user and group, by enabling "Disable Superuser" in General Settings.
 Cleanup: Validations in general.volt are all appended to their form keys, instead of triggering a Bootstrap Dialog.
+Change: Description Fields are optional now, reducing the steps needed to create new entries.
 
 1.6.0
 

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
@@ -23,7 +23,6 @@
         <id>reverse.description</id>
         <label>Description</label>
         <type>text</type>
-        <hint>example.com.443</hint>
         <help><![CDATA[Enter a description for this domain.]]></help>
     </field>
     <field>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogSubdomain.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogSubdomain.xml
@@ -22,7 +22,6 @@
         <id>subdomain.description</id>
         <label>Description</label>
         <type>text</type>
-        <hint>opn.example.com</hint>
         <help><![CDATA[Enter a description for this subdomain.]]></help>
     </field>
     <field>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -74,7 +74,7 @@
                         <source>OPNsense.Caddy.Caddy</source>
                         <items>reverseproxy.accesslist</items>
                         <display>accesslistName,description</display>
-                        <display_format>%s - %s</display_format>
+                        <display_format>%s %s</display_format>
                     </reverseproxy>
                 </Model>
             </accesslist>
@@ -158,7 +158,7 @@
                             <source>OPNsense.Caddy.Caddy</source>
                             <items>reverseproxy.accesslist</items>
                             <display>accesslistName,description</display>
-                            <display_format>%s - %s</display_format>
+                            <display_format>%s %s</display_format>
                         </reverseproxy>
                     </Model>
                 </accesslist>
@@ -168,14 +168,12 @@
                             <source>OPNsense.Caddy.Caddy</source>
                             <items>reverseproxy.basicauth</items>
                             <display>basicauthuser,description</display>
-                            <display_format>%s - %s</display_format>
+                            <display_format>%s %s</display_format>
                         </reverseproxy>
                     </Model>
                     <Multiple>Y</Multiple>
                 </basicauth>
-                <description type="DescriptionField">
-                    <Required>Y</Required>
-                </description>
+                <description type="DescriptionField"/>
                 <DnsChallenge type="BooleanField"/>
                 <CustomCertificate type="CertificateField"/>
                 <AccessLog type="BooleanField"/>
@@ -210,7 +208,7 @@
                             <source>OPNsense.Caddy.Caddy</source>
                             <items>reverseproxy.accesslist</items>
                             <display>accesslistName,description</display>
-                            <display_format>%s - %s</display_format>
+                            <display_format>%s %s</display_format>
                         </reverseproxy>
                     </Model>
                 </accesslist>
@@ -220,14 +218,12 @@
                             <source>OPNsense.Caddy.Caddy</source>
                             <items>reverseproxy.basicauth</items>
                             <display>basicauthuser,description</display>
-                            <display_format>%s - %s</display_format>
+                            <display_format>%s %s</display_format>
                         </reverseproxy>
                     </Model>
                     <Multiple>Y</Multiple>
                 </basicauth>
-                <description type="DescriptionField">
-                    <Required>Y</Required>
-                </description>
+                <description type="DescriptionField"/>
                 <DynDns type="BooleanField"/>
                 <AcmePassthrough type="HostnameField"/>
             </subdomain>
@@ -275,7 +271,7 @@
                             <source>OPNsense.Caddy.Caddy</source>
                             <items>reverseproxy.header</items>
                             <display>HeaderUpDown,HeaderType,HeaderValue,description</display>
-                            <display_format>%s %s %s - %s</display_format>
+                            <display_format>%s %s %s %s</display_format>
                         </reverseproxy>
                     </Model>
                     <Multiple>Y</Multiple>
@@ -332,9 +328,7 @@
                     <Type>ca</Type>
                 </HttpTlsTrustedCaCerts>
                 <HttpTlsServerName type="HostnameField"/>
-                <description type="DescriptionField">
-                    <Required>Y</Required>
-                </description>
+                <description type="DescriptionField"/>
             </handle>
             <accesslist type="ArrayField">
                 <accesslistName type="DescriptionField">
@@ -354,9 +348,7 @@
                     <ValidationMessage>Please enter a valid HTTP response code between 100 and 599</ValidationMessage>
                 </HttpResponseCode>
                 <HttpResponseMessage type="DescriptionField"/>
-                <description type="DescriptionField">
-                    <Required>Y</Required>
-                </description>
+                <description type="DescriptionField"/>
             </accesslist>
             <basicauth type="ArrayField">
                 <basicauthuser type="TextField">
@@ -367,9 +359,7 @@
                 <basicauthpass type="UpdateOnlyTextField">
                     <Required>Y</Required>
                 </basicauthpass>
-                <description type="DescriptionField">
-                    <Required>Y</Required>
-                </description>
+                <description type="DescriptionField"/>
             </basicauth>
             <header type="ArrayField">
                 <HeaderUpDown type="OptionField">
@@ -393,9 +383,7 @@
                     <Mask>/^([^"]{0,1024})$/u</Mask>
                     <ValidationMessage>The header replacement must not contain quotation marks (") and must be less than 1024 characters.</ValidationMessage>
                 </HeaderReplace>
-                <description type="DescriptionField">
-                    <Required>Y</Required>
-                </description>
+                <description type="DescriptionField"/>
             </header>
         </reverseproxy>
     </items>


### PR DESCRIPTION
- At no point in the model relation fields they are the only `display`, making them non required for functionality. There are always multiple `sprintf` references.
- The SafeDelete function shows UUIDs in the bootstrap dialog, which users can enable in the bootgrids by adding the optional field for them. The description is nice to have, but not necessary. It will just give users who fill out descriptions a better experience, but not by much.

This helps reducing the steps necessary to create new entries. It was an annoyance, also for me, but I just recently revisited this from feedback here: https://github.com/opnsense/plugins/issues/4095