### PR TITLE
net/frr - Routing: BFD - add multihop support for IPv4.

### DIFF
--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBFDNeighbor.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBFDNeighbor.xml
@@ -16,4 +16,13 @@
     <type>text</type>
     <help>Specify the IP of your neighbor.</help>
   </field>
+  <field>
+    <id>neighbor.multihop</id>
+    <label>Multihop</label>
+    <type>checkbox</type>
+    <help>multihop tells the BFD daemon that we should expect packets with TTL less than 254
+    (because it will take more than one hop) and to listen on the multihop port (4784).
+    When using multi-hop mode echo-mode will not work (see RFC 5883 section 3).
+    </help>
+  </field>
 </form>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BFD.php
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BFD.php
@@ -3,8 +3,10 @@
 namespace OPNsense\Quagga;
 
 use OPNsense\Base\BaseModel;
+use OPNsense\Base\Messages\Message;
 
 /*
+    Copyright (C) 2024 Deciso B.V.
     Copyright (C) 2017 Fabian Franz
     Copyright (C) 2017 - 2021 Michael Muenz <m.muenz@gmail.com>
     All rights reserved.
@@ -28,4 +30,25 @@ use OPNsense\Base\BaseModel;
 */
 class BFD extends BaseModel
 {
+       /**
+     * {@inheritdoc}
+     */
+    public function performValidation($validateFullModel = false)
+    {
+        $messages = parent::performValidation($validateFullModel);
+        foreach ($this->neighbors->neighbor->iterateItems() as $neighbor) {
+            if (!$validateFullModel && !$neighbor->isFieldChanged()) {
+                continue;
+            }
+            $key = $neighbor->__reference;
+            $address_proto = str_contains($neighbor->address, ':') ? 'inet6' : 'inet';
+            if (!empty((string)$neighbor->multihop) && $address_proto == 'inet6') {
+               $messages->appendMessage(
+                  new Message(gettext("Multihop is currently only supported for IPv4"), $key . ".multihop")
+              );
+            }
+
+        }
+        return $messages;
+    }
 }

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BFD.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BFD.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/quagga/bfd</mount>
     <description>BFD configuration</description>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <items>
         <enabled type="BooleanField">
             <default>0</default>
@@ -21,6 +21,10 @@
                     <default></default>
                     <Required>Y</Required>
                 </address>
+                <multihop  type="BooleanField">
+                    <default>0</default>
+                    <Required>Y</Required>
+                </multihop>
             </neighbor>
         </neighbors>
     </items>

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bfdd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bfdd.conf
@@ -21,7 +21,7 @@ bfd
 {%   if helpers.exists('OPNsense.quagga.bfd.neighbors.neighbor') %}
 {%     for neighbor in helpers.toList('OPNsense.quagga.bfd.neighbors.neighbor') %}
 {%       if neighbor.enabled == '1' %}
- peer {{ neighbor.address }}
+ peer {{ neighbor.address }} {% if neighbor.multihop|default('0') == '1' %}multihop{% endif +%}
 {%       endif %}
 {%     endfor %}
 {%   endif %}


### PR DESCRIPTION
closes https://github.com/opnsense/plugins/issues/4282

Although IPv6 also supports multihop, it does require a local-address to be set (https://docs.frrouting.org/en/latest/bfd.html#bfdd-commands), to avoid adding extra complexity now, start with IPv4 and see where that brings us.