### PR TITLE
Refactored dyndns check-ip

### DIFF
--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
@@ -139,7 +139,9 @@
                     <Default>web_dyndns</Default>
                     <ValidationMessage>An IP service type is required.</ValidationMessage>
                     <OptionValues>
-                        <web_dyndns>cloudflare</web_dyndns>
+                        <web_cloudflare>cloudflare</web_cloudflare>
+                        <web_cloudflare_ipv4 value="cloudflare-ipv4">cloudflare-ipv4</web_cloudflare_ipv4>
+                        <web_cloudflare_ipv6 value="cloudflare-ipv6">cloudflare-ipv6</web_cloudflare_ipv6>
                         <web_dyndns>dyndns</web_dyndns>
                         <web_freedns>freedns</web_freedns>
                         <web_he>he</web_he>

--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/address.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/address.py
@@ -26,10 +26,12 @@
 import subprocess
 import re
 import ipaddress
-
+from urllib.parse import urlparse
 
 checkip_service_list = {
   'cloudflare': '%s://one.one.one.one/cdn-cgi/trace',
+  'cloudflare-ipv4': '%s://1.1.1.1/cdn-cgi/trace',
+  'cloudflare-ipv6': '%s://[2606:4700:4700::1111]/cdn-cgi/trace',
   'dyndns': '%s://checkip.dyndns.org/',
   'freedns': '%s://freedns.afraid.org/dynamic/check.php',
   'he': '%s://checkip.dns.he.net/',
@@ -48,17 +50,18 @@ checkip_service_list = {
 }
 
 
-def extract_address(txt):
+def extract_address(host, txt):
     """ Extract first IPv4 or IPv6 address from provided string
         :param txt: text blob
         :return: str
     """
-    for regexp in [r'[^a-fA-F0-9\:]', r'[^F0-9\.]']:
-        for line in re.sub(regexp, ' ', txt).split():
-            if line.count('.') == 3 or line.count(':') >= 2:
+    for regexp in [r'(?:\d{1,3}\.){3}\d{1,3}', r'([a-f0-9:]+:+)+[a-f0-9]+']:
+        matches = re.finditer(regexp, txt)
+        for match in matches:
+            if match.group() != host:
                 try:
-                    ipaddress.ip_address(line)
-                    return line
+                    ipaddress.ip_address(match.group())
+                    return match.group()
                 except ValueError:
                     pass
     return ""
@@ -79,8 +82,10 @@ def checkip(service, proto='https', timeout='10', interface=None):
         if interface is not None:
             params.append("--interface")
             params.append(interface)
-        params.append(checkip_service_list[service] % proto)
-        return extract_address(subprocess.run(params, capture_output=True, text=True).stdout)
+        url = checkip_service_list[service] % proto 
+        params.append(url)
+        return extract_address(urlparse(url).hostname,
+            subprocess.run(params, capture_output=True, text=True).stdout)
     elif service in ['if', 'if6'] and interface is not None:
         # return first non private IPv[4|6] interface address
         ifcfg = subprocess.run(['/sbin/ifconfig', interface], capture_output=True, text=True).stdout


### PR DESCRIPTION
* Rewrote dyndns check-ip to use `re.finditer`, which is a bit cleaner
* Any IP results which are equal to the requested hostname IP are now ignored, this resolves the cloudflare `1.1.1.1` or `2606:4700:4700::1111` returned in results issue in a constructive re-usable way.
* Note, it looked like there was a small bug in the previous cloudflare added option as well, it was marked as `<web_dyndns>cloudflare</web_dyndns>`
* As mentioned before the new IP based cloudflare options are considerably faster (near-instant) compared to the pre-existing options.

Test results across all current available check-ip options:

|Provider|HTTP|HTTPS|IPv4|IPv6
|--|--|--|--|--|
|cloudflare|:x:|:white_check_mark:|:white_check_mark:|:white_check_mark:
|cloudflare-ipv4|:x:|:white_check_mark:|:white_check_mark::exclamation:|:x:|
|cloudflare-ipv6|:x:|:white_check_mark:|:x:|:white_check_mark::exclamation:|
|dyndns|:white_check_mark:|:x:|:white_check_mark:|:x:
|freedns|:white_check_mark:|:white_check_mark:|:white_check_mark:|:x:
|he|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:
|icanhazip|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
|ip4only.me|:white_check_mark:|:white_check_mark:|:white_check_mark::exclamation:|:x:|
|ip6only.me|:white_check_mark:|:white_check_mark:|:x:|:white_check_mark::exclamation:
|ipify-ipv4|:white_check_mark:|:white_check_mark:|:white_check_mark::exclamation:|:x:|
|ipify-ipv6|:white_check_mark:|:white_check_mark:|:x:|:white_check_mark::exclamation:
loopia|:white_check_mark:|:white_check_mark:|:white_check_mark:|:x:|
myonlineportal|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:
noip-ipv4|:white_check_mark:|:x:|:white_check_mark::exclamation:|:x:|
noip-ipv6|:white_check_mark:|:x:|:x:|:white_check_mark::exclamation:
nsupdate.info-ipv4|:white_check_mark:|:white_check_mark:|:white_check_mark::exclamation:|:x:|
nsupdate.info-ipv6|:white_check_mark:|:white_check_mark:|:x:|:white_check_mark::exclamation:|
zoneedit|:white_check_mark:|:white_check_mark:|:white_check_mark:|:x:|

:exclamation: - Forced IPv4 or IPv6-only result