### PR TITLE
www/caddy: Remove default route from layer4 since its obsolete

### DIFF
--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -94,8 +94,6 @@
                     import /usr/local/etc/caddy/caddy.d/*.layer4listener
                     {% set context_var = "listener_wrappers" %}
                     {% include "OPNsense/Caddy/includeLayer4" %}
-                    {# Empty Route that catches all other traffic #}
-                    route
                 }
                 {# Route all other traffic to HTTP App #}
                 tls


### PR DESCRIPTION
Why its not needed anymore: https://github.com/mholt/caddy-l4/pull/248#issuecomment-2400513639

It was also the main cause of this: https://github.com/mholt/caddy-l4/issues/250

Together with building with go1.23 (which has kyber support): https://github.com/opnsense/ports/pull/204
And updating the layer4 module to the main branch without the workaround patch: https://github.com/opnsense/tools/pull/440

The layer4 module is back on the main branch and can use the newer features and bugfixes again.
