### PR TITLE
security/etpro-telemetry: Fix widget not showing any data

### DIFF
--- a/security/etpro-telemetry/src/opnsense/www/js/widgets/ETProTelemetry.js
+++ b/security/etpro-telemetry/src/opnsense/www/js/widgets/ETProTelemetry.js
@@ -43,7 +43,7 @@ export default class ETProTelemetry extends BaseTableWidget {
 
     async onWidgetTick() {
         const data = await this.ajaxCall('/api/diagnostics/proofpoint_et/status');
-        if (data['sensor_status'] == 'active') {
+        if (data['sensor_status'].toLowerCase() == 'active') {
             $('#etpro_sensor_status').text(data['sensor_status']);
             $('#etpro_event_received').text(data['event_received']);
             $('#etpro_last_rule_download').text(data['last_rule_download']);


### PR DESCRIPTION
The API returns "sensor_status":"ACTIVE", which is upper case. The widget logic compares it to "active", which makes the widget fail to show any data. Converting "ACTIVE" to lower case solves that issue.

Reference: https://forum.opnsense.org/index.php?topic=41772.0

I use it too so I know it works now.