### PR TITLE
add Tunnel-Password field to radius user

### DIFF
--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/dialogEditFreeRADIUSUser.xml
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/dialogEditFreeRADIUSUser.xml
@@ -164,4 +164,10 @@
         <allownew>true</allownew>
         <help>Select the configured AVPairs for this user.</help>
     </field>
+    <field>
+        <id>user.tunnel_password</id>
+        <label>Tunnel-Password</label>
+        <type>password</type>
+        <help>Set the Tunnel-Password attribute for the user. Allowed characters are 0-9, a-z, A-Z, and ,._-!$%/()+#=: with up to 128 characters.</help>
+    </field>
 </form>

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/User.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/User.xml
@@ -132,6 +132,10 @@
                     <Multiple>Y</Multiple>
                     <Required>N</Required>
                 </linkedAVPair>
+                <tunnel_password type="TextField">
+                    <Required>N</Required>
+                    <mask>/^([0-9a-zA-Z._\-\!\$\%\/\(\)\+\#\=\{\}:]){1,128}$/u</mask>
+                </tunnel_password>
             </user>
         </users>
     </items>

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/users
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/users
@@ -24,6 +24,9 @@
        Service-Type = {{ servicelist }},
 {%         endfor %}
 {%       endif %}
+{%       if user_list.tunnel_password is defined %}
+       Tunnel-Password = {{ user_list.tunnel_password }},
+{%       endif %}
 {%       if helpers.exists('OPNsense.freeradius.general.vlanassign') and OPNsense.freeradius.general.vlanassign == '1' %}
 {%         if user_list.vlan is defined %}
        Tunnel-Type = VLAN,


### PR DESCRIPTION
This PR adds the ability to configure the "Tunnel-Password" Radius attribute for a user.
This usefull e.g. to define a PPSK Wifi Key for a user.