### PR TITLE
www/caddy: Handler and other dialogue form cleanup

### DIFF
--- a/www/caddy/Makefile
+++ b/www/caddy/Makefile
@@ -1,6 +1,5 @@
 PLUGIN_NAME=		caddy
-PLUGIN_VERSION=		1.7.0
-PLUGIN_REVISION=	1
+PLUGIN_VERSION=		1.7.1
 PLUGIN_DEPENDS=		caddy-custom
 PLUGIN_COMMENT=		Modern Reverse Proxy with Automatic HTTPS, Dynamic DNS and Layer4 Routing
 PLUGIN_MAINTAINER=	cedrik@pischem.com

--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -16,7 +16,7 @@ Plugin Changelog
 1.7.1
 
 * Add: Frontend HTTP Version can be selected in General Settings, can be used to disable QUIC protocol
-* Cleanup: Some checkboxes have been converted to dropdowns for clarity
+* Cleanup: TLS checkboxes have been converted to dropdowns with http/https for clarity
 * Cleanup: Layer4, Domain and Handle dialogues have been cleaned up, some options are now hidden in advanced mode
 
 1.7.0

--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -13,6 +13,12 @@ DOC: https://docs.opnsense.org/manual/how-tos/caddy.html
 Plugin Changelog
 ================
 
+1.7.1
+
+* Add: Frontend HTTP Version can be selected in General Settings, can be used to disable QUIC protocol
+* Cleanup: Some checkboxes have been converted to dropdowns for clarity
+* Cleanup: Layer4, Domain and Handle dialogues have been cleaned up, some options are now hidden in advanced mode
+
 1.7.0
 
 * Add: Layer4 protocols: DNS

--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -16,6 +16,7 @@ Plugin Changelog
 1.7.1
 
 * Add: Frontend HTTP Version can be selected in General Settings, can be used to disable QUIC protocol
+* Change: Caddy Domains widget will now open links to managed websites in new browser tabs
 * Cleanup: TLS checkboxes have been converted to dropdowns with http/https for clarity
 * Cleanup: Layer4, Domain and Handle dialogues have been cleaned up, some options are now hidden in advanced mode
 

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogAccessList.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogAccessList.xml
@@ -23,14 +23,12 @@
         <id>accesslist.HttpResponseCode</id>
         <label>HTTP Response Code</label>
         <type>text</type>
-        <hint>403</hint>
         <help><![CDATA[Set a custom HTTP response code that should be returned to the requesting client when the access list does not match. Setting this will replace "Abort Connections" only for this access list. All clients will stay connected but will receive the response code.]]></help>
     </field>
     <field>
         <id>accesslist.HttpResponseMessage</id>
         <label>HTTP Response Message</label>
         <type>text</type>
-        <hint>Forbidden</hint>
         <help><![CDATA[Set a custom HTTP response message in addition to the HTTP response code.]]></help>
     </field>
     <field>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -133,6 +133,7 @@
         <id>handle.HttpTlsInsecureSkipVerify</id>
         <label>TLS Insecure Skip Verify</label>
         <type>checkbox</type>
+        <style>HttpTls</style>
         <help><![CDATA[Caddy uses HTTP by default to connect to the Upstream. If the Upstream is only reachable via HTTPS, this option disables the TLS handshake verification. This makes the connection insecure and vulnerable to man-in-the-middle attacks. In private networks the risk is low, though do not use in production if possible. It is advised to either use plain HTTP, or proper TLS handling by using the options in "Trust".]]></help>
     </field>
     <field>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -6,6 +6,16 @@
         <help><![CDATA[Enable this handler.]]></help>
     </field>
     <field>
+        <id>handle.description</id>
+        <label>Description</label>
+        <type>text</type>
+        <help><![CDATA[Enter a description for this handler.]]></help>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Frontend</label>
+    </field>
+    <field>
         <id>handle.reverse</id>
         <label>Domain</label>
         <type>dropdown</type>
@@ -18,55 +28,43 @@
         <help><![CDATA[Select a subdomain to handle. Make sure to additionaly choose a wildcard domain as "Domain". Leave unset, if not using subdomains.]]></help>
     </field>
     <field>
-        <id>handle.description</id>
-        <label>Description</label>
-        <type>text</type>
-        <help><![CDATA[Enter a description for this handler.]]></help>
-    </field>
-    <field>
-        <type>header</type>
-        <label>Handle</label>
-        <collapse>true</collapse>
-    </field>
-    <field>
         <id>handle.HandleType</id>
         <label>Handle Type</label>
         <type>dropdown</type>
-        <help><![CDATA[Choose a handling directive. "handle" (default) will keep the URI of "Handle URI" in all requests. "handle_path" will strip the URI of "Handle URI" from all requests.]]></help>
+        <help><![CDATA[Choose a handling directive. "handle" (default) will keep the path in all requests. "handle_path" will strip the path from all requests.]]></help>
+        <advanced>true</advanced>
     </field>
     <field>
         <id>handle.HandlePath</id>
-        <label>Handle URI</label>
+        <label>Path</label>
         <type>text</type>
-        <help><![CDATA[Enter an URI to handle. Choose a pattern like "/*" or "/example/*". Leave empty to catch all URIs (recommended). Any request matching this pattern will be handled.]]></help>
-    </field>
-    <field>
-        <type>header</type>
-        <label>Access</label>
-        <collapse>true</collapse>
-    </field>
-    <field>
-        <id>handle.ForwardAuth</id>
-        <label>Forward Auth</label>
-        <type>checkbox</type>
-        <help><![CDATA[Enable or disable Forward Auth. Requires an "Auth Provider" in "General Settings". Headers are set automatically to the standard of the chosen provider. Enabling this option will additionally generate the forward_auth directive in front of the reverse_proxy directive inside the scope of this handler.]]></help>
-    </field>
-    <field>
-        <type>header</type>
-        <label>Header</label>
-        <collapse>true</collapse>
-    </field>
-    <field>
-        <id>handle.header</id>
-        <label>Header Manipulation</label>
-        <type>dropdown</type>
-        <type>select_multiple</type>
-        <size>5</size>
-        <help><![CDATA[Select one or multiple header manipulations. Caddy sets "X-Forwarded-For", "X-Forwarded-Proto" and "X-Forwarded-Host" by default, adding them here is not needed. Setting a wrong configuration can be a security risk or break functionality.]]></help>
+        <help><![CDATA[Enter a path to handle. Choose a pattern like "/*" or "/example/*". Leave empty to handle any paths (recommended). Any request matching this pattern will be reverse proxied.]]></help>
+        <advanced>true</advanced>
     </field>
     <field>
         <type>header</type>
         <label>Upstream</label>
+    </field>
+    <field>
+        <id>handle.HttpTls</id>
+        <label>Protocol</label>
+        <type>dropdown</type>
+        <help><![CDATA[Enable or disable HTTP over TLS (HTTPS) to communicate with the upstream destination. Caddy uses HTTP with the upstream destination by default.]]></help>
+    </field>
+    <field>
+        <id>handle.HttpVersion</id>
+        <label>HTTP Version</label>
+        <type>dropdown</type>
+        <help><![CDATA[The default versions are highly recommended. Choose a HTTP version for the upstream destination. HTTP/3 (HTTP over QUIC) requires HTTPS, and only establishes connections to webservers that also support HTTP/3.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>handle.HttpKeepalive</id>
+        <label>HTTP Keepalive</label>
+        <type>text</type>
+        <hint>120</hint>
+        <help><![CDATA[Leave empty to use default. Keepalive is either 0 (off) or a duration value that specifies how long to keep connections open (timeout) in seconds.]]></help>
+        <advanced>true</advanced>
     </field>
     <field>
         <id>handle.ToDomain</id>
@@ -92,56 +90,42 @@
         <advanced>true</advanced>
     </field>
     <field>
+        <id>handle.PassiveHealthFailDuration</id>
+        <label>Upstream Fail Duration</label>
+        <type>text</type>
+        <help><![CDATA[Enables a passive health check when multiple destinations in "Upstream Domain" are set. "Fail Duration" is a value that defines how long to remember a failed request. A duration of 1 or more seconds enables passive health checking; the default is empty (off). A reasonable starting point might be 30s to balance error rates with responsiveness when bringing an unhealthy upstream back online.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
         <id>handle.HttpTlsInsecureSkipVerify</id>
         <label>TLS Insecure Skip Verify</label>
         <type>checkbox</type>
         <help><![CDATA[Caddy uses HTTP by default to connect to the Upstream. If the Upstream is only reachable via HTTPS, this option disables the TLS handshake verification. This makes the connection insecure and vulnerable to man-in-the-middle attacks. In private networks the risk is low, though do not use in production if possible. It is advised to either use plain HTTP, or proper TLS handling by using the options in "Trust".]]></help>
     </field>
     <field>
-        <type>header</type>
-        <label>Health Check</label>
-        <collapse>true</collapse>
-    </field>
-    <field>
-        <id>handle.PassiveHealthFailDuration</id>
-        <label>Upstream Fail Duration</label>
-        <type>text</type>
-        <help><![CDATA[Enables a passive health check when multiple destinations in "Upstream Domain" are set. "Fail Duration" is a value that defines how long to remember a failed request. A duration of 1 or more seconds enables passive health checking; the default is empty (off). A reasonable starting point might be 30s to balance error rates with responsiveness when bringing an unhealthy upstream back online.]]></help>
+        <id>handle.HttpNtlm</id>
+        <label>NTLM</label>
+        <type>checkbox</type>
+        <help><![CDATA[Enable or disable NTLM. Needed to reverse proxy an Exchange Server. Warning: NTLM has been deprecated by Microsoft. This option will stay for as long as the optional http.reverse_proxy.transport.http_ntlm module can be compiled without errors.]]></help>
+        <advanced>true</advanced>
     </field>
     <field>
         <type>header</type>
-        <label>HTTP Transport</label>
+        <label>Header</label>
         <collapse>true</collapse>
     </field>
     <field>
-        <id>handle.HttpVersion</id>
-        <label>HTTP Version</label>
+        <id>handle.header</id>
+        <label>HTTP Headers</label>
         <type>dropdown</type>
-        <help><![CDATA[The default versions are highly recommended. Choose a HTTP version for the upstream destination. HTTP/3 (HTTP over QUIC) requires TLS, and only establishes connections to webservers that also support HTTP/3.]]></help>
-    </field>
-    <field>
-        <id>handle.HttpKeepalive</id>
-        <label>HTTP Keepalive</label>
-        <type>text</type>
-        <hint>120</hint>
-        <help><![CDATA[Leave empty to use default. Keepalive is either 0 (off) or a duration value that specifies how long to keep connections open (timeout) in seconds.]]></help>
+        <type>select_multiple</type>
+        <size>5</size>
+        <help><![CDATA[Select one or multiple headers. Caddy sets "X-Forwarded-For", "X-Forwarded-Proto" and "X-Forwarded-Host" by default, adding them here is not needed. Setting a wrong configuration can be a security risk or break functionality.]]></help>
     </field>
     <field>
         <type>header</type>
         <label>Trust</label>
         <collapse>true</collapse>
-    </field>
-    <field>
-        <id>handle.HttpTls</id>
-        <label>TLS</label>
-        <type>checkbox</type>
-        <help><![CDATA[Enable or disable HTTP over TLS (HTTPS) to communicate with the upstream destination. Caddy uses HTTP with the upstream destination by default.]]></help>
-    </field>
-    <field>
-        <id>handle.HttpNtlm</id>
-        <label>NTLM</label>
-        <type>checkbox</type>
-        <help><![CDATA[Enable or disable NTLM. Needed to reverse proxy an Exchange Server. Warning: NTLM has been deprecated by Microsoft. This option will stay for as long as the optional http.reverse_proxy.transport.http_ntlm module can be compiled without errors.]]></help>
     </field>
     <field>
         <id>handle.HttpTlsTrustedCaCerts</id>
@@ -154,5 +138,16 @@
         <label>TLS Server Name</label>
         <type>text</type>
         <help><![CDATA[Enter a hostname or IP address that matches the SAN "Subject Alternative Name" of the offered upstream certificate. This will change the SNI "Server Name Indication" of Caddy. Setting an IP address as "Upstream Domain", enabling "TLS" and selecting a "TLS Trust Pool", would make the SAN of the offered upstream certificate not match with the SNI of Caddy, since it will be an IP address instead of a hostname. Setting the hostname of the certificate here, fixes this issue. Please note that only SAN certificates are supported; CN "Common Name" will not work.]]></help>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Access</label>
+        <collapse>true</collapse>
+    </field>
+    <field>
+        <id>handle.ForwardAuth</id>
+        <label>Forward Auth</label>
+        <type>checkbox</type>
+        <help><![CDATA[Enable or disable Forward Auth. Requires an "Auth Provider" in "General Settings". Headers are set automatically to the standard of the chosen provider. Enabling this option will additionally generate the forward_auth directive in front of the reverse_proxy directive inside the scope of this handler.]]></help>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -140,6 +140,11 @@
         <help><![CDATA[Enable or disable NTLM. Needed to reverse proxy an Exchange Server. Warning: NTLM has been deprecated by Microsoft. This option will stay for as long as the optional http.reverse_proxy.transport.http_ntlm module can be compiled without errors.]]></help>
     </field>
     <field>
+        <type>header</type>
+        <label>Access</label>
+        <advanced>true</advanced>
+    </field>
+    <field>
         <id>handle.ForwardAuth</id>
         <label>Forward Auth</label>
         <type>checkbox</type>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -12,12 +12,6 @@
         <help><![CDATA[Enter a description for this handler.]]></help>
     </field>
     <field>
-        <id>handle.HandleType</id>
-        <label>Type</label>
-        <type>dropdown</type>
-        <help><![CDATA[Choose a handling directive. "handle" (default) will keep the path in all requests. "handle_path" will strip the path from all requests.]]></help>
-    </field>
-    <field>
         <type>header</type>
         <label>Frontend</label>
     </field>
@@ -31,7 +25,20 @@
         <id>handle.subdomain</id>
         <label>Subdomain</label>
         <type>dropdown</type>
+        <style>Subdomain</style>
         <help><![CDATA[Select a subdomain to handle. Make sure to additionaly choose a wildcard domain as "Domain". Leave unset, if not using subdomains.]]></help>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Handler</label>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>handle.HandleType</id>
+        <label>Handler</label>
+        <type>dropdown</type>
+        <help><![CDATA[Choose a handling directive. "handle" (default) will keep the path in all requests. "handle_path" will strip the path from all requests.]]></help>
+        <advanced>true</advanced>
     </field>
     <field>
         <id>handle.HandlePath</id>
@@ -39,6 +46,7 @@
         <type>text</type>
         <hint>any</hint>
         <help><![CDATA[Enter a path to handle. Choose a pattern like "/*" or "/example/*". Leave empty to handle any paths (recommended). Any request matching this pattern will be reverse proxied.]]></help>
+        <advanced>true</advanced>
     </field>
     <field>
         <type>header</type>
@@ -63,6 +71,15 @@
         <type>text</type>
         <hint>120</hint>
         <help><![CDATA[Leave empty to use default. Keepalive is either 0 (off) or a duration value that specifies how long to keep connections open (timeout) in seconds.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>handle.header</id>
+        <label>HTTP Headers</label>
+        <type>dropdown</type>
+        <type>select_multiple</type>
+        <size>5</size>
+        <help><![CDATA[Select one or multiple headers. Caddy sets "X-Forwarded-For", "X-Forwarded-Proto" and "X-Forwarded-Host" by default, adding them here is not needed. Setting a wrong configuration can be a security risk or break functionality.]]></help>
         <advanced>true</advanced>
     </field>
     <field>
@@ -95,57 +112,38 @@
         <advanced>true</advanced>
     </field>
     <field>
-        <id>handle.HttpTlsInsecureSkipVerify</id>
-        <label>TLS Insecure Skip Verify</label>
-        <type>checkbox</type>
-        <help><![CDATA[Caddy uses HTTP by default to connect to the Upstream. If the Upstream is only reachable via HTTPS, this option disables the TLS handshake verification. This makes the connection insecure and vulnerable to man-in-the-middle attacks. In private networks the risk is low, though do not use in production if possible. It is advised to either use plain HTTP, or proper TLS handling by using the options in "Trust".]]></help>
-    </field>
-    <field>
-        <id>handle.HttpNtlm</id>
-        <label>NTLM</label>
-        <type>checkbox</type>
-        <help><![CDATA[Enable or disable NTLM. Needed to reverse proxy an Exchange Server. Warning: NTLM has been deprecated by Microsoft. This option will stay for as long as the optional http.reverse_proxy.transport.http_ntlm module can be compiled without errors.]]></help>
-        <advanced>true</advanced>
-    </field>
-    <field>
-        <type>header</type>
-        <label>Trust</label>
-        <collapse>true</collapse>
-    </field>
-    <field>
         <id>handle.HttpTlsTrustedCaCerts</id>
         <label>TLS Trust Pool</label>
         <type>dropdown</type>
+        <style>HttpTls</style>
         <help><![CDATA[Choose a CA or self-signed certificate to trust from "System - Trust - Authorities". Useful if the upstream destination only accepts TLS connections and offers a self signed certificate. Adding that certificate here will allow for the encrypted connection to succeed.]]></help>
     </field>
     <field>
         <id>handle.HttpTlsServerName</id>
         <label>TLS Server Name</label>
         <type>text</type>
+        <style>HttpTls</style>
         <help><![CDATA[Enter a hostname or IP address that matches the SAN "Subject Alternative Name" of the offered upstream certificate. This will change the SNI "Server Name Indication" of Caddy. Setting an IP address as "Upstream Domain", enabling "TLS" and selecting a "TLS Trust Pool", would make the SAN of the offered upstream certificate not match with the SNI of Caddy, since it will be an IP address instead of a hostname. Setting the hostname of the certificate here, fixes this issue. Please note that only SAN certificates are supported; CN "Common Name" will not work.]]></help>
     </field>
     <field>
-        <type>header</type>
-        <label>Header</label>
-        <collapse>true</collapse>
+        <id>handle.HttpTlsInsecureSkipVerify</id>
+        <label>TLS Insecure Skip Verify</label>
+        <type>checkbox</type>
+        <style>HttpTls</style>
+        <help><![CDATA[Caddy uses HTTP by default to connect to the Upstream. If the Upstream is only reachable via HTTPS, this option disables the TLS handshake verification. This makes the connection insecure and vulnerable to man-in-the-middle attacks. In private networks the risk is low, though do not use in production if possible. It is advised to either use plain HTTP, or proper TLS handling by using the options in "Trust".]]></help>
     </field>
     <field>
-        <id>handle.header</id>
-        <label>HTTP Headers</label>
-        <type>dropdown</type>
-        <type>select_multiple</type>
-        <size>5</size>
-        <help><![CDATA[Select one or multiple headers. Caddy sets "X-Forwarded-For", "X-Forwarded-Proto" and "X-Forwarded-Host" by default, adding them here is not needed. Setting a wrong configuration can be a security risk or break functionality.]]></help>
-    </field>
-    <field>
-        <type>header</type>
-        <label>Access</label>
-        <collapse>true</collapse>
+        <id>handle.HttpNtlm</id>
+        <label>NTLM</label>
+        <type>checkbox</type>
+        <style>HttpTls</style>
+        <help><![CDATA[Enable or disable NTLM. Needed to reverse proxy an Exchange Server. Warning: NTLM has been deprecated by Microsoft. This option will stay for as long as the optional http.reverse_proxy.transport.http_ntlm module can be compiled without errors.]]></help>
     </field>
     <field>
         <id>handle.ForwardAuth</id>
         <label>Forward Auth</label>
         <type>checkbox</type>
         <help><![CDATA[Enable or disable Forward Auth. Requires an "Auth Provider" in "General Settings". Headers are set automatically to the standard of the chosen provider. Enabling this option will additionally generate the forward_auth directive in front of the reverse_proxy directive inside the scope of this handler.]]></help>
+        <advanced>true</advanced>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -30,18 +30,6 @@
     </field>
     <field>
         <type>header</type>
-        <label>Access</label>
-        <advanced>true</advanced>
-    </field>
-    <field>
-        <id>handle.ForwardAuth</id>
-        <label>Forward Auth</label>
-        <type>checkbox</type>
-        <help><![CDATA[Enable or disable Forward Auth. Requires an "Auth Provider" in "General Settings". Headers are set automatically to the standard of the chosen provider. Enabling this option will additionally generate the forward_auth directive in front of the reverse_proxy directive inside the scope of this handler.]]></help>
-        <advanced>true</advanced>
-    </field>
-    <field>
-        <type>header</type>
         <label>Handler</label>
         <advanced>true</advanced>
     </field>
@@ -58,6 +46,18 @@
         <type>text</type>
         <hint>any</hint>
         <help><![CDATA[Enter a path to handle. Choose a pattern like "/*" or "/example/*". Leave empty to handle any paths (recommended). Any request matching this pattern will be reverse proxied.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Access</label>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>handle.ForwardAuth</id>
+        <label>Forward Auth</label>
+        <type>checkbox</type>
+        <help><![CDATA[Enable or disable Forward Auth. Requires an "Auth Provider" in "General Settings". Headers are set automatically to the standard of the chosen provider. Enabling this option will additionally generate the forward_auth directive in front of the reverse_proxy directive inside the scope of this handler.]]></help>
         <advanced>true</advanced>
     </field>
     <field>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -12,6 +12,12 @@
         <help><![CDATA[Enter a description for this handler.]]></help>
     </field>
     <field>
+        <id>handle.HandleType</id>
+        <label>Type</label>
+        <type>dropdown</type>
+        <help><![CDATA[Choose a handling directive. "handle" (default) will keep the path in all requests. "handle_path" will strip the path from all requests.]]></help>
+    </field>
+    <field>
         <type>header</type>
         <label>Frontend</label>
     </field>
@@ -28,18 +34,11 @@
         <help><![CDATA[Select a subdomain to handle. Make sure to additionaly choose a wildcard domain as "Domain". Leave unset, if not using subdomains.]]></help>
     </field>
     <field>
-        <id>handle.HandleType</id>
-        <label>Handle Type</label>
-        <type>dropdown</type>
-        <help><![CDATA[Choose a handling directive. "handle" (default) will keep the path in all requests. "handle_path" will strip the path from all requests.]]></help>
-        <advanced>true</advanced>
-    </field>
-    <field>
         <id>handle.HandlePath</id>
         <label>Path</label>
         <type>text</type>
+        <hint>any</hint>
         <help><![CDATA[Enter a path to handle. Choose a pattern like "/*" or "/example/*". Leave empty to handle any paths (recommended). Any request matching this pattern will be reverse proxied.]]></help>
-        <advanced>true</advanced>
     </field>
     <field>
         <type>header</type>
@@ -72,8 +71,7 @@
         <type>select_multiple</type>
         <style>tokenize</style>
         <allownew>true</allownew>
-        <hint>192.168.1.1</hint>
-        <help><![CDATA[Enter a domain name or IP address of the upstream destination. If multiple are chosen, they will be load balanced with the default random policy. A health check can be activated by populating "Upstream Fail Duration".]]></help>
+        <help><![CDATA[Enter a domain name or IP address of the upstream destination. If multiple are chosen, they will be load balanced with the default random policy. A health check can be activated by populating "Upstream Fail Duration" in advanced mode.]]></help>
     </field>
     <field>
         <id>handle.ToPort</id>
@@ -86,7 +84,7 @@
         <id>handle.ToPath</id>
         <label>Upstream Path</label>
         <type>text</type>
-        <help><![CDATA[Enter a path prefix like "/guacamole" that should be prepended to the upstream request because the application demands it.]]></help>
+        <help><![CDATA[Enter a path prefix like "/guacamole" that should be prepended to the upstream request. This is useful for destinations that have a virtual directory as their base path.]]></help>
         <advanced>true</advanced>
     </field>
     <field>
@@ -111,19 +109,6 @@
     </field>
     <field>
         <type>header</type>
-        <label>Header</label>
-        <collapse>true</collapse>
-    </field>
-    <field>
-        <id>handle.header</id>
-        <label>HTTP Headers</label>
-        <type>dropdown</type>
-        <type>select_multiple</type>
-        <size>5</size>
-        <help><![CDATA[Select one or multiple headers. Caddy sets "X-Forwarded-For", "X-Forwarded-Proto" and "X-Forwarded-Host" by default, adding them here is not needed. Setting a wrong configuration can be a security risk or break functionality.]]></help>
-    </field>
-    <field>
-        <type>header</type>
         <label>Trust</label>
         <collapse>true</collapse>
     </field>
@@ -138,6 +123,19 @@
         <label>TLS Server Name</label>
         <type>text</type>
         <help><![CDATA[Enter a hostname or IP address that matches the SAN "Subject Alternative Name" of the offered upstream certificate. This will change the SNI "Server Name Indication" of Caddy. Setting an IP address as "Upstream Domain", enabling "TLS" and selecting a "TLS Trust Pool", would make the SAN of the offered upstream certificate not match with the SNI of Caddy, since it will be an IP address instead of a hostname. Setting the hostname of the certificate here, fixes this issue. Please note that only SAN certificates are supported; CN "Common Name" will not work.]]></help>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Header</label>
+        <collapse>true</collapse>
+    </field>
+    <field>
+        <id>handle.header</id>
+        <label>HTTP Headers</label>
+        <type>dropdown</type>
+        <type>select_multiple</type>
+        <size>5</size>
+        <help><![CDATA[Select one or multiple headers. Caddy sets "X-Forwarded-For", "X-Forwarded-Proto" and "X-Forwarded-Host" by default, adding them here is not needed. Setting a wrong configuration can be a security risk or break functionality.]]></help>
     </field>
     <field>
         <type>header</type>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -53,12 +53,6 @@
         <label>Upstream</label>
     </field>
     <field>
-        <id>handle.HttpTls</id>
-        <label>Protocol</label>
-        <type>dropdown</type>
-        <help><![CDATA[Enable or disable HTTP over TLS (HTTPS) to communicate with the upstream destination. Caddy uses HTTP with the upstream destination by default.]]></help>
-    </field>
-    <field>
         <id>handle.HttpVersion</id>
         <label>HTTP Version</label>
         <type>dropdown</type>
@@ -81,6 +75,12 @@
         <size>5</size>
         <help><![CDATA[Select one or multiple headers. Caddy sets "X-Forwarded-For", "X-Forwarded-Proto" and "X-Forwarded-Host" by default, adding them here is not needed. Setting a wrong configuration can be a security risk or break functionality.]]></help>
         <advanced>true</advanced>
+    </field>
+    <field>
+        <id>handle.HttpTls</id>
+        <label>Protocol</label>
+        <type>dropdown</type>
+        <help><![CDATA[Enable or disable HTTP over TLS (HTTPS) to communicate with the upstream destination. Caddy uses HTTP with the upstream destination by default.]]></help>
     </field>
     <field>
         <id>handle.ToDomain</id>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -30,6 +30,18 @@
     </field>
     <field>
         <type>header</type>
+        <label>Access</label>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>handle.ForwardAuth</id>
+        <label>Forward Auth</label>
+        <type>checkbox</type>
+        <help><![CDATA[Enable or disable Forward Auth. Requires an "Auth Provider" in "General Settings". Headers are set automatically to the standard of the chosen provider. Enabling this option will additionally generate the forward_auth directive in front of the reverse_proxy directive inside the scope of this handler.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <type>header</type>
         <label>Handler</label>
         <advanced>true</advanced>
     </field>
@@ -46,6 +58,20 @@
         <type>text</type>
         <hint>any</hint>
         <help><![CDATA[Enter a path to handle. Choose a pattern like "/*" or "/example/*". Leave empty to handle any paths (recommended). Any request matching this pattern will be reverse proxied.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Header</label>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>handle.header</id>
+        <label>HTTP Headers</label>
+        <type>dropdown</type>
+        <type>select_multiple</type>
+        <size>5</size>
+        <help><![CDATA[Select one or multiple headers. Caddy sets "X-Forwarded-For", "X-Forwarded-Proto" and "X-Forwarded-Host" by default, adding them here is not needed. Setting a wrong configuration can be a security risk or break functionality.]]></help>
         <advanced>true</advanced>
     </field>
     <field>
@@ -68,15 +94,6 @@
         <advanced>true</advanced>
     </field>
     <field>
-        <id>handle.header</id>
-        <label>HTTP Headers</label>
-        <type>dropdown</type>
-        <type>select_multiple</type>
-        <size>5</size>
-        <help><![CDATA[Select one or multiple headers. Caddy sets "X-Forwarded-For", "X-Forwarded-Proto" and "X-Forwarded-Host" by default, adding them here is not needed. Setting a wrong configuration can be a security risk or break functionality.]]></help>
-        <advanced>true</advanced>
-    </field>
-    <field>
         <id>handle.HttpTls</id>
         <label>Protocol</label>
         <type>dropdown</type>
@@ -88,6 +105,7 @@
         <type>select_multiple</type>
         <style>tokenize</style>
         <allownew>true</allownew>
+        <hint>192.168.1.1</hint>
         <help><![CDATA[Enter a domain name or IP address of the upstream destination. If multiple are chosen, they will be load balanced with the default random policy. A health check can be activated by populating "Upstream Fail Duration" in advanced mode.]]></help>
     </field>
     <field>
@@ -112,6 +130,12 @@
         <advanced>true</advanced>
     </field>
     <field>
+        <id>handle.HttpTlsInsecureSkipVerify</id>
+        <label>TLS Insecure Skip Verify</label>
+        <type>checkbox</type>
+        <help><![CDATA[Caddy uses HTTP by default to connect to the Upstream. If the Upstream is only reachable via HTTPS, this option disables the TLS handshake verification. This makes the connection insecure and vulnerable to man-in-the-middle attacks. In private networks the risk is low, though do not use in production if possible. It is advised to either use plain HTTP, or proper TLS handling by using the options in "Trust".]]></help>
+    </field>
+    <field>
         <id>handle.HttpTlsTrustedCaCerts</id>
         <label>TLS Trust Pool</label>
         <type>dropdown</type>
@@ -126,29 +150,10 @@
         <help><![CDATA[Enter a hostname or IP address that matches the SAN "Subject Alternative Name" of the offered upstream certificate. This will change the SNI "Server Name Indication" of Caddy. Setting an IP address as "Upstream Domain", enabling "TLS" and selecting a "TLS Trust Pool", would make the SAN of the offered upstream certificate not match with the SNI of Caddy, since it will be an IP address instead of a hostname. Setting the hostname of the certificate here, fixes this issue. Please note that only SAN certificates are supported; CN "Common Name" will not work.]]></help>
     </field>
     <field>
-        <id>handle.HttpTlsInsecureSkipVerify</id>
-        <label>TLS Insecure Skip Verify</label>
-        <type>checkbox</type>
-        <style>HttpTls</style>
-        <help><![CDATA[Caddy uses HTTP by default to connect to the Upstream. If the Upstream is only reachable via HTTPS, this option disables the TLS handshake verification. This makes the connection insecure and vulnerable to man-in-the-middle attacks. In private networks the risk is low, though do not use in production if possible. It is advised to either use plain HTTP, or proper TLS handling by using the options in "Trust".]]></help>
-    </field>
-    <field>
         <id>handle.HttpNtlm</id>
         <label>NTLM</label>
         <type>checkbox</type>
         <style>HttpTls</style>
         <help><![CDATA[Enable or disable NTLM. Needed to reverse proxy an Exchange Server. Warning: NTLM has been deprecated by Microsoft. This option will stay for as long as the optional http.reverse_proxy.transport.http_ntlm module can be compiled without errors.]]></help>
-    </field>
-    <field>
-        <type>header</type>
-        <label>Access</label>
-        <advanced>true</advanced>
-    </field>
-    <field>
-        <id>handle.ForwardAuth</id>
-        <label>Forward Auth</label>
-        <type>checkbox</type>
-        <help><![CDATA[Enable or disable Forward Auth. Requires an "Auth Provider" in "General Settings". Headers are set automatically to the standard of the chosen provider. Enabling this option will additionally generate the forward_auth directive in front of the reverse_proxy directive inside the scope of this handler.]]></help>
-        <advanced>true</advanced>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHeader.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHeader.xml
@@ -8,14 +8,12 @@
     <field>
         <id>header.HeaderType</id>
         <label>Header Type</label>
-        <hint>Host</hint>
         <type>text</type>
         <help><![CDATA[Enter a header, for example "Host". Use the "+" or "-" prefix to add or remove this header, for example "-Host" or "+Host". A suffix match like "-Host-*" is also supported. To replace a header, use "Host" without "+" or "-".]]></help>
     </field>
     <field>
         <id>header.HeaderValue</id>
         <label>Header Value</label>
-        <hint>{upstream_hostport}</hint>
         <type>text</type>
         <help><![CDATA[Enter a value for the selected header. One of the most common options is "{upstream_hostport}". It is also possible to use a regular expression to search for a specific value in a header. For example: "^prefix-([A-Za-z0-9]*)$" which uses the regular expression language RE2 included in Go.]]></help>
     </field>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogLayer4.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogLayer4.xml
@@ -6,6 +6,16 @@
         <help><![CDATA[Enable this Layer4 route.]]></help>
     </field>
     <field>
+        <id>layer4.description</id>
+        <label>Description</label>
+        <type>text</type>
+        <help><![CDATA[Enter a description for this Layer4 route.]]></help>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Frontend</label>
+    </field>
+    <field>
         <id>layer4.FromDomain</id>
         <label>Domain</label>
         <type>select_multiple</type>
@@ -18,6 +28,10 @@
         <label>Matchers</label>
         <type>dropdown</type>
         <help><![CDATA[Match the traffic of the selected domains. The TCP/UDP packets will be routed to the selected upstream domains without terminating TLS or altering the traffic. Only protocols that send a "Client Hello" (like TLS), or a "Host Header" (like HTTP) can be routed here. Routing Precedence: 1. "SSH (or other protocols)", 2. "HTTP (Host Header)", 3. "TLS (SNI)", 4. "TLS (inverted SNI)", 5. "HTTP Handlers" (hidden default route for all unmatched traffic). The "SSH" matcher (and any other matcher that does not evaluate Host Header or SNI), will match any SSH like traffic on the default ports. That means, these protocols will only match once per ruleset and will proxy traffic to one upstream.]]></help>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Upstream</label>
     </field>
     <field>
         <id>layer4.ToDomain</id>
@@ -34,32 +48,18 @@
         <help><![CDATA[Choose a custom port for the upstream destination.]]></help>
     </field>
     <field>
-        <id>layer4.description</id>
-        <label>Description</label>
-        <type>text</type>
-        <help><![CDATA[Enter a description for this Layer4 route.]]></help>
-    </field>
-    <field>
-        <type>header</type>
-        <label>Health Check</label>
-        <collapse>true</collapse>
-    </field>
-    <field>
         <id>layer4.PassiveHealthFailDuration</id>
         <label>Upstream Fail Duration</label>
         <type>text</type>
         <help><![CDATA[Enables a passive health check when multiple destinations in "Upstream Domain" are set. "Fail Duration" is a value that defines how long to remember a failed request. A duration of 1 or more seconds enables passive health checking; the default is empty (off). A reasonable starting point might be 30s to balance error rates with responsiveness when bringing an unhealthy upstream back online.]]></help>
-    </field>
-    <field>
-        <type>header</type>
-        <label>Proxy Protocol</label>
-        <collapse>true</collapse>
+        <advanced>true</advanced>
     </field>
     <field>
         <id>layer4.ProxyProtocol</id>
         <label>Proxy Protocol</label>
         <type>dropdown</type>
         <help><![CDATA[Add the HA Proxy Protocol header. Either version 1 or 2 can be chosen. The default is off, since it is only needed when the upstream can use the Proxy Protocol header.]]></help>
+        <advanced>true</advanced>
     </field>
     <field>
         <type>header</type>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
@@ -9,14 +9,14 @@
         <id>reverse.DisableTls</id>
         <label>Protocol</label>
         <type>dropdown</type>
-        <help><![CDATA[When choosing HTTPS, the ACME HTTP-01, TLS-ALPN-01 or DNS-01 challenge will be used to get automatic Let's Encrypt or ZeroSSL certificates, without the need of any additional plugin. When choosing HTTP, it will disable HTTP over TLS (HTTPS) for this domain, automatic certificate management will be disabled and all traffic to and from this domain will be unencrypted.]]></help>
+        <help><![CDATA[When choosing HTTPS, the "HTTP-01", "TLS-ALPN-01" or "DNS-01" ACME challenge will be used to get automatic "Let's Encrypt" or "ZeroSSL" certificates, without the need of any additional plugin. When choosing HTTP, it will disable HTTP over TLS (HTTPS) for this domain, automatic certificate management will be disabled and all traffic to and from this domain will be unencrypted.]]></help>
     </field>
     <field>
         <id>reverse.FromDomain</id>
         <label>Domain</label>
         <type>text</type>
         <hint>example.com</hint>
-        <help><![CDATA[Enter a domain name. For a base domain, use "example.com" or "opn.example.com". Using a base domain enables automatic "Let's Encrypt" and "ZeroSSL" certificates by default. For a wildcard domain, use "*.example.com". Only use wildcard domains with wildcard certificates, which require a DNS Provider. Adding a wildcard domain and pressing "Apply" will activate the "Subdomain" Tab, in which subdomains can be configured.]]></help>
+        <help><![CDATA[Enter a domain name. For a base domain, use "example.com" or "opn.example.com". For a wildcard domain, use "*.example.com". Adding a wildcard domain and pressing "Apply" will activate the "Subdomain" Tab, in which subdomains can be configured. Using subdomains requires a "DNS Provider" and the "DNS-01" challenge.]]></help>
     </field>
     <field>
         <id>reverse.FromPort</id>
@@ -43,15 +43,15 @@
         <help><![CDATA[Enable or disable Dynamic DNS. Requires a "DNS Provider" in "General Settings". The DNS records of this domain will be automatically updated.]]></help>
     </field>
     <field>
-        <type>header</type>
-        <label>Trust</label>
-        <collapse>true</collapse>
-    </field>
-    <field>
         <id>reverse.DnsChallenge</id>
         <label>DNS-01 Challenge</label>
         <type>checkbox</type>
         <help><![CDATA[Enable the DNS-01 challenge for this domain. Requires a "DNS Provider" in "General Settings". This is mostly only needed for wildcard domains, or when the HTTP-01 and TLS-ALPN-01 challenge can not be used due to restrictive firewall policies.]]></help>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Trust</label>
+        <collapse>true</collapse>
     </field>
     <field>
         <id>reverse.CustomCertificate</id>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
@@ -6,10 +6,20 @@
         <help><![CDATA[Enable this domain.]]></help>
     </field>
     <field>
+        <id>reverse.description</id>
+        <label>Description</label>
+        <type>text</type>
+        <help><![CDATA[Enter a description for this domain.]]></help>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Frontend</label>
+    </field>
+    <field>
         <id>reverse.DisableTls</id>
         <label>Protocol</label>
         <type>dropdown</type>
-        <help><![CDATA[When choosing HTTPS, the "HTTP-01", "TLS-ALPN-01" or "DNS-01" ACME challenge will be used to get automatic "Let's Encrypt" or "ZeroSSL" certificates, without the need of any additional plugin. When choosing HTTP, it will disable HTTP over TLS (HTTPS) for this domain, automatic certificate management will be disabled and all traffic to and from this domain will be unencrypted.]]></help>
+        <help><![CDATA[When choosing HTTP, automatic certificate management will be disabled and all traffic to and from this domain will be unencrypted.]]></help>
     </field>
     <field>
         <id>reverse.FromDomain</id>
@@ -26,44 +36,31 @@
         <help><![CDATA[Leave empty to use ports 80 and 443 with automatic redirection from HTTP to HTTPS or choose a custom port. Don't forget to allow these ports with a Firewall rule. If the default ports have been changed in "General Settings", leaving this empty will use the chosen alternative ports instead.]]></help>
     </field>
     <field>
-        <id>reverse.description</id>
-        <label>Description</label>
-        <type>text</type>
-        <help><![CDATA[Enter a description for this domain.]]></help>
-    </field>
-    <field>
-        <type>header</type>
-        <label>DNS</label>
-        <collapse>true</collapse>
-    </field>
-    <field>
-        <id>reverse.DynDns</id>
-        <label>Dynamic DNS</label>
-        <type>checkbox</type>
-        <help><![CDATA[Enable or disable Dynamic DNS. Requires a "DNS Provider" in "General Settings". The DNS records of this domain will be automatically updated.]]></help>
-    </field>
-    <field>
-        <id>reverse.DnsChallenge</id>
-        <label>DNS-01 Challenge</label>
-        <type>checkbox</type>
-        <help><![CDATA[Enable the DNS-01 challenge for this domain. Requires a "DNS Provider" in "General Settings". This is mostly only needed for wildcard domains, or when the HTTP-01 and TLS-ALPN-01 challenge can not be used due to restrictive firewall policies.]]></help>
-    </field>
-    <field>
-        <type>header</type>
-        <label>Trust</label>
-        <collapse>true</collapse>
-    </field>
-    <field>
         <id>reverse.CustomCertificate</id>
-        <label>Custom Certificate</label>
+        <label>Certificate</label>
         <type>dropdown</type>
-        <help><![CDATA[Choose a custom certificate from "System - Trust - Certificates" for this domain. Make sure the full chain has been imported.]]></help>
+        <style>DisableTls</style>
+        <help><![CDATA[Choose ACME to get automatic certificates with the built in ACME client; no additional plugin required. The "HTTP-01", "TLS-ALPN-01" or "DNS-01" challenge will be used to get automatic "Let's Encrypt" or "ZeroSSL" certificates. Alternatively, choose a custom certificate from "System - Trust - Certificates" for this domain. Make sure the full chain has been imported.]]></help>
     </field>
     <field>
         <id>reverse.AcmePassthrough</id>
         <label>HTTP-01 Challenge Redirection</label>
         <type>text</type>
         <help><![CDATA[Enter a domain name or IP address. The HTTP-01 challenge will be redirected to that destination. This enables an ACME Client behind Caddy to serve "/.well-known/acme-challenge/" on port 80. Caddy will reverse proxy the HTTP-01 challenge for this domain, and will still issue a certificate using the TLS-ALPN-01 challenge or DNS-01 challenge for itself. This option can be used for High Availability when using Caddy with a master and backup OPNsense.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>reverse.DnsChallenge</id>
+        <label>DNS-01 Challenge</label>
+        <type>checkbox</type>
+        <style>DisableTls</style>
+        <help><![CDATA[Enable the DNS-01 challenge for this domain. Requires a "DNS Provider" in "General Settings". This is mostly only needed for wildcard domains, or when the HTTP-01 and TLS-ALPN-01 challenge can not be used due to restrictive firewall policies.]]></help>
+    </field>
+    <field>
+        <id>reverse.DynDns</id>
+        <label>Dynamic DNS</label>
+        <type>checkbox</type>
+        <help><![CDATA[Enable or disable Dynamic DNS. Requires a "DNS Provider" in "General Settings". The DNS records of this domain will be automatically updated. A wildcard domain will create a "*.example.com" record. A base domain will create a "example.com" or "opn.example.com" record. Some providers need subdomains to set records for domains like "opn.example.com"; in that case use the checkbox in the subdomains tab.]]></help>
     </field>
     <field>
         <type>header</type>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
@@ -26,7 +26,7 @@
         <label>Domain</label>
         <type>text</type>
         <hint>example.com</hint>
-        <help><![CDATA[Enter a domain name. For a base domain, use "example.com" or "opn.example.com". For a wildcard domain, use "*.example.com". Adding a wildcard domain and pressing "Apply" will activate the "Subdomain" Tab, in which subdomains can be configured. Using subdomains requires a "DNS Provider" and the "DNS-01" challenge.]]></help>
+        <help><![CDATA[Enter a domain name. For a base domain, use "example.com" or "opn.example.com". For a wildcard domain, use "*.example.com". Adding a wildcard domain and pressing "Apply" will activate the "Subdomain" Tab, in which subdomains can be configured. Using subdomains requires a "DNS Provider" and the "DNS-01 Challenge" or a custom certificate.]]></help>
     </field>
     <field>
         <id>reverse.FromPort</id>
@@ -54,7 +54,7 @@
         <label>DNS-01 Challenge</label>
         <type>checkbox</type>
         <style>DisableTls</style>
-        <help><![CDATA[Enable the DNS-01 challenge for this domain. Requires a "DNS Provider" in "General Settings". This is mostly only needed for wildcard domains, or when the HTTP-01 and TLS-ALPN-01 challenge can not be used due to restrictive firewall policies.]]></help>
+        <help><![CDATA[Enable the DNS-01 Challenge for this domain. Requires a "DNS Provider" in "General Settings". This is only needed for wildcard domains, or when the default challenges can not be used due to restrictive firewall policies.]]></help>
     </field>
     <field>
         <id>reverse.DynDns</id>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogSubdomain.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogSubdomain.xml
@@ -6,6 +6,16 @@
         <help><![CDATA[Enable this subdomain.]]></help>
     </field>
     <field>
+        <id>subdomain.description</id>
+        <label>Description</label>
+        <type>text</type>
+        <help><![CDATA[Enter a description for this subdomain.]]></help>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Frontend</label>
+    </field>
+    <field>
         <id>subdomain.reverse</id>
         <label>Domain</label>
         <type>dropdown</type>
@@ -16,18 +26,7 @@
         <label>Subdomain</label>
         <type>text</type>
         <hint>opn.example.com</hint>
-        <help><![CDATA[Enter a subdomain. For example, "opn.example.com" if the wildcard domain is "*.example.com". All subdomains use the same ports as their parent wildcard domain.]]></help>
-    </field>
-    <field>
-        <id>subdomain.description</id>
-        <label>Description</label>
-        <type>text</type>
-        <help><![CDATA[Enter a description for this subdomain.]]></help>
-    </field>
-    <field>
-        <type>header</type>
-        <label>DNS</label>
-        <collapse>true</collapse>
+        <help><![CDATA[Enter a subdomain. For example, "opn.example.com" if the wildcard domain is "*.example.com". All subdomains use the same ports and protocols as their parent wildcard domain.]]></help>
     </field>
     <field>
         <id>subdomain.DynDns</id>
@@ -36,15 +35,11 @@
         <help><![CDATA[Enable or disable Dynamic DNS. Requires a "DNS Provider" in "General Settings". The DNS records of this subdomain will be automatically updated.]]></help>
     </field>
     <field>
-        <type>header</type>
-        <label>Trust</label>
-        <collapse>true</collapse>
-    </field>
-    <field>
         <id>subdomain.AcmePassthrough</id>
         <label>HTTP-01 Challenge Redirection</label>
         <type>text</type>
         <help><![CDATA[Enter a domain name or IP address. The HTTP-01 challenge will be redirected to that destination. This enables an ACME Client behind Caddy to serve "/.well-known/acme-challenge/" on port 80. Caddy will reverse proxy the HTTP-01 challenge for this subdomain.]]></help>
+        <advanced>true</advanced>
     </field>
     <field>
         <type>header</type>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
@@ -212,6 +212,12 @@
             <help><![CDATA[Select a Forward Auth Provider. It can be added inside a "Handler" by enabling the "Forward Auth" checkbox. For Authelia only the basic subdomain example is supported. More information: https://www.authelia.com/integration/proxies/caddy/#basic-examples. For Authentik custom headers are not supported. More information: https://docs.goauthentik.io/docs/providers/proxy/server_caddy]]></help>
         </field>
         <field>
+            <id>caddy.general.AuthToTls</id>
+            <label>Protocol</label>
+            <type>dropdown</type>
+            <help><![CDATA[Enable or disable HTTP over TLS (HTTPS) to communicate with the Forward Auth Provider.]]></help>
+        </field>
+        <field>
             <id>caddy.general.AuthToDomain</id>
             <label>Forward Auth Domain</label>
             <type>text</type>
@@ -222,12 +228,6 @@
             <label>Forward Auth Port</label>
             <type>text</type>
             <help><![CDATA[Enter the listen port of the chosen Forward Auth Provider.]]></help>
-        </field>
-        <field>
-            <id>caddy.general.AuthToTls</id>
-            <label>TLS</label>
-            <type>checkbox</type>
-            <help><![CDATA[Enable or disable HTTP over TLS (HTTPS) to communicate with the Forward Auth Provider.]]></help>
         </field>
         <field>
             <id>caddy.general.AuthToUri</id>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -207,7 +207,7 @@
                 <description type="DescriptionField"/>
                 <DnsChallenge type="BooleanField"/>
                 <CustomCertificate type="CertificateField">
-                    <BlankDesc>ACME (default)</BlankDesc>
+                    <BlankDesc>ACME (HTTP-01, TLS-ALPN-01)</BlankDesc>
                 </CustomCertificate>
                 <AccessLog type="BooleanField"/>
                 <DynDns type="BooleanField"/>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -295,7 +295,7 @@
                     <Required>Y</Required>
                     <Default>handle</Default>
                     <OptionValues>
-                        <handle>handle</handle>
+                        <handle>handle (default)</handle>
                         <handle_path>handle_path</handle_path>
                     </OptionValues>
                 </HandleType>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -157,7 +157,14 @@
             </AuthProvider>
             <AuthToDomain type="HostnameField"/>
             <AuthToPort type="PortField"/>
-            <AuthToTls type="BooleanField"/>
+            <AuthToTls type="OptionField">
+                <Required>Y</Required>
+                <Default>0</Default>
+                <OptionValues>
+                    <http value="0">HTTP (default)</http>
+                    <https value="1">HTTPS</https>
+                </OptionValues>
+            </AuthToTls>
             <AuthToUri type="TextField">
                 <Mask>/^(\/.*)?$/u</Mask>
                 <ValidationMessage>Please enter a valid 'URI' that starts with '/'.</ValidationMessage>
@@ -324,10 +331,16 @@
                     <ValidationMessage>Please enter a value between 1 to 100.</ValidationMessage>
                 </PassiveHealthFailDuration>
                 <ForwardAuth type="BooleanField"/>
-                <HttpTls type="BooleanField">
+                <HttpTls type="OptionField">
+                    <Required>Y</Required>
+                    <Default>0</Default>
+                    <OptionValues>
+                        <http value="0">HTTP (default)</http>
+                        <https value="1">HTTPS</https>
+                    </OptionValues>
                     <Constraints>
                         <check001>
-                            <ValidationMessage>TLS and NTLM must be enabled at the same time.</ValidationMessage>
+                            <ValidationMessage>HTTPS and NTLM must be enabled at the same time.</ValidationMessage>
                             <type>DependConstraint</type>
                             <addFields>
                                 <field1>HttpNtlm</field1>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -161,8 +161,8 @@
                 <Required>Y</Required>
                 <Default>0</Default>
                 <OptionValues>
-                    <http value="0">HTTP (default)</http>
-                    <https value="1">HTTPS</https>
+                    <http value="0">http://</http>
+                    <https value="1">https://</https>
                 </OptionValues>
             </AuthToTls>
             <AuthToUri type="TextField">
@@ -214,8 +214,8 @@
                     <Required>Y</Required>
                     <Default>0</Default>
                     <OptionValues>
-                        <https value="0">HTTPS (default)</https>
-                        <http value="1">HTTP</http>
+                        <https value="0">https://</https>
+                        <http value="1">http://</http>
                     </OptionValues>
                 </DisableTls>
             </reverse>
@@ -276,8 +276,8 @@
                         <reverseproxy>
                             <source>OPNsense.Caddy.Caddy</source>
                             <items>reverseproxy.reverse</items>
-                            <display>FromDomain,FromPort</display>
-                            <display_format>%s %s</display_format>
+                            <display>DisableTls,FromDomain,FromPort</display>
+                            <display_format>%s%s %s</display_format>
                         </reverseproxy>
                     </Model>
                 </reverse>
@@ -295,7 +295,7 @@
                     <Required>Y</Required>
                     <Default>handle</Default>
                     <OptionValues>
-                        <handle>handle (default)</handle>
+                        <handle>handle</handle>
                         <handle_path>handle_path</handle_path>
                     </OptionValues>
                 </HandleType>
@@ -335,8 +335,8 @@
                     <Required>Y</Required>
                     <Default>0</Default>
                     <OptionValues>
-                        <http value="0">HTTP (default)</http>
-                        <https value="1">HTTPS</https>
+                        <http value="0">http://</http>
+                        <https value="1">https://</https>
                     </OptionValues>
                     <Constraints>
                         <check001>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -206,7 +206,9 @@
                 </basicauth>
                 <description type="DescriptionField"/>
                 <DnsChallenge type="BooleanField"/>
-                <CustomCertificate type="CertificateField"/>
+                <CustomCertificate type="CertificateField">
+                    <BlankDesc>ACME</BlankDesc>
+                </CustomCertificate>
                 <AccessLog type="BooleanField"/>
                 <DynDns type="BooleanField"/>
                 <AcmePassthrough type="HostnameField"/>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -207,7 +207,7 @@
                 <description type="DescriptionField"/>
                 <DnsChallenge type="BooleanField"/>
                 <CustomCertificate type="CertificateField">
-                    <BlankDesc>ACME</BlankDesc>
+                    <BlankDesc>ACME (default)</BlankDesc>
                 </CustomCertificate>
                 <AccessLog type="BooleanField"/>
                 <DynDns type="BooleanField"/>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/diagnostics.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/diagnostics.volt
@@ -133,10 +133,6 @@
 </script>
 
 <style>
-    .nav-tabs a {
-        font-weight: bold;
-    }
-
     .custom-style .content-box {
         padding: 10px;
     }

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -184,6 +184,7 @@
                     // Check for wildcards in domains to toggle Subdomains tab
                     const hasWildcard = Object.values(response.caddy.reverseproxy.reverse).some(entry => entry.FromDomain.startsWith('*'));
                     toggleTabVisibility('#tab-subdomains', hasWildcard);
+                    toggleSubdomainOptions(hasWildcard);
 
                     // Check if Layer 4 is enabled to toggle the Layer 4 tab
                     const enableLayer4 = response.caddy.general.EnableLayer4 === '1';
@@ -211,6 +212,19 @@
                 if (tab.hasClass('active')) {
                     $('#tab-domains a').tab('show');
                 }
+            }
+        }
+
+        /**
+         * Toggles the visibility of Subdomain options in dialogHandle based on wildcard domain existence.
+         *
+         * @param {boolean} hasWildcard - Whether a wildcard domain exists.
+         */
+        function toggleSubdomainOptions(hasWildcard) {
+            if (hasWildcard) {
+                $(".Subdomain").closest('tr').show();
+            } else {
+                $(".Subdomain").closest('tr').hide();
             }
         }
 
@@ -299,6 +313,15 @@
             }
         });
 
+        // Show TLS options based on chosen protocol
+        $("#handle\\.HttpTls").change(function() {
+            if ($(this).val() === "0") {
+                $(".HttpTls").closest('tr').hide();
+            } else {
+                $(".HttpTls").closest('tr').show();
+            }
+        });
+
         // Initialize tabs, service control and filter selectpicker
         initializeTabs();
         updateServiceControlUI('caddy');
@@ -360,6 +383,7 @@
                         <tr>
                             <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
                             <th data-column-id="enabled" data-width="6em" data-type="boolean" data-formatter="rowtoggle">{{ lang._('Enabled') }}</th>
+                            <th data-column-id="DisableTls" data-type="string">{{ lang._('Protocol') }}</th>
                             <th data-column-id="FromDomain" data-type="string">{{ lang._('Domain') }}</th>
                             <th data-column-id="FromPort" data-type="string">{{ lang._('Port') }}</th>
                             <th data-column-id="accesslist" data-type="string" data-visible="false">{{ lang._('Access List') }}</th>
@@ -369,7 +393,6 @@
                             <th data-column-id="AccessLog" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('HTTP Access Log') }}</th>
                             <th data-column-id="CustomCertificate" data-type="string" data-visible="false">{{ lang._('Custom Certificate') }}</th>
                             <th data-column-id="AcmePassthrough" data-type="string" data-visible="false">{{ lang._('HTTP-01 redirection') }}</th>
-                            <th data-column-id="DisableTls" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('Disable TLS') }}</th>
                             <th data-column-id="description" data-type="string">{{ lang._('Description') }}</th>
                             <th data-column-id="commands" data-width="7em" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
                         </tr>
@@ -437,16 +460,16 @@
                             <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
                             <th data-column-id="enabled" data-width="6em" data-type="boolean" data-formatter="rowtoggle">{{ lang._('Enabled') }}</th>
                             <th data-column-id="reverse" data-type="string">{{ lang._('Domain') }}</th>
-                            <th data-column-id="subdomain" data-type="string">{{ lang._('Subdomain') }}</th>
+                            <th data-column-id="subdomain" data-type="string" data-visible="false">{{ lang._('Subdomain') }}</th>
                             <th data-column-id="HandleType" data-type="string" data-visible="false">{{ lang._('Handle Type') }}</th>
                             <th data-column-id="HandlePath" data-type="string" data-visible="false">{{ lang._('Handle Path') }}</th>
                             <th data-column-id="header" data-type="string" data-visible="false">{{ lang._('Header') }}</th>
+                            <th data-column-id="HttpTls" data-type="string" data-visible="false">{{ lang._('Protocol') }}</th>
                             <th data-column-id="ToDomain" data-type="string">{{ lang._('Upstream Domain') }}</th>
                             <th data-column-id="ToPort" data-type="string">{{ lang._('Upstream Port') }}</th>
                             <th data-column-id="ToPath" data-type="string" data-visible="false">{{ lang._('Upstream Path') }}</th>
                             <th data-column-id="PassiveHealthFailDuration" data-type="string" data-visible="false">{{ lang._('Fail Duration') }}</th>
                             <th data-column-id="ForwardAuth" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('Forward Auth') }}</th>
-                            <th data-column-id="HttpTls" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('TLS') }}</th>
                             <th data-column-id="HttpVersion" data-type="string" data-visible="false">{{ lang._('HTTP Version') }}</th>
                             <th data-column-id="HttpKeepalive" data-type="string" data-visible="false">{{ lang._('HTTP Keepalive') }}</th>
                             <th data-column-id="HttpTlsTrustedCaCerts" data-type="string" data-visible="false">{{ lang._('TLS CA') }}</th>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -395,7 +395,7 @@
                             <th data-column-id="DnsChallenge" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('DNS-01 Challenge') }}</th>
                             <th data-column-id="DynDns" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('Dynamic DNS') }}</th>
                             <th data-column-id="AccessLog" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('HTTP Access Log') }}</th>
-                            <th data-column-id="CustomCertificate" data-type="string">{{ lang._('Certificate') }}</th>
+                            <th data-column-id="CustomCertificate" data-type="string" data-visible="false">{{ lang._('Certificate') }}</th>
                             <th data-column-id="AcmePassthrough" data-type="string" data-visible="false">{{ lang._('HTTP-01 Challenge Redirection') }}</th>
                             <th data-column-id="description" data-type="string">{{ lang._('Description') }}</th>
                             <th data-column-id="commands" data-width="7em" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -343,10 +343,6 @@
         font-style: italic;
     }
 
-    .nav-tabs a {
-        font-weight: bold;
-    }
-
 </style>
 
 <ul class="nav nav-tabs" data-tabs="tabs" id="maintabs">

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -322,6 +322,14 @@
             }
         });
 
+        $("#reverse\\.DisableTls").change(function() {
+            if ($(this).val() === "1") {
+                $(".DisableTls").closest('tr').hide();
+            } else {
+                $(".DisableTls").closest('tr').show();
+            }
+        });
+
         // Initialize tabs, service control and filter selectpicker
         initializeTabs();
         updateServiceControlUI('caddy');
@@ -384,11 +392,11 @@
                             <th data-column-id="FromPort" data-type="string">{{ lang._('Port') }}</th>
                             <th data-column-id="accesslist" data-type="string" data-visible="false">{{ lang._('Access List') }}</th>
                             <th data-column-id="basicauth" data-type="string" data-visible="false">{{ lang._('Basic Auth') }}</th>
-                            <th data-column-id="DnsChallenge" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('DNS-01 challenge') }}</th>
+                            <th data-column-id="DnsChallenge" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('DNS-01 Challenge') }}</th>
                             <th data-column-id="DynDns" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('Dynamic DNS') }}</th>
                             <th data-column-id="AccessLog" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('HTTP Access Log') }}</th>
-                            <th data-column-id="CustomCertificate" data-type="string" data-visible="false">{{ lang._('Custom Certificate') }}</th>
-                            <th data-column-id="AcmePassthrough" data-type="string" data-visible="false">{{ lang._('HTTP-01 redirection') }}</th>
+                            <th data-column-id="CustomCertificate" data-type="string">{{ lang._('Certificate') }}</th>
+                            <th data-column-id="AcmePassthrough" data-type="string" data-visible="false">{{ lang._('HTTP-01 Challenge Redirection') }}</th>
                             <th data-column-id="description" data-type="string">{{ lang._('Description') }}</th>
                             <th data-column-id="commands" data-width="7em" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
                         </tr>
@@ -424,7 +432,7 @@
                             <th data-column-id="accesslist" data-type="string" data-visible="false">{{ lang._('Access List') }}</th>
                             <th data-column-id="basicauth" data-type="string" data-visible="false">{{ lang._('Basic Auth') }}</th>
                             <th data-column-id="DynDns" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('Dynamic DNS') }}</th>
-                            <th data-column-id="AcmePassthrough" data-type="string" data-visible="false">{{ lang._('HTTP-01 redirection') }}</th>
+                            <th data-column-id="AcmePassthrough" data-type="string" data-visible="false">{{ lang._('HTTP-01 Challenge Redirection') }}</th>
                             <th data-column-id="description" data-type="string">{{ lang._('Description') }}</th>
                             <th data-column-id="commands" data-width="7em" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
                         </tr>
@@ -456,19 +464,19 @@
                             <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
                             <th data-column-id="enabled" data-width="6em" data-type="boolean" data-formatter="rowtoggle">{{ lang._('Enabled') }}</th>
                             <th data-column-id="reverse" data-type="string">{{ lang._('Domain') }}</th>
-                            <th data-column-id="subdomain" data-type="string" data-visible="false">{{ lang._('Subdomain') }}</th>
-                            <th data-column-id="HandleType" data-type="string" data-visible="false">{{ lang._('Handle Type') }}</th>
-                            <th data-column-id="HandlePath" data-type="string" data-visible="false">{{ lang._('Handle Path') }}</th>
-                            <th data-column-id="header" data-type="string" data-visible="false">{{ lang._('Header') }}</th>
+                            <th data-column-id="subdomain" data-type="string">{{ lang._('Subdomain') }}</th>
+                            <th data-column-id="HandleType" data-type="string" data-visible="false">{{ lang._('Handler') }}</th>
+                            <th data-column-id="HandlePath" data-type="string" data-visible="false">{{ lang._('Path') }}</th>
+                            <th data-column-id="header" data-type="string" data-visible="false">{{ lang._('HTTP Headers') }}</th>
                             <th data-column-id="HttpTls" data-type="string" data-visible="false">{{ lang._('Protocol') }}</th>
                             <th data-column-id="ToDomain" data-type="string">{{ lang._('Upstream Domain') }}</th>
                             <th data-column-id="ToPort" data-type="string">{{ lang._('Upstream Port') }}</th>
                             <th data-column-id="ToPath" data-type="string" data-visible="false">{{ lang._('Upstream Path') }}</th>
-                            <th data-column-id="PassiveHealthFailDuration" data-type="string" data-visible="false">{{ lang._('Fail Duration') }}</th>
+                            <th data-column-id="PassiveHealthFailDuration" data-type="string" data-visible="false">{{ lang._('Upstream Fail Duration') }}</th>
                             <th data-column-id="ForwardAuth" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('Forward Auth') }}</th>
                             <th data-column-id="HttpVersion" data-type="string" data-visible="false">{{ lang._('HTTP Version') }}</th>
                             <th data-column-id="HttpKeepalive" data-type="string" data-visible="false">{{ lang._('HTTP Keepalive') }}</th>
-                            <th data-column-id="HttpTlsTrustedCaCerts" data-type="string" data-visible="false">{{ lang._('TLS CA') }}</th>
+                            <th data-column-id="HttpTlsTrustedCaCerts" data-type="string" data-visible="false">{{ lang._('TLS Trust Pool') }}</th>
                             <th data-column-id="HttpTlsServerName" data-type="string" data-visible="false">{{ lang._('TLS Server Name') }}</th>
                             <th data-column-id="HttpNtlm" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('NTLM') }}</th>
                             <th data-column-id="HttpTlsInsecureSkipVerify" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('TLS Insecure Skip Verify') }}</th>

--- a/www/caddy/src/opnsense/www/js/widgets/CaddyDomain.js
+++ b/www/caddy/src/opnsense/www/js/widgets/CaddyDomain.js
@@ -91,7 +91,7 @@ export default class CaddyDomain extends BaseTableWidget {
                             data-tooltip="caddy-domain-${domainPort}" title="${tooltipText}">
                         </i>
                         &nbsp;
-                        <a class="caddy-domainport" href="/ui/caddy/reverse_proxy">
+                        <a class="caddy-domainport" href="https://${domainPort}" target="_blank">
                             ${domainPort}
                         </a>
                     </div>


### PR DESCRIPTION
One of the final cleanups of the GUI.

Now I am pretty much satisfied with everything (finally). _Remind me of what I said when I try to move options around again._

Biggest change happened to the Handler dialogue, I disliked how there were so many options always visible.

- Headers and options are hidden more in advanced mode again
- http/https can be chosen explicitely (replacing the tls checkbox (yes its backwards compatible)) and some tls specific options will hide and show based on selection
- The subdomain field will only show if the subdomain tab also shows (aka a wildcard domain has been configured)

Other stuff is just some minor shuffling around but now everything feels great. This will please both newcomers and experts alike.

Handler without advanced and http and without subdomain showing:
![image](https://github.com/user-attachments/assets/62d0b199-363c-4ad5-a0ec-de0681382a42)

Handler in its /final form/ (xD best pun ever):
![image](https://github.com/user-attachments/assets/bf2e1dda-a261-44c1-80cc-0bacafc2157a)

