### PR TITLE
ddclient: Cloudflare - add Cloudflare dns ip check option

### DIFF
--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
@@ -142,6 +142,7 @@
                         <web_cloudflare>cloudflare</web_cloudflare>
                         <web_cloudflare_ipv4 value="cloudflare-ipv4">cloudflare-ipv4</web_cloudflare_ipv4>
                         <web_cloudflare_ipv6 value="cloudflare-ipv6">cloudflare-ipv6</web_cloudflare_ipv6>
+                        <dns_cloudflare value="dns_cloudflare-dns">cloudflare-dns</dns_cloudflare>
                         <web_dyndns>dyndns</web_dyndns>
                         <web_freedns>freedns</web_freedns>
                         <web_he>he</web_he>


### PR DESCRIPTION
This adds an IP check option that utilizes Cloudflare's DNS "whoami" service.

Motivation: I encountered a service provider that proxies web traffic, which results in the public IP returned through web services being incorrect. Using Cloudflare's DNS "whoami" services resolved this issue. Other DNS providers' "whoami" services could easily be added using the same general logic. 