### PR TITLE
www/caddy: Add buttons to guide users, conditionally hide subdomain tab, simplify forms

### DIFF
--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -30,6 +30,7 @@ Plugin Changelog
 Add: Run Caddy as "www" user and group, by enabling "Disable Superuser" in General Settings.
 Cleanup: Validations in general.volt are all appended to their form keys, instead of triggering a Bootstrap Dialog.
 Change: Description Fields are optional now, reducing the steps needed to create new entries.
+Add: Shortcuts to add new Domains and Handlers, reducing friction in UI.
 
 1.6.0
 

--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -30,7 +30,8 @@ Plugin Changelog
 Add: Run Caddy as "www" user and group, by enabling "Disable Superuser" in General Settings.
 Cleanup: Validations in general.volt are all appended to their form keys, instead of triggering a Bootstrap Dialog.
 Change: Description Fields are optional now, reducing the steps needed to create new entries.
-Add: Shortcuts to add new Domains and Handlers, reducing friction in UI.
+Add: Shortcuts to add new Domains and Handlers.
+Change: Subdomain Tab only appears when a wildcard domain has been configured.
 
 1.6.0
 

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -18,24 +18,27 @@
         <help><![CDATA[Select a subdomain to handle. Make sure to additionaly choose a wildcard domain as "Domain". Leave unset, if not using subdomains.]]></help>
     </field>
     <field>
+        <id>handle.description</id>
+        <label>Description</label>
+        <type>text</type>
+        <help><![CDATA[Enter a description for this handler.]]></help>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Handle</label>
+        <collapse>true</collapse>
+    </field>
+    <field>
         <id>handle.HandleType</id>
         <label>Handle Type</label>
         <type>dropdown</type>
         <help><![CDATA[Choose a handling directive. "handle" (default) will keep the URI of "Handle URI" in all requests. "handle_path" will strip the URI of "Handle URI" from all requests.]]></help>
-        <advanced>true</advanced>
     </field>
     <field>
         <id>handle.HandlePath</id>
         <label>Handle URI</label>
         <type>text</type>
         <help><![CDATA[Enter an URI to handle. Choose a pattern like "/*" or "/example/*". Leave empty to catch all URIs (recommended). Any request matching this pattern will be handled.]]></help>
-        <advanced>true</advanced>
-    </field>
-    <field>
-        <id>handle.description</id>
-        <label>Description</label>
-        <type>text</type>
-        <help><![CDATA[Enter a description for this handler.]]></help>
     </field>
     <field>
         <type>header</type>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -29,6 +29,7 @@
         <label>Handle URI</label>
         <type>text</type>
         <help><![CDATA[Enter an URI to handle. Choose a pattern like "/*" or "/example/*". Leave empty to catch all URIs (recommended). Any request matching this pattern will be handled.]]></help>
+        <advanced>true</advanced>
     </field>
     <field>
         <id>handle.description</id>
@@ -71,7 +72,7 @@
         <style>tokenize</style>
         <allownew>true</allownew>
         <hint>192.168.1.1</hint>
-        <help><![CDATA[Enter a domain name or IP address of the upstream destination. If multiple are chosen, they will be load balanced with the default random policy. A health check can be set in "Load Balancing"]]></help>
+        <help><![CDATA[Enter a domain name or IP address of the upstream destination. If multiple are chosen, they will be load balanced with the default random policy. A health check can be activated by populating "Upstream Fail Duration".]]></help>
     </field>
     <field>
         <id>handle.ToPort</id>
@@ -86,6 +87,11 @@
         <type>text</type>
         <help><![CDATA[Enter a path prefix like "/guacamole" that should be prepended to the upstream request because the application demands it.]]></help>
         <advanced>true</advanced>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Health Check</label>
+        <collapse>true</collapse>
     </field>
     <field>
         <id>handle.PassiveHealthFailDuration</id>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -92,6 +92,12 @@
         <advanced>true</advanced>
     </field>
     <field>
+        <id>handle.HttpTlsInsecureSkipVerify</id>
+        <label>TLS Insecure Skip Verify</label>
+        <type>checkbox</type>
+        <help><![CDATA[Caddy uses HTTP by default to connect to the Upstream. If the Upstream is only reachable via HTTPS, this option disables the TLS handshake verification. This makes the connection insecure and vulnerable to man-in-the-middle attacks. In private networks the risk is low, though do not use in production if possible. It is advised to either use plain HTTP, or proper TLS handling by using the options in "Trust".]]></help>
+    </field>
+    <field>
         <type>header</type>
         <label>Health Check</label>
         <collapse>true</collapse>
@@ -136,12 +142,6 @@
         <label>NTLM</label>
         <type>checkbox</type>
         <help><![CDATA[Enable or disable NTLM. Needed to reverse proxy an Exchange Server. Warning: NTLM has been deprecated by Microsoft. This option will stay for as long as the optional http.reverse_proxy.transport.http_ntlm module can be compiled without errors.]]></help>
-    </field>
-    <field>
-        <id>handle.HttpTlsInsecureSkipVerify</id>
-        <label>TLS Insecure Skip Verify</label>
-        <type>checkbox</type>
-        <help><![CDATA[Disable the TLS handshake verification, making the connection insecure and vulnerable to man-in-the-middle attacks. Do not use in production if possible. When having issues with an upstream that only accepts TLS connections, enabling this option can mitigate them.]]></help>
     </field>
     <field>
         <id>handle.HttpTlsTrustedCaCerts</id>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
@@ -10,14 +10,14 @@
         <label>Domain</label>
         <type>text</type>
         <hint>example.com</hint>
-        <help><![CDATA[Enter a domain name. For a base domain, use "example.com" or "opn.example.com". Using a base domain enables automatic "Let's Encrypt" and "ZeroSSL" certificates by default. For a wildcard domain, use "*.example.com". Only use wildcard domains with wildcard certificates, which require a DNS Provider.]]></help>
+        <help><![CDATA[Enter a domain name. For a base domain, use "example.com" or "opn.example.com". Using a base domain enables automatic "Let's Encrypt" and "ZeroSSL" certificates by default. For a wildcard domain, use "*.example.com". Only use wildcard domains with wildcard certificates, which require a DNS Provider. Adding a wildcard domain and pressing "Apply" will activate the "Subdomain" Tab, in which subdomains can be configured.]]></help>
     </field>
     <field>
         <id>reverse.FromPort</id>
         <label>Port</label>
         <type>text</type>
         <hint>443</hint>
-        <help><![CDATA[Leave empty to use ports 80 and 443 with automatic redirection from HTTP to HTTPS or choose a custom port. Don't forget to allow these ports with a Firewall rule.]]></help>
+        <help><![CDATA[Leave empty to use ports 80 and 443 with automatic redirection from HTTP to HTTPS or choose a custom port. Don't forget to allow these ports with a Firewall rule. If the default ports have been changed in "General Settings", leaving this empty will use the chosen alternative ports instead.]]></help>
     </field>
     <field>
         <id>reverse.description</id>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
@@ -46,6 +46,7 @@
         <label>Trusted Proxies</label>
         <type>dropdown</type>
         <help><![CDATA[Select an Access List to set IP ranges of Trusted Proxies. If Caddy is not the first server being connected to by clients (for example, when a "CDN" is in front of Caddy), configure "Trusted Proxies" with a list of IP ranges (CIDRs) from which incoming requests are trusted to have sent good values for these headers. Additionally, set the same Access List to the domains the Trusted Proxies connect to.]]></help>
+        <advanced>true</advanced>
     </field>
     <field>
         <id>caddy.general.abort</id>
@@ -59,5 +60,6 @@
         <type>text</type>
         <hint>10</hint>
         <help><![CDATA[Defines the grace period for shutting down Caddy during a reload in seconds. During the grace period, no new connections are accepted, idle connections are closed, and active connections are impatiently waited upon to finish their requests. If clients do not finish their requests within the grace period, the server will be forcefully terminated to allow the reload to complete and free up resources. This can influence how long "Apply" of new configurations take, since Caddy waits for all open connections to close.]]></help>
+        <advanced>true</advanced>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -230,10 +230,8 @@
         // Add click event listener for "Add Domain" button
         $("#addDomainBtn").on("click", function() {
             if ($('#maintabs .active a').attr('href') === "#domainsTab") {
-                // Directly open the dialog if already in the Domains tab
                 $("#addReverseProxyBtn").click();
             } else {
-                // Switch to the Domains tab if not already there
                 $('#maintabs a[href="#domainsTab"]').tab('show').one('shown.bs.tab', function(e) {
                     $("#addReverseProxyBtn").click();
                 });
@@ -281,6 +279,11 @@
         margin-right: 5px;
         padding: 0 15px;  // Align with the tables
     }
+    .custom-header {
+        font-weight: 800;
+        font-size: 16px;
+        font-style: italic;
+    }
 </style>
 
 <ul class="nav nav-tabs" data-tabs="tabs" id="maintabs">
@@ -309,7 +312,7 @@
     <div id="domainsTab" class="tab-pane fade in active">
         <div style="padding-left: 16px;">
             <!-- Reverse Proxy -->
-            <h1>{{ lang._('Domains') }}</h1>
+            <h1 class="custom-header">{{ lang._('Domains') }}</h1>
             <div style="display: block;"> <!-- Common container -->
                 <table id="reverseProxyGrid" class="table table-condensed table-hover table-striped" data-editDialog="DialogReverseProxy" data-editAlert="ConfigurationChangeMessage">
                     <thead>
@@ -349,7 +352,7 @@
     <!-- Subdomains Tab -->
     <div id="subdomainsTab" class="tab-pane fade">
         <div style="padding-left: 16px;">
-            <h1>{{ lang._('Subdomains') }}</h1>
+            <h1 class="custom-header">{{ lang._('Subdomains') }}</h1>
             <div style="display: block;"> <!-- Common container -->
                 <table id="reverseSubdomainGrid" class="table table-condensed table-hover table-striped" data-editDialog="DialogSubdomain" data-editAlert="ConfigurationChangeMessage">
                     <thead>
@@ -385,7 +388,7 @@
     <!-- Handle Tab -->
     <div id="handlesTab" class="tab-pane fade">
         <div style="padding-left: 16px;">
-            <h1>{{ lang._('Handlers') }}</h1>
+            <h1 class="custom-header">{{ lang._('Handlers') }}</h1>
             <div style="display: block;"> <!-- Common container -->
                 <table id="reverseHandleGrid" class="table table-condensed table-hover table-striped" data-editDialog="DialogHandle" data-editAlert="ConfigurationChangeMessage">
                     <thead>
@@ -433,7 +436,7 @@
     <div id="accessTab" class="tab-pane fade">
         <!-- Access Lists Section -->
         <div style="padding-left: 16px;">
-            <h1>{{ lang._('Access Lists') }}</h1>
+            <h1 class="custom-header">{{ lang._('Access Lists') }}</h1>
             <div style="display: block;">
                 <table id="accessListGrid" class="table table-condensed table-hover table-striped" data-editDialog="DialogAccessList" data-editAlert="ConfigurationChangeMessage">
                     <thead>
@@ -465,7 +468,7 @@
 
         <!-- Basic Auth Section -->
         <div style="padding-left: 16px;">
-            <h1>{{ lang._('Basic Auth') }}</h1>
+            <h1 class="custom-header">{{ lang._('Basic Auth') }}</h1>
             <div style="display: block;">
                 <table id="basicAuthGrid" class="table table-condensed table-hover table-striped" data-editDialog="DialogBasicAuth" data-editAlert="ConfigurationChangeMessage">
                     <thead>
@@ -495,7 +498,7 @@
     <!-- Header Tab -->
     <div id="headerTab" class="tab-pane fade">
         <div style="padding-left: 16px;">
-            <h1>{{ lang._('Headers') }}</h1>
+            <h1 class="custom-header">{{ lang._('Headers') }}</h1>
             <div style="display: block;"> <!-- Common container -->
                 <table id="reverseHeaderGrid" class="table table-condensed table-hover table-striped" data-editDialog="DialogHeader" data-editAlert="ConfigurationChangeMessage">
                     <thead>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -227,12 +227,8 @@
 
         // Add click event listener for "Add Domain" button
         $("#addDomainBtn").on("click", function() {
-            // Switch to the "Handlers" tab
             $('#maintabs a[href="#domainsTab"]').tab('show');
-
-            // Once the tab is shown, click the "Add Reverse Handle" button
             $('#maintabs a[href="#domainsTab"]').one('shown.bs.tab', function(e) {
-                // Ensure the button is visible and click it
                 $("#addReverseProxyBtn").click();
             });
         });
@@ -302,8 +298,8 @@
                         </tr>
                     </tfoot>
                 </table>
-                <div style="margin-top: 10px;">
-                    <button id="addHandleBtn" type="button" class="btn btn-primary">Step 2: Add Handler</button>
+                <div style="margin-top: 10px; margin-bottom: 10px; margin-left: 4px">
+                    <button id="addHandleBtn" type="button" class="btn btn-primary">{{ lang._('Step 2: Add Upstream') }}</button>
                 </div>
             </div>
         </div>
@@ -385,8 +381,8 @@
                         </tr>
                     </tfoot>
                 </table>
-                <div style="margin-top: 10px; margin-bottom: 10px;">
-                    <button id="addDomainBtn" type="button" class="btn btn-primary">Step 1: Add Domain</button>
+                <div style="margin-top: 10px; margin-bottom: 10px; margin-left: 4px">
+                    <button id="addDomainBtn" type="button" class="btn btn-primary">{{ lang._('Step 1: Add Domain') }}</button>
                 </div>
             </div>
         </div>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -213,6 +213,29 @@
             toggleSelectPicker(currentTab);
         });
 
+        // Add click event listener for "Add Handle" button
+        $("#addHandleBtn").on("click", function() {
+            // Switch to the "Handlers" tab
+            $('#maintabs a[href="#handlesTab"]').tab('show');
+
+            // Once the tab is shown, click the "Add Reverse Handle" button
+            $('#maintabs a[href="#handlesTab"]').one('shown.bs.tab', function(e) {
+                // Ensure the button is visible and click it
+                $("#addReverseHandleBtn").click();
+            });
+        });
+
+        // Add click event listener for "Add Domain" button
+        $("#addDomainBtn").on("click", function() {
+            // Switch to the "Handlers" tab
+            $('#maintabs a[href="#domainsTab"]').tab('show');
+
+            // Once the tab is shown, click the "Add Reverse Handle" button
+            $('#maintabs a[href="#domainsTab"]').one('shown.bs.tab', function(e) {
+                // Ensure the button is visible and click it
+                $("#addReverseProxyBtn").click();
+            });
+        });
     });
 </script>
 
@@ -279,6 +302,9 @@
                         </tr>
                     </tfoot>
                 </table>
+                <div style="margin-top: 10px;">
+                    <button id="addHandleBtn" type="button" class="btn btn-primary">Step 2: Add Handler</button>
+                </div>
             </div>
         </div>
         <div style="padding-left: 16px;">
@@ -359,6 +385,9 @@
                         </tr>
                     </tfoot>
                 </table>
+                <div style="margin-top: 10px; margin-bottom: 10px;">
+                    <button id="addDomainBtn" type="button" class="btn btn-primary">Step 1: Add Domain</button>
+                </div>
             </div>
         </div>
     </div>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -248,7 +248,7 @@
                 type: 'GET',
                 dataType: 'json',
                 success: function(response) {
-                    var hasWildcard = response.rows.some(domain => domain.domainPort.startsWith('*'));
+                    let hasWildcard = response.rows.some(domain => domain.domainPort.startsWith('*'));
                     toggleSubdomainsTab(hasWildcard);
                 },
                 error: function() {
@@ -259,7 +259,7 @@
 
         // Function to show or hide the Subdomains tab
         function toggleSubdomainsTab(visible) {
-            var subdomainsTab = $('#maintabs a[href="#subdomainsTab"]').parent();
+            let subdomainsTab = $('#maintabs a[href="#subdomainsTab"]').parent();
             if (visible) {
                 subdomainsTab.show();
             } else {

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -254,7 +254,7 @@
                     toggleSubdomainsTab(hasWildcard);
                 },
                 error: function() {
-                    console.error('Failed to load domain data from getAllReverseDomains');
+                    console.error("{{ lang._('Failed to load domain data from getAllReverseDomains') }}");
                 }
             });
         }

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -45,7 +45,7 @@
             del:'/api/caddy/ReverseProxy/delReverseProxy/',
             toggle:'/api/caddy/ReverseProxy/toggleReverseProxy/',
             options: {
-                requestHandler: addDomainFilterToRequest,
+                requestHandler: addDomainFilterToRequest
             }
         });
 


### PR DESCRIPTION
For a first time user, the UI of the Caddy plugin can look a bit intimidating on the domain landing page in Reverse Proxy.

This PR tries to improve it without adding too much trickery, keeping it simple so it won't break in the future.

------
- Two buttons are added, that will programmatically change tabs and trigger add dialogues.
- Step 1: Add Domain -> The tab is changed to the domain tab, and the add domain button is clicked automatically
- Step 2: Add Upstream -> Same, but the add handler button is clicked
- These buttons guide first time users intuitively.

------
- Subdomains are in their own Tab now, uncluttering the UI on the main domain page. This puts the normal domains into clear focus, which should be the primary entry point for anybody.
- As soon as a wildcard domain is added, and the apply key is pressed, the subdomain tab appears. It disappears when no wildcard domain is left.
- This visibility change prevents too much focus on subdomains, since normal configurations don't need them.

------
![screen01](https://github.com/user-attachments/assets/ef620b04-fea0-40be-a135-dd81bfa142cf)
