### PR TITLE
security/wazuh-agent: implement options to change server ports

### DIFF
--- a/security/wazuh-agent/src/opnsense/mvc/app/controllers/OPNsense/WazuhAgent/forms/settings.xml
+++ b/security/wazuh-agent/src/opnsense/mvc/app/controllers/OPNsense/WazuhAgent/forms/settings.xml
@@ -23,6 +23,13 @@
         <help>Specifies the transport protocol to use.</help>
     </field>
     <field>
+        <id>agent.general.port</id>
+        <label>Manager port</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>Specifies the port to use for communicating with the Wazuh manager.</help>
+    </field>
+    <field>
         <id>agent.logcollector.syslog_programs</id>
         <label>Applications</label>
         <type>select_multiple</type>
@@ -84,7 +91,7 @@
     </field>
     <field>
         <type>header</type>
-        <label>Authentication</label>
+        <label>Enrollment</label>
         <collapse>true</collapse>
     </field>
     <field>
@@ -92,6 +99,12 @@
         <label>Password</label>
         <type>password</type>
         <help>Password to use in authd.pass file.</help>
+    </field>
+    <field>
+        <id>agent.auth.port</id>
+        <label>Enrollment port</label>
+        <type>text</type>
+        <help>Specifies the port to use for communicating with the Wazuh manager during enrollment.</help>
     </field>
     <field>
         <type>header</type>

--- a/security/wazuh-agent/src/opnsense/mvc/app/models/OPNsense/WazuhAgent/WazuhAgent.xml
+++ b/security/wazuh-agent/src/opnsense/mvc/app/models/OPNsense/WazuhAgent/WazuhAgent.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/WazuhAgent</mount>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <description>
         Wazuh Agent
     </description>
@@ -22,6 +22,13 @@
                     <udp>UDP</udp>
                 </OptionValues>
             </protocol>
+            <port type="IntegerField">
+                <default>1514</default>
+                <Required>Y</Required>
+                <MinimumValue>1</MinimumValue>
+                <MaximumValue>65536</MaximumValue>
+                <ValidationMessage>This must be a valid port number.</ValidationMessage>
+            </port>
             <debug_level type="OptionField">
                 <default>0</default>
                 <Required>Y</Required>
@@ -35,6 +42,13 @@
         <auth>
             <password type="TextField">
             </password>
+            <port type="IntegerField">
+                <default>1515</default>
+                <Required>Y</Required>
+                <MinimumValue>1</MinimumValue>
+                <MaximumValue>65536</MaximumValue>
+                <ValidationMessage>This must be a valid port number.</ValidationMessage>
+            </port>
         </auth>
         <logcollector>
             <remote_commands type="BooleanField">

--- a/security/wazuh-agent/src/opnsense/service/templates/OPNsense/WazuhAgent/ossec.conf
+++ b/security/wazuh-agent/src/opnsense/service/templates/OPNsense/WazuhAgent/ossec.conf
@@ -3,8 +3,12 @@
     <server>
       <address>{{OPNsense.WazuhAgent.general.server_address}}</address>
       <protocol>{{OPNsense.WazuhAgent.general.protocol|default('tcp')}}</protocol>
+      <port>{{OPNsense.WazuhAgent.general.port|default('1514')}}</port>
     </server>
     <crypto_method>aes</crypto_method>
+    <enrollment>
+      <port>{{OPNsense.WazuhAgent.auth.port|default('1515')}}</port>
+    </enrollment>
   </client>
 
   <client_buffer>


### PR DESCRIPTION
closes: #4293

this pr adds options to configure the ports to use for sending events and for initial enrollment of the agent. defaults are 1514/1515, respectively, as wazuh uses these by default.
this also renames the header from "Authentication" to "Enrollment" as the `authd.pass` file is also only used for enrollment. i'm not sure whether it's possible to change the settings keys, so these have been left as `agent.auth.*`.

cc: @AdSchellevis 