### PR TITLE
Update plugins.mk to fix missing double-quotes

### DIFF
--- a/Mk/plugins.mk
+++ b/Mk/plugins.mk
@@ -211,7 +211,7 @@ scripts-post:
 install: check
 	@mkdir -p ${DESTDIR}${LOCALBASE}/opnsense/version
 	@(cd ${.CURDIR}/src 2> /dev/null && find * -type f) | while read FILE; do \
-		tar -C ${.CURDIR}/src -cpf - $${FILE} | \
+		tar -C ${.CURDIR}/src -cpf - "$${FILE}" | \
 		    tar -C ${DESTDIR}${LOCALBASE} -xpf -; \
 		if [ "$${FILE%%.in}" != "$${FILE}" ]; then \
 			sed -i '' ${SED_REPLACE} "${DESTDIR}${LOCALBASE}/$${FILE}"; \
@@ -253,17 +253,17 @@ metadata: check
 
 collect: check
 	@(cd ${.CURDIR}/src 2> /dev/null && find * -type f) | while read FILE; do \
-		tar -C ${DESTDIR}${LOCALBASE} -cpf - $${FILE} | \
+		tar -C ${DESTDIR}${LOCALBASE} -cpf - "$${FILE}" | \
 		    tar -C ${.CURDIR}/src -xpf -; \
 	done
 
 remove: check
 	@(cd ${.CURDIR}/src 2> /dev/null && find * -type f) | while read FILE; do \
-		rm -f ${DESTDIR}${LOCALBASE}/$${FILE}; \
+		rm -f "${DESTDIR}${LOCALBASE}/$${FILE}"; \
 	done
 	@(cd ${.CURDIR}/src 2> /dev/null && find * -type d -depth) | while read DIR; do \
-		if [ -d ${DESTDIR}${LOCALBASE}/$${DIR} ]; then \
-			rmdir ${DESTDIR}${LOCALBASE}/$${DIR} 2> /dev/null || true; \
+		if [ -d "${DESTDIR}${LOCALBASE}/$${DIR}" ]; then \
+			rmdir "${DESTDIR}${LOCALBASE}/$${DIR}" 2> /dev/null || true; \
 		fi; \
 	done
 
@@ -324,7 +324,7 @@ lint-shell:
 	    if [ "$$(head $${FILE} | grep -c '^#!\/')" == "0" ]; then \
 	        echo "Missing shebang in $${FILE}"; exit 1; \
 	    fi; \
-	    sh -n $${FILE} || exit 1; \
+	    sh -n "$${FILE}" || exit 1; \
 	done
 
 lint-xml:


### PR DESCRIPTION
I ran into problems building a plugin where some of the source files have spaces in the name. Unfortunately I don't control these filenames as they are pulled in from a 3rd party open-source project. Regardless of filename sanity, it seemed that the issue was caused by inconsistent quoting of file paths in the plugins.mk file. This PR resolves that issue.

Add double-quotes to fix problems when packaging files with spaces in the filenames