### PR TITLE
ddclient plugin: Added cloudflare to checkip providers

### DIFF
--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
@@ -139,6 +139,7 @@
                     <Default>web_dyndns</Default>
                     <ValidationMessage>An IP service type is required.</ValidationMessage>
                     <OptionValues>
+                        <web_dyndns>cloudflare</web_dyndns>
                         <web_dyndns>dyndns</web_dyndns>
                         <web_freedns>freedns</web_freedns>
                         <web_googledomains>googledomains</web_googledomains>

--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/address.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/address.py
@@ -29,7 +29,7 @@ import ipaddress
 
 
 checkip_service_list = {
-  'cloudflare': '%s://1.1.1.1/cdn-cgi/trace',
+  'cloudflare': '%s://one.one.one.one/cdn-cgi/trace',
   'dyndns': '%s://checkip.dyndns.org/',
   'freedns': '%s://freedns.afraid.org/dynamic/check.php',
   'googledomains': '%s://domains.google.com/checkip',
@@ -57,8 +57,6 @@ def extract_address(txt):
     for regexp in [r'[^a-fA-F0-9\:]', r'[^F0-9\.]']:
         for line in re.sub(regexp, ' ', txt).split():
             if line.count('.') == 3 or line.count(':') >= 2:
-                if line == '1.1.1.1':
-                    continue
                 try:
                     ipaddress.ip_address(line)
                     return line

--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/address.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/address.py
@@ -29,6 +29,7 @@ import ipaddress
 
 
 checkip_service_list = {
+  'cloudflare': '%s://1.1.1.1/cdn-cgi/trace',
   'dyndns': '%s://checkip.dyndns.org/',
   'freedns': '%s://freedns.afraid.org/dynamic/check.php',
   'googledomains': '%s://domains.google.com/checkip',
@@ -56,6 +57,8 @@ def extract_address(txt):
     for regexp in [r'[^a-fA-F0-9\:]', r'[^F0-9\.]']:
         for line in re.sub(regexp, ' ', txt).split():
             if line.count('.') == 3 or line.count(':') >= 2:
+                if line == '1.1.1.1':
+                    continue
                 try:
                     ipaddress.ip_address(line)
                     return line


### PR DESCRIPTION
Added cloudflare as a checkip provider for ddclient / DynDNS.

Cloudflare provides an information page at [https://1.1.1.1/cdn-cgi/trace](https://1.1.1.1/cdn-cgi/trace), which returns the requesting clients IP address.

The benefit is that the connection is using a direct IP (so no DNS lookup) and it is a geo multi-cast server deployment.
This leads to a near instant response time compared to other services for IP lookups.

The return format required ignoring the `h=1.1.1.1` IP value, which reflects the HTTP host header used in the request.