### PR TITLE
www/caddy: Force caddy to restart if a reload takes too long

### DIFF
--- a/www/caddy/Makefile
+++ b/www/caddy/Makefile
@@ -1,5 +1,6 @@
 PLUGIN_NAME=		caddy
 PLUGIN_VERSION=		1.7.1
+PLUGIN_REVISION=	1
 PLUGIN_DEPENDS=		caddy-custom
 PLUGIN_COMMENT=		Modern Reverse Proxy with Automatic HTTPS, Dynamic DNS and Layer4 Routing
 PLUGIN_MAINTAINER=	cedrik@pischem.com

--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -25,6 +25,7 @@ Plugin Changelog
 * Cleanup: Layer4, Domain and Handle dialogues have been cleaned up, some options are now hidden in advanced mode
 * Fix: Layer4 default ports did not render due to regression in previous version
 * Fix: Invert in Access Lists did not render due to regression in previous version
+* Fix: When Apply takes longer than 20 seconds, Caddy will be forcefully restarted
 
 1.7.0
 

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
@@ -64,7 +64,7 @@
             <label>Grace Period</label>
             <type>text</type>
             <hint>10</hint>
-            <help><![CDATA[Defines the grace period for shutting down Caddy during a reload in seconds. During the grace period, no new connections are accepted, idle connections are closed, and active connections are impatiently waited upon to finish their requests. If clients do not finish their requests within the grace period, the server will be forcefully terminated to allow the reload to complete and free up resources. This can influence how long "Apply" of new configurations take, since Caddy waits for all open connections to close.]]></help>
+            <help><![CDATA[Defines the grace period for shutting down Caddy during a reload in seconds. If clients do not finish their requests within the grace period, the server will be forcefully terminated to allow the reload to complete and free up resources. This can influence how long "Apply" of new configurations take, since Caddy waits for all open connections to close. If the grace period is over and Caddy is unresponsive, there will be a forced kill and service restart.]]></help>
         </field>
     </tab>
     <tab id="general-logsettings" description="Log Settings">

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -95,8 +95,8 @@
             <GracePeriod type="IntegerField">
                 <Default>10</Default>
                 <MinimumValue>1</MinimumValue>
-                <MaximumValue>3600</MaximumValue>
-                <ValidationMessage>Please enter a valid Grace Period between 1 and 3600 seconds.</ValidationMessage>
+                <MaximumValue>20</MaximumValue>
+                <ValidationMessage>Please enter a valid Grace Period between 1 and 20 seconds.</ValidationMessage>
                 <Required>Y</Required>
             </GracePeriod>
             <HttpVersion type="OptionField">


### PR DESCRIPTION
Patch behavior of caddy hanging during a reload or restart in some circumstances. This will avoid caddy waiting indefinitely when the NTLM module is active. After the Grace Period is over, there is a hard kill and restart. Since the template already regenerated the configuration, the new one will be used when Caddy starts. I think it fixes some reload issues with the Layer4 module as well, though unsure here.

It seems like Grace Period fix was not enough.

PR: https://forum.opnsense.org/index.php?topic=42664.msg212232#msg212232
PR2: https://github.com/opnsense/plugins/issues/3929 (Same as latest PR, Grace Period seemed to fix it there, but I guess its not for everyone)
PR2: https://github.com/opnsense/plugins/issues/3890  
PR3: https://github.com/opnsense/plugins/issues/3887  (This happens if caddy hangs too long. A new process will spawn with a new pid when the old one cant be killed)

Tested with `kill -STOP pid` and then reloading caddy. Apply resolves after around 22 seconds and Caddy is started again.

The constraint for Grace Period was lowered to 20 seconds and a hint was added to the option.