### PR TITLE
dns/ddclient: Hide and show dyndnsTable headers dynamically

### DIFF
--- a/dns/ddclient/src/opnsense/www/js/widgets/Dyndns.js
+++ b/dns/ddclient/src/opnsense/www/js/widgets/Dyndns.js
@@ -44,7 +44,7 @@ export default class Dyndns extends BaseTableWidget {
             headerPosition: 'top',
             headers: [
                 this.translations.service,
-                // this.translations.domains
+                this.translations.domains
             ]
         });
 
@@ -110,7 +110,6 @@ export default class Dyndns extends BaseTableWidget {
                     <div class="current-mtime"><em>${this.translations.currentmtime}:</em> ${localizedTime}</div>
                 `,
                 `
-                    <div><u>${this.translations.domains}</u></div>
                     <div class="domain-names">${domainNames}</div>
                 `
             ];
@@ -127,8 +126,10 @@ export default class Dyndns extends BaseTableWidget {
 
     onWidgetResize(elem, width, height) {
         if (width < 320) {
+            $('#header_dyndnsTable').hide();
             $('.domain-names').parent().hide();
         } else {
+            $('#header_dyndnsTable').show();
             $('.domain-names').parent().show();
         }
         return true; // Return true to force the grid to update its layout


### PR DESCRIPTION
This fixes the little Todo I still had in it.

Now the headers will only show when the widget is in the expanded state.

As soon as it is in a collapsed state (smaller than 320px) the headers will disappear.