### PR TITLE
net/freeradius: Added remote syslog support (#3990)

### DIFF
--- a/net/freeradius/Makefile
+++ b/net/freeradius/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		freeradius
-PLUGIN_VERSION=		1.9.24
+PLUGIN_VERSION=		1.9.25
 PLUGIN_COMMENT=		RADIUS Authentication, Authorization and Accounting Server
 PLUGIN_DEPENDS=		freeradius3
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net/freeradius/pkg-descr
+++ b/net/freeradius/pkg-descr
@@ -15,6 +15,10 @@ The server is fast, feature-rich, modular, and scalable.
 Plugin Changelog
 ================
 
+1.9.25
+
+* Added support for remote syslog
+
 1.9.24
 
 * Allow ":" character in usernames and passwords (contributed by Chris Helming)

--- a/net/freeradius/src/etc/inc/plugins.inc.d/freeradius.inc
+++ b/net/freeradius/src/etc/inc/plugins.inc.d/freeradius.inc
@@ -57,3 +57,10 @@ function freeradius_xmlrpc_sync()
     $result['services'] = ["freeradius"];
     return array($result);
 }
+
+function freeradius_syslog()
+{
+    return [
+        'freeradius' => ['facility' => ['radiusd']]
+    ];
+}


### PR DESCRIPTION
Hi all,

this small PR adds remote syslog support for the freeradius plugin, so that the plugin is listed in the applications list for a remote destination. It was only necessary to implement the `freeradius_syslog()` function since the logging mechanism to syslog was already there. 
To test this, it is required to set the `Log to File or Syslog` option of the freeradius plugin to `syslog`.

![CleanShot 2024-08-11 at 16 44 00](https://github.com/user-attachments/assets/73df3c91-3873-4aae-bccc-82918ebf769c)

If any changes are required to be compliant with any rules, just let me know.