### PR TITLE
ddclient plugin: Removed deprecated domains.google.com/checkip

### DIFF
--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
@@ -141,7 +141,6 @@
                     <OptionValues>
                         <web_dyndns>dyndns</web_dyndns>
                         <web_freedns>freedns</web_freedns>
-                        <web_googledomains>googledomains</web_googledomains>
                         <web_he>he</web_he>
                         <web_icanhazip>icanhazip</web_icanhazip>
                         <web_ip4only_me value="web_ip4only.me">ip4only.me</web_ip4only_me>

--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/address.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/address.py
@@ -31,7 +31,6 @@ import ipaddress
 checkip_service_list = {
   'dyndns': '%s://checkip.dyndns.org/',
   'freedns': '%s://freedns.afraid.org/dynamic/check.php',
-  'googledomains': '%s://domains.google.com/checkip',
   'he': '%s://checkip.dns.he.net/',
   'icanhazip': '%s://icanhazip.com/',
   'ip4only.me': '%s://ip4only.me/api/',


### PR DESCRIPTION
With the sunset of Google Domains (and migration to Square Space), https://domains.google.com/checkip (used by OPNsense checkip) is no longer working.

Reference:
https://github.com/ddclient/ddclient/issues/622
