### PR TITLE
Correct minor issues in OSPF6

### DIFF
--- a/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/ospf6.volt
+++ b/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/ospf6.volt
@@ -182,8 +182,7 @@
         <table id="grid-prefixlists" class="table table-responsive" data-editDialog="DialogEditPrefixLists">
             <thead>
                 <tr>
-                    <th data-column-id="enabled" data-type="string" data-formatter="rowt
-oggle" data-sortable="false">{{ lang._('Enabled') }}</th>
+                    <th data-column-id="enabled" data-type="string" data-formatter="rowtoggle" data-sortable="false">{{ lang._('Enabled') }}</th>
                     <th data-column-id="name" data-type="string" data-visible="true" data-sortable="true">{{ lang._('Name') }}</th>
                     <th data-column-id="seqnumber" data-type="string" data-visible="true" data-sortable="true">{{ lang._('Sequence Number') }}</th>
                     <th data-column-id="action" data-type="string" data-visible="true" data-sortable="false">{{ lang._('Action') }}</th>

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospf6d.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospf6d.conf
@@ -92,7 +92,7 @@ router ospf6
 {%   if helpers.exists('OPNsense.quagga.ospf6.prefixlists.prefixlist') %}
 {%     for prefixlist in helpers.sortDictList(OPNsense.quagga.ospf6.prefixlists.prefixlist, 'name', 'seqnumber' ) %}
 {%       if prefixlist.enabled == '1' %}
-ip prefix-list {{ prefixlist.name }} seq {{ prefixlist.seqnumber }} {{ prefixlist.action }} {{ prefixlist.network }}
+ipv6 prefix-list {{ prefixlist.name }} seq {{ prefixlist.seqnumber }} {{ prefixlist.action }} {{ prefixlist.network }}
 {%       endif %}
 {%     endfor %}
 {%   endif %}
@@ -105,7 +105,7 @@ route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
 {%           for prefixlist in routemap.match2.split(",") %}
 {%             set prefixlist_data = helpers.getUUID(prefixlist) %}
 {%             if 'match2' in routemap and routemap.match2 != '' %}
- match ip address prefix-list {{ prefixlist_data.name }}
+ match ipv6 address prefix-list {{ prefixlist_data.name }}
 {%             endif %}
 {%           endfor %}
 {%         endif %}


### PR DESCRIPTION
Template for ospf6d.conf should call out ipv6, not ip, for both route-map and prefix-list.  Also, a rogue newline crept into ospf6.volt - corrupting the enabled checkboxes in the Prefix Lists tab.