### PR TITLE
net/ndproxy: Add ndproxy count

### DIFF
--- a/net/ndproxy/src/opnsense/mvc/app/controllers/OPNsense/Ndproxy/Api/GeneralController.php
+++ b/net/ndproxy/src/opnsense/mvc/app/controllers/OPNsense/Ndproxy/Api/GeneralController.php
@@ -32,9 +32,15 @@ namespace OPNsense\Ndproxy\Api;
 
 use OPNsense\Base\ApiMutableModelControllerBase;
 use OPNsense\Core\Config;
+use OPNsense\Core\Backend;
 
 class GeneralController extends ApiMutableModelControllerBase
 {
     protected static $internalModelName = 'ndproxy';
     protected static $internalModelClass = 'OPNsense\Ndproxy\Ndproxy';
+
+    public function countAction()
+    {
+        return json_decode((new Backend())->configdRun('ndproxy count'), true);
+    }
 }

--- a/net/ndproxy/src/opnsense/mvc/app/views/OPNsense/Ndproxy/general.volt
+++ b/net/ndproxy/src/opnsense/mvc/app/views/OPNsense/Ndproxy/general.volt
@@ -49,13 +49,37 @@
             }
         });
 
+        function updateNdproxyCount() {
+            ajaxCall("/api/ndproxy/general/count", {}, function(data) {
+                if (data && data.ndproxycount !== undefined) {
+                    $("#ndproxyCount").text(data.ndproxycount);
+                }
+            });
+        }
+
+        $("#refreshCountBtn").on("click", function() {
+            updateNdproxyCount();
+        });
+
         updateServiceControlUI('ndproxy');
+        updateNdproxyCount();
     });
 </script>
 
 <section class="page-content-main">
     <div class="content-box">
         {{ partial("layout_partials/base_form", ['fields': generalForm, 'id': 'frm_GeneralSettings']) }}
+    </div>
+    <br/>
+    <div class="content-box">
+        <div class="col-md-12" id="ndproxyCountBox" style="display: flex; align-items: center; gap: 10px;">
+            <strong>net.inet6.ndproxycount:</strong>
+            <span id="ndproxyCount">0</span>
+            <button class="btn btn-default btn-sm" id="refreshCountBtn" aria-label="{{ lang._('Refresh') }}"
+                    style="margin-top: 10px; margin-bottom: 10px;">
+                <i class="fa fa-refresh fa-fw"></i>
+            </button>
+        </div>
     </div>
     <br/>
     <div class="content-box">

--- a/net/ndproxy/src/opnsense/scripts/OPNsense/Ndproxy/ndproxy_statistics.py
+++ b/net/ndproxy/src/opnsense/scripts/OPNsense/Ndproxy/ndproxy_statistics.py
@@ -1,0 +1,44 @@
+#!/usr/local/bin/python3
+
+"""
+    Copyright (c) 2024 Cedrik Pischem
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+"""
+
+import json
+import subprocess
+
+try:
+    result = subprocess.run(
+        ["sysctl", "net.inet6.ndproxycount"],
+        capture_output=True,
+        text=True,
+        check=True
+    )
+    ndproxycount = result.stdout.split(":", 1)[1].strip()
+
+except subprocess.CalledProcessError:
+    ndproxycount = "0"
+
+print(json.dumps({"ndproxycount": ndproxycount}))

--- a/net/ndproxy/src/opnsense/service/conf/actions.d/actions_ndproxy.conf
+++ b/net/ndproxy/src/opnsense/service/conf/actions.d/actions_ndproxy.conf
@@ -22,3 +22,9 @@ command:/usr/local/sbin/pluginctl -s ndproxy status
 parameters:
 type:script_output
 message:Request ndproxy status
+
+[count]
+command:/usr/local/opnsense/scripts/OPNsense/Ndproxy/ndproxy_statistics.py
+parameters:
+type:script_output
+message:Request ndproxy count


### PR DESCRIPTION
While troubleshooting I hammered `sysctl net.inet6.ndproxycount` in the shell relentlessly.

It is the only number that shows your configuration is correct and that something indeed happens. Having it exposed in the GUI is valuable.

![image](https://github.com/user-attachments/assets/35beb4e4-d47d-437e-aefa-e7aaa9190211)
