### PR TITLE
net/haproxy: Fix "not all arguments converted during string formatting" in cert_sync

### DIFF
--- a/net/haproxy/src/opnsense/service/conf/actions.d/actions_haproxy.conf
+++ b/net/haproxy/src/opnsense/service/conf/actions.d/actions_haproxy.conf
@@ -91,7 +91,7 @@ type:script_output
 message:Show diff between configured ssl certificates and certs from HAProxy memory for multiple frontends
 
 [cert_sync]
-command:configctl template reload OPNsense/HAProxy 2 > /dev/null; /usr/local/opnsense/scripts/OPNsense/HAProxy/syncCerts.py
+command:configctl -q template reload OPNsense/HAProxy; /usr/local/opnsense/scripts/OPNsense/HAProxy/syncCerts.py
 parameters: sync --frontend-ids %s --output json
 type:script_output
 message:Sync ssl certificates into HAProxy memory for multiple frontends
@@ -103,7 +103,7 @@ type:script_output
 message:Show diff between configured ssl certificates and certs from HAProxy memory for all frontends
 
 [cert_sync_bulk]
-command:configctl template reload OPNsense/HAProxy 2 > /dev/null; /usr/local/opnsense/scripts/OPNsense/HAProxy/syncCerts.py sync --output json
+command:configctl -q template reload OPNsense/HAProxy; /usr/local/opnsense/scripts/OPNsense/HAProxy/syncCerts.py sync --output json
 parameters:
 type:script_output
 message:Sync ssl certificates into HAProxy memory for all frontends


### PR DESCRIPTION
fix for opnsense/plugins#4035

Workaround for this ligering issue is simple and well described, but it seems that noone has created a PR yet. So here it is.