### PR TITLE
 security/etpro-telemetry: Lower logging priority

### DIFF
--- a/security/etpro-telemetry/src/opnsense/scripts/etpro_telemetry/send_telemetry.py
+++ b/security/etpro-telemetry/src/opnsense/scripts/etpro_telemetry/send_telemetry.py
@@ -78,7 +78,7 @@ if not telemetry_state.is_running():
             # data collected, log and push
             if row_count > 0 and max_timestamp is not None:
                 syslog.syslog(
-                    syslog.LOG_NOTICE,
+                    syslog.LOG_DEBUG,
                     'telemetry data collected %d records in %.2f seconds @%s' % (
                         row_count, time.time() - send_start_time, max_timestamp
                     )


### PR DESCRIPTION
PR: https://forum.opnsense.org/index.php?topic=42759.0

See man syslog(3) and https://github.com/opnsense/core/issues/7101

This log message is of no interest to anyone beyond debugging telemetry functionality.