### PR TITLE
www/caddy: Add h2c protocol to handler

### DIFF
--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -356,6 +356,7 @@
                     <OptionValues>
                         <http value="0">http://</http>
                         <https value="1">https://</https>
+                        <h2c value="2">h2c://</h2c>
                     </OptionValues>
                     <Constraints>
                         <check001>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -248,6 +248,7 @@
             }
         });
 
+        // Hide TLS specific options when http or h2c is selected
         $("#handle\\.HttpTls").change(function() {
             if ($(this).val() != "1") {
                 $(".style_tls").closest('tr').hide();
@@ -266,6 +267,7 @@
             }
         });
 
+        // Hide TLS specific options when http is selected
         $("#reverse\\.DisableTls").change(function() {
             if ($(this).val() === "1") {
                 $(".style_tls").closest('tr').hide();

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -249,7 +249,7 @@
         });
 
         $("#handle\\.HttpTls").change(function() {
-            if ($(this).val() === "0") {
+            if ($(this).val() != "1") {
                 $(".style_tls").closest('tr').hide();
             } else {
                 $(".style_tls").closest('tr').show();

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -392,6 +392,7 @@ http://{{ domain }} {
 {% macro reverse_proxy_configuration(handle) %}
     {{ handle.HandleType }} {{ handle.HandlePath|default("") }} {
         {{ handle_accesslist(handle.accesslist) }}
+        {# All IPs not matched by accesslist will continue processing #}
         {% if handle.ForwardAuth|default("0") == "1" %}
             {% include "OPNsense/Caddy/includeAuthProvider" %}
         {% endif %}
@@ -451,8 +452,7 @@ http://{{ domain }} {
                 }
             {% endif %}
         }
-        {% endif %}
-        {% if handle.HandleDirective == "redir" %}
+        {% elif handle.HandleDirective == "redir" %}
             {{ handle.HandleDirective }} {{ formatted_domains[0] }}{{ handle.ToPath|default("{uri}") }}
         {% endif %}
     }

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -392,25 +392,34 @@ http://{{ domain }} {
 {% macro reverse_proxy_configuration(handle) %}
     {{ handle.HandleType }} {{ handle.HandlePath|default("") }} {
         {{ handle_accesslist(handle.accesslist) }}
-        {# All IPs not matched by accesslist will continue processing #}
         {% if handle.ForwardAuth|default("0") == "1" %}
             {% include "OPNsense/Caddy/includeAuthProvider" %}
         {% endif %}
         {% if handle.HandleDirective == "reverse_proxy" and handle.ToPath|default("") != "" %}
             rewrite * {{ handle.ToPath }}{uri}
         {% endif %}
+        {# http:// is the empty default #}
+        {% set protocol = 'https://' if handle.HttpTls == "1" else 'h2c://' if handle.HttpTls == "2" else '' -%}
+        {% set formatted_domains = [] -%}
+        {% for domain in handle.ToDomain.split(',') -%}
+            {% set is_ipv6 = (':' in domain and domain.count(':') >= 2) -%}
+            {% set formatted_domain =
+                ( '[' ~ domain ~ ']' if is_ipv6 else domain ) ~
+                ( ':' ~ handle.ToPort if handle.ToPort else '' ) -%}
+            {% set _ = formatted_domains.append(protocol ~ formatted_domain) -%}
+        {% endfor -%}
         {% if handle.HandleDirective == "reverse_proxy" %}
-        {{ handle.HandleDirective }} {% for domain in handle.ToDomain.split(',') %}
-            {# Check if the domain is IPv6 and wrap in square brackets if necessary #}
-            {% set is_ipv6 = (':' in domain and domain.count(':') >= 2) %}
-            {# For each domain/IP, append the port if it's specified, followed by a space #}
-            {{- '[' if is_ipv6 else '' -}}{{ domain }}{{ ']' if is_ipv6 else '' -}}{% if handle.ToPort %}:{{ handle.ToPort }}{% endif %}{% if not loop.last %} {% endif %}
-        {% endfor %} {
+        {{ handle.HandleDirective }} {{ formatted_domains | join(' ') }} {
             {{ header_manipulation(handle) }}
             {% if handle.PassiveHealthFailDuration|default("") %}
                 fail_duration {{ handle.PassiveHealthFailDuration }}s
             {% endif %}
-            {% set has_transport_options = handle.HttpVersion or handle.HttpKeepalive or handle.HttpTls|default("0") == "1" or handle.HttpTlsInsecureSkipVerify|default("0") == "1" or handle.HttpTlsTrustedCaCerts or handle.HttpTlsServerName %}
+            {% set has_transport_options =
+                handle.HttpVersion or
+                handle.HttpKeepalive or
+                handle.HttpTlsInsecureSkipVerify|default("0") == "1" or
+                handle.HttpTlsTrustedCaCerts or
+                handle.HttpTlsServerName -%}
             {% if has_transport_options %}
                 {% if handle.HttpNtlm|default("0") == "1" %}
                 transport http_ntlm {
@@ -428,32 +437,23 @@ http://{{ domain }} {
                             keepalive {{ handle.HttpKeepalive }}s
                         {% endif %}
                     {% endif %}
-                    {% if handle.HttpTls|default("0") == "1" %}
-                        tls
-                    {% endif %}
-                    {% if handle.HttpTlsInsecureSkipVerify|default("0") == "1" %}
-                        tls_insecure_skip_verify
-                    {% endif %}
-                    {% if handle.HttpTlsTrustedCaCerts %}
-                        tls_trust_pool file /var/db/caddy/data/caddy/certificates/temp/{{ handle.HttpTlsTrustedCaCerts }}.pem
-                    {% endif %}
-                    {% if handle.HttpTlsServerName %}
-                        tls_server_name {{ handle.HttpTlsServerName }}
+                    {% if handle.HttpTls == "1" %}
+                        {% if handle.HttpTlsInsecureSkipVerify|default("0") == "1" %}
+                            tls_insecure_skip_verify
+                        {% endif %}
+                        {% if handle.HttpTlsTrustedCaCerts %}
+                            tls_trust_pool file /var/db/caddy/data/caddy/certificates/temp/{{ handle.HttpTlsTrustedCaCerts }}.pem
+                        {% endif %}
+                        {% if handle.HttpTlsServerName %}
+                            tls_server_name {{ handle.HttpTlsServerName }}
+                        {% endif %}
                     {% endif %}
                 }
             {% endif %}
         }
-        {% else %}
-            {% set protocol = 'https://' if handle.HttpTls == "1" else 'http://' %}
-            {% set domain = handle.ToDomain.split(',')[0] %}
-            {% set is_ipv6 = (':' in domain and domain.count(':') >= 2) %}
-            {% set formatted_domain = ('[' ~ domain ~ ']') if is_ipv6 else domain %}
-            {% if handle.ToPort %}
-                {% set domain_with_port = formatted_domain ~ ':' ~ handle.ToPort %}
-            {% else %}
-                {% set domain_with_port = formatted_domain %}
-            {% endif %}
-            {{ handle.HandleDirective }} {{ protocol }}{{ domain_with_port }}{{ handle.ToPath|default("{uri}") }}
+        {% endif %}
+        {% if handle.HandleDirective == "redir" %}
+            {{ handle.HandleDirective }} {{ formatted_domains[0] }}{{ handle.ToPath|default("{uri}") }}
         {% endif %}
     }
 {% endmacro %}


### PR DESCRIPTION
Fixes: https://github.com/opnsense/plugins/issues/4368

This got a bit more spicy than expected since I had to deduplicate, change and cleanup some logic in the template.

I handled `http://` and `https://` indirectly before by adding `tls`. Now its added as protocol in front of each domain:port (except http which is the default).

To prevent options that are incompatible to be rendered inside the `transport_http` block its logic was changed too.

To make `reverse_proxy` and `redir` the same, the logic for setting the domains has been centralized.