### PR TITLE
security/acme-client: fix vault support, added vault token

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogAction.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogAction.xml
@@ -368,12 +368,18 @@
         <id>action.acme_vault_prefix</id>
         <label>Vault Prefix</label>
         <type>text</type>
-        <help>This specifies the prefix path in Vault.</help>
+        <help>This specifies the prefix path in Vault. If you select KV v2 you need to add .../data/... between the secret-mount-path and the path. Example: v1 prefix path: secret/acme, v2 prefix path: secret/data/acme.</help>
+    </field>
+    <field>
+        <id>action.acme_vault_token</id>
+        <label>Vault Token</label>
+        <type>password</type>
+        <help>This specifies the Vault token to authenticate with.</help>
     </field>
     <field>
         <id>action.acme_vault_kvv2</id>
         <label>Use KV v2</label>
         <type>checkbox</type>
-        <help>If checked version 2 of the kv store will be used, otherwise version 1.</help>
+        <help>If checked version 2 of the kv store will be used, otherwise version 1. If you use v2 please consider the comment in the field "Vault Prefix".</help>
     </field>
 </form>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeAutomation/AcmeVault.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeAutomation/AcmeVault.php
@@ -45,6 +45,9 @@ class AcmeVault extends Base implements LeAutomationInterface
         if ((string)$this->config->acme_vault_kvv2 == 1) {
             $this->acme_env['VAULT_KV_V2'] = 1;
         }
+        if (!empty((string)$this->config->acme_vault_token)) {
+            $this->acme_env['VAULT_TOKEN'] = (string)$this->config->acme_vault_token;
+        }
         $this->acme_args[] = '--deploy-hook vault';
         return true;
     }

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -1592,6 +1592,11 @@
                     <mask>/^.{1,1024}$/u</mask>
                     <ValidationMessage>Should be a string between 1 and 1024 characters.</ValidationMessage>
                 </acme_vault_prefix>
+                <acme_vault_token type="TextField">
+                    <Required>Y</Required>
+                    <mask>/^.{1,1024}$/u</mask>
+                    <ValidationMessage>Should be a string between 1 and 1024 characters.</ValidationMessage>
+                </acme_vault_token>
                 <acme_vault_kvv2 type="BooleanField">
                     <default>1</default>
                 </acme_vault_kvv2>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -1593,7 +1593,7 @@
                     <ValidationMessage>Should be a string between 1 and 1024 characters.</ValidationMessage>
                 </acme_vault_prefix>
                 <acme_vault_token type="TextField">
-                    <Required>Y</Required>
+                    <Required>N</Required>
                     <mask>/^.{1,1024}$/u</mask>
                     <ValidationMessage>Should be a string between 1 and 1024 characters.</ValidationMessage>
                 </acme_vault_token>


### PR DESCRIPTION
The vault token is needed to enable the storage of keys in vault. This was not considered so far.

https://github.com/opnsense/plugins/issues/3525 discusses the issue and the reporter suggested a solution in his [blog](https://blog.infoitech.co.uk/opnsense-bugfix-acme-plugin-upload-to-vault/#1-opnsense-acme-plugin-form). This is the second step of getting the solution implemented after acme.sh merged the first fix: https://github.com/acmesh-official/acme.sh/pull/5159 and opnsense merged the [release](https://github.com/acmesh-official/acme.sh/releases/tag/3.0.8) to make it available there.

With that pull request is now possible to use vault for storing certificates for opnsense.