### PR TITLE
Fix/net-mgmt/net-snmp/sysServices

### DIFF
--- a/net-mgmt/net-snmp/src/opnsense/service/templates/OPNsense/Netsnmp/snmpd.conf
+++ b/net-mgmt/net-snmp/src/opnsense/service/templates/OPNsense/Netsnmp/snmpd.conf
@@ -42,6 +42,8 @@ sysContact {{ OPNsense.netsnmp.general.syscontact }}
 
 {% if helpers.exists('OPNsense.netsnmp.general.l3visibility') and OPNsense.netsnmp.general.l3visibility == '1' %}
 sysServices 76
+{% else %}
+sysServices 72
 {% endif %}
 
 {% if helpers.exists('OPNsense.netsnmp.general.versionoid') and OPNsense.netsnmp.general.versionoid == '1' %}

--- a/net/freeradius/pkg-descr
+++ b/net/freeradius/pkg-descr
@@ -15,6 +15,10 @@ The server is fast, feature-rich, modular, and scalable.
 Plugin Changelog
 ================
 
+1.9.26
+
+* Added support for `require_message_authenticator` in client configuration (contributed by Patrick M. Hausen)
+
 1.9.25
 
 * Added support for remote syslog

--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/dialogEditFreeRADIUSClient.xml
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/dialogEditFreeRADIUSClient.xml
@@ -23,4 +23,11 @@
         <type>text</type>
         <help>Set the IP address of the remote client or the complete network like 10.10.10.0/24</help>
     </field>
+    <field>
+        <id>client.require_ma</id>
+        <label>Require Message-Authenticator</label>
+        <type>checkbox</type>
+        <advanced>true</advanced>
+        <help>RFC 5080 suggests that all clients should include it in an Access-Request. If the server requires it (option checked) and the client does not, then the packet will be silently discarded.</help>
+    </field>
 </form>

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Client.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Client.xml
@@ -18,6 +18,10 @@
                 <ip type="NetworkField">
                     <Required>N</Required>
                 </ip>
+                <require_ma type="BooleanField">
+                    <default>0</default>
+                    <Required>Y</Required>
+                </require_ma>
             </client>
         </clients>
     </items>

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/clients.conf
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/clients.conf
@@ -11,6 +11,9 @@ client "{{ client_list.name }}" {
 {%       else %}
        ipaddr    = {{ client_list.ip }}
 {%       endif %}
+{%       if client_list.require_ma == '1' %}
+       require_message_authenticator = yes
+{%       endif %}
 }
 
 {%     endif %}


### PR DESCRIPTION
The plugin offers an option to enable "Layer 3 Visibility" which leads to the sysServices OID being set to 76.

This boils down to the following services being advertised:
- datalink/subnetwork
- internet
- end-to-end

I really don't know why this is necessary as an option and not simply hardwired - but maybe OPNsense as a transparent bridge does not count as an internet/IP providing system. I can see that ...

That being said in the absence of that option the sysServices OID is not set at all which I consider a bug. It should be set to 72 instead. This pull request does exactly that.

Reference:

https://oidref.com/1.3.6.1.4.1.1978.2.18.1.7

Kind regards,
Patrick