### PR TITLE
qemu-ga: fixes disabled-rpcs broke service start

### DIFF
--- a/emulators/qemu-guest-agent/src/opnsense/service/templates/OPNsense/QemuGuestAgent/rc.conf.d
+++ b/emulators/qemu-guest-agent/src/opnsense/service/templates/OPNsense/QemuGuestAgent/rc.conf.d
@@ -6,7 +6,7 @@
 {%     do optional_flags.append('-v') %}
 {%   endif %}
 {%   if helpers.exists('OPNsense.QemuGuestAgent.general.DisabledRPCs') and not helpers.empty('OPNsense.QemuGuestAgent.general.DisabledRPCs') %}
-{%     do optional_flags.append('--blacklist=' ~ OPNsense.QemuGuestAgent.general.DisabledRPCs) %}
+{%     do optional_flags.append('--block-rpcs=' ~ OPNsense.QemuGuestAgent.general.DisabledRPCs) %}
 {%   endif %}
 qemu_guest_agent_setup="/usr/local/opnsense/scripts/OPNsense/QemuGuestAgent/setup.sh"
 qemu_guest_agent_enable="YES"


### PR DESCRIPTION
Applies renamed CLI arg `blacklist` > `block-rpcs`. 
See: https://bugzilla.redhat.com/show_bug.cgi?id=2156515

````
qemu-ga --help | grep -E 'black|block' -C5
  -t, --statedir    specify dir to store state information (absolute paths
                    only, default is /var/run)
  -v, --verbose     log extra debugging information
  -V, --version     print version information and exit
  -d, --daemonize   become a daemon
  -b, --block-rpcs  comma-separated list of RPCs to disable (no spaces,
                    use "--block-rpcs=help" to list available RPCs)
  -a, --allow-rpcs  comma-separated list of RPCs to enable (no spaces,
                    use "--allow-rpcs=help" to list available RPCs)
  -D, --dump-conf   dump a qemu-ga config file based on current config
                    options / command-line parameters to stdout
  -r, --retry-path  attempt re-opening path if it's unavailable or closed
````

May also fix #4255