### PR TITLE
net/ftp-proxy: Fix php errors in ServiceController

### DIFF
--- a/net/ftp-proxy/Makefile
+++ b/net/ftp-proxy/Makefile
@@ -1,6 +1,6 @@
 PLUGIN_NAME=		ftp-proxy
 PLUGIN_VERSION=		1.0
-PLUGIN_REVISION=	3
+PLUGIN_REVISION=	4
 PLUGIN_COMMENT=		Control ftp-proxy processes
 PLUGIN_MAINTAINER=	frank.brendel@eurolog.com
 

--- a/net/ftp-proxy/src/opnsense/mvc/app/controllers/OPNsense/FtpProxy/Api/ServiceController.php
+++ b/net/ftp-proxy/src/opnsense/mvc/app/controllers/OPNsense/FtpProxy/Api/ServiceController.php
@@ -41,9 +41,6 @@ class ServiceController extends ApiControllerBase
     public function statusAction($uuid)
     {
         $result = array("result" => "failed", "function" => "status");
-        if (isset($this->request) && $this->request->isPost()) {
-            $this->sessionClose();
-        }
         if ($uuid != null) {
             $mdlFtpProxy = new FtpProxy();
             $node = $mdlFtpProxy->getNodeByReference('ftpproxy.' . $uuid);
@@ -83,9 +80,6 @@ class ServiceController extends ApiControllerBase
     public function stopAction($uuid)
     {
         $result = array("result" => "failed", "function" => "stop");
-        if (isset($this->request) && $this->request->isPost()) {
-            $this->sessionClose();
-        }
         if ($uuid != null) {
             $mdlFtpProxy = new FtpProxy();
             $node = $mdlFtpProxy->getNodeByReference('ftpproxy.' . $uuid);
@@ -103,9 +97,6 @@ class ServiceController extends ApiControllerBase
      */
     public function restartAction($uuid)
     {
-        if (isset($this->request) && $this->request->isPost()) {
-            $this->sessionClose();
-        }
         if ($uuid != null) {
             $mdlFtpProxy = new FtpProxy();
             $node = $mdlFtpProxy->getNodeByReference('ftpproxy.' . $uuid);
@@ -123,9 +114,6 @@ class ServiceController extends ApiControllerBase
     public function configAction()
     {
         $result = array("result" => "failed", "function" => "config");
-        if (isset($this->request) && $this->request->isPost()) {
-            $this->sessionClose();
-        }
         $result['result'] = $this->callBackend('template');
         return $result;
     }
@@ -136,9 +124,6 @@ class ServiceController extends ApiControllerBase
      */
     public function reloadAction()
     {
-        if (isset($this->request) && $this->request->isPost()) {
-            $this->sessionClose();
-        }
         $result = $this->configAction();
         if ($result['result'] == 'OK') {
             $result['function'] = "reload";

--- a/net/ftp-proxy/src/opnsense/mvc/app/controllers/OPNsense/FtpProxy/Api/ServiceController.php
+++ b/net/ftp-proxy/src/opnsense/mvc/app/controllers/OPNsense/FtpProxy/Api/ServiceController.php
@@ -41,7 +41,7 @@ class ServiceController extends ApiControllerBase
     public function statusAction($uuid)
     {
         $result = array("result" => "failed", "function" => "status");
-        if ($this->request->isPost()) {
+        if (isset($this->request) && $this->request->isPost()) {
             $this->sessionClose();
         }
         if ($uuid != null) {
@@ -62,7 +62,7 @@ class ServiceController extends ApiControllerBase
     public function startAction($uuid)
     {
         $result = array("result" => "failed", "function" => "start");
-        if ($this->request->isPost()) {
+        if (isset($this->request) && $this->request->isPost()) {
             $this->sessionClose();
         }
         if ($uuid != null) {
@@ -83,7 +83,7 @@ class ServiceController extends ApiControllerBase
     public function stopAction($uuid)
     {
         $result = array("result" => "failed", "function" => "stop");
-        if ($this->request->isPost()) {
+        if (isset($this->request) && $this->request->isPost()) {
             $this->sessionClose();
         }
         if ($uuid != null) {
@@ -103,7 +103,7 @@ class ServiceController extends ApiControllerBase
      */
     public function restartAction($uuid)
     {
-        if ($this->request->isPost()) {
+        if (isset($this->request) && $this->request->isPost()) {
             $this->sessionClose();
         }
         if ($uuid != null) {
@@ -123,7 +123,7 @@ class ServiceController extends ApiControllerBase
     public function configAction()
     {
         $result = array("result" => "failed", "function" => "config");
-        if ($this->request->isPost()) {
+        if (isset($this->request) && $this->request->isPost()) {
             $this->sessionClose();
         }
         $result['result'] = $this->callBackend('template');
@@ -136,7 +136,7 @@ class ServiceController extends ApiControllerBase
      */
     public function reloadAction()
     {
-        if ($this->request->isPost()) {
+        if (isset($this->request) && $this->request->isPost()) {
             $this->sessionClose();
         }
         $result = $this->configAction();

--- a/net/ftp-proxy/src/opnsense/mvc/app/controllers/OPNsense/FtpProxy/Api/ServiceController.php
+++ b/net/ftp-proxy/src/opnsense/mvc/app/controllers/OPNsense/FtpProxy/Api/ServiceController.php
@@ -59,9 +59,6 @@ class ServiceController extends ApiControllerBase
     public function startAction($uuid)
     {
         $result = array("result" => "failed", "function" => "start");
-        if (isset($this->request) && $this->request->isPost()) {
-            $this->sessionClose();
-        }
         if ($uuid != null) {
             $mdlFtpProxy = new FtpProxy();
             $node = $mdlFtpProxy->getNodeByReference('ftpproxy.' . $uuid);


### PR DESCRIPTION
Fixes: https://github.com/opnsense/plugins/issues/4129

Added checks to ensure $this->request is set before accessing it.

Error: Typed property OPNsense\Mvc\Controller::$request must not be accessed before initialization in /usr/local/opnsense/mvc/app/controllers/OPNsense/FtpProxy/Api/ServiceController.php:52