### PR TITLE
New plugin: net-mgmt/arp-ndp-logging

### DIFF
--- a/net-mgmt/arp-ndp-logging/LICENSE
+++ b/net-mgmt/arp-ndp-logging/LICENSE
@@ -1,0 +1,25 @@
+BSD 2-Clause License
+
+Copyright (c) 2025 github.com/mr-manuel
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/net-mgmt/arp-ndp-logging/Makefile
+++ b/net-mgmt/arp-ndp-logging/Makefile
@@ -1,0 +1,7 @@
+PLUGIN_NAME=		ARP/NDP Logging
+PLUGIN_VERSION=		0.1
+PLUGIN_REVISION=	1
+PLUGIN_COMMENT=		arpwatch alternative for OPNsense
+PLUGIN_MAINTAINER=	github.com/mr-manuel
+
+.include "../../Mk/plugins.mk"

--- a/net-mgmt/arp-ndp-logging/pkg-descr
+++ b/net-mgmt/arp-ndp-logging/pkg-descr
@@ -1,0 +1,12 @@
+ARP/NDP Logging is a versatile network monitoring tool that tracks and logs changes in ARP (Address Resolution Protocol) and NDP (Neighbor Discovery Protocol) tables, capturing key details such as IPv4 and IPv6 addresses, hostnames, MAC addresses, and interface changes. The plugin is configurable, allowing administrators to selectively enable or disable tracking for different modifications based on specific needs, whether it’s for IP address shifts, hostname updates, new MAC detections, or interface changes. This customization and comprehensive logging ensure precise, up-to-date network visibility, ideal for securing networks and managing dynamic device inventories effectively.
+
+LICENSE: BSD 2-Clause
+
+WWW: https://github.com/opnsense/plugins
+
+Plugin Changelog
+================
+
+0.1
+
+* Initial release

--- a/net-mgmt/arp-ndp-logging/src/bin/arpndplogging.py
+++ b/net-mgmt/arp-ndp-logging/src/bin/arpndplogging.py
@@ -1,0 +1,613 @@
+#!/usr/local/bin/python3
+
+"""
+
+Copyright (C) 2025 github.com/mr-manuel
+All rights reserved.
+
+License: BSD 2-Clause
+
+"""
+
+
+import os
+import subprocess
+import time
+import shutil
+import logging
+import socket
+import configparser
+import sqlite3
+import requests
+import csv
+import gc
+from io import StringIO
+from datetime import datetime
+
+
+CONFIG_FILE = "/usr/local/etc/arpndplogging.conf"
+DB_FILE = "/var/db/arpndplogging/arpndplogging.db"
+LOG_FILE = "/var/log/arpndplogging.log"
+MAC_VENDOR_FILE = "/var/db/arpndplogging/oui.csv"
+
+# Create directories
+os.makedirs(os.path.dirname(DB_FILE), exist_ok=True)
+
+
+# Set up logging to match RFC 5424
+class CustomLogRecord(logging.LogRecord):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.hostname = socket.gethostname()
+        self.appname = "arpndplogging"
+        self.procid = os.getpid()
+
+
+logging.basicConfig(
+    filename=LOG_FILE,
+    level=logging.INFO,
+    format="<134>1 %(asctime)s %(hostname)s %(appname)s %(procid)s - [meta] %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S%z",
+)
+
+
+# Add hostname, appname, procid to the log records
+logging.Formatter.converter = time.localtime  # Use local time
+logging.Formatter.default_msec_format = "%s.%03d"
+
+logging.setLogRecordFactory(CustomLogRecord)
+
+# Create database
+conn = sqlite3.connect(DB_FILE)
+cursor = conn.cursor()
+cursor.execute(
+    """
+    CREATE TABLE IF NOT EXISTS arp_entries (
+        mac TEXT,
+        ipv4 TEXT,
+        ipv6 TEXT,
+        interface TEXT,
+        hostname TEXT,
+        timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )
+    """
+)
+
+
+# Read configuration file
+config = configparser.ConfigParser()
+with open(CONFIG_FILE) as f:
+    config.read_file(StringIO("[default]\n" + f.read()))
+
+protocols = config["default"].get("protocols")
+interfaces = (
+    config["default"].get("interfaces").replace("_", ".").split(" ")
+    if config["default"].get("interfaces") is not None
+    else []
+)
+suppress_mac = (
+    config["default"].get("suppress_mac").split(" ")
+    if config["default"].get("suppress_mac") is not None
+    else []
+)
+log_new_entries = config["default"].getboolean("log_new_entries")
+log_mac_changes = config["default"].getboolean("log_mac_changes")
+log_ipv4_changes = config["default"].getboolean("log_ipv4_changes")
+log_ipv6_changes = config["default"].getboolean("log_ipv6_changes")
+log_hostname_changes = config["default"].getboolean("log_hostname_changes")
+log_interface_changes = config["default"].getboolean("log_interface_changes")
+retention_days = config["default"].getint("retention_days")
+
+# add firewall MAC addresses to suppress_mac
+device_mac_addresses = (
+    subprocess.run(
+        "ifconfig -a | grep ether  | awk '{print $2}' | sort | uniq",
+        shell=True,
+        capture_output=True,
+        text=True,
+    )
+    .stdout.strip()
+    .split("\n")
+)
+
+suppress_mac.extend(device_mac_addresses)
+
+
+def main():
+    while True:
+        time_now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+        # create a dictionary with the current entries
+        current_entries_dict = {}
+
+        # Check ARP table
+        if protocols == "all" or protocols == "ipv4_only":
+            # $2 = IPv4, $4 = MAC, $6 = Interface
+            filter = ' | grep -v \'incomplete\' | awk \'{gsub(/[()]/, "", $2); print $2 " " $4 " " $6}\''
+            if len(interfaces) == 0:
+                result = subprocess.run(
+                    "arp -an" + filter,
+                    shell=True,
+                    capture_output=True,
+                    text=True,
+                )
+                current_ipv4_entries = result.stdout.strip().split("\n")
+            else:
+                current_ipv4_entries = []
+                for interface in interfaces:
+                    result = subprocess.run(
+                        "arp -i " + interface + " -an" + filter,
+                        shell=True,
+                        capture_output=True,
+                        text=True,
+                    )
+                    current_ipv4_entries.extend(result.stdout.strip().split("\n"))
+
+            # Filter out empty strings
+            current_ipv4_entries = [
+                entries for entries in current_ipv4_entries if entries
+            ]
+
+            # populate the current_entries_dict
+            if len(current_ipv4_entries) > 0:
+                for entry in current_ipv4_entries:
+                    ipv4, mac, interface = entry.split()
+                    current_entries_dict[mac] = {
+                        "ipv4": ipv4,
+                        "ipv6": "<unknown>",
+                        "interface": interface,
+                    }
+
+        # Check NDP table
+        if protocols == "all" or protocols == "ipv6_only":
+            # $1 = IPv6, $2 = MAC, $3 = Interface
+            filter = ' | grep -v "incomplete" | grep -v "Neighbor" | awk \'{gsub(/%.*/, "", $1); print $1 " " $2 " " $3}\''
+            if len(interfaces) == 0:
+                result = subprocess.run(
+                    "ndp -an" + filter,
+                    shell=True,
+                    capture_output=True,
+                    text=True,
+                )
+                current_ipv6_entries = result.stdout.strip().split("\n")
+            else:
+                current_ipv6_entries = []
+                for interface in interfaces:
+                    result = subprocess.run(
+                        "ndp -an | grep " + interface + filter,
+                        shell=True,
+                        capture_output=True,
+                        text=True,
+                    )
+                    current_ipv6_entries.extend(result.stdout.strip().split("\n"))
+
+            # Filter out empty strings
+            current_ipv6_entries = [
+                entries for entries in current_ipv6_entries if entries
+            ]
+
+            # populate the current_entries_dict
+            if len(current_ipv6_entries) > 0:
+                for entry in current_ipv6_entries:
+                    ipv6, mac, interface = entry.split()
+                    if mac in current_entries_dict:
+                        current_entries_dict[mac]["ipv6"] = ipv6
+                    else:
+                        current_entries_dict[mac] = {
+                            "ipv4": "<unknown>",
+                            "ipv6": ipv6,
+                            "interface": interface,
+                        }
+
+        # Delete expired ARP entries
+        cursor.execute(
+            f"DELETE FROM arp_entries WHERE timestamp < datetime('now', '-{retention_days} day')"
+        )
+
+        # Select all current ARP entries
+        cursor.execute(
+            "SELECT mac, ipv4, ipv6, interface, hostname, timestamp FROM arp_entries"
+        )
+        saved_ipv4_entries = set(cursor.fetchall())
+
+        # Save entries in a dictionary with MAC as the key
+        saved_entries_dict_by_mac = {
+            entry[0]: {
+                "ipv4": entry[1],
+                "ipv6": entry[2],
+                "interface": entry[3],
+                "hostname": entry[4],
+                "timestamp": entry[5],
+            }
+            for entry in saved_ipv4_entries
+        }
+
+        # Save entries in a dictionary with MAC as the key
+        saved_ipv4_entries_dict_by_ip = {
+            entry[1]: {
+                "mac": entry[0],
+                "interface": entry[3],
+                "hostname": entry[4],
+                "timestamp": entry[5],
+            }
+            for entry in saved_ipv4_entries
+        }
+
+        # Save entries in a dictionary with MAC as the key
+        saved_ipv6_entries_dict_by_ip = {
+            entry[2]: {
+                "mac": entry[0],
+                "interface": entry[3],
+                "hostname": entry[4],
+                "timestamp": entry[5],
+            }
+            for entry in saved_ipv4_entries
+        }
+
+        # check if current_ipv4_entries_dict is empty
+        if len(current_entries_dict) > 0:
+            for mac, entry in current_entries_dict.items():
+
+                ipv4 = entry["ipv4"]
+                ipv6 = entry["ipv6"]
+                interface = entry["interface"]
+
+                # Get hostname from IPv4
+                hostname = (
+                    subprocess.run(
+                        "host "
+                        + ipv4
+                        + " | grep -v 'not found' | awk '{print $5}' | sed 's/\\.$//'",
+                        shell=True,
+                        capture_output=True,
+                        text=True,
+                    )
+                    .stdout.strip()
+                    .split("\n")
+                )
+                # Get hostname from IPv6
+                hostname += (
+                    subprocess.run(
+                        "host "
+                        + ipv6
+                        + " | grep -v 'not found' | awk '{print $5}' | sed 's/\\.$//'",
+                        shell=True,
+                        capture_output=True,
+                        text=True,
+                    )
+                    .stdout.strip()
+                    .split("\n")
+                )
+                # Remove duplicates and sort the hostname list
+                hostname = sorted(set(hostname))
+                # Filter out empty strings
+                hostname = [name for name in hostname if name]
+
+                if not hostname:
+                    hostname = "<unknown>"
+                else:
+                    # split by newline, sort and join with ;
+                    hostname = "; ".join(sorted(hostname))
+
+                # Skip suppressed MAC addresses
+                if mac in suppress_mac:
+                    continue
+
+                # Check if the MAC entry already exists
+                if mac in saved_entries_dict_by_mac:
+
+                    changes = False
+                    changes_message = []
+
+                    # Check if the IPv4 address has changed
+                    if (
+                        (protocols == "all" or protocols == "ipv4_only")
+                        and log_ipv4_changes
+                        and ipv4 != saved_entries_dict_by_mac[mac]["ipv4"]
+                    ):
+                        changes = True
+                        changes_message.append(
+                            f"OLD IPv4: {saved_entries_dict_by_mac[mac]['ipv4']}"
+                        )
+
+                    # Check if the IPv6 address has changed
+                    if (
+                        (protocols == "all" or protocols == "ipv6_only")
+                        and log_ipv6_changes
+                        and ipv6 != saved_entries_dict_by_mac[mac]["ipv6"]
+                    ):
+                        changes = True
+                        changes_message.append(
+                            f"OLD IPv6: {saved_entries_dict_by_mac[mac]['ipv6']}"
+                        )
+
+                    # Check if the hostname has changed
+                    if (
+                        log_hostname_changes
+                        and hostname != saved_entries_dict_by_mac[mac]["hostname"]
+                    ):
+                        changes = True
+                        changes_message.append(
+                            f"OLD Hostname: {saved_entries_dict_by_mac[mac]['hostname']}"
+                        )
+
+                    # Check if the interface has changed
+                    if (
+                        log_interface_changes
+                        and interface != saved_entries_dict_by_mac[mac]["interface"]
+                    ):
+                        changes = True
+                        changes_message.append(
+                            f"OLD Interface: {saved_entries_dict_by_mac[mac]['interface']}"
+                        )
+
+                    # Update the entry
+                    if changes:
+                        cursor.execute(
+                            "UPDATE arp_entries SET ipv4 = ?, ipv6 = ?, interface = ?, hostname = ?, timestamp = ? WHERE mac = ?",
+                            (ipv4, ipv6, interface, hostname, time_now, mac),
+                        )
+                        logging.info(
+                            "ARP - Changes detected! "
+                            + (
+                                f"IPv4: {ipv4} | "
+                                if protocols == "all" or protocols == "ipv4_only"
+                                else ""
+                            )
+                            + (
+                                f"IPv6: {ipv6} | "
+                                if protocols == "all" or protocols == "ipv6_only"
+                                else ""
+                            )
+                            + f"Hostname: {hostname} | MAC: {mac} | Vendor: {mac_vendor_check(mac)} | Interface: {interface}"
+                            + (
+                                " | " + " | ".join(changes_message)
+                                if len(changes_message) > 0
+                                else ""
+                            )
+                        )
+                    # Update the timestamp
+                    else:
+                        cursor.execute(
+                            "UPDATE arp_entries SET timestamp = ? WHERE ipv4 = ?",
+                            (time_now, ipv4),
+                        )
+
+                # Check if the IPv4 entry already exists
+                # This check allows to see, if an address is spoofed or multiple devices have the same IP
+                elif ipv4 != "<unknown>" and ipv4 in saved_ipv4_entries_dict_by_ip:
+
+                    changes = False
+                    changes_message = []
+
+                    # Check if the MAC address has changed
+                    if (
+                        log_mac_changes
+                        and mac != saved_ipv4_entries_dict_by_ip[ipv4]["mac"]
+                    ):
+                        changes = True
+                        changes_message.append(
+                            f"OLD MAC: {saved_ipv4_entries_dict_by_ip[ipv4]['mac']} | OLD vendor: {mac_vendor_check(saved_ipv4_entries_dict_by_ip[ipv4]['mac'])}"
+                        )
+
+                    # Check if the hostname has changed
+                    if (
+                        log_hostname_changes
+                        and hostname != saved_ipv4_entries_dict_by_ip[ipv4]["hostname"]
+                    ):
+                        changes = True
+                        changes_message.append(
+                            f"OLD Hostname: {saved_ipv4_entries_dict_by_ip[ipv4]['hostname']}"
+                        )
+
+                    # Check if the interface has changed
+                    if (
+                        log_interface_changes
+                        and interface
+                        != saved_ipv4_entries_dict_by_ip[ipv4]["interface"]
+                    ):
+                        changes = True
+                        changes_message.append(
+                            f"OLD Interface: {saved_ipv4_entries_dict_by_ip[ipv4]['interface']}"
+                        )
+
+                    # Update the entry
+                    if changes:
+                        cursor.execute(
+                            "UPDATE arp_entries SET mac = ?, ipv6 = ?, interface = ?, hostname = ?, timestamp = ? WHERE ipv4 = ?",
+                            (mac, ipv6, interface, hostname, time_now, ipv4),
+                        )
+                        logging.info(
+                            "ARP - Changes detected! "
+                            + (
+                                f"IPv4: {ipv4} | "
+                                if protocols == "all" or protocols == "ipv4_only"
+                                else ""
+                            )
+                            + (
+                                f"IPv6: {ipv6} | "
+                                if protocols == "all" or protocols == "ipv6_only"
+                                else ""
+                            )
+                            + f"Hostname: {hostname} | MAC: {mac} | Vendor: {mac_vendor_check(mac)} | Interface: {interface}"
+                            + (
+                                " | " + " | ".join(changes_message)
+                                if len(changes_message) > 0
+                                else ""
+                            )
+                        )
+                    # Update the timestamp
+                    else:
+                        cursor.execute(
+                            "UPDATE arp_entries SET timestamp = ? WHERE ipv4 = ?",
+                            (time_now, ipv4),
+                        )
+
+                # Check if the IPv6 entry already exists
+                # This check allows to see, if an address is spoofed or multiple devices have the same IP
+                elif ipv6 != "<unknown>" and ipv6 in saved_ipv6_entries_dict_by_ip:
+
+                    changes = False
+                    changes_message = []
+
+                    # Check if the MAC address has changed
+                    if (
+                        log_mac_changes
+                        and mac != saved_ipv6_entries_dict_by_ip[ipv6]["mac"]
+                    ):
+                        changes = True
+                        changes_message.append(
+                            f"OLD MAC: {saved_ipv6_entries_dict_by_ip[ipv6]['mac']} | OLD vendor: {mac_vendor_check(saved_ipv6_entries_dict_by_ip[ipv6]['mac'])}"
+                        )
+
+                    # Check if the hostname has changed
+                    if (
+                        log_hostname_changes
+                        and hostname != saved_ipv6_entries_dict_by_ip[ipv6]["hostname"]
+                    ):
+                        changes = True
+                        changes_message.append(
+                            f"OLD Hostname: {saved_ipv6_entries_dict_by_ip[ipv6]['hostname']}"
+                        )
+
+                    # Check if the interface has changed
+                    if (
+                        log_interface_changes
+                        and interface
+                        != saved_ipv6_entries_dict_by_ip[ipv6]["interface"]
+                    ):
+                        changes = True
+                        changes_message.append(
+                            f"OLD Interface: {saved_ipv6_entries_dict_by_ip[ipv6]['interface']}"
+                        )
+
+                    # Update the entry
+                    if changes:
+                        cursor.execute(
+                            "UPDATE arp_entries SET mac = ?, ipv4 = ?, interface = ?, hostname = ?, timestamp = ? WHERE ipv6 = ?",
+                            (mac, ipv4, interface, hostname, time_now, ipv6),
+                        )
+                        logging.info(
+                            "ARP - Changes detected! "
+                            + (
+                                f"IPv4: {ipv4} | "
+                                if protocols == "all" or protocols == "ipv4_only"
+                                else ""
+                            )
+                            + (
+                                f"IPv6: {ipv6} | "
+                                if protocols == "all" or protocols == "ipv6_only"
+                                else ""
+                            )
+                            + f"Hostname: {hostname} | MAC: {mac} | Vendor: {mac_vendor_check(mac)} | Interface: {interface}"
+                            + (
+                                " | " + " | ".join(changes_message)
+                                if len(changes_message) > 0
+                                else ""
+                            )
+                        )
+                    # Update the timestamp
+                    else:
+                        cursor.execute(
+                            "UPDATE arp_entries SET timestamp = ? WHERE ipv6 = ?",
+                            (time_now, ipv6),
+                        )
+
+                elif log_new_entries:
+                    logging.info(
+                        "ARP - New entry detected! "
+                        + (
+                            f"IPv4: {ipv4} | "
+                            if protocols == "all" or protocols == "ipv4_only"
+                            else ""
+                        )
+                        + (
+                            f"IPv6: {ipv6} | "
+                            if protocols == "all" or protocols == "ipv6_only"
+                            else ""
+                        )
+                        + f"Hostname: {hostname} | MAC: {mac} | Vendor: {mac_vendor_check(mac)} | Interface: {interface}"
+                    )
+                    cursor.execute(
+                        "INSERT INTO arp_entries (mac, ipv4, ipv6, interface, hostname, timestamp) VALUES (?, ?, ?, ?, ?, ?)",
+                        (mac, ipv4, ipv6, interface, hostname, time_now),
+                    )
+
+        conn.commit()
+
+        # check if the log need to be rotated
+        rotate_log()
+
+        # Wait before next check
+        time.sleep(60)
+
+
+def rotate_log():
+    # Rotate log file if necessary
+    if os.path.exists(LOG_FILE) and os.path.getsize(LOG_FILE) > 102400:
+        if os.path.exists(LOG_FILE + ".1"):
+            os.remove(LOG_FILE + ".1")
+        shutil.move(LOG_FILE, LOG_FILE + ".1")
+        open(LOG_FILE, "a").close()
+        logging.info("Rotated log file")
+
+
+def mac_vendor_list_download():
+    # Download MAC address vendor list if older than 365 days
+    if (
+        not os.path.exists(MAC_VENDOR_FILE)
+        or (time.time() - os.path.getmtime(MAC_VENDOR_FILE)) > 365 * 86400
+    ):
+        url = "https://maclookup.app/downloads/csv-database/get-db"
+        response = requests.get(url)
+        if response.status_code == 200:
+            with open(MAC_VENDOR_FILE, "wb") as f:
+                f.write(response.content)
+            logging.info("Downloaded MAC vendor list")
+        else:
+            logging.error("Failed to download MAC vendor list")
+
+
+def mac_vendor_check(mac):
+    # Load MAC vendor list into a dictionary
+    mac_vendor = {}
+    with open(MAC_VENDOR_FILE, "r") as f:
+        reader = csv.reader(f)
+        for row in reader:
+            if len(row) >= 2:
+                mac_prefix = row[0].strip().replace(":", "").lower()
+                vendor = row[1].strip()
+                mac_vendor[mac_prefix] = vendor
+
+    # Search for the vendor by progressively increasing the length of the MAC prefix
+    for length in range(6, 9):
+        matches = [
+            vendor
+            for prefix, vendor in mac_vendor.items()
+            if mac.replace(":", "").lower().startswith(prefix[:length])
+        ]
+        if len(matches) == 1:
+            # Release memory
+            del mac_vendor
+            gc.collect()
+            return matches[0]
+
+    # Release memory
+    del mac_vendor
+    gc.collect()
+    return "<unknown>"
+
+
+if __name__ == "__main__":
+    # check if the log need to be rotated
+    rotate_log()
+
+    logging.info("*** Starting ARP/NDP Logging ***")
+
+    logging.info(f"protocols: {protocols}")
+    logging.info(f"interfaces: {interfaces}")
+    logging.info(f"suppress_mac: {suppress_mac}")
+
+    mac_vendor_list_download()
+
+    main()

--- a/net-mgmt/arp-ndp-logging/src/etc/inc/plugins.inc.d/arpndplogging.inc
+++ b/net-mgmt/arp-ndp-logging/src/etc/inc/plugins.inc.d/arpndplogging.inc
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * Copyright (C) 2025 github.com/mr-manuel
+ * All rights reserved.
+ *
+ * License: BSD 2-Clause
+ */
+
+function arpndplogging_services()
+{
+    global $config;
+
+    $services = array();
+
+    if (isset($config['OPNsense']['ArpNdpLogging']['general']['enabled']) && $config['OPNsense']['ArpNdpLogging']['general']['enabled'] == 1) {
+        $services[] = array(
+            'description' => gettext('ArpNdpLogging Daemon'),
+            'configd' => array(
+                'restart' => array('arpndplogging restart'),
+                'start' => array('arpndplogging start'),
+                'stop' => array('arpndplogging stop'),
+            ),
+            'name' => 'arpndplogging',
+            'pidfile' => '/var/run/arpndplogging.pid',
+        );
+    }
+
+    return $services;
+}

--- a/net-mgmt/arp-ndp-logging/src/etc/rc.d/arpndplogging
+++ b/net-mgmt/arp-ndp-logging/src/etc/rc.d/arpndplogging
@@ -1,0 +1,23 @@
+#!/bin/sh
+#
+# $FreeBSD$
+#
+# PROVIDE: arpndplogging
+# REQUIRE: SERVERS
+# KEYWORD: shutdown
+#
+
+. /etc/rc.subr
+
+name=arpndplogging
+
+rcvar=arpndplogging_enable
+pidfile=/var/run/${name}.pid
+command=/usr/sbin/daemon
+command_args="-f -P ${pidfile} /usr/local/bin/python3 /usr/local/bin/arpndplogging.py"
+
+load_rc_config ${name}
+
+: ${arpndplogging_enable="NO"}
+
+run_rc_command $1

--- a/net-mgmt/arp-ndp-logging/src/opnsense/mvc/app/controllers/OPNsense/ArpNdpLogging/Api/GeneralController.php
+++ b/net-mgmt/arp-ndp-logging/src/opnsense/mvc/app/controllers/OPNsense/ArpNdpLogging/Api/GeneralController.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * Copyright (C) 2025 github.com/mr-manuel
+ * All rights reserved.
+ *
+ * License: BSD 2-Clause
+ */
+
+namespace OPNsense\ArpNdpLogging\Api;
+
+use OPNsense\Base\ApiMutableModelControllerBase;
+
+class GeneralController extends ApiMutableModelControllerBase
+{
+    protected static $internalModelClass = '\OPNsense\ArpNdpLogging\General';
+    protected static $internalModelName = 'general';
+}

--- a/net-mgmt/arp-ndp-logging/src/opnsense/mvc/app/controllers/OPNsense/ArpNdpLogging/Api/ServiceController.php
+++ b/net-mgmt/arp-ndp-logging/src/opnsense/mvc/app/controllers/OPNsense/ArpNdpLogging/Api/ServiceController.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Copyright (C) 2025 github.com/mr-manuel
+ * All rights reserved.
+ *
+ * License: BSD 2-Clause
+ */
+
+namespace OPNsense\ArpNdpLogging\Api;
+
+use OPNsense\Base\ApiMutableServiceControllerBase;
+use OPNsense\Core\Backend;
+use OPNsense\ArpNdpLogging\General;
+
+class ServiceController extends ApiMutableServiceControllerBase
+{
+    protected static $internalServiceClass = '\OPNsense\ArpNdpLogging\General';
+    protected static $internalServiceTemplate = 'OPNsense/ArpNdpLogging';
+    protected static $internalServiceEnabled = 'enabled';
+    protected static $internalServiceName = 'arpndplogging';
+
+    /**
+     * remove database folder
+     * @return array
+     */
+    public function resetdbAction()
+    {
+        $backend = new Backend();
+        $response = $backend->configdRun("arpndplogging resetdb");
+        return array("response" => $response);
+    }
+
+}

--- a/net-mgmt/arp-ndp-logging/src/opnsense/mvc/app/controllers/OPNsense/ArpNdpLogging/GeneralController.php
+++ b/net-mgmt/arp-ndp-logging/src/opnsense/mvc/app/controllers/OPNsense/ArpNdpLogging/GeneralController.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * Copyright (C) 2025 github.com/mr-manuel
+ * All rights reserved.
+ *
+ * License: BSD 2-Clause
+ */
+
+namespace OPNsense\ArpNdpLogging;
+
+class GeneralController extends \OPNsense\Base\IndexController
+{
+    public function indexAction()
+    {
+        $this->view->generalForm = $this->getForm('general');
+        $this->view->pick('OPNsense/ArpNdpLogging/general');
+    }
+}

--- a/net-mgmt/arp-ndp-logging/src/opnsense/mvc/app/controllers/OPNsense/ArpNdpLogging/forms/general.xml
+++ b/net-mgmt/arp-ndp-logging/src/opnsense/mvc/app/controllers/OPNsense/ArpNdpLogging/forms/general.xml
@@ -1,0 +1,75 @@
+<form>
+    <field>
+        <id>general.enabled</id>
+        <label>Enable</label>
+        <type>checkbox</type>
+        <help>Enable or disable ARP/NDP Logging. This will not automatically enable any mail notifications, see notes below</help>
+    </field>
+    <field>
+        <id>general.protocols</id>
+        <label>Protocols</label>
+        <type>dropdown</type>
+        <help>Select the protocols you want to watch</help>
+    </field>
+    <field>
+        <id>general.interfaces</id>
+        <label>Interfaces</label>
+        <type>select_multiple</type>
+        <help>Leave empty to track on all interfaces or add the interfaces you want to track</help>
+        <hint>All (default)</hint>
+    </field>
+    <field>
+        <id>general.suppress_mac</id>
+        <label>Suppress MAC address</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <allownew>true</allownew>
+        <help>
+            <![CDATA[Add MAC addresses you want to exclude from the notifications in the following format: xx:xx:xx:xx:xx<br>
+            The firewall MAC addresses are already excluded]]>
+        </help>
+    </field>
+    <field>
+        <id>general.log_new_entries</id>
+        <label>Log new MAC/IP address entries</label>
+        <type>checkbox</type>
+        <help>Enable or disable the logging of new entries</help>
+    </field>
+    <field>
+        <id>general.log_mac_changes</id>
+        <label>Log MAC address changes</label>
+        <type>checkbox</type>
+        <help>Enable or disable the logging of MAC address changes (helps to find duplicates or spoofing)</help>
+    </field>
+    <field>
+        <id>general.log_ipv4_changes</id>
+        <label>Log IPv4 address changes</label>
+        <type>checkbox</type>
+        <help>Enable or disable the logging of IPv4 address changes</help>
+    </field>
+    <field>
+        <id>general.log_ipv6_changes</id>
+        <label>Log IPv6 address changes</label>
+        <type>checkbox</type>
+        <help>Enable or disable the logging of IPv6 address changes</help>
+    </field>
+    <field>
+        <id>general.log_hostname_changes</id>
+        <label>Log hostname changes</label>
+        <type>checkbox</type>
+        <help>Enable or disable the logging of hostname changes</help>
+    </field>
+    <field>
+        <id>general.log_interface_changes</id>
+        <label>Log interface changes</label>
+        <type>checkbox</type>
+        <help>Enable or disable the logging of interface changes</help>
+    </field>
+    <field>
+        <id>general.retention_days</id>
+        <label>Retention</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>After how many days should an inactive MAC address be deleted from the database? After this period the device is recognized as new</help>
+    </field>
+</form>

--- a/net-mgmt/arp-ndp-logging/src/opnsense/mvc/app/models/OPNsense/ArpNdpLogging/ACL/ACL.xml
+++ b/net-mgmt/arp-ndp-logging/src/opnsense/mvc/app/models/OPNsense/ArpNdpLogging/ACL/ACL.xml
@@ -1,0 +1,9 @@
+<acl>
+   <page-arpndplogging-config>
+      <name>Services: ARP/NDP Logging</name>
+      <patterns>
+         <pattern>ui/arpndplogging/*</pattern>
+         <pattern>api/arpndplogging/*</pattern>
+      </patterns>
+   </page-arpndplogging-config>
+</acl>

--- a/net-mgmt/arp-ndp-logging/src/opnsense/mvc/app/models/OPNsense/ArpNdpLogging/FieldTypes/ArpNdpLoggingInterfaceField.php
+++ b/net-mgmt/arp-ndp-logging/src/opnsense/mvc/app/models/OPNsense/ArpNdpLogging/FieldTypes/ArpNdpLoggingInterfaceField.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * BSD 2-Clause License
+ *
+ * Copyright (C) 2024 Deciso B.V.
+ * Copyright (C) 2025 github.com/mr-manuel
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\ArpNdpLogging\FieldTypes;
+
+use OPNsense\Base\FieldTypes\BaseListField;
+use OPNsense\Core\Config;
+
+/**
+ * Class ArpNdpLoggingDomainField
+ * @package OPNsense\ArpNdpLogging\FieldTypes
+ * Created from src\opnsense\mvc\app\models\OPNsense\Unbound\FieldTypes\UnboundInterfaceField.php
+ */
+class ArpNdpLoggingInterfaceField extends BaseListField
+{
+    /**
+     * Iterate over all interfaces in the configuration and only exclude virtual interfaces.
+     */
+    public function actionPostLoadingEvent()
+    {
+        $config = Config::getInstance()->object();
+
+        foreach ($config->interfaces->children() as $key => $node) {
+            if (empty($node->virtual)) {
+                $this->internalOptionList[str_replace(".", "_", $node->if)] = !empty($node->descr) ? (string)$node->descr : strtoupper($key);
+            }
+        }
+
+        natcasesort($this->internalOptionList);
+    }
+}

--- a/net-mgmt/arp-ndp-logging/src/opnsense/mvc/app/models/OPNsense/ArpNdpLogging/General.php
+++ b/net-mgmt/arp-ndp-logging/src/opnsense/mvc/app/models/OPNsense/ArpNdpLogging/General.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * Copyright (C) 2025 github.com/mr-manuel
+ * All rights reserved.
+ *
+ * License: BSD 2-Clause
+ */
+
+namespace OPNsense\ArpNdpLogging;
+
+use OPNsense\Base\BaseModel;
+
+class General extends BaseModel
+{
+}

--- a/net-mgmt/arp-ndp-logging/src/opnsense/mvc/app/models/OPNsense/ArpNdpLogging/General.xml
+++ b/net-mgmt/arp-ndp-logging/src/opnsense/mvc/app/models/OPNsense/ArpNdpLogging/General.xml
@@ -1,0 +1,54 @@
+<model>
+    <mount>//OPNsense/arpndplogging/general</mount>
+    <description>ArpNdpLogging general configuration</description>
+    <version>0.0.1</version>
+    <items>
+        <enabled type="BooleanField">
+            <default>0</default>
+            <Required>Y</Required>
+        </enabled>
+        <protocols type="OptionField">
+            <Default>IPv4 and IPv6</Default>
+            <Required>Y</Required>
+            <OptionValues>
+                <opt1 value="all">IPv4 and IPv6</opt1>
+                <opt2 value="ipv4_only">IPv4 only</opt2>
+                <opt3 value="ipv6_only">IPv6 only</opt3>
+            </OptionValues>
+        </protocols>
+        <interfaces type=".\ArpNdpLoggingInterfaceField">
+            <Required>N</Required>
+            <Multiple>Y</Multiple>
+        </interfaces>
+        <suppress_mac type="CSVListField">
+            <Required>N</Required>
+            <Multiple>Y</Multiple>
+        </suppress_mac>
+        <log_new_entries type="BooleanField">
+            <default>1</default>
+        </log_new_entries>
+        <log_mac_changes type="BooleanField">
+            <default>1</default>
+        </log_mac_changes>
+        <log_ipv4_changes type="BooleanField">
+            <default>0</default>
+        </log_ipv4_changes>
+        <log_ipv6_changes type="BooleanField">
+            <default>0</default>
+        </log_ipv6_changes>
+        <log_hostname_changes type="BooleanField">
+            <default>0</default>
+        </log_hostname_changes>
+        <log_interface_changes type="BooleanField">
+            <default>0</default>
+        </log_interface_changes>
+        <retention_days type="IntegerField">
+            <Default>30</Default>
+            <Required>Y</Required>
+            <advanced>true</advanced>
+            <MinimumValue>1</MinimumValue>
+            <MaximumValue>365</MaximumValue>
+            <ValidationMessage>Retention needs to be an integer value between 1 and 365</ValidationMessage>
+        </retention_days>
+    </items>
+</model>

--- a/net-mgmt/arp-ndp-logging/src/opnsense/mvc/app/models/OPNsense/ArpNdpLogging/Menu/Menu.xml
+++ b/net-mgmt/arp-ndp-logging/src/opnsense/mvc/app/models/OPNsense/ArpNdpLogging/Menu/Menu.xml
@@ -1,0 +1,8 @@
+<menu>
+  <Services>
+    <ArpNdpLogging VisibleName="ARP/NDP Logging" cssClass="fa fa-eye fa-fw">
+      <General VisibleName="General" url="/ui/arpndplogging/general" />
+      <LogFile VisibleName="Log File" url="/ui/diagnostics/log/core/arpndplogging" />
+    </ArpNdpLogging>
+  </Services>
+</menu>

--- a/net-mgmt/arp-ndp-logging/src/opnsense/mvc/app/views/OPNsense/ArpNdpLogging/general.volt
+++ b/net-mgmt/arp-ndp-logging/src/opnsense/mvc/app/views/OPNsense/ArpNdpLogging/general.volt
@@ -1,0 +1,144 @@
+{#
+ # Copyright (c) 2025 github.com/mr-manuel
+ # All rights reserved.
+ #
+ # License: BSD 2-Clause
+ #}
+
+<div class="content-box" style="padding-bottom: 1.5em;">
+    {{ partial("layout_partials/base_form",['fields':generalForm,'id':'frm_general_settings'])}}
+    <table class="table-responsive table table-striped">
+        <tr>
+            <td>
+                <p>⚠️ Enabling this plugin will NOT automatically send mail notifications</p>
+                <p><a id="help_for_general.install" href="#" class="showhelp"><i class="fa fa-info-circle"></i></a> To get alerted by mail, you have to set up <a href="/ui/monit" target="_blank">Monit</a> with a Service and Service Test that monitors the <code>/var/log/arpndplogging.log</code> logfile.</p>
+                <p>Click <a id="help_for_general.install" href="#" class="showhelp">here</a> to display the mail alerting setup instructions at the end of this page.</p>
+                <p>Do you like this plugin? Consider to <a href="https://github.md0.eu/links/opnsense-arp-ndp-logging" target="_blank">make a donation</a>.</p>
+            </td>
+        </tr>
+    </table>
+    <div class="col-md-12">
+        <hr />
+        <button class="btn btn-primary" id="saveAct" type="button"><b>{{ lang._('Save') }}</b> <i id="saveAct_progress"></i></button>
+        <button class="btn pull-right" id="resetdbAct" type="button"><b>{{ lang._('Reset database') }}</b> <i id="resetdbAct_progress" class=""></i></button>
+    </div>
+    <div class="col-md-12 hidden" data-for="help_for_general.install">
+        <hr />
+        <h2>How to setup mail alerting</h2>
+        <ol>
+            <li>
+                <p>Go to <code>Services</code> -&gt; <code>Monit</code> -&gt; <code>Settings</code> and then to the <code>General Settings</code> tab. Make sure you enabled Monit and populated the mail fields.</p>
+            </li>
+            <li>
+                <p>Go to the <code>Alert Settings</code> tab. Make sure, you added an alert. If not add a new alert, fill out the fields and then save:</p>
+            <ul>
+            <li>
+                <p>Enable alert: ☑</p>
+            </li>
+            <li>
+                <p>Recipient: Insert the mail address where you want to receive the notifications</p>
+            </li>
+            <li>
+                <p>Not on: ☐</p>
+            </li>
+            <li>
+                <p>Events: <code>Nothing selected</code> or at least <code>Content failed</code></p>
+            </li>
+            <li>
+                <p>Mail format:</p>
+                <p>Copy the code below. Do not forget to replace <code>sender_mail_address@example.tld</code> with the mail from the account you set under <code>General Settings</code> -&gt; <code>Mail Server Username</code>.</p>
+<pre>
+from: sender_mail_address@example.tld
+subject: Monit alert -- $EVENT: $SERVICE
+message:
+$EVENT: $SERVICE
+
+# Host
+$HOST
+
+# Date
+$DATE
+
+# Action
+$ACTION
+
+# Description
+$DESCRIPTION
+</pre>
+            </li>
+            <li>
+                <p>Reminder: leave empty</p>
+            </li>
+            <li>
+                <p>Description: Not needed, but you can insert whatever you like</p>
+            </li>
+            </ul>
+            </li>
+            <li>
+                <p>Go to the <code>Service Tests Settings</code> tab. Add a new test, fill out the fields and then save:</p>
+                <ul>
+                    <li>Name: <code>ArpNdpLogging_common</code> or whatever you like</li>
+                    <li>Condition: <code>content = "detected"</code></li>
+                    <li>Action: <code>Alert</code></li>
+                </ul>
+            </li>
+            <li>
+                <p>Go to the <code>Service Settings</code> tab. Add a new service, fill out the fields and then save:</p>
+                <ul>
+                    <li>Enable service checks: ☑</li>
+                    <li>Name: <code>ArpNdpLogging_common</code> or whatever you like</li>
+                    <li>Type: <code>File</code></li>
+                    <li>Path: <code>/var/log/arpndplogging.log</code></li>
+                    <li>Start: leave empty</li>
+                    <li>Stop: leave empty</li>
+                    <li>Tests: Select <code>ArpNdpLogging_common</code> or whatever you inserted in step 2</li>
+                    <li>Depends: leave empty</li>
+                    <li>Description: Not needed, but you can insert whatever you like</li>
+                </ul>
+            </li>
+            <li>
+                <p>Test it by connecting a new device or by clicking on the <code>Reset database</code> button on this page.</p>
+            </li>
+        </ol>
+    </div>
+</div>
+
+<script>
+    $(function() {
+        var data_get_map = {'frm_general_settings':"/api/arpndplogging/general/get"};
+        mapDataToFormUI(data_get_map).done(function(data){
+            formatTokenizersUI();
+            $('.selectpicker').selectpicker('refresh');
+        });
+
+        updateServiceControlUI('arpndplogging');
+
+        $("#saveAct").click(function(){
+            saveFormToEndpoint(url="/api/arpndplogging/general/set", formid='frm_general_settings',callback_ok=function(){
+            $("#saveAct_progress").addClass("fa fa-spinner fa-pulse");
+                ajaxCall(url="/api/arpndplogging/service/reconfigure", sendData={}, callback=function(data,status) {
+                    updateServiceControlUI('arpndplogging');
+                    $("#saveAct_progress").removeClass("fa fa-spinner fa-pulse");
+                });
+            });
+        });
+
+        $("#resetdbAct").click(function () {
+            stdDialogConfirm(
+                '{{ lang._('Confirm database reset') }}',
+                '{{ lang._('Do you want to reset the database?') }}',
+                '{{ lang._('Yes') }}', '{{ lang._('Cancel') }}', function () {
+                    $("#resetdbAct_progress").addClass("fa fa-spinner fa-pulse");
+                    ajaxCall(url="/api/arpndplogging/service/stop", sendData={}, callback=function(data,status) {
+                        ajaxCall(url="/api/arpndplogging/service/resetdb", sendData={}, callback=function(data,status) {
+                            ajaxCall(url="/api/arpndplogging/service/start", sendData={}, callback=function(data,status) {
+                            updateServiceControlUI('arpndplogging');
+                            $("#resetdbAct_progress").removeClass("fa fa-spinner fa-pulse");
+                        });
+                    });
+                });
+            });
+        });
+
+    });
+</script>

--- a/net-mgmt/arp-ndp-logging/src/opnsense/service/conf/actions.d/actions_arpndplogging.conf
+++ b/net-mgmt/arp-ndp-logging/src/opnsense/service/conf/actions.d/actions_arpndplogging.conf
@@ -1,0 +1,29 @@
+[start]
+command:service arpndplogging start
+parameters:
+type:script
+message:starting ArpNdpLogging
+
+[stop]
+command:service arpndplogging stop
+parameters:
+type:script
+message:stopping ArpNdpLogging
+
+[restart]
+command:service arpndplogging restart
+parameters:
+type:script
+message:restarting ArpNdpLogging
+
+[status]
+command:service arpndplogging status;exit 0
+parameters:
+type:script_output
+message:request ArpNdpLogging status
+
+[resetdb]
+command:rm -f /var/db/arpndplogging/arpndplogging.db; echo "`date '+%Y-%m-%d_%H:%M:%S,000'`: database reset" >> /var/log/arpndplogging.log
+parameters:
+type:script
+message:reset database

--- a/net-mgmt/arp-ndp-logging/src/opnsense/service/templates/OPNsense/ArpNdpLogging/+TARGETS
+++ b/net-mgmt/arp-ndp-logging/src/opnsense/service/templates/OPNsense/ArpNdpLogging/+TARGETS
@@ -1,0 +1,2 @@
+arpndplogging:/etc/rc.conf.d/arpndplogging
+arpndplogging.conf:/usr/local/etc/arpndplogging.conf

--- a/net-mgmt/arp-ndp-logging/src/opnsense/service/templates/OPNsense/ArpNdpLogging/arpndplogging
+++ b/net-mgmt/arp-ndp-logging/src/opnsense/service/templates/OPNsense/ArpNdpLogging/arpndplogging
@@ -1,0 +1,5 @@
+{% if helpers.exists('OPNsense.arpndplogging.general.enabled') and OPNsense.arpndplogging.general.enabled == '1' %}
+arpndplogging_enable="YES"
+{% else %}
+arpndplogging_enable="NO"
+{% endif %}

--- a/net-mgmt/arp-ndp-logging/src/opnsense/service/templates/OPNsense/ArpNdpLogging/arpndplogging.conf
+++ b/net-mgmt/arp-ndp-logging/src/opnsense/service/templates/OPNsense/ArpNdpLogging/arpndplogging.conf
@@ -1,0 +1,18 @@
+{% if helpers.exists('OPNsense.arpndplogging.general.enabled') and OPNsense.arpndplogging.general.enabled == '1' %}
+{%   if helpers.exists('OPNsense.arpndplogging.general.protocols') and OPNsense.arpndplogging.general.protocols != '' %}
+protocols={{ OPNsense.arpndplogging.general.protocols }}
+{%   endif %}
+{%   if helpers.exists('OPNsense.arpndplogging.general.interfaces') and OPNsense.arpndplogging.general.interfaces != '' %}
+interfaces={{ OPNsense.arpndplogging.general.interfaces.replace(',', ' ') }}
+{%   endif %}
+{%   if helpers.exists('OPNsense.arpndplogging.general.suppress_mac') and OPNsense.arpndplogging.general.suppress_mac != '' %}
+suppress_mac={{ OPNsense.arpndplogging.general.suppress_mac.replace(',', ' ') }}
+{%   endif %}
+log_new_entries={{ OPNsense.arpndplogging.general.log_new_entries }}
+log_mac_changes={{ OPNsense.arpndplogging.general.log_mac_changes }}
+log_ipv4_changes={{ OPNsense.arpndplogging.general.log_ipv4_changes }}
+log_ipv6_changes={{ OPNsense.arpndplogging.general.log_ipv6_changes }}
+log_hostname_changes={{ OPNsense.arpndplogging.general.log_hostname_changes }}
+log_interface_changes={{ OPNsense.arpndplogging.general.log_interface_changes }}
+retention_days={{ OPNsense.arpndplogging.general.retention_days }}
+{% endif %}


### PR DESCRIPTION
Hello,

I wrote a new plugin that has similar features as arpwatch. I would like to share it with the community so that everyone can use it.

This is my first plugin and I still not fully understand how everything interacts with the OPNsense UI/API. Could you help me with a few questions?

1. How to troubleshoot API errors? When the GUI tries to call `https://192.168.133.1/api/opnarplog/service/stop` then it returns `{"response":"Error (127)"}`. Before I renamed my plugin everything worked. Now I'm clueless where the error could be. Same for `https://192.168.133.1/api/opnarplog/service/status` where I get `{"status":"unknown","widget":{"caption_stop":"stop service","caption_start":"start service","caption_restart":"restart service"}}`.
    **SOLVED:** I made a call to `/usr/local/bin/bash` which does not exist on a plain installation. It was replaced with a service call.

2. How does the logging work in OPNsense? Currently I'm writing to a logfile under `/var/log/opnarplog.log` and rotate it with my script. The logformat is not recognized, but somehow the logfile is recognized on the logpage.


To test the plugin :

1. Copy the content of the repository folder `net-mgmt/opnarplog/src` to the firewall folder `/usr/local`
2. Set the permission for two files:
    ```bash
    chmod 755 /usr/local/bin/openarplog.py
    chmod 755 /usr/local/etc/rc.d/opnarplog
    ```
3. Restart configd
    ```bash
    service configd restart
    ```
