### PR TITLE
net/freeradius: Allow `&` as a password character

### DIFF
--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/dialogEditFreeRADIUSUser.xml
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/dialogEditFreeRADIUSUser.xml
@@ -15,7 +15,7 @@
         <id>user.password</id>
         <label>Password</label>
         <type>password</type>
-        <help>Set the password for the user. Allowed characters are 0-9, a-z, A-Z, and ,._-!$%/()+#=: with up to 128 characters.</help>
+        <help><![CDATA[Set the password for the user. Allowed characters are 0-9, a-z, A-Z, and ,._-!$%/()+#=:& with up to 128 characters.]]></help>
     </field>
     <field>
         <id>user.passwordencryption</id>

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/User.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/User.xml
@@ -15,7 +15,7 @@
                 </username>
                 <password type="TextField">
                     <Required>Y</Required>
-                    <mask>/^([0-9a-zA-Z._\-\!\$\%\/\(\)\+\#\=\{\}:]){1,128}$/u</mask>
+                    <mask><![CDATA[/^([0-9a-zA-Z._\-\!\$\%\/\(\)\+\#\=\{\}:&]){1,128}$/u]]></mask>
                 </password>
                 <passwordencryption type="OptionField">
                     <default>Cleartext-Password</default>


### PR DESCRIPTION
Fixes #4115 

Allow `&` to in password