### PR TITLE
www/caddy: Fix WebGUI ports validation (by removing it)

### DIFF
--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
@@ -82,8 +82,9 @@ class Caddy extends BaseModel
         if (!empty($webgui) && empty((string)$webgui->interfaces)) {
             $webGuiPorts[] = !empty($webgui->port) ? (string)$webgui->port : '443';
 
-            if (empty((string)$webgui->disablehttpredirect)
-                && (string)$webgui->protocol !== 'http'
+            if (
+                empty((string) $webgui->disablehttpredirect) &&
+                (string) $webgui->protocol !== 'http'
             ) {
                 $webGuiPorts[] = '80';
             }


### PR DESCRIPTION
Fix WebGUI ports validation: 
- Do not validate with empty ACME email address to prevent migration issues on first install.
- Do not validate WebGUI redirect rule when WebGUI protocol is http. 
- Attach validation message additionally to Caddy HTTP and HTTPS port fields.

Fixes: https://github.com/opnsense/plugins/issues/4288