### PR TITLE
www/caddy: Add TLS termination to Layer4 Proxy

### DIFF
--- a/www/caddy/Makefile
+++ b/www/caddy/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		caddy
-PLUGIN_VERSION=		1.7.4
+PLUGIN_VERSION=		1.7.5
 PLUGIN_DEPENDS=		caddy-custom
 PLUGIN_COMMENT=		Modern Reverse Proxy with Automatic HTTPS, Dynamic DNS and Layer4 Routing
 PLUGIN_MAINTAINER=	cedrik@pischem.com

--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -13,6 +13,10 @@ DOC: https://docs.opnsense.org/manual/how-tos/caddy.html
 Plugin Changelog
 ================
 
+1.7.5
+
+* Add: Layer4 TLS Termination
+
 1.7.4
 
 * Add: Layer4 OpenVPN matcher with mode, digest and static key support

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogLayer4.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogLayer4.xml
@@ -67,6 +67,14 @@
         <help><![CDATA[Enter one or multiple domains to route via SNI or Host Header. Wildcard domains and host wildcards are allowed, e.g. "*.example.com" and "*".]]></help>
     </field>
     <field>
+        <id>layer4.TerminateTls</id>
+        <label>Terminate TLS</label>
+        <type>checkbox</type>
+        <style>style_matchers matchers_domain</style>
+        <help><![CDATA[Terminate TLS before routing to the upstream. Since this requires a certificate, ensure there is a domain configured in "Reverse Proxy" that matches the SNI of "Domain"; it will be automatically matched for this route.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
         <id>layer4.FromOpenvpnModes</id>
         <label>OpenVPN Mode</label>
         <type>dropdown</type>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogLayer4.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogLayer4.xml
@@ -20,33 +20,28 @@
     <field>
         <type>header</type>
         <label>Type</label>
-        <advanced>true</advanced>
     </field>
     <field>
         <id>layer4.Type</id>
         <label>Routing Type</label>
         <type>dropdown</type>
         <help><![CDATA[Choose either "listener_wrappers" for multiplexing protocols on the default HTTP and HTTPS ports on OSI Layer 7, or "global" for raw TCP/UDP traffic routing on a custom "Local port" on OSI Layer 4 with optional OSI Layer 7 protocol matching.]]></help>
-        <advanced>true</advanced>
     </field>
     <field>
         <type>header</type>
         <label>Layer 4</label>
-        <advanced>true</advanced>
     </field>
     <field>
         <id>layer4.Protocol</id>
         <label>Protocol</label>
         <type>dropdown</type>
         <help><![CDATA[Match the received traffic on OSI Layer 4, either TCP or UDP. When "Routing Type" is "listener_wrappers", currently only TCP will match.]]></help>
-        <advanced>true</advanced>
     </field>
     <field>
         <id>layer4.FromPort</id>
         <label>Local Port</label>
         <type>text</type>
         <help><![CDATA[Choose a custom local port to listen on.]]></help>
-        <advanced>true</advanced>
     </field>
     <field>
         <type>header</type>
@@ -65,14 +60,6 @@
         <style>style_matchers tokenize matchers_domain</style>
         <allownew>true</allownew>
         <help><![CDATA[Enter one or multiple domains to route via SNI or Host Header. Wildcard domains and host wildcards are allowed, e.g. "*.example.com" and "*".]]></help>
-    </field>
-    <field>
-        <id>layer4.TerminateTls</id>
-        <label>Terminate TLS</label>
-        <type>checkbox</type>
-        <style>style_matchers matchers_domain</style>
-        <help><![CDATA[Terminate TLS before routing to the upstream. Since this requires a certificate, ensure there is a domain configured in "Reverse Proxy" that matches the SNI of "Domain"; it will be automatically matched for this route.]]></help>
-        <advanced>true</advanced>
     </field>
     <field>
         <id>layer4.FromOpenvpnModes</id>
@@ -96,6 +83,13 @@
         <type>checkbox</type>
         <help><![CDATA[Invert the sense of the matcher. E.g., if the protocol is TLS, inverting will match all traffic that is not TLS. When domains have been chosen, these will be equally inverted.]]></help>
         <advanced>true</advanced>
+    </field>
+    <field>
+        <id>layer4.TerminateTls</id>
+        <label>Terminate TLS</label>
+        <type>checkbox</type>
+        <style>style_matchers matchers_domain</style>
+        <help><![CDATA[Terminate TLS before routing to the upstream. Since this requires a certificate, ensure there is a domain configured in "Reverse Proxy" that matches the SNI of "Domain"; it will be automatically matched for this route.]]></help>
     </field>
     <field>
         <type>header</type>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
@@ -208,6 +208,18 @@ class Caddy extends BaseModel
                     ));
                 }
 
+                if (!in_array((string)$item->Matchers, ['tlssni', 'quicsni']) && !empty((string)$item->TerminateTls)) {
+                    $messages->appendMessage(new Message(
+                        sprintf(
+                            gettext(
+                                'When "%s" matcher is selected, TLS can not be terminated.'
+                            ),
+                            $item->Matchers
+                        ),
+                        $key . ".TerminateTls"
+                    ));
+                }
+
                 if ((string)$item->Matchers !== 'openvpn' && !empty((string)$item->FromOpenvpnModes)) {
                     $messages->appendMessage(new Message(
                         sprintf(

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -543,6 +543,7 @@
                     <AsList>Y</AsList>
                     <ValidationMessage>Please enter one or multiple valid IP addresses, hostnames or FQDNs.</ValidationMessage>
                 </ToDomain>
+                <TerminateTls type="BooleanField"/>
                 <ToPort type="PortField">
                     <Required>Y</Required>
                 </ToPort>

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/includeLayer4
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/includeLayer4
@@ -23,6 +23,9 @@
 {% set layer4_configs = unsorted_layer4_configs | sort(attribute='Sequence') %}
 
 {% macro define_proxy(layer4, to_domains, to_port, fail_duration, proxy_protocol) %}
+    {% if layer4.TerminateTls and layer4.TerminateTls == "1" %}
+    tls
+    {% endif %}
     proxy {% for domain in to_domains.split(',') %}
         {% set is_ipv6 = (':' in domain) %}
         {{ layer4.Protocol }}/{{ '[' if is_ipv6 }}{{ domain }}{{ ']' if is_ipv6 }}:{{ to_port }}{% if not loop.last %} {% endif %}


### PR DESCRIPTION
A small feature I forgot to add to the Layer4 Proxy.

Allows using the same certificate from the Reverse Proxy also for Layer4 routes that use TLS, terminating it.

The example below should be self explanatory. It terminates TLS of secured mail ports, and sends the unencrypted traffic to a plain mail protocol port. At the same time, the Reverse Proxy secures e.g. a webmailer on the same domain name.

```
# Global Options
{
	layer4 {
		tcp/:993 {
			@imaps tls sni mail.example.com
			route @imaps {
				tls
				proxy tcp/192.168.1.1:143 {
				}
			}
		}
		tcp/:995 {
			@pop3s tls sni mail.example.com
			route @pop3s {
				tls
				proxy tcp/192.168.1.1:110 {
				}
			}
		}
                	tcp/:465 {
			@smtps tls sni mail.example.com
			route @smtps {
				tls
				proxy tcp/192.168.1.1:587 {
				}
			}
		}
	}
}

# Reverse Proxy Domain: "49a9aea3-13be-4c1e-9ef3-76d805614a02"
mail.example.com:443 {
	handle {
		reverse_proxy 192.168.1.1:80 {
		}
	}
}
```