### PR TITLE
www/caddy: Add redir directive to HTTP Handler

### DIFF
--- a/www/caddy/Makefile
+++ b/www/caddy/Makefile
@@ -1,6 +1,5 @@
 PLUGIN_NAME=		caddy
-PLUGIN_VERSION=		1.7.1
-PLUGIN_REVISION=	1
+PLUGIN_VERSION=		1.7.2
 PLUGIN_DEPENDS=		caddy-custom
 PLUGIN_COMMENT=		Modern Reverse Proxy with Automatic HTTPS, Dynamic DNS and Layer4 Routing
 PLUGIN_MAINTAINER=	cedrik@pischem.com

--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -13,6 +13,10 @@ DOC: https://docs.opnsense.org/manual/how-tos/caddy.html
 Plugin Changelog
 ================
 
+1.7.2
+
+* Add: Directive in HTTP Handler can be chosen, "reverse_proxy" and "redir"
+
 1.7.1
 
 * Add: Frontend HTTP Version can be selected in General Settings, can be used to disable QUIC protocol

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -37,7 +37,7 @@
         <id>handle.HandleType</id>
         <label>Handler</label>
         <type>dropdown</type>
-        <help><![CDATA[Choose a handling directive. "handle" (default) will keep the path in all requests. "handle_path" will strip the path from all requests.]]></help>
+        <help><![CDATA[Choose a handling type: "handle" (default) will keep the path in all requests. "handle_path" will strip the path from all requests.]]></help>
         <advanced>true</advanced>
     </field>
     <field>
@@ -45,7 +45,7 @@
         <label>Path</label>
         <type>text</type>
         <hint>any</hint>
-        <help><![CDATA[Enter a path to handle. Choose a pattern like "/*" or "/example/*". Leave empty to handle any paths (recommended). Any request matching this pattern will be reverse proxied.]]></help>
+        <help><![CDATA[Enter a path to handle. Choose a pattern like "/*" or "/example/*". Leave empty to handle any paths (recommended). Any request matching this pattern will be handled by the chosen directive.]]></help>
         <advanced>true</advanced>
     </field>
     <field>
@@ -83,6 +83,18 @@
     </field>
     <field>
         <type>header</type>
+        <label>Directive</label>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>handle.HandleDirective</id>
+        <label>Directive</label>
+        <type>dropdown</type>
+        <help><![CDATA[Choose a handling directive: "reverse_proxy" will proxy all HTTP traffic to the selected upstream. "redir" will create a HTTP redirect.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <type>header</type>
         <label>Upstream</label>
     </field>
     <field>
@@ -113,7 +125,7 @@
         <style>tokenize</style>
         <allownew>true</allownew>
         <hint>192.168.1.1</hint>
-        <help><![CDATA[Enter a domain name or IP address of the upstream destination. If multiple are chosen, they will be load balanced with the default random policy. A health check can be activated by populating "Upstream Fail Duration" in advanced mode.]]></help>
+        <help><![CDATA[Enter a domain name or IP address of the upstream destination. If multiple are chosen, they will be load balanced with the default random policy. A health check can be activated by populating "Upstream Fail Duration" in advanced mode. When directive is "redir", only the first domain will be evaluated.]]></help>
     </field>
     <field>
         <id>handle.ToPort</id>
@@ -126,7 +138,7 @@
         <id>handle.ToPath</id>
         <label>Upstream Path</label>
         <type>text</type>
-        <help><![CDATA[Enter a path prefix like "/guacamole" that should be prepended to the upstream request. This is useful for destinations that have a virtual directory as their base path.]]></help>
+        <help><![CDATA[When directive is "reverse_proxy", enter a path prefix like "/guacamole" that should be prepended to the upstream request. This is useful for destinations that have a virtual directory as their base path. When directive is "redir", add the path the request should be redirected to; leaving it empty will append {uri}.]]></help>
         <advanced>true</advanced>
     </field>
     <field>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -69,29 +69,13 @@
     </field>
     <field>
         <type>header</type>
-        <label>Header</label>
-        <advanced>true</advanced>
-    </field>
-    <field>
-        <id>handle.header</id>
-        <label>HTTP Headers</label>
-        <type>dropdown</type>
-        <type>select_multiple</type>
-        <size>5</size>
-        <help><![CDATA[Select one or multiple headers. Caddy sets "X-Forwarded-For", "X-Forwarded-Proto" and "X-Forwarded-Host" by default, adding them here is not needed. Setting a wrong configuration can be a security risk or break functionality.]]></help>
-        <advanced>true</advanced>
-    </field>
-    <field>
-        <type>header</type>
         <label>Directive</label>
-        <advanced>true</advanced>
     </field>
     <field>
         <id>handle.HandleDirective</id>
         <label>Directive</label>
         <type>dropdown</type>
         <help><![CDATA[Choose a handling directive: "reverse_proxy" will proxy all HTTP traffic to the selected upstream. "redir" will create a HTTP redirect.]]></help>
-        <advanced>true</advanced>
     </field>
     <field>
         <type>header</type>
@@ -101,7 +85,18 @@
         <id>handle.HttpVersion</id>
         <label>HTTP Version</label>
         <type>dropdown</type>
+        <style>style_reverse_proxy</style>
         <help><![CDATA[The default versions are highly recommended. Choose a HTTP version for the upstream destination. HTTP/3 (HTTP over QUIC) requires HTTPS, and only establishes connections to webservers that also support HTTP/3.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>handle.header</id>
+        <label>HTTP Headers</label>
+        <type>dropdown</type>
+        <type>select_multiple</type>
+        <size>5</size>
+        <style>style_reverse_proxy selectpicker</style>
+        <help><![CDATA[Select one or multiple headers. Caddy sets "X-Forwarded-For", "X-Forwarded-Proto" and "X-Forwarded-Host" by default, adding them here is not needed. Setting a wrong configuration can be a security risk or break functionality.]]></help>
         <advanced>true</advanced>
     </field>
     <field>
@@ -109,6 +104,7 @@
         <label>HTTP Keepalive</label>
         <type>text</type>
         <hint>120</hint>
+        <style>style_reverse_proxy</style>
         <help><![CDATA[Leave empty to use default. Keepalive is either 0 (off) or a duration value that specifies how long to keep connections open (timeout) in seconds.]]></help>
         <advanced>true</advanced>
     </field>
@@ -145,6 +141,7 @@
         <id>handle.PassiveHealthFailDuration</id>
         <label>Upstream Fail Duration</label>
         <type>text</type>
+        <style>style_reverse_proxy</style>
         <help><![CDATA[Enables a passive health check when multiple destinations in "Upstream Domain" are set. "Fail Duration" is a value that defines how long to remember a failed request. A duration of 1 or more seconds enables passive health checking; the default is empty (off). A reasonable starting point might be 30s to balance error rates with responsiveness when bringing an unhealthy upstream back online.]]></help>
         <advanced>true</advanced>
     </field>
@@ -152,28 +149,28 @@
         <id>handle.HttpTlsInsecureSkipVerify</id>
         <label>TLS Insecure Skip Verify</label>
         <type>checkbox</type>
-        <style>HttpTls</style>
+        <style>style_tls style_reverse_proxy</style>
         <help><![CDATA[Caddy uses HTTP by default to connect to the Upstream. If the Upstream is only reachable via HTTPS, this option disables the TLS handshake verification. This makes the connection insecure and vulnerable to man-in-the-middle attacks. In private networks the risk is low, though do not use in production if possible. It is advised to either use plain HTTP, or proper TLS handling by using the options in "Trust".]]></help>
     </field>
     <field>
         <id>handle.HttpTlsTrustedCaCerts</id>
         <label>TLS Trust Pool</label>
         <type>dropdown</type>
-        <style>HttpTls</style>
+        <style>style_tls style_reverse_proxy</style>
         <help><![CDATA[Choose a CA or self-signed certificate to trust from "System - Trust - Authorities". Useful if the upstream destination only accepts TLS connections and offers a self signed certificate. Adding that certificate here will allow for the encrypted connection to succeed.]]></help>
     </field>
     <field>
         <id>handle.HttpTlsServerName</id>
         <label>TLS Server Name</label>
         <type>text</type>
-        <style>HttpTls</style>
+        <style>style_tls style_reverse_proxy</style>
         <help><![CDATA[Enter a hostname or IP address that matches the SAN "Subject Alternative Name" of the offered upstream certificate. This will change the SNI "Server Name Indication" of Caddy. Setting an IP address as "Upstream Domain", enabling "TLS" and selecting a "TLS Trust Pool", would make the SAN of the offered upstream certificate not match with the SNI of Caddy, since it will be an IP address instead of a hostname. Setting the hostname of the certificate here, fixes this issue. Please note that only SAN certificates are supported; CN "Common Name" will not work.]]></help>
     </field>
     <field>
         <id>handle.HttpNtlm</id>
         <label>NTLM</label>
         <type>checkbox</type>
-        <style>HttpTls</style>
+        <style>style_tls style_reverse_proxy</style>
         <help><![CDATA[Enable or disable NTLM. Needed to reverse proxy an Exchange Server. Warning: NTLM has been deprecated by Microsoft. This option will stay for as long as the optional http.reverse_proxy.transport.http_ntlm module can be compiled without errors.]]></help>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
@@ -39,7 +39,7 @@
         <id>reverse.CustomCertificate</id>
         <label>Certificate</label>
         <type>dropdown</type>
-        <style>DisableTls</style>
+        <style>style_tls</style>
         <help><![CDATA[Choose ACME to get automatic certificates with the built in ACME client; no additional plugin required. The "HTTP-01", "TLS-ALPN-01" or "DNS-01" challenge will be used to get automatic "Let's Encrypt" or "ZeroSSL" certificates. Alternatively, choose a custom certificate from "System - Trust - Certificates" for this domain. Make sure the full chain has been imported.]]></help>
     </field>
     <field>
@@ -53,7 +53,7 @@
         <id>reverse.DnsChallenge</id>
         <label>DNS-01 Challenge</label>
         <type>checkbox</type>
-        <style>DisableTls</style>
+        <style>style_tls</style>
         <help><![CDATA[Enable the DNS-01 Challenge for this domain. Requires a "DNS Provider" in "General Settings". This is only needed for wildcard domains, or when the default challenges can not be used due to restrictive firewall policies.]]></help>
     </field>
     <field>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//Pischem/caddy</mount>
     <description>Caddy Reverse Proxy</description>
-    <version>1.3.1</version>
+    <version>1.3.2</version>
     <items>
         <general>
             <enabled type="BooleanField">
@@ -325,6 +325,14 @@
                     </Model>
                     <Multiple>Y</Multiple>
                 </header>
+                <HandleDirective type="OptionField">
+                    <Required>Y</Required>
+                    <Default>reverse_proxy</Default>
+                    <OptionValues>
+                        <reverse_proxy>reverse_proxy</reverse_proxy>
+                        <redir>redir</redir>
+                    </OptionValues>
+                </HandleDirective>
                 <ToDomain type="HostnameField">
                     <Required>Y</Required>
                     <FieldSeparator>,</FieldSeparator>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -468,6 +468,7 @@
                             <th data-column-id="HandleType" data-type="string" data-visible="false">{{ lang._('Handler') }}</th>
                             <th data-column-id="HandlePath" data-type="string" data-visible="false">{{ lang._('Path') }}</th>
                             <th data-column-id="header" data-type="string" data-visible="false">{{ lang._('HTTP Headers') }}</th>
+                            <th data-column-id="HandleDirective" data-type="string" data-visible="false">{{ lang._('Directive') }}</th>
                             <th data-column-id="HttpTls" data-type="string" data-visible="false">{{ lang._('Protocol') }}</th>
                             <th data-column-id="ToDomain" data-type="string">{{ lang._('Upstream Domain') }}</th>
                             <th data-column-id="ToPort" data-type="string">{{ lang._('Upstream Port') }}</th>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -313,20 +313,29 @@
             }
         });
 
-        // Show TLS options based on chosen protocol
         $("#handle\\.HttpTls").change(function() {
             if ($(this).val() === "0") {
-                $(".HttpTls").closest('tr').hide();
+                $(".style_tls").closest('tr').hide();
             } else {
-                $(".HttpTls").closest('tr').show();
+                $(".style_tls").closest('tr').show();
+            }
+        });
+
+        $("#handle\\.HandleDirective").change(function() {
+            if ($(this).val() === "redir") {
+                $(".style_reverse_proxy").prop('disabled', true);
+                $("#handle\\.header").selectpicker('refresh');
+            } else {
+                $(".style_reverse_proxy").prop('disabled', false);
+                $("#handle\\.header").selectpicker('refresh');
             }
         });
 
         $("#reverse\\.DisableTls").change(function() {
             if ($(this).val() === "1") {
-                $(".DisableTls").closest('tr').hide();
+                $(".style_tls").closest('tr').hide();
             } else {
-                $(".DisableTls").closest('tr').show();
+                $(".style_tls").closest('tr').show();
             }
         });
 
@@ -468,7 +477,7 @@
                             <th data-column-id="HandleType" data-type="string" data-visible="false">{{ lang._('Handler') }}</th>
                             <th data-column-id="HandlePath" data-type="string" data-visible="false">{{ lang._('Path') }}</th>
                             <th data-column-id="header" data-type="string" data-visible="false">{{ lang._('HTTP Headers') }}</th>
-                            <th data-column-id="HandleDirective" data-type="string" data-visible="false">{{ lang._('Directive') }}</th>
+                            <th data-column-id="HandleDirective" data-type="string">{{ lang._('Directive') }}</th>
                             <th data-column-id="HttpTls" data-type="string" data-visible="false">{{ lang._('Protocol') }}</th>
                             <th data-column-id="ToDomain" data-type="string">{{ lang._('Upstream Domain') }}</th>
                             <th data-column-id="ToPort" data-type="string">{{ lang._('Upstream Port') }}</th>

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -384,10 +384,11 @@ http://{{ domain }} {
         {% if handle.ForwardAuth|default("0") == "1" %}
             {% include "OPNsense/Caddy/includeAuthProvider" %}
         {% endif %}
-        {% if handle.ToPath|default("") != "" %}
+        {% if handle.HandleDirective == "reverse_proxy" and handle.ToPath|default("") != "" %}
             rewrite * {{ handle.ToPath }}{uri}
         {% endif %}
-        reverse_proxy {% for domain in handle.ToDomain.split(',') %}
+        {% if handle.HandleDirective == "reverse_proxy" %}
+        {{ handle.HandleDirective }} {% for domain in handle.ToDomain.split(',') %}
             {# Check if the domain is IPv6 and wrap in square brackets if necessary #}
             {% set is_ipv6 = (':' in domain and domain.count(':') >= 2) %}
             {# For each domain/IP, append the port if it's specified, followed by a space #}
@@ -430,6 +431,18 @@ http://{{ domain }} {
                 }
             {% endif %}
         }
+        {% else %}
+            {% set protocol = 'https://' if handle.HttpTls == "1" else 'http://' %}
+            {% set domain = handle.ToDomain.split(',')[0] %}
+            {% set is_ipv6 = (':' in domain and domain.count(':') >= 2) %}
+            {% set formatted_domain = ('[' ~ domain ~ ']') if is_ipv6 else domain %}
+            {% if handle.ToPort %}
+                {% set domain_with_port = formatted_domain ~ ':' ~ handle.ToPort %}
+            {% else %}
+                {% set domain_with_port = formatted_domain %}
+            {% endif %}
+            {{ handle.HandleDirective|default("redir") }} {{ protocol }}{{ domain_with_port }}{{ handle.ToPath|default("{uri}") }}
+        {% endif %}
     }
 {% endmacro %}
 

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -441,7 +441,7 @@ http://{{ domain }} {
             {% else %}
                 {% set domain_with_port = formatted_domain %}
             {% endif %}
-            {{ handle.HandleDirective|default("redir") }} {{ protocol }}{{ domain_with_port }}{{ handle.ToPath|default("{uri}") }}
+            {{ handle.HandleDirective }} {{ protocol }}{{ domain_with_port }}{{ handle.ToPath|default("{uri}") }}
         {% endif %}
     }
 {% endmacro %}


### PR DESCRIPTION
Fixes: https://github.com/opnsense/plugins/issues/4221

Allows for a configuration like this:

```
# Reverse Proxy Domain: "f33de7bf-83d9-48f9-988d-5804429420e5"
nextcloud.example.com {
	handle /.well-known/carddav {
		redir https://nextcloud.example.com/remote.php/dav/
	}

	handle /.well-known/caldav {
		redir https://nextcloud.example.com/remote.php/dav/
	}

	handle {
		reverse_proxy 192.168.1.10:11000 {
			header_down +Strict-Transport-Security "max-age=31536000;"
		}
	}
}
```

Needs testing, draft for now.