### PR TITLE
Add Postfix setting for always_add_missing_headers and local_header_rewrite_clients

### DIFF
--- a/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
+++ b/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
@@ -248,6 +248,11 @@
         <help>Use Recipient Address Verification. Please keep in mind that this could put significant load onto the next server.</help>
     </field>
     <field>
+        <id>general.always_add_missing_headers</id>
+        <label>Always add missing headers</label>
+        <type>checkbox</type>
+    </field>
+    <field>
         <id>general.delay_warning_time</id>
         <label>Delay Warning Time</label>
         <type>text</type>

--- a/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
+++ b/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
@@ -253,6 +253,14 @@
         <type>checkbox</type>
     </field>
     <field>
+        <id>general.local_header_rewrite_clients</id>
+        <label>Local header rewrite clients</label>
+        <style>tokenize</style>
+        <type>select_multiple</type>
+        <allownew>false</allownew>
+        <help>Rewrite or add message headers in mail from these clients, updating incomplete addresses with the domain name in $myorigin or $mydomain, and adding missing headers.</help>
+    </field>
+    <field>
         <id>general.delay_warning_time</id>
         <label>Delay Warning Time</label>
         <type>text</type>

--- a/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
+++ b/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
@@ -190,6 +190,19 @@
             <default>0</default>
             <Required>Y</Required>
         </always_add_missing_headers>
+        <local_header_rewrite_clients type="OptionField">
+            <Required>N</Required>
+            <default>permit_inet_interfaces</default>
+            <Sorted>Y</Sorted>
+            <Multiple>Y</Multiple>
+            <OptionValues>
+                <permit_inet_interfaces>permit_inet_interfaces</permit_inet_interfaces>
+                <permit_mynetworks>permit_mynetworks</permit_mynetworks>
+                <permit_sasl_authenticated>permit_sasl_authenticated</permit_sasl_authenticated>
+                <permit_tls_clientcerts>permit_tls_clientcerts</permit_tls_clientcerts>
+                <permit_tls_all_clientcerts>permit_tls_all_clientcerts</permit_tls_all_clientcerts>
+            </OptionValues>
+        </local_header_rewrite_clients>
         <delay_warning_time type="IntegerField">
             <default>0</default>
             <Required>N</Required>

--- a/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
+++ b/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
@@ -186,6 +186,10 @@
             <default>0</default>
             <Required>Y</Required>
         </reject_unverified_recipient>
+        <always_add_missing_headers type="BooleanField">
+            <default>0</default>
+            <Required>Y</Required>
+        </always_add_missing_headers>
         <delay_warning_time type="IntegerField">
             <default>0</default>
             <Required>N</Required>

--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
@@ -156,6 +156,9 @@ relayhost = {{ OPNsense.postfix.general.relayhost }}
 {% if helpers.exists('OPNsense.postfix.general.always_add_missing_headers') and OPNsense.postfix.general.always_add_missing_headers == '1' %}
 always_add_missing_headers = yes
 {% endif %}
+{% if helpers.exists('OPNsense.postfix.general.local_header_rewrite_clients') and OPNsense.postfix.general.local_header_rewrite_clients != '' %}
+local_header_rewrite_clients = {{ OPNsense.postfix.general.local_header_rewrite_clients }}
+{% endif %}
 
 {% if helpers.exists('OPNsense.postfix.general.smtpauth_enabled') and OPNsense.postfix.general.smtpauth_enabled != '' %}
 smtp_sasl_auth_enable = yes

--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/main.cf
@@ -153,6 +153,10 @@ tls_preempt_cipherlist = no
 relayhost = {{ OPNsense.postfix.general.relayhost }}
 {% endif %}
 
+{% if helpers.exists('OPNsense.postfix.general.always_add_missing_headers') and OPNsense.postfix.general.always_add_missing_headers == '1' %}
+always_add_missing_headers = yes
+{% endif %}
+
 {% if helpers.exists('OPNsense.postfix.general.smtpauth_enabled') and OPNsense.postfix.general.smtpauth_enabled != '' %}
 smtp_sasl_auth_enable = yes
 smtp_sasl_password_maps = hash:/usr/local/etc/postfix/smtp_auth


### PR DESCRIPTION
As requested in #3489 and in for example [this topic on the forums](https://forum.opnsense.org/index.php?topic=11068.0).

Adds `always_add_missing_headers` and `local_header_rewrite_clients` settings to the Postfix config.