### PR TITLE
www/caddy: Implement sequence into handlers to support custom configuration order

### DIFF
--- a/www/caddy/Makefile
+++ b/www/caddy/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		caddy
-PLUGIN_VERSION=		1.7.2
+PLUGIN_VERSION=		1.7.3
 PLUGIN_DEPENDS=		caddy-custom
 PLUGIN_COMMENT=		Modern Reverse Proxy with Automatic HTTPS, Dynamic DNS and Layer4 Routing
 PLUGIN_MAINTAINER=	cedrik@pischem.com

--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -13,6 +13,13 @@ DOC: https://docs.opnsense.org/manual/how-tos/caddy.html
 Plugin Changelog
 ================
 
+1.7.3
+
+* Add: Sequence number to HTTP Handlers
+* Add: Migration of HTTP Handlers to sequence numbers that preserve their original automatic order
+* Change: HTTP Handlers are not sorted automatically anymore, enabling more complex configuration scenarios where processing order matters
+* Fix: Migration lockout on first plugin installation if default WebGUI ports are used
+
 1.7.2
 
 * Add: Directive in HTTP Handler can be chosen, "reverse_proxy" and "redir"

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -6,6 +6,12 @@
         <help><![CDATA[Enable this handler.]]></help>
     </field>
     <field>
+        <id>handle.Sequence</id>
+        <label>Sequence</label>
+        <type>text</type>
+        <help><![CDATA[Handlers are sorted based on the sequence number, higher number means lower priority. Use the sequence number to generate handlers in a custom order inside the scope of their domain if there are multiple handlers per domain. If there is only a single handler in a domain, the sequence does not matter and can be left default or empty.]]></help>
+    </field>
+    <field>
         <id>handle.description</id>
         <label>Description</label>
         <type>text</type>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogLayer4.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogLayer4.xml
@@ -9,7 +9,7 @@
         <id>layer4.Sequence</id>
         <label>Sequence</label>
         <type>text</type>
-        <help><![CDATA[Rules are sorted based on the sequence number, higher number means lower priority. Rules without a sequence number will be processed first.]]></help>
+        <help><![CDATA[Rules are sorted based on the sequence number, higher number means lower priority. Use the sequence number to generate rules in a custom order inside the scope of the listener_wrapper or a global port if there are multiple rules per port. If there is only a single rule per port, the sequence does not matter and can be left default or empty.]]></help>
     </field>
     <field>
         <id>layer4.description</id>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
@@ -104,9 +104,13 @@ class Caddy extends BaseModel
         /**
          * The intend to use Lets Encrypt is populated email address and empty AutoHttps field.
          * This prevents a migration lockout during first install of the plugin
-         * when AutoHttps is "on" (empty) per default but the webgui ports are still default, too.
+         * when AutoHttps is "on" (empty) per default but the WebGUI ports are still default.
          */
-        if (!empty($overlap) && !empty((string)$this->general->TlsEmail) && empty((string)$this->general->TlsAutoHttps)) {
+        if (
+            !empty($overlap) &&
+            !empty((string)$this->general->TlsEmail) &&
+            empty((string)$this->general->TlsAutoHttps)
+        ) {
             $portOverlap = implode(', ', $overlap);
             $messages->appendMessage(new Message(
                 sprintf(
@@ -243,23 +247,23 @@ class Caddy extends BaseModel
                         ),
                         $key . ".FromDomain"
                     ));
-                    } elseif (
-                        !in_array((string)$item->Matchers, ['httphost', 'tlssni']) &&
-                        (
-                            !empty((string)$item->FromDomain) &&
-                            (string)$item->FromDomain != '*'
-                        )
-                    ) {
-                        $messages->appendMessage(new Message(
-                            sprintf(
-                                gettext(
-                                    'When "%s" matcher is selected, domain must be empty or *.'
-                                ),
-                                $item->Matchers
+                } elseif (
+                    !in_array((string)$item->Matchers, ['httphost', 'tlssni']) &&
+                    (
+                        !empty((string)$item->FromDomain) &&
+                        (string)$item->FromDomain != '*'
+                    )
+                ) {
+                    $messages->appendMessage(new Message(
+                        sprintf(
+                            gettext(
+                                'When "%s" matcher is selected, domain must be empty or *.'
                             ),
-                            $key . ".FromDomain"
-                        ));
-                    }
+                            $item->Matchers
+                        ),
+                        $key . ".FromDomain"
+                    ));
+                }
 
                 if ((string)$item->Type === 'global' && empty((string)$item->FromPort)) {
                     $messages->appendMessage(new Message(
@@ -295,7 +299,8 @@ class Caddy extends BaseModel
                     ));
                 }
 
-                if ((string)$item->Type !== 'global' &&
+                if (
+                    (string)$item->Type !== 'global' &&
                     (
                         (string)$item->Matchers == 'tls' ||
                         (string)$item->Matchers == 'http'

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
@@ -98,12 +98,15 @@ class Caddy extends BaseModel
         // Get custom caddy ports if set. If empty, default to 80 and 443.
         $httpPort = !empty((string)$this->general->HttpPort) ? (string)$this->general->HttpPort : '80';
         $httpsPort = !empty((string)$this->general->HttpsPort) ? (string)$this->general->HttpsPort : '443';
-        $tlsAutoHttpsSetting = (string)$this->general->TlsAutoHttps;
 
-        // Check for conflicts
         $overlap = array_intersect($this->getWebGuiPorts(), [$httpPort, $httpsPort]);
 
-        if (!empty($overlap) && $tlsAutoHttpsSetting !== 'off') {
+        /**
+         * The intend to use Lets Encrypt is populated email address and empty AutoHttps field.
+         * This prevents a migration lockout during first install of the plugin
+         * when AutoHttps is "on" (empty) per default but the webgui ports are still default, too.
+         */
+        if (!empty($overlap) && !empty((string)$this->general->TlsEmail) && empty((string)$this->general->TlsAutoHttps)) {
             $portOverlap = implode(', ', $overlap);
             $messages->appendMessage(new Message(
                 sprintf(

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//Pischem/caddy</mount>
     <description>Caddy Reverse Proxy</description>
-    <version>1.3.3</version>
+    <version>1.4.0</version>
     <items>
         <general>
             <enabled type="BooleanField">
@@ -271,6 +271,17 @@
                     <Default>1</Default>
                     <Required>Y</Required>
                 </enabled>
+                <Sequence type="AutoNumberField">
+                    <MinimumValue>1</MinimumValue>
+                    <MaximumValue>99999</MaximumValue>
+                    <ValidationMessage>Please enter a value between 1 and 99999 or leave empty.</ValidationMessage>
+                    <Constraints>
+                        <check001>
+                            <ValidationMessage>Sequence value has to be unique or empty.</ValidationMessage>
+                            <type>UniqueConstraint</type>
+                        </check001>
+                    </Constraints>
+                </Sequence>
                 <reverse type="ModelRelationField">
                     <Required>Y</Required>
                     <Model>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Migrations/M1_4_0.php
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Migrations/M1_4_0.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ *    Copyright (C) 2024 Cedrik Pischem
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Caddy\Migrations;
+
+use OPNsense\Base\BaseModelMigration;
+use OPNsense\Core\Config;
+
+/*
+ * Empty HandlePath start at high decreasing sequence
+ * to generate them last in the Caddyfile, non-empty HandlePath are the opposite.
+ * If the sequence becomes empty, the Caddyfile template has a default to 0.
+ */
+
+// @codingStandardsIgnoreStart
+class M1_4_0 extends BaseModelMigration
+// @codingStandardsIgnoreEnd
+{
+    public function run($model)
+    {
+        $config = Config::getInstance()->object();
+
+        if (!empty($config->Pischem->caddy->reverseproxy)) {
+            static $emptySequence = 99999;
+            static $nonEmptySequence = 1;
+
+            foreach ($config->Pischem->caddy->reverseproxy->handle as $configNode) {
+                $uuid = (string)$configNode->attributes()->uuid;
+                $modelNode = $model->getNodeByReference('reverseproxy.handle.' . $uuid);
+
+                if ($modelNode === null) {
+                    continue;
+                }
+
+                if (empty((string)$configNode->HandlePath)) {
+                    if ($emptySequence < 50000) {
+                        $modelNode->Sequence = '';
+                    } else {
+                        $modelNode->Sequence = $emptySequence--;
+                    }
+                } else {
+                    if ($nonEmptySequence >= 50000) {
+                        $modelNode->Sequence = '';
+                    } else {
+                        $modelNode->Sequence = $nonEmptySequence++;
+                    }
+                }
+            }
+        }
+    }
+
+    // Model is saved by 'run_migrations.php'
+}

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -480,6 +480,7 @@
                         <tr>
                             <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
                             <th data-column-id="enabled" data-width="6em" data-type="boolean" data-formatter="rowtoggle">{{ lang._('Enabled') }}</th>
+                            <th data-column-id="Sequence" data-type="string">{{ lang._('Sequence') }}</th>
                             <th data-column-id="reverse" data-type="string">{{ lang._('Domain') }}</th>
                             <th data-column-id="subdomain" data-type="string">{{ lang._('Subdomain') }}</th>
                             <th data-column-id="HandleType" data-type="string" data-visible="false">{{ lang._('Handler') }}</th>

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -509,7 +509,7 @@ http://{{ domain }} {
 
 {#
 #   Macro: render_handles
-#   Purpose: Renders the handles in the correct order (path-specific first, then catch-all),
+#   Purpose: Renders the handles,
 #            including basic authentication configuration.
 #   Parameters:
 #   @param handles (list): A list of handle objects to be rendered.
@@ -518,12 +518,7 @@ http://{{ domain }} {
 {% macro render_handles(handles, basicauth_uuids=None) %}
     {{ render_basic_auth(basicauth_uuids) }}
     {% for handle in handles %}
-        {% if handle.enabled|default("0") == "1" and handle.HandlePath %}
-            {{ reverse_proxy_configuration(handle) }}
-        {% endif %}
-    {% endfor %}
-    {% for handle in handles %}
-        {% if handle.enabled|default("0") == "1" and not handle.HandlePath %}
+        {% if handle.enabled|default("0") == "1" %}
             {{ reverse_proxy_configuration(handle) }}
         {% endif %}
     {% endfor %}
@@ -543,6 +538,12 @@ http://{{ domain }} {
 #   - Order of Path specific Handles: Prioritizes order of specific path handles over catch-all handles.
 #   - Order of Wildcard Domains and Subdomains: Handles for wildcard domains come after all subdomains.
 #}
+{% set unsorted_handles = helpers.toList('Pischem.caddy.reverseproxy.handle') %}
+{% for handle in unsorted_handles %}
+    {% set _ = handle.update({'Sequence': handle.get('Sequence', '0') | int}) %}
+{% endfor %}
+{% set sorted_handles = unsorted_handles | sort(attribute='Sequence') %}
+
 {% for reverse in helpers.toList('Pischem.caddy.reverseproxy.reverse') %}
     {% if reverse.enabled|default("0") == "1" %}
         # Reverse Proxy Domain: "{{ reverse['@uuid'] }}"
@@ -580,7 +581,7 @@ http://{{ domain }} {
                         host {{ subdomain.FromDomain }}
                     }
                     handle @{{ subdomain['@uuid'] }} {
-                        {% set subdomain_handles = helpers.toList('Pischem.caddy.reverseproxy.handle') | selectattr('subdomain', 'equalto', subdomain['@uuid']) | list %}
+                        {% set subdomain_handles = sorted_handles | selectattr('subdomain', 'equalto', subdomain['@uuid']) %}
                         {{ handle_accesslist(subdomain.accesslist) }}
                         {# All IPs not matched by accesslist will continue processing #}
                         {{ render_handles(subdomain_handles, subdomain.basicauth) }}
@@ -588,7 +589,7 @@ http://{{ domain }} {
                 {% endif %}
             {% endfor %}
 
-            {% set domain_handles = helpers.toList('Pischem.caddy.reverseproxy.handle') | selectattr('reverse', 'equalto', reverse['@uuid']) | selectattr('subdomain', 'undefined') | list %}
+            {% set domain_handles = sorted_handles | selectattr('reverse', 'equalto', reverse['@uuid']) | selectattr('subdomain', 'undefined') %}
             {{ handle_accesslist(reverse.accesslist) }}
             {# All IPs not matched by accesslist will continue processing #}
             {{ render_handles(domain_handles, reverse.basicauth) }}


### PR DESCRIPTION
The current implementation auto generated an order for the handlers.

- Populated "HandlePath" (e.g., /opnsense/docs/*) would be rendered in the order they appeared in the config.xml
- Empty "HandlePath" would be rendered last

This has a lot of drawbacks, because everything is implicit and when a domain has multiple handlers that would need to be in a certain order to match, it was painful to clone/delete them and rearrange them with tricks in the GUI.

This PR here solves that issue once and for all by introducing a sequence number and a migration.

The migration will migrate all:
- Populated "HandlePath" to a sequence of 1+, so 1,2,3,4,5...
- All empty "HandlePath" to a sequence of 99999-, so 99999,99998,99997...
- There is a failsafe if somebody would happens to have more than 100k handles (lol I want to see that), which would leave the sequence empty. An empty sequence will default to 0 in the Caddyfile template, rendering these first come first serve style.
- This migration will make the old implicit default behavior explicit.

The PR also includes:
- Style fix in PHP file
- Fix too strict validation that can trigger on first installation of os-caddy, leaving config.xml section at v0.0.0.