### PR TITLE
www/caddy: Allow access lists in handlers

### DIFF
--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -23,6 +23,7 @@ Plugin Changelog
 * Cleanup: Caddyfile template logic for Access Lists has been rewritten
 * Cleanup: TLS checkboxes have been converted to dropdowns with http/https for clarity
 * Cleanup: Layer4, Domain and Handle dialogues have been cleaned up, some options are now hidden in advanced mode
+* Fix: Layer4 ports did not render in 1.7.0 due to a small regression in Caddyfile template
 
 1.7.0
 

--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -23,7 +23,8 @@ Plugin Changelog
 * Cleanup: Caddyfile template logic for Access Lists has been rewritten
 * Cleanup: TLS checkboxes have been converted to dropdowns with http/https for clarity
 * Cleanup: Layer4, Domain and Handle dialogues have been cleaned up, some options are now hidden in advanced mode
-* Fix: Layer4 ports did not render in 1.7.0 due to a small regression in Caddyfile template
+* Fix: Layer4 default ports did not render due to regression in previous version
+* Fix: Invert in Access Lists did not render due to regression in previous version
 
 1.7.0
 

--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -16,7 +16,11 @@ Plugin Changelog
 1.7.1
 
 * Add: Frontend HTTP Version can be selected in General Settings, can be used to disable QUIC protocol
+* Add: Access Lists can now be defined per HTTP Handler in advanced mode
 * Change: Caddy Domains widget will now open links to managed websites in new browser tabs
+* Change: To select tls_insecure_skip_verify in a HTTP Handler, the protocol https:// must be chosen
+* Change: Abort from General Settings has been removed, it is now automatically added to all Access Lists
+* Cleanup: Caddyfile template logic for Access Lists has been rewritten
 * Cleanup: TLS checkboxes have been converted to dropdowns with http/https for clarity
 * Cleanup: Layer4, Domain and Handle dialogues have been cleaned up, some options are now hidden in advanced mode
 

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogAccessList.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogAccessList.xml
@@ -23,13 +23,15 @@
         <id>accesslist.HttpResponseCode</id>
         <label>HTTP Response Code</label>
         <type>text</type>
-        <help><![CDATA[Set a custom HTTP response code that should be returned to the requesting client when the access list does not match. Setting this will replace "Abort Connections" only for this access list. All clients will stay connected but will receive the response code.]]></help>
+        <help><![CDATA[Set a custom HTTP response code that should be returned to the requesting client when the access list does not match. If empty, the connection is aborted with no response.]]></help>
+        <advanced>true</advanced>
     </field>
     <field>
         <id>accesslist.HttpResponseMessage</id>
         <label>HTTP Response Message</label>
         <type>text</type>
-        <help><![CDATA[Set a custom HTTP response message in addition to the HTTP response code.]]></help>
+        <help><![CDATA[Set a custom HTTP response message in addition to the HTTP response code. If empty, the connection is aborted with no response.]]></help>
+        <advanced>true</advanced>
     </field>
     <field>
         <id>accesslist.description</id>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogAccessList.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogAccessList.xml
@@ -23,6 +23,7 @@
         <id>accesslist.HttpResponseCode</id>
         <label>HTTP Response Code</label>
         <type>text</type>
+        <hint>abort</hint>
         <help><![CDATA[Set a custom HTTP response code that should be returned to the requesting client when the access list does not match. If empty, the connection is aborted with no response.]]></help>
         <advanced>true</advanced>
     </field>
@@ -30,7 +31,7 @@
         <id>accesslist.HttpResponseMessage</id>
         <label>HTTP Response Message</label>
         <type>text</type>
-        <help><![CDATA[Set a custom HTTP response message in addition to the HTTP response code. If empty, the connection is aborted with no response.]]></help>
+        <help><![CDATA[Set a custom HTTP response message in addition to the HTTP response code. If empty, the default HTTP response message for the chosen HTTP response code will be used.]]></help>
         <advanced>true</advanced>
     </field>
     <field>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -54,6 +54,13 @@
         <advanced>true</advanced>
     </field>
     <field>
+        <id>handle.accesslist</id>
+        <label>Access List</label>
+        <type>dropdown</type>
+        <help><![CDATA[Select an Access List to restrict access to this handler. If unset, any local or remote client is allowed access.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
         <id>handle.ForwardAuth</id>
         <label>Forward Auth</label>
         <type>checkbox</type>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
@@ -60,12 +60,6 @@
             <help><![CDATA[Select an Access List to set IP ranges of Trusted Proxies. If Caddy is not the first server being connected to by clients (for example, when a "CDN" is in front of Caddy), configure "Trusted Proxies" with a list of IP ranges (CIDRs) from which incoming requests are trusted to have sent good values for these headers. Additionally, set the same Access List to the domains the Trusted Proxies connect to.]]></help>
         </field>
         <field>
-            <id>caddy.general.abort</id>
-            <label>Abort Connections</label>
-            <type>checkbox</type>
-            <help><![CDATA[Abort all connections that don't have a matching Handle or Access List. This option does not conflict with "Let's Encrypt" or "ZeroSSL". Disable it for troubleshooting purposes, e.g., testing if the "Domain" works and the automatic certificate has been installed. For production use, enabling this option is recommended.]]></help>
-        </field>
-        <field>
             <id>caddy.general.GracePeriod</id>
             <label>Grace Period</label>
             <type>text</type>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -287,7 +287,7 @@
                         <reverseproxy>
                             <source>OPNsense.Caddy.Caddy</source>
                             <items>reverseproxy.subdomain</items>
-                            <display>FromDomain,FromPort</display>
+                            <display>FromDomain,description</display>
                             <display_format>%s %s</display_format>
                         </reverseproxy>
                     </Model>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -305,6 +305,16 @@
                     <Mask>/^(\/.*)?$/u</Mask>
                     <ValidationMessage>Please enter a valid Path that starts with '/'.</ValidationMessage>
                 </HandlePath>
+                <accesslist type="ModelRelationField">
+                    <Model>
+                        <reverseproxy>
+                            <source>OPNsense.Caddy.Caddy</source>
+                            <items>reverseproxy.accesslist</items>
+                            <display>accesslistName,description</display>
+                            <display_format>%s %s</display_format>
+                        </reverseproxy>
+                    </Model>
+                </accesslist>
                 <header type="ModelRelationField">
                     <Model>
                         <reverseproxy>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -84,7 +84,6 @@
                     </reverseproxy>
                 </Model>
             </accesslist>
-            <abort type="BooleanField"/>
             <DisableSuperuser type="OptionField">
                 <Required>Y</Required>
                 <Default>0</Default>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -474,6 +474,7 @@
                             <th data-column-id="ToPath" data-type="string" data-visible="false">{{ lang._('Upstream Path') }}</th>
                             <th data-column-id="PassiveHealthFailDuration" data-type="string" data-visible="false">{{ lang._('Upstream Fail Duration') }}</th>
                             <th data-column-id="ForwardAuth" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('Forward Auth') }}</th>
+                            <th data-column-id="accesslist" data-type="string" data-visible="false">{{ lang._('Access List') }}</th>
                             <th data-column-id="HttpVersion" data-type="string" data-visible="false">{{ lang._('HTTP Version') }}</th>
                             <th data-column-id="HttpKeepalive" data-type="string" data-visible="false">{{ lang._('HTTP Keepalive') }}</th>
                             <th data-column-id="HttpTlsTrustedCaCerts" data-type="string" data-visible="false">{{ lang._('TLS Trust Pool') }}</th>

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -379,25 +379,8 @@ http://{{ domain }} {
 #}
 {% macro reverse_proxy_configuration(handle) %}
     {{ handle.HandleType }} {{ handle.HandlePath|default("") }} {
-        {# Access list logic for dropping connections based on IP inside handler #}
-        {% if handle.accesslist %}
-            {% set accesslist_obj = helpers.toList('Pischem.caddy.reverseproxy.accesslist') | selectattr('@uuid', 'equalto', handle.accesslist) | first %}
-            {% if accesslist_obj %}
-                {% set client_ips = accesslist_obj.clientIps.split(',') | join(' ') %}
-                @{{ accesslist_obj['@uuid'] }} {
-                    {# Non-inverted access lists have "not" as default, inverted ones '' #}
-                    {{ 'not' if accesslist_obj.accesslistInvert|default("0") == "0" else '' }} client_ip {{ client_ips }}
-                }
-                {# When IP is matched, abort or send response code. This will end processing in the scope of this handler #}
-                handle @{{ accesslist_obj['@uuid'] }} {
-                    {% if accesslist_obj.HttpResponseCode or accesslist_obj.HttpResponseMessage %}
-                        respond {{ '"' + accesslist_obj.HttpResponseMessage|default('') + '"' if accesslist_obj.HttpResponseMessage else '' }} {{ accesslist_obj.HttpResponseCode|default(403) }}
-                    {% else %}
-                        abort
-                    {% endif %}
-                }
-            {% endif %}
-        {% endif %}
+        {# Access list logic for dropping connections based on IP #}
+        {{ handle_accesslist(handle.accesslist) }}
         {# All unmatched IPs will continue processing here #}
         {% if handle.ForwardAuth|default("0") == "1" %}
             {% include "OPNsense/Caddy/includeAuthProvider" %}
@@ -456,21 +439,26 @@ http://{{ domain }} {
 #   Purpose: Manages the logic for access lists, including configuration and handling.
 #   Parameters:
 #   @param accesslist (string): The UUID of the access list to be applied.
-#   @param content (string): The content to be wrapped in the access list handler.
-#   @param invert (boolean): A flag that inverts the logic of the access list.
 #}
-{% macro handle_accesslist(accesslist, content) %}
+{% macro handle_accesslist(accesslist) %}
+    {# Access list logic for dropping connections based on IP inside handler #}
     {% if accesslist %}
         {% set accesslist_obj = helpers.toList('Pischem.caddy.reverseproxy.accesslist') | selectattr('@uuid', 'equalto', accesslist) | first %}
-        {% set client_ips = accesslist_obj.clientIps.split(',') | join(' ') %}
-        @{{ accesslist_obj['@uuid'] }} {
-            {{ 'not' if accesslist_obj.accesslistInvert|default("0") == "1" else '' }} client_ip {{ client_ips }}
-        }
-        handle @{{ accesslist_obj['@uuid'] }} {
-            {{ content }}
-        }
-    {% else %}
-        {{ content }}
+        {% if accesslist_obj %}
+            {% set client_ips = accesslist_obj.clientIps.split(',') | join(' ') %}
+            @{{ accesslist_obj['@uuid'] }} {
+                {# Non-inverted access lists have "not" as default, inverted ones '' #}
+                {{ 'not' if accesslist_obj.accesslistInvert|default("0") == "0" else '' }} client_ip {{ client_ips }}
+            }
+            {# When IP is matched, abort or send response code. This will end processing in the scope of this handler #}
+            handle @{{ accesslist_obj['@uuid'] }} {
+                {% if accesslist_obj.HttpResponseCode or accesslist_obj.HttpResponseMessage %}
+                    respond {{ '"' + accesslist_obj.HttpResponseMessage|default('') + '"' if accesslist_obj.HttpResponseMessage else '' }} {{ accesslist_obj.HttpResponseCode|default(403) }}
+                {% else %}
+                    abort
+                {% endif %}
+            }
+        {% endif %}
     {% endif %}
 {% endmacro %}
 
@@ -490,25 +478,6 @@ http://{{ domain }} {
             {% endif %}
         {% endfor %}
     }
-    {% endif %}
-{% endmacro %}
-
-{#
-#   Macro: handle_response
-#   Purpose: Manages the response logic for access lists and aborts.
-#   Parameters:
-#   @param accesslist (object): The access list object containing response settings.
-#   @param general_abort (string): The global abort setting.
-#}
-{% macro handle_response(accesslist, general_abort) %}
-    {% if accesslist %}
-        {% if accesslist.HttpResponseCode or accesslist.HttpResponseMessage %}
-            respond {{ '"' + accesslist.HttpResponseMessage|default('') + '"' if accesslist.HttpResponseMessage else '' }} {{ accesslist.HttpResponseCode|default(403) }}
-        {% elif general_abort == "1" %}
-            abort
-        {% endif %}
-    {% elif general_abort == "1" %}
-        abort
     {% endif %}
 {% endmacro %}
 
@@ -589,10 +558,7 @@ http://{{ domain }} {
                         {% set subdomain_content %}
                             {{ render_handles(subdomain_handles, subdomain.basicauth) }}
                         {% endset %}
-                        {{ handle_accesslist(subdomain.accesslist, subdomain_content) }}
-
-                        {% set accesslist = helpers.toList('Pischem.caddy.reverseproxy.accesslist') | selectattr('@uuid', 'equalto', subdomain.accesslist) | first %}
-                        {{ handle_response(accesslist, Pischem.caddy.general.abort|default("0")) }}
+                        {{ handle_accesslist(subdomain.accesslist) }}
                     }
                 {% endif %}
             {% endfor %}
@@ -601,10 +567,7 @@ http://{{ domain }} {
             {% set wildcard_content %}
                 {{ render_handles(wildcard_handles, reverse.basicauth) }}
             {% endset %}
-            {{ handle_accesslist(reverse.accesslist, wildcard_content) }}
-
-            {% set accesslist = helpers.toList('Pischem.caddy.reverseproxy.accesslist') | selectattr('@uuid', 'equalto', reverse.accesslist) | first %}
-            {{ handle_response(accesslist, Pischem.caddy.general.abort|default("0")) }}
+            {{ handle_accesslist(reverse.accesslist) }}
         }
     {% endif %}
 {% endfor %}

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -378,6 +378,11 @@ http://{{ domain }} {
 #   @param handle (object)
 #}
 {% macro reverse_proxy_configuration(handle) %}
+    {% set domain_info = handle.ToDomain|replace('.', '_') %}
+    {% set path_info = handle.HandlePath|replace('/', '_') %}
+    {% set unique_suffix = domain_info ~ path_info %}
+
+    {% set proxy_content %}
     {{ handle.HandleType }} {{ handle.HandlePath|default("") }} {
         {% if handle.ForwardAuth|default("0") == "1" %}
             {% include "OPNsense/Caddy/includeAuthProvider" %}
@@ -429,6 +434,9 @@ http://{{ domain }} {
             {% endif %}
         }
     }
+    {% endset %}
+
+    {{ handle_accesslist(handle.accesslist, proxy_content, unique_suffix) }}
 {% endmacro %}
 
 {#
@@ -439,15 +447,14 @@ http://{{ domain }} {
 #   @param content (string): The content to be wrapped in the access list handler.
 #   @param invert (boolean): A flag that inverts the logic of the access list.
 #}
-{% macro handle_accesslist(accesslist, content, invert=false) %}
+{% macro handle_accesslist(accesslist, content, unique_suffix="", invert=false) %}
     {% if accesslist %}
         {% set accesslist_obj = helpers.toList('Pischem.caddy.reverseproxy.accesslist') | selectattr('@uuid', 'equalto', accesslist) | first %}
-        {% set client_ips = accesslist_obj.clientIps.split(',') %}
-        {% set client_ips_space_separated = client_ips | join(' ') %}
-        @{{ accesslist_obj['@uuid'] }} {
-            {{ 'not' if invert or accesslist_obj.accesslistenvert|default("0") == "1" else '' }} client_ip {{ client_ips_space_separated }}
+        {% set client_ips = accesslist_obj.clientIps.split(',') | join(' ') %}
+        @{{ accesslist_obj['@uuid'] }}_{{ unique_suffix }} {
+            {{ 'not' if accesslist_obj.accesslistInvert|default("0") == "1" else '' }} client_ip {{ client_ips }}
         }
-        handle @{{ accesslist_obj['@uuid'] }} {
+        handle @{{ accesslist_obj['@uuid'] }}_{{ unique_suffix }} {
             {{ content }}
         }
     {% else %}

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -379,9 +379,8 @@ http://{{ domain }} {
 #}
 {% macro reverse_proxy_configuration(handle) %}
     {{ handle.HandleType }} {{ handle.HandlePath|default("") }} {
-        {# Access list logic for dropping connections based on IP #}
         {{ handle_accesslist(handle.accesslist) }}
-        {# All unmatched IPs will continue processing here #}
+        {# All IPs not matched by accesslist will continue processing #}
         {% if handle.ForwardAuth|default("0") == "1" %}
             {% include "OPNsense/Caddy/includeAuthProvider" %}
         {% endif %}
@@ -436,12 +435,12 @@ http://{{ domain }} {
 
 {#
 #   Macro: handle_accesslist
-#   Purpose: Manages the logic for access lists, including configuration and handling.
+#   Purpose: Manages the logic for access lists, used for handlers, domains and subdomains
 #   Parameters:
 #   @param accesslist (string): The UUID of the access list to be applied.
 #}
 {% macro handle_accesslist(accesslist) %}
-    {# Access list logic for dropping connections based on IP inside handler #}
+    {# Access list logic for dropping connections based on IP #}
     {% if accesslist %}
         {% set accesslist_obj = helpers.toList('Pischem.caddy.reverseproxy.accesslist') | selectattr('@uuid', 'equalto', accesslist) | first %}
         {% if accesslist_obj %}
@@ -450,7 +449,7 @@ http://{{ domain }} {
                 {# Non-inverted access lists have "not" as default, inverted ones '' #}
                 {{ 'not' if accesslist_obj.accesslistInvert|default("0") == "0" else '' }} client_ip {{ client_ips }}
             }
-            {# When IP is matched, abort or send response code. This will end processing in the scope of this handler #}
+            {# When IP is matched, abort or send response code. This will end processing and drop the request #}
             handle @{{ accesslist_obj['@uuid'] }} {
                 {% if accesslist_obj.HttpResponseCode or accesslist_obj.HttpResponseMessage %}
                     respond {{ '"' + accesslist_obj.HttpResponseMessage|default('') + '"' if accesslist_obj.HttpResponseMessage else '' }} {{ accesslist_obj.HttpResponseCode|default(403) }}
@@ -555,19 +554,17 @@ http://{{ domain }} {
                     }
                     handle @{{ subdomain['@uuid'] }} {
                         {% set subdomain_handles = helpers.toList('Pischem.caddy.reverseproxy.handle') | selectattr('subdomain', 'equalto', subdomain['@uuid']) | list %}
-                        {% set subdomain_content %}
-                            {{ render_handles(subdomain_handles, subdomain.basicauth) }}
-                        {% endset %}
                         {{ handle_accesslist(subdomain.accesslist) }}
+                        {# All IPs not matched by accesslist will continue processing #}
+                        {{ render_handles(subdomain_handles, subdomain.basicauth) }}
                     }
                 {% endif %}
             {% endfor %}
 
-            {% set wildcard_handles = helpers.toList('Pischem.caddy.reverseproxy.handle') | selectattr('reverse', 'equalto', reverse['@uuid']) | selectattr('subdomain', 'undefined') | list %}
-            {% set wildcard_content %}
-                {{ render_handles(wildcard_handles, reverse.basicauth) }}
-            {% endset %}
+            {% set domain_handles = helpers.toList('Pischem.caddy.reverseproxy.handle') | selectattr('reverse', 'equalto', reverse['@uuid']) | selectattr('subdomain', 'undefined') | list %}
             {{ handle_accesslist(reverse.accesslist) }}
+            {# All IPs not matched by accesslist will continue processing #}
+            {{ render_handles(domain_handles, reverse.basicauth) }}
         }
     {% endif %}
 {% endfor %}

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -378,12 +378,27 @@ http://{{ domain }} {
 #   @param handle (object)
 #}
 {% macro reverse_proxy_configuration(handle) %}
-    {% set domain_info = handle.ToDomain|replace('.', '_') %}
-    {% set path_info = handle.HandlePath|replace('/', '_') %}
-    {% set unique_suffix = domain_info ~ path_info %}
-
-    {% set proxy_content %}
     {{ handle.HandleType }} {{ handle.HandlePath|default("") }} {
+        {# Access list logic for dropping connections based on IP inside handler #}
+        {% if handle.accesslist %}
+            {% set accesslist_obj = helpers.toList('Pischem.caddy.reverseproxy.accesslist') | selectattr('@uuid', 'equalto', handle.accesslist) | first %}
+            {% if accesslist_obj %}
+                {% set client_ips = accesslist_obj.clientIps.split(',') | join(' ') %}
+                @{{ accesslist_obj['@uuid'] }} {
+                    {# Non-inverted access lists have "not" as default, inverted ones '' #}
+                    {{ 'not' if accesslist_obj.accesslistInvert|default("0") == "0" else '' }} client_ip {{ client_ips }}
+                }
+                {# When IP is matched, abort or send response code. This will end processing in the scope of this handler #}
+                handle @{{ accesslist_obj['@uuid'] }} {
+                    {% if accesslist_obj.HttpResponseCode or accesslist_obj.HttpResponseMessage %}
+                        respond {{ '"' + accesslist_obj.HttpResponseMessage|default('') + '"' if accesslist_obj.HttpResponseMessage else '' }} {{ accesslist_obj.HttpResponseCode|default(403) }}
+                    {% else %}
+                        abort
+                    {% endif %}
+                }
+            {% endif %}
+        {% endif %}
+        {# All unmatched IPs will continue processing here #}
         {% if handle.ForwardAuth|default("0") == "1" %}
             {% include "OPNsense/Caddy/includeAuthProvider" %}
         {% endif %}
@@ -434,9 +449,6 @@ http://{{ domain }} {
             {% endif %}
         }
     }
-    {% endset %}
-
-    {{ handle_accesslist(handle.accesslist, proxy_content, unique_suffix) }}
 {% endmacro %}
 
 {#
@@ -447,14 +459,14 @@ http://{{ domain }} {
 #   @param content (string): The content to be wrapped in the access list handler.
 #   @param invert (boolean): A flag that inverts the logic of the access list.
 #}
-{% macro handle_accesslist(accesslist, content, unique_suffix="", invert=false) %}
+{% macro handle_accesslist(accesslist, content) %}
     {% if accesslist %}
         {% set accesslist_obj = helpers.toList('Pischem.caddy.reverseproxy.accesslist') | selectattr('@uuid', 'equalto', accesslist) | first %}
         {% set client_ips = accesslist_obj.clientIps.split(',') | join(' ') %}
-        @{{ accesslist_obj['@uuid'] }}_{{ unique_suffix }} {
+        @{{ accesslist_obj['@uuid'] }} {
             {{ 'not' if accesslist_obj.accesslistInvert|default("0") == "1" else '' }} client_ip {{ client_ips }}
         }
-        handle @{{ accesslist_obj['@uuid'] }}_{{ unique_suffix }} {
+        handle @{{ accesslist_obj['@uuid'] }} {
             {{ content }}
         }
     {% else %}

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -234,7 +234,7 @@
 #   There are no regressions to set these ports up.
 #}
 
-{% if enableLayer4|default("0") == "1" %}
+{% if generalSettings.EnableLayer4|default("0") == "1" %}
     # Layer4 default HTTP port
     {% if httpPort %}
         :{{ httpPort }} {
@@ -451,8 +451,8 @@ http://{{ domain }} {
             }
             {# When IP is matched, abort or send response code. This will end processing and drop the request #}
             handle @{{ accesslist_obj['@uuid'] }} {
-                {% if accesslist_obj.HttpResponseCode or accesslist_obj.HttpResponseMessage %}
-                    respond {{ '"' + accesslist_obj.HttpResponseMessage|default('') + '"' if accesslist_obj.HttpResponseMessage else '' }} {{ accesslist_obj.HttpResponseCode|default(403) }}
+                {% if accesslist_obj.HttpResponseCode %}
+                    respond {{ '"' + accesslist_obj.HttpResponseMessage + '"' if accesslist_obj.HttpResponseMessage else '' }} {{ accesslist_obj.HttpResponseCode }}
                 {% else %}
                     abort
                 {% endif %}


### PR DESCRIPTION
Fixes: https://github.com/opnsense/plugins/issues/4223

Details:

- When no access list in a handler is chosen, it will render without as before
- If an access list is chosen, it will render inside the path handler, kinda like the forward auth directive. This prevents further processing if IPs have been matched.

There is an additional bug fix in here that fixes a typo that prevented inverted access lists being rendered correctly. If nobody tests this I will extract the bugfix and merge it in a separate PR.

EDIT:

The whole access list feature has been rewritten to be simpler and the same in the whole template