### PR TITLE
www/caddy: Fix api endpoints in widgets via lint-acl

### DIFF
--- a/www/caddy/src/opnsense/www/js/widgets/Metadata/Caddy.xml
+++ b/www/caddy/src/opnsense/www/js/widgets/Metadata/Caddy.xml
@@ -3,7 +3,7 @@
         <filename>CaddyDomain.js</filename>
         <link>/ui/caddy/reverse_proxy</link>
         <endpoints>
-            <endpoint>/api/caddy/reverse_proxy/*</endpoint>
+            <endpoint>/api/caddy/reverse_proxy/get</endpoint>
         </endpoints>
         <translations>
             <title>Caddy Domains</title>
@@ -16,8 +16,8 @@
         <filename>CaddyCertificate.js</filename>
         <link>/ui/caddy/reverse_proxy</link>
         <endpoints>
-            <endpoint>/api/caddy/diagnostics/*</endpoint>
-            <endpoint>/api/caddy/reverse_proxy/*</endpoint>
+            <endpoint>/api/caddy/diagnostics/certificate</endpoint>
+            <endpoint>/api/caddy/reverse_proxy/get</endpoint>
         </endpoints>
         <translations>
             <title>Caddy Certificates</title>

--- a/www/caddy/src/opnsense/www/js/widgets/Metadata/Caddy.xml
+++ b/www/caddy/src/opnsense/www/js/widgets/Metadata/Caddy.xml
@@ -3,7 +3,7 @@
         <filename>CaddyDomain.js</filename>
         <link>/ui/caddy/reverse_proxy</link>
         <endpoints>
-            <endpoint>/api/caddy/reverse_proxy/get</endpoint>
+            <endpoint>/api/caddy/reverse_proxy/*</endpoint>
         </endpoints>
         <translations>
             <title>Caddy Domains</title>
@@ -16,8 +16,8 @@
         <filename>CaddyCertificate.js</filename>
         <link>/ui/caddy/reverse_proxy</link>
         <endpoints>
-            <endpoint>/api/caddy/diagnostics/certificate</endpoint>
-            <endpoint>/api/caddy/reverse_proxy/get</endpoint>
+            <endpoint>/api/caddy/diagnostics/*</endpoint>
+            <endpoint>/api/caddy/reverse_proxy/*</endpoint>
         </endpoints>
         <translations>
             <title>Caddy Certificates</title>

--- a/www/caddy/src/opnsense/www/js/widgets/Metadata/Caddy.xml
+++ b/www/caddy/src/opnsense/www/js/widgets/Metadata/Caddy.xml
@@ -2,7 +2,7 @@
     <caddydomain>
         <filename>CaddyDomain.js</filename>
         <endpoints>
-            <endpoint>/api/caddy/reverse_proxy/*</endpoint>
+            <endpoint>/api/caddy/reverse_proxy/get</endpoint>
         </endpoints>
         <translations>
             <title>Caddy Domains</title>
@@ -14,7 +14,8 @@
     <caddycertificate>
         <filename>CaddyCertificate.js</filename>
         <endpoints>
-            <endpoint>/api/caddy/*</endpoint>
+            <endpoint>/api/caddy/diagnostics/certificate</endpoint>
+            <endpoint>/api/caddy/reverse_proxy/get</endpoint>
         </endpoints>
         <translations>
             <title>Caddy Certificates</title>

--- a/www/caddy/src/opnsense/www/js/widgets/Metadata/Caddy.xml
+++ b/www/caddy/src/opnsense/www/js/widgets/Metadata/Caddy.xml
@@ -1,6 +1,7 @@
 <metadata>
     <caddydomain>
         <filename>CaddyDomain.js</filename>
+        <link>/ui/caddy/reverse_proxy</link>
         <endpoints>
             <endpoint>/api/caddy/reverse_proxy/get</endpoint>
         </endpoints>
@@ -13,6 +14,7 @@
     </caddydomain>
     <caddycertificate>
         <filename>CaddyCertificate.js</filename>
+        <link>/ui/caddy/reverse_proxy</link>
         <endpoints>
             <endpoint>/api/caddy/diagnostics/certificate</endpoint>
             <endpoint>/api/caddy/reverse_proxy/get</endpoint>


### PR DESCRIPTION
As discussed earlier.

The new ``lint-acl`` wants some changes to the widget ACL endpoints.