### PR TITLE
dns/bind: Add option to allow the rndc-key for zone transfers

### DIFF
--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindPrimaryDomain.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindPrimaryDomain.xml
@@ -18,6 +18,12 @@
         <help>Define the ACLs where you allow which server can retrieve this zone.</help>
     </field>
     <field>
+        <id>domain.allowrndctransfer</id>
+        <label>Allow RDNC key transfer</label>
+        <type>checkbox</type>
+        <help>Allow transfers via the RDNC key named "rndc-key". The key is shown in the general tab.</help>
+    </field>
+    <field>
         <id>domain.allowquery</id>
         <label>Allow Query</label>
         <type>select_multiple</type>

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Domain.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Domain.xml
@@ -61,6 +61,10 @@
                     <Multiple>Y</Multiple>
                     <Required>N</Required>
                 </allowtransfer>
+                <allowrndctransfer type="BooleanField">
+                    <default>1</default>
+                    <Required>Y</Required>
+                </allowrndctransfer>
                 <allowquery type="ModelRelationField">
                     <Model>
                         <template>

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Domain.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Domain.xml
@@ -61,9 +61,7 @@
                     <Multiple>Y</Multiple>
                     <Required>N</Required>
                 </allowtransfer>
-                <allowrndctransfer type="BooleanField">
-                    <Required>N</Required>
-                </allowrndctransfer>
+                <allowrndctransfer type="BooleanField"/>
                 <allowquery type="ModelRelationField">
                     <Model>
                         <template>

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Domain.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Domain.xml
@@ -62,8 +62,7 @@
                     <Required>N</Required>
                 </allowtransfer>
                 <allowrndctransfer type="BooleanField">
-                    <default>1</default>
-                    <Required>Y</Required>
+                    <Required>N</Required>
                 </allowrndctransfer>
                 <allowquery type="ModelRelationField">
                     <Model>

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
@@ -164,12 +164,17 @@ zone "{{ domain.domainname }}" {
 {%       else %}
         file "/usr/local/etc/namedb/primary/{{ domain.domainname }}.db";
 {%       endif %}
-{%      if domain.allowtransfer is defined %}
+{%      if domain.allowtransfer is defined or (domain.allowrndctransfer is defined and domain.allowrndctransfer == "1") %}
         allow-transfer {
-{%              for acl in domain.allowtransfer.split(',') %}
-{%              set transfer_acl = helpers.getUUID(acl) %}
+{%              if domain.allowrndctransfer is defined and domain.allowrndctransfer == "1" %}
+                key "rndc-key";
+{%              endif %}
+{%              if domain.allowtransfer is defined %}
+{%                for acl in domain.allowtransfer.split(',') %}
+{%                  set transfer_acl = helpers.getUUID(acl) %}
                 {{ transfer_acl.name }};
-{%              endfor %}
+{%                endfor %}
+{%              endif %}
         };
 {%      endif %}
 {%      if domain.allowquery is defined %}


### PR DESCRIPTION
This adds a zone option to allow the RNDC key to be used for transfers.
My use case for this is for [kubernetes-sig/external-dns](https://github.com/kubernetes-sigs/external-dns) to manage my cluster's DNS records with [dynamic updates](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/rfc2136.md).