### PR TITLE
net-mgmt/net-snmp: do not drop privileges

### DIFF
--- a/net-mgmt/net-snmp/Makefile
+++ b/net-mgmt/net-snmp/Makefile
@@ -1,6 +1,6 @@
 PLUGIN_NAME=		net-snmp
 PLUGIN_VERSION=		1.5
-PLUGIN_REVISION=	4
+PLUGIN_REVISION=	5
 PLUGIN_COMMENT=		Net-SNMP is a daemon for the SNMP protocol
 PLUGIN_DEPENDS=		net-snmp
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net-mgmt/net-snmp/src/opnsense/service/templates/OPNsense/Netsnmp/snmpd
+++ b/net-mgmt/net-snmp/src/opnsense/service/templates/OPNsense/Netsnmp/snmpd
@@ -1,6 +1,7 @@
 {% if helpers.exists('OPNsense.netsnmp.general.enabled') and OPNsense.netsnmp.general.enabled == '1' %}
 snmpd_setup="/usr/local/opnsense/scripts/OPNsense/Netsnmp/setup.sh"
 snmpd_enable="YES"
+snmpd_sugid="NO"
 {% else %}
 snmpd_enable="NO"
 {% endif %}


### PR DESCRIPTION
Appears to have changed in FreeBSD ports default behaviour.

PR: https://github.com/opnsense/plugins/issues/4137