### PR TITLE
Fix for "ipv4 vs ipv6" and  mixed configuration on telegraf ping section.

### DIFF
--- a/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
+++ b/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
@@ -313,7 +313,8 @@
 
 {% if helpers.exists('OPNsense.telegraf.input.ping') and OPNsense.telegraf.input.ping == '1' %}
 [[inputs.ping]]
-  method = "exec"
+  method = "native"
+  ipv4 = true
 {%   if helpers.exists('OPNsense.telegraf.input.ping_hosts') and OPNsense.telegraf.input.ping_hosts != '' %}
   urls = [{{ "'" + ("','".join(OPNsense.telegraf.input.ping_hosts.split(','))) + "'" }}]
 {%   endif %}
@@ -324,8 +325,8 @@
 
 {% if helpers.exists('OPNsense.telegraf.input.ping6') and OPNsense.telegraf.input.ping6 == '1' %}
 [[inputs.ping]]
-  method = "exec"
-  binary = "ping6"
+  method = "native"
+  ipv6 = true
 {%   if helpers.exists('OPNsense.telegraf.input.ping6_hosts') and OPNsense.telegraf.input.ping6_hosts != '' %}
   urls = [{{ "'" + ("','".join(OPNsense.telegraf.input.ping6_hosts.split(','))) + "'" }}]
 {%   endif %}


### PR DESCRIPTION
Fix for [#4317](https://github.com/opnsense/plugins/issues/4317)

With this, the "ipv4 vs ipv6" will be respected, and the count is respected too.