### PR TITLE
[openconnect] move interface changes from start/stop to vpnc script's hooks

### DIFF
--- a/security/openconnect/src/etc/rc.d/opnsense-openconnect
+++ b/security/openconnect/src/etc/rc.d/opnsense-openconnect
@@ -35,7 +35,6 @@ openconnect_stop()
 {
         if [ -n "$rc_pid" ]; then
             echo "stopping openconnect"
-            ifconfig ocvpn0 name tun30000
             kill -2 ${rc_pid}
         else
             echo "${name} is not running."
@@ -46,9 +45,6 @@ openconnect_start()
 {
         echo "starting openconnect"
 	/usr/local/sbin/openconnect ${openconnect_flags} < /usr/local/etc/openconnect.secret 2>&1 > /dev/null
-        sleep 5
-	ifconfig tun30000 name ocvpn0
-	ifconfig ocvpn0 group ocvpn
 	return 0
 }
 

--- a/security/openconnect/src/etc/vpnc/attempt-reconnect.d/restore-ifname
+++ b/security/openconnect/src/etc/vpnc/attempt-reconnect.d/restore-ifname
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+ifconfig ocvpn0 name tun30000

--- a/security/openconnect/src/etc/vpnc/disconnect.d/restore-ifname
+++ b/security/openconnect/src/etc/vpnc/disconnect.d/restore-ifname
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+ifconfig ocvpn0 name tun30000

--- a/security/openconnect/src/etc/vpnc/post-attemp-reconnect.d/set-ifname
+++ b/security/openconnect/src/etc/vpnc/post-attemp-reconnect.d/set-ifname
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+ifconfig tun30000 name ocvpn0
+ifconfig ocvpn0 group ocvpn

--- a/security/openconnect/src/etc/vpnc/post-connect.d/set-ifname
+++ b/security/openconnect/src/etc/vpnc/post-connect.d/set-ifname
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+ifconfig tun30000 name ocvpn0
+ifconfig ocvpn0 group ocvpn

--- a/security/openconnect/src/etc/vpnc/restore-ifname
+++ b/security/openconnect/src/etc/vpnc/restore-ifname
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+ifconfig ocvpn0 name tun30000

--- a/security/openconnect/src/etc/vpnc/set-ifname
+++ b/security/openconnect/src/etc/vpnc/set-ifname
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+ifconfig tun30000 name ocvpn0
+ifconfig ocvpn0 group ocvpn


### PR DESCRIPTION
This changes allow to change the interface names created from openconnect even if the connection was drop by server and not only by client. It uses standard hooks provided by vpnc-script.
It's related to this issue  #4050  