### PR TITLE
www/caddy: Allow tooltips of caddy widgets to break out of modal

### DIFF
--- a/www/caddy/src/opnsense/www/js/widgets/CaddyCertificate.js
+++ b/www/caddy/src/opnsense/www/js/widgets/CaddyCertificate.js
@@ -112,6 +112,6 @@ export default class CaddyCertificate extends BaseTableWidget {
         super.updateTable('caddyCertificateTable', sortedRows);
 
         // Initialize tooltips for new elements
-        $('[data-toggle="tooltip"]').tooltip();
+        $('[data-toggle="tooltip"]').tooltip({container: 'body'});
     }
 }

--- a/www/caddy/src/opnsense/www/js/widgets/CaddyDomain.js
+++ b/www/caddy/src/opnsense/www/js/widgets/CaddyDomain.js
@@ -109,6 +109,6 @@ export default class CaddyDomain extends BaseTableWidget {
         super.updateTable('caddyDomainTable', rows.map(row => [row.html]));
 
         // Initialize tooltips for interactivity
-        $('[data-toggle="tooltip"]').tooltip();
+        $('[data-toggle="tooltip"]').tooltip({container: 'body'});
     }
 }


### PR DESCRIPTION
Reference: https://github.com/opnsense/core/blob/684ee270f181397655ca105871db5ede126de6d8/src/opnsense/www/js/widgets/Gateways.js#L95