### PR TITLE
backup: Fix git backup branch handling for non-master branches

### DIFF
--- a/sysutils/git-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Git.php
+++ b/sysutils/git-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Git.php
@@ -137,6 +137,7 @@ class Git extends Base implements IBackupProvider
         }
         if (!is_dir('{$targetdir}/.git')) {
             exec("{$git} init {$targetdir}");
+            exec("cd {$targetdir} && {$git} checkout -b {$mdl->branch}");
         }
         // XXX: since our git backup is plain text and already contains the private key, it doesn't really matter
         //      to keep the same key in the git directory (we're not going to push it)
@@ -162,7 +163,7 @@ class Git extends Base implements IBackupProvider
         exec("cd {$targetdir} && {$git} remote remove origin");
         exec("cd {$targetdir} && {$git} remote add origin " . escapeshellarg($url));
         $pushtxt = shell_exec(
-            "(cd {$targetdir} && {$git} push origin " . escapeshellarg("master:{$mdl->branch}") .
+            "(cd {$targetdir} && {$git} push origin " . escapeshellarg("{$mdl->branch}:{$mdl->branch}") .
             " && echo '__exit_ok__') 2>&1"
         );
         if (strpos($pushtxt, '__exit_ok__')) {


### PR DESCRIPTION
The current git backup functionality assumes a 'master' branch when pushing changes, which caused issues when using different branch names (like 'main'). This PR fixes two issues:

1. Creates the configured branch on git init instead of relying on default `master`
2. Uses the configured branch name for both source and destination in push command

These changes allow users to properly use any branch name in their git backup configuration without needing manual workarounds.

Testing:
- Tested with new repository using 'main' branch
- Tested with unique repository names such as `test` and `potato`
- Confirmed backup works without manual branch creation
- Verified push command uses correct branch names


Fixes opnsense/plugins#4143