### PR TITLE
www/caddy: Add option to disable QUIC protocol

### DIFF
--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
@@ -43,9 +43,9 @@
     </field>
     <field>
         <id>reverse.DisableTls</id>
-        <label>Disable TLS</label>
-        <type>checkbox</type>
-        <help><![CDATA[Disable HTTP over TLS (HTTPS) for this domain. When disabling TLS, automatic certificate management will be disabled and all traffic to and from this domain will be unencrypted.]]></help>
+        <label>Protocol</label>
+        <type>dropdown</type>
+        <help><![CDATA[When choosing HTTP, it will disable HTTP over TLS (HTTPS) for this domain. Automatic certificate management will be disabled and all traffic to and from this domain will be unencrypted.]]></help>
     </field>
     <field>
         <id>reverse.DnsChallenge</id>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
@@ -6,6 +6,12 @@
         <help><![CDATA[Enable this domain.]]></help>
     </field>
     <field>
+        <id>reverse.DisableTls</id>
+        <label>Protocol</label>
+        <type>dropdown</type>
+        <help><![CDATA[When choosing HTTPS, the ACME HTTP-01, TLS-ALPN-01 or DNS-01 challenge will be used to get automatic Let's Encrypt or ZeroSSL certificates, without the need of any additional plugin. When choosing HTTP, it will disable HTTP over TLS (HTTPS) for this domain, automatic certificate management will be disabled and all traffic to and from this domain will be unencrypted.]]></help>
+    </field>
+    <field>
         <id>reverse.FromDomain</id>
         <label>Domain</label>
         <type>text</type>
@@ -42,28 +48,22 @@
         <collapse>true</collapse>
     </field>
     <field>
-        <id>reverse.DisableTls</id>
-        <label>Protocol</label>
-        <type>dropdown</type>
-        <help><![CDATA[When choosing HTTP, it will disable HTTP over TLS (HTTPS) for this domain. Automatic certificate management will be disabled and all traffic to and from this domain will be unencrypted.]]></help>
-    </field>
-    <field>
         <id>reverse.DnsChallenge</id>
         <label>DNS-01 Challenge</label>
         <type>checkbox</type>
         <help><![CDATA[Enable the DNS-01 challenge for this domain. Requires a "DNS Provider" in "General Settings". This is mostly only needed for wildcard domains, or when the HTTP-01 and TLS-ALPN-01 challenge can not be used due to restrictive firewall policies.]]></help>
     </field>
     <field>
-        <id>reverse.AcmePassthrough</id>
-        <label>HTTP-01 Challenge Redirection</label>
-        <type>text</type>
-        <help><![CDATA[Enter a domain name or IP address. The HTTP-01 challenge will be redirected to that destination. This enables an ACME Client behind Caddy to serve "/.well-known/acme-challenge/" on port 80. Caddy will reverse proxy the HTTP-01 challenge for this domain, and will still issue a certificate using the TLS-ALPN-01 challenge or DNS-01 challenge for itself. This option can be used for High Availability when using Caddy with a master and backup OPNsense.]]></help>
-    </field>
-    <field>
         <id>reverse.CustomCertificate</id>
         <label>Custom Certificate</label>
         <type>dropdown</type>
         <help><![CDATA[Choose a custom certificate from "System - Trust - Certificates" for this domain. Make sure the full chain has been imported.]]></help>
+    </field>
+    <field>
+        <id>reverse.AcmePassthrough</id>
+        <label>HTTP-01 Challenge Redirection</label>
+        <type>text</type>
+        <help><![CDATA[Enter a domain name or IP address. The HTTP-01 challenge will be redirected to that destination. This enables an ACME Client behind Caddy to serve "/.well-known/acme-challenge/" on port 80. Caddy will reverse proxy the HTTP-01 challenge for this domain, and will still issue a certificate using the TLS-ALPN-01 challenge or DNS-01 challenge for itself. This option can be used for High Availability when using Caddy with a master and backup OPNsense.]]></help>
     </field>
     <field>
         <type>header</type>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
@@ -29,15 +29,15 @@
         </field>
         <field>
             <id>caddy.general.DisableSuperuser</id>
-            <label>Disable Superuser</label>
-            <type>checkbox</type>
+            <label>System User</label>
+            <type>dropdown</type>
             <help><![CDATA[Run this service as "www" user and group, instead of "root". This setting increases security, but comes with the hard restriction that the well-known port range can not be used anymore. After enabling and saving this setting, the service has to be totally restarted. For this, please disable Caddy and press Apply. Afterwards enable Caddy and press Apply. This setting is reversible by following the same steps.]]></help>
         </field>
         <field>
-            <id>caddy.general.DisableQuic</id>
-            <label>Disable QUIC</label>
-            <type>checkbox</type>
-            <help><![CDATA[Disable the QUIC protocol for the frontend listeners. This will free up port 443 UDP so it can be used for other services.]]></help>
+            <id>caddy.general.HttpVersion</id>
+            <label>HTTP Version</label>
+            <type>select_multiple</type>
+            <help><![CDATA[Select the HTTP Version for the frontend listeners. By default, QUIC (HTTP/3) is enabled. This means, UDP/443 will be used by Caddy. To free this protocol port combination for a different service, choose a different combination of protocols that does not include HTTP/3.]]></help>
         </field>
         <field>
             <id>caddy.general.HttpPort</id>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
@@ -34,6 +34,12 @@
             <help><![CDATA[Run this service as "www" user and group, instead of "root". This setting increases security, but comes with the hard restriction that the well-known port range can not be used anymore. After enabling and saving this setting, the service has to be totally restarted. For this, please disable Caddy and press Apply. Afterwards enable Caddy and press Apply. This setting is reversible by following the same steps.]]></help>
         </field>
         <field>
+            <id>caddy.general.DisableQuic</id>
+            <label>Disable QUIC</label>
+            <type>checkbox</type>
+            <help><![CDATA[Disable the QUIC protocol for the frontend listeners. This will free up port 443 UDP so it can be used for other services.]]></help>
+        </field>
+        <field>
             <id>caddy.general.HttpPort</id>
             <label>HTTP Port</label>
             <type>text</type>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -93,6 +93,7 @@
                 <ValidationMessage>Please enter a valid Grace Period between 1 and 3600 seconds.</ValidationMessage>
                 <Required>Y</Required>
             </GracePeriod>
+            <DisableQuic type="BooleanField"/>
             <LogCredentials type="BooleanField"/>
             <LogAccessPlain type="BooleanField"/>
             <LogAccessPlainKeep type="IntegerField">

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//Pischem/caddy</mount>
     <description>Caddy Reverse Proxy</description>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
     <items>
         <general>
             <enabled type="BooleanField">
@@ -85,7 +85,12 @@
                 </Model>
             </accesslist>
             <abort type="BooleanField"/>
-            <DisableSuperuser type="BooleanField"/>
+            <DisableSuperuser type="OptionField">
+                <BlankDesc>root (default)</BlankDesc>
+                <OptionValues>
+                    <www value="1">www</www>
+                </OptionValues>
+            </DisableSuperuser>
             <GracePeriod type="IntegerField">
                 <Default>10</Default>
                 <MinimumValue>1</MinimumValue>
@@ -93,7 +98,16 @@
                 <ValidationMessage>Please enter a valid Grace Period between 1 and 3600 seconds.</ValidationMessage>
                 <Required>Y</Required>
             </GracePeriod>
-            <DisableQuic type="BooleanField"/>
+            <HttpVersion type="OptionField">
+                <Required>Y</Required>
+                <Default>h1,h2,h3</Default>
+                <Multiple>Y</Multiple>
+                <OptionValues>
+                    <h1>HTTP/1.1</h1>
+                    <h2>HTTP/2</h2>
+                    <h3>HTTP/3</h3>
+                </OptionValues>
+            </HttpVersion>
             <LogCredentials type="BooleanField"/>
             <LogAccessPlain type="BooleanField"/>
             <LogAccessPlainKeep type="IntegerField">
@@ -187,7 +201,12 @@
                 <AccessLog type="BooleanField"/>
                 <DynDns type="BooleanField"/>
                 <AcmePassthrough type="HostnameField"/>
-                <DisableTls type="BooleanField"/>
+                <DisableTls type="OptionField">
+                    <BlankDesc>HTTPS (default)</BlankDesc>
+                    <OptionValues>
+                        <http value="1">HTTP</http>
+                    </OptionValues>
+                </DisableTls>
             </reverse>
             <subdomain type="ArrayField">
                 <enabled type="BooleanField">
@@ -313,7 +332,7 @@
                     </Constraints>
                 </HttpTls>
                 <HttpVersion type="OptionField">
-                    <BlankDesc>HTTP/1.1, HTTP/2</BlankDesc>
+                    <BlankDesc>HTTP/1.1, HTTP/2 (default)</BlankDesc>
                     <OptionValues>
                         <http1>HTTP/1.1</http1>
                         <http2>HTTP/2</http2>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -86,8 +86,10 @@
             </accesslist>
             <abort type="BooleanField"/>
             <DisableSuperuser type="OptionField">
-                <BlankDesc>root (default)</BlankDesc>
+                <Required>Y</Required>
+                <Default>0</Default>
                 <OptionValues>
+                    <root value="0">root (default)</root>
                     <www value="1">www</www>
                 </OptionValues>
             </DisableSuperuser>
@@ -202,8 +204,10 @@
                 <DynDns type="BooleanField"/>
                 <AcmePassthrough type="HostnameField"/>
                 <DisableTls type="OptionField">
-                    <BlankDesc>HTTPS (default)</BlankDesc>
+                    <Required>Y</Required>
+                    <Default>0</Default>
                     <OptionValues>
+                        <https value="0">HTTPS (default)</https>
                         <http value="1">HTTP</http>
                     </OptionValues>
                 </DisableTls>

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -76,46 +76,19 @@
     #   Purpose: The trusted proxy section is important when using CDNs so that headers are trusted.
     #            Credential logging is useful for troubleshooting basic auth.
     #}
-    {% set accessListUuid = generalSettings.accesslist %}
-    {% set logCredentials = generalSettings.LogCredentials %}
-    {% set enableLayer4 = generalSettings.EnableLayer4 %}
-    {% set disableQuic = generalSettings.DisableQuic %}
-
-    {% set hasAccessList = false %}
-    {% set hasLogCredentials = false %}
-    {% set hasEnableLayer4 = false %}
-
-    {% if accessListUuid %}
-        {% set accessList = helpers.toList('Pischem.caddy.reverseproxy.accesslist') | selectattr('@uuid', 'equalto', accessListUuid) | first %}
-        {% if accessList %}
-            {% set hasAccessList = true %}
-        {% endif %}
+    {% if generalSettings.accesslist %}
+        {% set accessList = helpers.toList('Pischem.caddy.reverseproxy.accesslist') | selectattr('@uuid', 'equalto', generalSettings.accesslist) | first %}
     {% endif %}
 
-    {% if logCredentials == '1' %}
-        {% set hasLogCredentials = true %}
-    {% endif %}
-
-    {% if disableQuic == '1' %}
-        {% set hasDisableQuic = true %}
-    {% endif %}
-
-    {% if enableLayer4 == '1' %}
-        {% set hasEnableLayer4 = true %}
-    {% endif %}
-
-    {% if hasAccessList or hasLogCredentials or hasEnableLayer4 or hasDisableQuic %}
     servers {
-        {% if hasDisableQuic %}
-            protocols h1 h2
-        {% endif %}
-        {% if hasAccessList %}
+        protocols {{ generalSettings.HttpVersion.split(',') | join(' ') }}
+        {% if accessList %}
             trusted_proxies static {{ accessList.clientIps.split(',') | join(' ') }}
         {% endif %}
-        {% if hasLogCredentials %}
+        {% if generalSettings.LogCredentials|default("0") == "1" %}
             log_credentials
         {% endif %}
-        {% if hasEnableLayer4 %}
+        {% if generalSettings.EnableLayer4|default("0") == "1" %}
             listener_wrappers {
                 {# Plug the Layer 4 template in #}
                 {% include "OPNsense/Caddy/includeLayer4" %}
@@ -123,7 +96,6 @@
             }
         {% endif %}
     }
-    {% endif %}
 
     {#
     #   Section: Dynamic DNS Global Configuration

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -79,6 +79,7 @@
     {% set accessListUuid = generalSettings.accesslist %}
     {% set logCredentials = generalSettings.LogCredentials %}
     {% set enableLayer4 = generalSettings.EnableLayer4 %}
+    {% set disableQuic = generalSettings.DisableQuic %}
 
     {% set hasAccessList = false %}
     {% set hasLogCredentials = false %}
@@ -95,12 +96,19 @@
         {% set hasLogCredentials = true %}
     {% endif %}
 
+    {% if disableQuic == '1' %}
+        {% set hasDisableQuic = true %}
+    {% endif %}
+
     {% if enableLayer4 == '1' %}
         {% set hasEnableLayer4 = true %}
     {% endif %}
 
-    {% if hasAccessList or hasLogCredentials or hasEnableLayer4 %}
+    {% if hasAccessList or hasLogCredentials or hasEnableLayer4 or hasDisableQuic %}
     servers {
+        {% if hasDisableQuic %}
+            protocols h1 h2
+        {% endif %}
         {% if hasAccessList %}
             trusted_proxies static {{ accessList.clientIps.split(',') | join(' ') }}
         {% endif %}


### PR DESCRIPTION
Fixes: https://github.com/opnsense/plugins/issues/4201

Caddy listens on 443/UDP since QUIC support is default on.

This PR will add the option to disable QUIC to use this protocol port combination somewhere else, e.g. for Wireguard on UDP/443.