### PR TITLE
www/caddy: Add Layer4 SSH traffic matcher

### DIFF
--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogLayer4.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogLayer4.xml
@@ -17,7 +17,7 @@
         <id>layer4.Matchers</id>
         <label>Matchers</label>
         <type>dropdown</type>
-        <help><![CDATA[Match the traffic of the selected domains. The TCP/UDP packets will be routed to the selected upstream domains without terminating TLS or altering the traffic. Only protocols that send a "Client Hello" (like TLS), or a "Host Header" (like HTTP) can be routed here. Routing Precedence: 1. "Host", 2. "SNI", 3. "not SNI", 4. "HTTP Handlers" (hidden default route for all unmatched traffic). The "not" operator will invert the match of the selected domains.]]></help>
+        <help><![CDATA[Match the traffic of the selected domains. The TCP/UDP packets will be routed to the selected upstream domains without terminating TLS or altering the traffic. Only protocols that send a "Client Hello" (like TLS), or a "Host Header" (like HTTP) can be routed here. Routing Precedence: 1. "SSH", 2. "Host (HTTP)", 3. "SNI (TLS)", 4. "not SNI (TLS)", 5. "HTTP Handlers" (hidden default route for all unmatched traffic). The "not" operator will invert the match of the selected domains. The "SSH" matcher will match any SSH like traffic on the default ports. Since it does not support SNI or Host Headers, only the first one will match.]]></help>
     </field>
     <field>
         <id>layer4.ToDomain</id>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
@@ -266,6 +266,28 @@ class Caddy extends BaseModel
         }
     }
 
+    // 7. Check that when Layer4 SSH matcher is selected, only "*" is valid as FromDomain
+    private function checkSshMatchers($messages)
+    {
+        foreach ($this->reverseproxy->layer4->iterateItems() as $item) {
+            $matchers = (string) $item->Matchers;
+            $fromDomain = (string) $item->FromDomain;
+
+            if ($matchers === 'ssh' && $fromDomain !== '*') {
+                $key = $item->__reference;
+                $messages->appendMessage(new Message(
+                    sprintf(
+                        gettext(
+                            'When "SSH" matcher is selected, the only valid entry in Domain is "*".'
+                        ),
+                        $fromDomain
+                    ),
+                    $key . ".FromDomain"
+                ));
+            }
+        }
+    }
+
     // Perform the actual validation
     public function performValidation($validateFullModel = false)
     {
@@ -295,6 +317,9 @@ class Caddy extends BaseModel
 
         // 6. Check DisableSuperuser Port conflicts
         $this->checkSuperuserPorts($messages);
+
+        // 7. Check Layer4 SSH matchers
+        $this->checkSshMatchers($messages);
 
         return $messages;
     }

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -405,6 +405,7 @@
                     <Required>Y</Required>
                     <Default>tlssni</Default>
                     <OptionValues>
+                        <ssh>SSH</ssh>
                         <httphost>Host (HTTP)</httphost>
                         <tlssni>SNI (TLS)</tlssni>
                         <nottlssni>not SNI (TLS)</nottlssni>

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/includeLayer4
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/includeLayer4
@@ -23,7 +23,16 @@
 {# Set up Layer4 App #}
 layer4 {
     import /usr/local/etc/caddy/caddy.d/*.layer4
-    {# 1. loop to handle http host matchers #}
+    {# 1. loop to handle raw ssh traffic matchers #}
+    {% for layer4 in layer4_configs %}
+        {% if layer4.enabled == "1" and layer4.Matchers == 'ssh' %}
+            @{{ layer4['@uuid'] }} ssh
+            route @{{ layer4['@uuid'] }} {
+                {{ setup_proxy(layer4.ToDomain, layer4.ToPort, layer4.PassiveHealthFailDuration, layer4.ProxyProtocol) }}
+            }
+        {% endif %}
+    {% endfor %}
+    {# 2. loop to handle http host matchers #}
     {% for layer4 in layer4_configs %}
         {% if layer4.enabled == "1" and layer4.Matchers == 'httphost' %}
             @{{ layer4['@uuid'] }} http host {{ layer4.FromDomain.replace(',', ' ') }}
@@ -32,7 +41,7 @@ layer4 {
             }
         {% endif %}
     {% endfor %}
-    {# 2. loop to handle tls sni matchers #}
+    {# 3. loop to handle tls sni matchers #}
     {% for layer4 in layer4_configs %}
         {% if layer4.enabled == "1" and layer4.Matchers == 'tlssni' %}
             @{{ layer4['@uuid'] }} tls sni {{ layer4.FromDomain.replace(',', ' ') }}
@@ -41,7 +50,7 @@ layer4 {
             }
         {% endif %}
     {% endfor %}
-    {# 3. loop to handle not tls sni matchers #}
+    {# 4. loop to handle not tls sni matchers #}
     {% for layer4 in layer4_configs %}
         {% if layer4.enabled == "1" and layer4.Matchers == 'nottlssni' %}
             @{{ layer4['@uuid'] }} not tls sni {{ layer4.FromDomain.replace(',', ' ') }}


### PR DESCRIPTION
Adds the following matcher:

https://github.com/mholt/caddy-l4?tab=readme-ov-file#introduction

``layer4.matchers.ssh - matches connections that look like SSH connections.``

Since the SSH matcher won't evaluate SNI or Host Header, the user is forced via validation to input a host wildcard. This is purely cosmetic, it is not added to the template. But it will show the user that only one of these SSH matchers can be made, without making the validation more complicated by only permitting one SSH matcher item.

This matcher behaves nicely with the rest of them, so no trouble adding that too.