### PR TITLE
www/caddy: Complete Layer4 routing feature

### DIFF
--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -16,6 +16,10 @@ Plugin Changelog
 1.7.2
 
 * Add: Directive in HTTP Handler can be chosen, "reverse_proxy" and "redir"
+* Add: Layer4 routes feature. Routing Type "global" or "listener_wrapper" can be chosen
+* Add: Any Layer4 TCP/UDP traffic can be proxied without choosing a Layer 7 protocol matcher
+* Change: Layer4 routes are not ordered automatically anymore
+* Change: Layer4 "not tls sni" matcher has been replaced by generalized "Invert Matchers" checkbox
 * Build: Update Caddy Layer4 module, fixes TLS matcher in chromium based browsers
 * Fix: When Apply takes longer than 20 seconds, Caddy will be forcefully restarted
 

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogLayer4.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogLayer4.xml
@@ -56,9 +56,9 @@
         <id>layer4.FromDomain</id>
         <label>Domain</label>
         <type>select_multiple</type>
-        <style>tokenize</style>
+        <style>style_matchers tokenize</style>
         <allownew>true</allownew>
-        <help><![CDATA[Enter one or multiple domains to route via SNI or Host Header on OSI Layer 7. Wildcard domains and host wildcards are allowed, e.g. "*.example.com" and "*". Some protocols match all domains and "*" is mandatory. Only applicable when a matched protocol offers this information.]]></help>
+        <help><![CDATA[Enter one or multiple domains to route via SNI or Host Header. Wildcard domains and host wildcards are allowed, e.g. "*.example.com" and "*".]]></help>
     </field>
     <field>
         <type>header</type>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogLayer4.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogLayer4.xml
@@ -50,7 +50,7 @@
         <id>layer4.Matchers</id>
         <label>Matchers</label>
         <type>dropdown</type>
-        <help><![CDATA[Match the received traffic on OSI Layer 7. When choosing a protocol like TLS, it will be matched and routed to the upstream destination. When "Routing Type" of the matcher is "listener_wrapper", any unmatched traffic will be received by the "HTTP App" (reverse_proxy). When routing type of the matcher is global, unmatched traffic will be consumed and blocked. Choose "ANY" to not match on OSI Layer 7 and allow any traffic.]]></help>
+        <help><![CDATA[Match the received traffic on OSI Layer 7. When choosing a protocol like TLS, it will be matched and routed to the upstream destination. When "Routing Type" of the matcher is "listener_wrapper", any unmatched traffic will be received by the "HTTP App" (reverse_proxy). When "Routing Type" of the matcher is "global", unmatched traffic will be consumed and blocked. Choose "ANY" to not match on OSI Layer 7 and allow any traffic.]]></help>
     </field>
     <field>
         <id>layer4.FromDomain</id>
@@ -59,6 +59,13 @@
         <style>style_matchers tokenize</style>
         <allownew>true</allownew>
         <help><![CDATA[Enter one or multiple domains to route via SNI or Host Header. Wildcard domains and host wildcards are allowed, e.g. "*.example.com" and "*".]]></help>
+    </field>
+    <field>
+        <id>layer4.InvertMatchers</id>
+        <label>Invert Matchers</label>
+        <type>checkbox</type>
+        <help><![CDATA[Invert the sense of the matcher. E.g., if the protocol is TLS, inverting will match all traffic that is not TLS. When domains have been chosen, these will be equally inverted.]]></help>
+        <advanced>true</advanced>
     </field>
     <field>
         <type>header</type>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogLayer4.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogLayer4.xml
@@ -13,7 +13,44 @@
     </field>
     <field>
         <type>header</type>
-        <label>Frontend</label>
+        <label>Type</label>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>layer4.Type</id>
+        <label>Routing Type</label>
+        <type>dropdown</type>
+        <help><![CDATA[Choose either "listener_wrappers" for multiplexing protocols on the default HTTP and HTTPS ports on OSI Layer 7, or "global" for raw TCP/UDP traffic routing on a custom "Local port" on OSI Layer 4 with optional OSI Layer 7 protocol matching.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Layer 4</label>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>layer4.Protocol</id>
+        <label>Protocol</label>
+        <type>dropdown</type>
+        <help><![CDATA[Match the received traffic on OSI Layer 4, either TCP or UDP. When "Routing Type" is "listener_wrappers", currently only TCP will match.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>layer4.FromPort</id>
+        <label>Local Port</label>
+        <type>text</type>
+        <help><![CDATA[Choose a custom local port to listen on.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Layer 7</label>
+    </field>
+    <field>
+        <id>layer4.Matchers</id>
+        <label>Matchers</label>
+        <type>dropdown</type>
+        <help><![CDATA[Match the received traffic on OSI Layer 7. When choosing a protocol like TLS, it will be matched and routed to the upstream destination. When "Routing Type" of the matcher is "listener_wrapper", any unmatched traffic will be received by the "HTTP App" (reverse_proxy). When routing type of the matcher is global, unmatched traffic will be consumed and blocked. Choose "ANY" to not match on OSI Layer 7 and allow any traffic.]]></help>
     </field>
     <field>
         <id>layer4.FromDomain</id>
@@ -21,13 +58,7 @@
         <type>select_multiple</type>
         <style>tokenize</style>
         <allownew>true</allownew>
-        <help><![CDATA[Enter one or multiple domains to route via SNI or Host Header. The domain will be added to the "listener_wrapper". Essentially, all traffic that Caddy receives on its frontend listeners (most likely the default HTTP and HTTPS ports) is funnelled through this wrapper to be processed and routed. Wildcard domains are allowed, e.g. "*.example.com". Host wildcards are allowed too, e.g. "*". Some protocols match all domains and "*" is mandatory.]]></help>
-    </field>
-    <field>
-        <id>layer4.Matchers</id>
-        <label>Matchers</label>
-        <type>dropdown</type>
-        <help><![CDATA[Match the traffic of the selected domains. The TCP/UDP packets will be routed to the selected upstream domains without terminating TLS or altering the traffic. Only protocols that send a "Client Hello" (like TLS), or a "Host Header" (like HTTP) can be routed here. Routing Precedence: 1. "SSH (or other protocols)", 2. "HTTP (Host Header)", 3. "TLS (SNI)", 4. "TLS (inverted SNI)", 5. "HTTP Handlers" (hidden default route for all unmatched traffic). The "SSH" matcher (and any other matcher that does not evaluate Host Header or SNI), will match any SSH like traffic on the default ports. That means, these protocols will only match once per ruleset and will proxy traffic to one upstream.]]></help>
+        <help><![CDATA[Enter one or multiple domains to route via SNI or Host Header on OSI Layer 7. Wildcard domains and host wildcards are allowed, e.g. "*.example.com" and "*". Some protocols match all domains and "*" is mandatory. Only applicable when a matched protocol offers this information.]]></help>
     </field>
     <field>
         <type>header</type>
@@ -64,7 +95,6 @@
     <field>
         <type>header</type>
         <label>Access</label>
-        <collapse>true</collapse>
     </field>
     <field>
         <id>layer4.RemoteIp</id>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogLayer4.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogLayer4.xml
@@ -6,6 +6,12 @@
         <help><![CDATA[Enable this Layer4 route.]]></help>
     </field>
     <field>
+        <id>layer4.Sequence</id>
+        <label>Sequence</label>
+        <type>text</type>
+        <help><![CDATA[Rules are sorted based on the sequence number, higher number means lower priority. Rules without a sequence number will be processed first.]]></help>
+    </field>
+    <field>
         <id>layer4.description</id>
         <label>Description</label>
         <type>text</type>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
@@ -240,17 +240,23 @@ class Caddy extends BaseModel
                         ),
                         $key . ".FromDomain"
                     ));
-                } elseif (!in_array((string)$item->Matchers, ['httphost', 'tlssni']) && !empty((string)$item->FromDomain)) {
-                    $messages->appendMessage(new Message(
-                        sprintf(
-                            gettext(
-                                'When "%s" matcher is selected, domain must be empty.'
+                    } elseif (
+                        !in_array((string)$item->Matchers, ['httphost', 'tlssni']) &&
+                        (
+                            !empty((string)$item->FromDomain) &&
+                            (string)$item->FromDomain != '*'
+                        )
+                    ) {
+                        $messages->appendMessage(new Message(
+                            sprintf(
+                                gettext(
+                                    'When "%s" matcher is selected, domain must be empty or *.'
+                                ),
+                                $item->Matchers
                             ),
-                            $item->Matchers
-                        ),
-                        $key . ".FromDomain"
-                    ));
-                }
+                            $key . ".FromDomain"
+                        ));
+                    }
 
                 if ((string)$item->Type === 'global' && empty((string)$item->FromPort)) {
                     $messages->appendMessage(new Message(

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
@@ -240,23 +240,33 @@ class Caddy extends BaseModel
                         ),
                         $key . ".FromDomain"
                     ));
-                }
-
-                if ((string)$item->Type !== 'global' && !empty((string)$item->FromPort)) {
+                } elseif (!in_array((string)$item->Matchers, ['httphost', 'tlssni']) && !empty((string)$item->FromDomain)) {
                     $messages->appendMessage(new Message(
                         sprintf(
                             gettext(
-                                'When routing type is "%s", port must be empty.'
+                                'When "%s" matcher is selected, domain must be empty.'
+                            ),
+                            $item->Matchers
+                        ),
+                        $key . ".FromDomain"
+                    ));
+                }
+
+                if ((string)$item->Type === 'global' && empty((string)$item->FromPort)) {
+                    $messages->appendMessage(new Message(
+                        sprintf(
+                            gettext(
+                                'When routing type is "%s", port is required.'
                             ),
                             $item->Type
                         ),
                         $key . ".FromPort"
                     ));
-                } elseif ((string)$item->Type === 'global' && empty((string)$item->FromPort)) {
+                } elseif ((string)$item->Type !== 'global' && !empty((string)$item->FromPort)) {
                     $messages->appendMessage(new Message(
                         sprintf(
                             gettext(
-                                'When routing type is "%s", port is required.'
+                                'When routing type is "%s", port must be empty.'
                             ),
                             $item->Type
                         ),
@@ -273,6 +283,23 @@ class Caddy extends BaseModel
                             $item->Type
                         ),
                         $key . ".Protocol"
+                    ));
+                }
+
+                if ((string)$item->Type !== 'global' &&
+                    (
+                        (string)$item->Matchers == 'tls' ||
+                        (string)$item->Matchers == 'http'
+                    )
+                ) {
+                    $messages->appendMessage(new Message(
+                        sprintf(
+                            gettext(
+                                'When routing type is "%s", matchers "HTTP" or "TLS" cannot be chosen.'
+                            ),
+                            $item->Type
+                        ),
+                        $key . ".Matchers"
                     ));
                 }
             }

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
@@ -276,11 +276,11 @@ class Caddy extends BaseModel
         foreach ($this->reverseproxy->layer4->iterateItems() as $item) {
             $key = $item->__reference;
 
-            if (!in_array((string)$item->Matchers, ['httphost', 'tlssni']) && (string)$item->FromDomain !== '*') {
+            if (in_array((string)$item->Matchers, ['httphost', 'tlssni']) && empty((string)$item->FromDomain)) {
                 $messages->appendMessage(new Message(
                     sprintf(
                         gettext(
-                            'When "%s" matcher is selected, the only valid entry in Domain is "*".'
+                            'When "%s" matcher is selected, domain is required.'
                         ),
                         $item->Matchers
                     ),

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -453,6 +453,17 @@
                     <Default>1</Default>
                     <Required>Y</Required>
                 </enabled>
+                <Sequence type="AutoNumberField">
+                    <MinimumValue>1</MinimumValue>
+                    <MaximumValue>99999</MaximumValue>
+                    <ValidationMessage>Please enter a value between 1 and 99999 or leave empty.</ValidationMessage>
+                    <Constraints>
+                        <check001>
+                            <ValidationMessage>Sequence value has to be unique or empty.</ValidationMessage>
+                            <type>UniqueConstraint</type>
+                        </check001>
+                    </Constraints>
+                </Sequence>
                 <Type type="OptionField">
                     <Required>Y</Required>
                     <Default>listener_wrappers</Default>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -453,6 +453,23 @@
                     <Default>1</Default>
                     <Required>Y</Required>
                 </enabled>
+                <Type type="OptionField">
+                    <Required>Y</Required>
+                    <Default>listener_wrappers</Default>
+                    <OptionValues>
+                        <listener_wrappers>listener_wrappers</listener_wrappers>
+                        <global>global</global>
+                    </OptionValues>
+                </Type>
+                <Protocol type="OptionField">
+                    <Required>Y</Required>
+                    <Default>tcp</Default>
+                    <OptionValues>
+                        <tcp>TCP</tcp>
+                        <udp>UDP</udp>
+                    </OptionValues>
+                </Protocol>
+                <FromPort type="PortField"/>
                 <FromDomain type="HostnameField">
                     <Required>Y</Required>
                     <IpAllowed>N</IpAllowed>
@@ -466,6 +483,7 @@
                     <Required>Y</Required>
                     <Default>tlssni</Default>
                     <OptionValues>
+                        <any>ANY</any>
                         <dns>DNS</dns>
                         <httphost>HTTP (Host Header)</httphost>
                         <postgres>Postgres</postgres>
@@ -475,7 +493,7 @@
                         <socks5>SOCKSv5</socks5>
                         <ssh>SSH</ssh>
                         <tlssni>TLS (SNI)</tlssni>
-                        <nottlssni>TLS (inverted SNI)</nottlssni>
+                        <wireguard>Wireguard</wireguard>
                         <xmpp>XMPP</xmpp>
                     </OptionValues>
                 </Matchers>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -484,6 +484,7 @@
                     <OptionValues>
                         <any>ANY</any>
                         <dns>DNS</dns>
+                        <http>HTTP</http>
                         <httphost>HTTP (Host Header)</httphost>
                         <postgres>Postgres</postgres>
                         <proxy_protocol>Proxy Protocol</proxy_protocol>
@@ -491,11 +492,13 @@
                         <socks4>SOCKSv4</socks4>
                         <socks5>SOCKSv5</socks5>
                         <ssh>SSH</ssh>
-                        <tlssni>TLS (SNI)</tlssni>
+                        <tls>TLS</tls>
+                        <tlssni>TLS (SNI Client Hello)</tlssni>
                         <wireguard>Wireguard</wireguard>
                         <xmpp>XMPP</xmpp>
                     </OptionValues>
                 </Matchers>
+                <InvertMatchers type="BooleanField"/>
                 <ToDomain type="HostnameField">
                     <Required>Y</Required>
                     <FieldSeparator>,</FieldSeparator>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//Pischem/caddy</mount>
     <description>Caddy Reverse Proxy</description>
-    <version>1.3.2</version>
+    <version>1.3.3</version>
     <items>
         <general>
             <enabled type="BooleanField">

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -471,7 +471,6 @@
                 </Protocol>
                 <FromPort type="PortField"/>
                 <FromDomain type="HostnameField">
-                    <Required>Y</Required>
                     <IpAllowed>N</IpAllowed>
                     <FqdnWildcardAllowed>Y</FqdnWildcardAllowed>
                     <HostWildcardAllowed>Y</HostWildcardAllowed>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -617,6 +617,9 @@
                         <tr>
                             <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
                             <th data-column-id="enabled" data-width="6em" data-type="boolean" data-formatter="rowtoggle">{{ lang._('Enabled') }}</th>
+                            <th data-column-id="Type" data-type="string" data-visible="false">{{ lang._('Routing Type') }}</th>
+                            <th data-column-id="Protocol" data-type="string" data-visible="false">{{ lang._('Protocol') }}</th>
+                            <th data-column-id="FromPort" data-type="string" data-visible="false">{{ lang._('Local Port') }}</th>
                             <th data-column-id="FromDomain" data-type="string">{{ lang._('Domain') }}</th>
                             <th data-column-id="Matchers" data-type="string">{{ lang._('Matcher') }}</th>
                             <th data-column-id="ToDomain" data-type="string">{{ lang._('Upstream Domain') }}</th>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -625,6 +625,7 @@
                         <tr>
                             <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
                             <th data-column-id="enabled" data-width="6em" data-type="boolean" data-formatter="rowtoggle">{{ lang._('Enabled') }}</th>
+                            <th data-column-id="Sequence" data-type="string">{{ lang._('Sequence') }}</th>
                             <th data-column-id="Type" data-type="string" data-visible="false">{{ lang._('Routing Type') }}</th>
                             <th data-column-id="Protocol" data-type="string">{{ lang._('Protocol') }}</th>
                             <th data-column-id="FromPort" data-type="string" data-visible="false">{{ lang._('Local Port') }}</th>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -339,6 +339,14 @@
             }
         });
 
+        $("#layer4\\.Matchers").change(function() {
+            if ($(this).val() !== "tlssni" && $(this).val() !== "httphost") {
+                $(".style_matchers").closest('tr').hide();
+            } else {
+                $(".style_matchers").closest('tr').show();
+            }
+        });
+
         // Initialize tabs, service control and filter selectpicker
         initializeTabs();
         updateServiceControlUI('caddy');

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -630,7 +630,7 @@
                             <th data-column-id="FromPort" data-type="string" data-visible="false">{{ lang._('Local Port') }}</th>
                             <th data-column-id="FromDomain" data-type="string">{{ lang._('Domain') }}</th>
                             <th data-column-id="Matchers" data-type="string">{{ lang._('Matchers') }}</th>
-                            <th data-column-id="InvertMatchers" data-type="boolean" data-formatter="boolean">{{ lang._('Invert Matchers') }}</th>
+                            <th data-column-id="InvertMatchers" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('Invert Matchers') }}</th>
                             <th data-column-id="ToDomain" data-type="string">{{ lang._('Upstream Domain') }}</th>
                             <th data-column-id="ToPort" data-type="string">{{ lang._('Upstream Port') }}</th>
                             <th data-column-id="RemoteIp" data-type="string" data-visible="false">{{ lang._('Remote IP') }}</th>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -626,10 +626,11 @@
                             <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
                             <th data-column-id="enabled" data-width="6em" data-type="boolean" data-formatter="rowtoggle">{{ lang._('Enabled') }}</th>
                             <th data-column-id="Type" data-type="string" data-visible="false">{{ lang._('Routing Type') }}</th>
-                            <th data-column-id="Protocol" data-type="string" data-visible="false">{{ lang._('Protocol') }}</th>
+                            <th data-column-id="Protocol" data-type="string">{{ lang._('Protocol') }}</th>
                             <th data-column-id="FromPort" data-type="string" data-visible="false">{{ lang._('Local Port') }}</th>
                             <th data-column-id="FromDomain" data-type="string">{{ lang._('Domain') }}</th>
-                            <th data-column-id="Matchers" data-type="string">{{ lang._('Matcher') }}</th>
+                            <th data-column-id="Matchers" data-type="string">{{ lang._('Matchers') }}</th>
+                            <th data-column-id="InvertMatchers" data-type="boolean" data-formatter="boolean">{{ lang._('Invert Matchers') }}</th>
                             <th data-column-id="ToDomain" data-type="string">{{ lang._('Upstream Domain') }}</th>
                             <th data-column-id="ToPort" data-type="string">{{ lang._('Upstream Port') }}</th>
                             <th data-column-id="RemoteIp" data-type="string" data-visible="false">{{ lang._('Remote IP') }}</th>

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -90,12 +90,26 @@
         {% endif %}
         {% if generalSettings.EnableLayer4|default("0") == "1" %}
             listener_wrappers {
-                {# Plug the Layer 4 template in #}
-                {% include "OPNsense/Caddy/includeLayer4" %}
-
+                layer4 {
+                    import /usr/local/etc/caddy/caddy.d/*.layer4listener
+                    {% set context_var = "listener_wrappers" %}
+                    {% include "OPNsense/Caddy/includeLayer4" %}
+                    {# Empty Route that catches all other traffic #}
+                    route
+                }
+                {# Route all other traffic to HTTP App #}
+                tls
             }
         {% endif %}
     }
+
+    {% if generalSettings.EnableLayer4|default("0") == "1" %}
+        layer4 {
+            import /usr/local/etc/caddy/caddy.d/*.layer4global
+            {% set context_var = "global" %}
+            {% include "OPNsense/Caddy/includeLayer4" %}
+        }
+    {% endif %}
 
     {#
     #   Section: Dynamic DNS Global Configuration

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/includeLayer4
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/includeLayer4
@@ -12,7 +12,15 @@
 #  This context is for advanced usecases where raw TCP/UDP traffic on custom ports should be proxied or load balanced.
 #}
 
-{% set layer4_configs = helpers.toList('Pischem.caddy.reverseproxy.layer4') %}
+{% set unsorted_layer4_configs = helpers.toList('Pischem.caddy.reverseproxy.layer4') %}
+
+{# Ensure that 'Sequence' is present and converted to an integer in each item #}
+{% for item in unsorted_layer4_configs %}
+    {% set _ = item.update({'Sequence': item.get('Sequence', '0') | int}) %}
+{% endfor %}
+
+{# Sort the configurations based on 'Sequence' #}
+{% set layer4_configs = unsorted_layer4_configs | sort(attribute='Sequence') %}
 
 {% macro define_proxy(layer4, to_domains, to_port, fail_duration, proxy_protocol) %}
     proxy {% for domain in to_domains.split(',') %}

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/includeLayer4
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/includeLayer4
@@ -1,15 +1,23 @@
 {#
-# This file sets up the listener_wrapper for layer 4 routing support.
-# - Section: Servers Global Configuration
-# Also allows for custom configurations with the import statement.
+#  This file sets up layer4 routing support.
+#  There are two contexts: "listener_wrappers" and "global"
+#
+#  "listener_wrappers" multiplexes on OSI Layer 7 on the default HTTP and HTTPS ports and requires a traffic matcher since
+#  otherwise the "reverse_proxy" would stop receiving any requests. The "any" Layer 7 matcher is not allowed here.
+#  This context allows for matching domains via SNI and route them without terminating TLS.
+#
+#  "global" can set up custom ports and also route any OSI Layer 4 TCP/UDP traffic without a matcher.
+#  They will be grouped under the same protocol/port combination
+#  to allow multiple Layer 7 matchers inside the scope of the same Layer 4 matcher.
+#  This context is for advanced usecases where raw TCP/UDP traffic on custom ports should be proxied or load balanced.
 #}
+
 {% set layer4_configs = helpers.toList('Pischem.caddy.reverseproxy.layer4') %}
 
-{# Nested Macro for proxy definition #}
-{% macro define_proxy(to_domains, to_port, fail_duration, proxy_protocol) %}
+{% macro define_proxy(layer4, to_domains, to_port, fail_duration, proxy_protocol) %}
     proxy {% for domain in to_domains.split(',') %}
-        {% set is_ipv6 = (':' in domain) %}  {# Check if the domain contains a colon, typical in IPv6 addresses #}
-        {{ '[' if is_ipv6 }}{{ domain }}{{ ']' if is_ipv6 }}:{{ to_port }}{% if not loop.last %} {% endif %}
+        {% set is_ipv6 = (':' in domain) %}
+        {{ layer4.Protocol }}/{{ '[' if is_ipv6 }}{{ domain }}{{ ']' if is_ipv6 }}:{{ to_port }}{% if not loop.last %} {% endif %}
     {% endfor %} {
     {% if fail_duration %}
         fail_duration {{ fail_duration }}s
@@ -20,64 +28,72 @@
     }
 {% endmacro %}
 
-{# Macro for configuring the proxy with additional remote IP access list #}
-{% macro configure_proxy(to_domains, to_port, remote_ips, fail_duration, proxy_protocol) %}
-    {% if remote_ips %}
-        {% set ip_list = remote_ips.split(',') %}
-        subroute {
-            @allowed_ips remote_ip {{ ip_list|join(' ') }}
-            route @allowed_ips {
-                {# Call Nested Macro #}
-                {{ define_proxy(to_domains, to_port, fail_duration, proxy_protocol) }}
+{% macro configure_proxy(layer4, to_domains, to_port, remote_ips, fail_duration, proxy_protocol) %}
+    {% set content %}
+        {% if remote_ips %}
+            {% set ip_list = remote_ips.split(',') %}
+            subroute {
+                @allowed_ips remote_ip {{ ip_list|join(' ') }}
+                route @allowed_ips {
+                    {{ define_proxy(layer4, to_domains, to_port, fail_duration, proxy_protocol) }}
+                }
             }
-        }
+        {% else %}
+            {{ define_proxy(layer4, to_domains, to_port, fail_duration, proxy_protocol) }}
+        {% endif %}
+    {% endset %}
+    {{ content|trim }}
+{% endmacro %}
+
+{% set grouped_configs = {} %}
+{% for layer4 in layer4_configs %}
+    {% if layer4.FromPort and layer4.Protocol and layer4.enabled == "1"  %}
+        {% set key = layer4.Protocol ~ '/:' ~ layer4.FromPort %}
+        {% if not key in grouped_configs %}
+            {% set _ = grouped_configs.update({key: []}) %}
+        {% endif %}
+        {% set _ = grouped_configs[key].append(layer4) %}
+    {% endif %}
+{% endfor %}
+
+{% macro handle_special_matchers(layer4) %}
+    {% if layer4.Matchers == 'httphost' %}
+        http host {{ layer4.FromDomain.replace(',', ' ') }}
+    {% elif layer4.Matchers == 'tlssni' %}
+        tls sni {{ layer4.FromDomain.replace(',', ' ') }}
     {% else %}
-        {# Call Nested Macro #}
-        {{ define_proxy(to_domains, to_port, fail_duration, proxy_protocol) }}
+        {{ layer4.Matchers }}
     {% endif %}
 {% endmacro %}
 
-{# Set up Layer4 App #}
-layer4 {
-    import /usr/local/etc/caddy/caddy.d/*.layer4
-    {# 1. loop to handle any traffic matchers that can only be added once since they match all specific protocol traffic. #}
+{% if context_var == 'listener_wrappers' %}
     {% for layer4 in layer4_configs %}
-        {% if layer4.enabled == "1" and layer4.Matchers not in ['httphost', 'tlssni', 'nottlssni'] %}
-            @{{ layer4['@uuid'] }} {{ layer4.Matchers }}
-            route @{{ layer4['@uuid'] }} {
-                {{ configure_proxy(layer4.ToDomain, layer4.ToPort, layer4.RemoteIp, layer4.PassiveHealthFailDuration, layer4.ProxyProtocol) }}
-            }
+        {% if layer4.enabled == "1" and layer4.Type == 'listener_wrappers' %}
+            {% if layer4.Matchers != 'any' %}
+                @{{ layer4['@uuid'] }} {{ handle_special_matchers(layer4) }}
+                route @{{ layer4['@uuid'] }} {
+                    {{ configure_proxy(layer4, layer4.ToDomain, layer4.ToPort, layer4.RemoteIp, layer4.PassiveHealthFailDuration, layer4.ProxyProtocol) }}
+                }
+            {% endif %}
         {% endif %}
     {% endfor %}
-    {# 2. loop to handle http host matchers #}
-    {% for layer4 in layer4_configs %}
-        {% if layer4.enabled == "1" and layer4.Matchers == 'httphost' %}
-            @{{ layer4['@uuid'] }} http host {{ layer4.FromDomain.replace(',', ' ') }}
-            route @{{ layer4['@uuid'] }} {
-                {{ configure_proxy(layer4.ToDomain, layer4.ToPort, layer4.RemoteIp, layer4.PassiveHealthFailDuration, layer4.ProxyProtocol) }}
-            }
-        {% endif %}
+{% elif context_var == 'global' %}
+    {% for key, layers in grouped_configs.items() %}
+        {{ key }} {
+            {% for layer4 in layers %}
+                {% if layer4.enabled == "1" and layer4.Type == 'global' %}
+                    {% if layer4.Matchers != 'any' %}
+                        @{{ layer4['@uuid'] }} {{ handle_special_matchers(layer4) }}
+                        route @{{ layer4['@uuid'] }} {
+                            {{ configure_proxy(layer4, layer4.ToDomain, layer4.ToPort, layer4.RemoteIp, layer4.PassiveHealthFailDuration, layer4.ProxyProtocol) }}
+                        }
+                    {% else %}
+                        route {
+                            {{ configure_proxy(layer4, layer4.ToDomain, layer4.ToPort, layer4.RemoteIp, layer4.PassiveHealthFailDuration, layer4.ProxyProtocol) }}
+                        }
+                    {% endif %}
+                {% endif %}
+            {% endfor %}
+        }
     {% endfor %}
-    {# 3. loop to handle tls sni matchers #}
-    {% for layer4 in layer4_configs %}
-        {% if layer4.enabled == "1" and layer4.Matchers == 'tlssni' %}
-            @{{ layer4['@uuid'] }} tls sni {{ layer4.FromDomain.replace(',', ' ') }}
-            route @{{ layer4['@uuid'] }} {
-                {{ configure_proxy(layer4.ToDomain, layer4.ToPort, layer4.RemoteIp, layer4.PassiveHealthFailDuration, layer4.ProxyProtocol) }}
-            }
-        {% endif %}
-    {% endfor %}
-    {# 4. loop to handle not tls sni matchers #}
-    {% for layer4 in layer4_configs %}
-        {% if layer4.enabled == "1" and layer4.Matchers == 'nottlssni' %}
-            @{{ layer4['@uuid'] }} not tls sni {{ layer4.FromDomain.replace(',', ' ') }}
-            route @{{ layer4['@uuid'] }} {
-                {{ configure_proxy(layer4.ToDomain, layer4.ToPort, layer4.RemoteIp, layer4.PassiveHealthFailDuration, layer4.ProxyProtocol) }}
-            }
-        {% endif %}
-    {% endfor %}
-    {# Empty Route that catches all other traffic #}
-    route
-}
-{# Route all other traffic to HTTP App #}
-tls
+{% endif %}

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/includeLayer4
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/includeLayer4
@@ -57,12 +57,13 @@
 {% endfor %}
 
 {% macro handle_special_matchers(layer4) %}
+    {% set invert_prefix = 'not ' if layer4.InvertMatchers == '1' else '' %}
     {% if layer4.Matchers == 'httphost' %}
-        http host {{ layer4.FromDomain.replace(',', ' ') }}
+        {{ invert_prefix }}http host {{ layer4.FromDomain.replace(',', ' ') }}
     {% elif layer4.Matchers == 'tlssni' %}
-        tls sni {{ layer4.FromDomain.replace(',', ' ') }}
+        {{ invert_prefix }}tls sni {{ layer4.FromDomain.replace(',', ' ') }}
     {% else %}
-        {{ layer4.Matchers }}
+        {{ invert_prefix }}{{ layer4.Matchers }}
     {% endif %}
 {% endmacro %}
 


### PR DESCRIPTION
The current layer 4 implementation was like a draft and feature preview.

This here adds the real deal while also cleaning it up quite a lot.

It is a quite complicated feature and will be properly documented. Though, there is quite some validation added to ensure no layer4 Route can be added that would totally break everything.

<details>

![image](https://github.com/user-attachments/assets/7051d51d-50cd-4bd2-a2ab-2d96017896a2)

![image](https://github.com/user-attachments/assets/30930afa-87e0-4819-a9d8-37818d1b85a1)

![image](https://github.com/user-attachments/assets/f3c58b85-2349-4195-aa97-fdc827fb21d6)

</details>