### PR TITLE
fix false negatives

### DIFF
--- a/net/wol/src/opnsense/www/js/widgets/WakeOnLan.js
+++ b/net/wol/src/opnsense/www/js/widgets/WakeOnLan.js
@@ -94,7 +94,7 @@ export default class WakeOnLan extends BaseTableWidget {
   }
 
   checkActive(arp_list, mac, intf) {
-    const arp = arp_list.find((obj) => obj.mac === mac);
+    const arp = arp_list.find((obj) => obj.mac === mac.toLowerCase());
     if (arp === undefined) {
       return 0;
     } else {


### PR DESCRIPTION
if you add WOL clients in uppercase mac adresses then onlinestatus won't work. Just added a toLowerCase so the comparison always works.