### PR TITLE
security/acme-client: Add support for MyDNS.JP DNS API

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -936,6 +936,21 @@
         <help>MailinaBox Server FQDN</help>
     </field>
     <field>
+        <label>MyDNS.JP</label>
+        <type>header</type>
+        <style>table_dns table_dns_mydnsjp</style>
+    </field>
+    <field>
+        <id>validation.dns_mydnsjp_masterid</id>
+        <label>Master ID</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_mydnsjp_password</id>
+        <label>Password</label>
+        <type>password</type>
+    </field>
+    <field>
         <label>Mythic Beasts</label>
         <type>header</type>
         <style>table_dns table_dns_mythic_beasts</style>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsMydnsjp.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsMydnsjp.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright (C) 2024 Frank Wall
+ * Copyright (C) 2024 W516
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsMydnsjp.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsMydnsjp.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * Copyright (C) 2024 Frank Wall
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\AcmeClient\LeValidation;
+  
+use OPNsense\AcmeClient\LeValidationInterface;
+use OPNsense\Core\Config;
+  
+class DnsMydnsjp extends Base implements LeValidationInterface
+{
+    public function prepare()
+    {
+        $this->acme_env['MYDNSJP_MasterID'] = (string)$this->config->dns_mydnsjp_masterid;
+        $this->acme_env['MYDNSJP_Password'] = (string)$this->config->dns_mydnsjp_password;
+    }
+}
+

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -490,6 +490,7 @@
                         <dns_loopia>Loopia</dns_loopia>
                         <dns_lua>LuaDNS.com</dns_lua>
                         <dns_miab>MailinaBox</dns_miab>
+                        <dns_mydnsjp>MyDNS.JP</dns_mydnsjp>
                         <dns_mythic_beasts>Mythic Beasts</dns_mythic_beasts>
                         <dns_namecom>Name.com</dns_namecom>
                         <dns_namecheap>Namecheap</dns_namecheap>
@@ -906,6 +907,12 @@
                 <dns_me_secret type="TextField">
                     <Required>N</Required>
                 </dns_me_secret>
+                <dns_mydnsjp_masterid type="TextField">
+                    <Required>N</Required>
+                </dns_mydnsjp_masterid>
+                <dns_mydnsjp_password type="TextField">
+                    <Required>N</Required>
+                </dns_mydnsjp_password>
                 <dns_mythic_beasts_key type="TextField">
                     <Required>N</Required>
                 </dns_mythic_beasts_key>


### PR DESCRIPTION
MyDNS.JP is integrated in acme.sh. This PR adds support in the interface.

https://github.com/acmesh-official/acme.sh/wiki/dnsapi#dns_mydnsjp
