### PR TITLE
UDPBroadcastrelay UI fix for 24.7

### DIFF
--- a/net/udpbroadcastrelay/src/opnsense/mvc/app/controllers/OPNsense/UDPBroadcastRelay/Api/ServiceController.php
+++ b/net/udpbroadcastrelay/src/opnsense/mvc/app/controllers/OPNsense/UDPBroadcastRelay/Api/ServiceController.php
@@ -35,6 +35,7 @@ use OPNsense\Core\Backend;
  * Class ServiceController Handles settings related API actions for the UDPBroadcastRelay
  * @package OPNsense\UDPBroadcastRelay
  */
+
 class ServiceController extends ApiMutableModelControllerBase
 {
     protected static $internalModelName = 'udpbroadcastrelay';
@@ -44,6 +45,7 @@ class ServiceController extends ApiMutableModelControllerBase
     public function statusAction($uuid)
     {
         if ($uuid != null) {
+            $result = array("result" => "failed", "function" => "status");
             $mdlUDPBroadcastRelay = new UDPBroadcastRelay();
             $node = $mdlUDPBroadcastRelay->getNodeByReference('udpbroadcastrelay.' . $uuid);
             if ($node != null) {
@@ -121,6 +123,7 @@ class ServiceController extends ApiMutableModelControllerBase
      */
     public function configAction()
     {
+        $result = array("result" => "failed", "function" => "status");
         $result['result'] = $this->callBackend('template');
         return $result;
     }

--- a/net/udpbroadcastrelay/src/opnsense/mvc/app/controllers/OPNsense/UDPBroadcastRelay/Api/ServiceController.php
+++ b/net/udpbroadcastrelay/src/opnsense/mvc/app/controllers/OPNsense/UDPBroadcastRelay/Api/ServiceController.php
@@ -31,7 +31,6 @@ namespace OPNsense\UDPBroadcastRelay\Api;
 use OPNsense\Base\ApiMutableModelControllerBase;
 use OPNsense\UDPBroadcastRelay\UDPBroadcastRelay;
 use OPNsense\Core\Backend;
-
 /**
  * Class ServiceController Handles settings related API actions for the UDPBroadcastRelay
  * @package OPNsense\UDPBroadcastRelay
@@ -44,10 +43,6 @@ class ServiceController extends ApiMutableModelControllerBase
 
     public function statusAction($uuid)
     {
-        $result = array("result" => "failed", "function" => "status");
-        if ($this->request->isPost()) {
-            $this->sessionClose();
-        }
         if ($uuid != null) {
             $mdlUDPBroadcastRelay = new UDPBroadcastRelay();
             $node = $mdlUDPBroadcastRelay->getNodeByReference('udpbroadcastrelay.' . $uuid);
@@ -126,10 +121,6 @@ class ServiceController extends ApiMutableModelControllerBase
      */
     public function configAction()
     {
-        $result = array("result" => "failed", "function" => "config");
-        if ($this->request->isPost()) {
-            $this->sessionClose();
-        }
         $result['result'] = $this->callBackend('template');
         return $result;
     }
@@ -140,9 +131,6 @@ class ServiceController extends ApiMutableModelControllerBase
      */
     public function reloadAction()
     {
-        if ($this->request->isPost()) {
-            $this->sessionClose();
-        }
         $result = $this->configAction();
         if ($result['result'] == 'OK') {
             $result['function'] = "reload";


### PR DESCRIPTION
The UI was causing errors when running under 24.7, this issue was not present in 24.1 and earlier versions. Not sure what's causing it but removing the following:
 ```
if ($this->request->isPost()) {
            $this->sessionClose();
        }
```
fixes the issue.