### PR TITLE
net/freeradius add `require_message_authenticator` client option

### DIFF
--- a/net/freeradius/Makefile
+++ b/net/freeradius/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		freeradius
-PLUGIN_VERSION=		1.9.25
+PLUGIN_VERSION=		1.9.26
 PLUGIN_REVISION=	1
 PLUGIN_COMMENT=		RADIUS Authentication, Authorization and Accounting Server
 PLUGIN_DEPENDS=		freeradius3

--- a/net/freeradius/pkg-descr
+++ b/net/freeradius/pkg-descr
@@ -15,6 +15,10 @@ The server is fast, feature-rich, modular, and scalable.
 Plugin Changelog
 ================
 
+1.9.26
+
+* Added support for `require_message_authenticator` in client configuration (contributed by Patrick M. Hausen)
+
 1.9.25
 
 * Added support for remote syslog

--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/dialogEditFreeRADIUSClient.xml
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/dialogEditFreeRADIUSClient.xml
@@ -23,4 +23,11 @@
         <type>text</type>
         <help>Set the IP address of the remote client or the complete network like 10.10.10.0/24</help>
     </field>
+    <field>
+        <id>client.require_ma</id>
+        <label>Require Message-Authenticator</label>
+        <type>checkbox</type>
+        <advanced>true</advanced>
+        <help>RFC 5080 suggests that all clients should include it in an Access-Request. If the server requires it (option checked) and the client does not, then the packet will be silently discarded.</help>
+    </field>
 </form>

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Client.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Client.xml
@@ -18,6 +18,10 @@
                 <ip type="NetworkField">
                     <Required>N</Required>
                 </ip>
+                <require_ma type="BooleanField">
+                    <default>0</default>
+                    <Required>Y</Required>
+                </require_ma>
             </client>
         </clients>
     </items>

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Client.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Client.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/freeradius/client</mount>
     <description>FreeRADIUS client configuration</description>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <items>
         <clients>
             <client type="ArrayField">

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/clients.conf
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/clients.conf
@@ -11,6 +11,9 @@ client "{{ client_list.name }}" {
 {%       else %}
        ipaddr    = {{ client_list.ip }}
 {%       endif %}
+{%       if client_list.require_ma == '1' %}
+       require_message_authenticator = yes
+{%       endif %}
 }
 
 {%     endif %}


### PR DESCRIPTION
It is recommended for RADIUS clients to use a message authenticator for all requests to protect against the [BlastRADIUS](https://www.freeradius.org/vul_notifications/2024/07/09/blastradius.html) attack.

Further this should be enforced by the RADIUS server.

These changes add the required function to the client settings as an advanced option.

Initiated and tested in this forum thread:
https://forum.opnsense.org/index.php?topic=42094.msg207448

Kind regards,
Patrick