### PR TITLE
smart plugin: nvd to nda

### DIFF
--- a/sysutils/smart/src/opnsense/scripts/OPNsense/Smart/detailed_list.sh
+++ b/sysutils/smart/src/opnsense/scripts/OPNsense/Smart/detailed_list.sh
@@ -30,9 +30,9 @@ RESULT=
 for DEV in $(sysctl -n kern.disks); do
     IDENT=$(/usr/sbin/diskinfo -s ${DEV})
 
-    if [ "${DEV#nvd}" != "${DEV}" ]; then
-        # the disk formerly know as nvdX
-        DEV="nvme${DEV#nvd}"
+    if [ "${DEV#nda}" != "${DEV}" ]; then
+        # the disk formerly know as ndaX
+        DEV="nvme${DEV#nda}"
     fi
 
     STATE=$(/usr/local/sbin/smartctl -jH /dev/${DEV})

--- a/sysutils/smart/src/opnsense/service/conf/actions.d/actions_smart.conf
+++ b/sysutils/smart/src/opnsense/service/conf/actions.d/actions_smart.conf
@@ -1,5 +1,5 @@
 [list]
-command:sysctl -n kern.disks | sed s:nvd:nvme:g
+command:sysctl -n kern.disks | sed s:nda:nvme:g
 parameters:
 type:script_output
 message:list installed devices


### PR DESCRIPTION
FreeBSD 14 changed from the nvd driver to the nda driver for x86. This change modifies the smart service to utilize the new driver name on the UI and the backend script that pulls the smartctl data (thanks @jbilac!). Issue https://github.com/opnsense/plugins/issues/4155

https://www.freebsd.org/releases/14.0R/relnotes/
https://cgit.freebsd.org/src/commit/?id=bdc81eeda05d
