### PR TITLE
www/caddy: Add Load Balancing options to Reverse Proxy and Layer4 Proxy

### DIFF
--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -15,6 +15,7 @@ Plugin Changelog
 
 1.7.5
 
+* Add: Load Balancing options to Layer 4 Proxy and HTTP Handle
 * Add: Layer4 TLS Termination
 * Add: h2c protocol to HTTP Handler
 * Cleanup: Refactor caddy_certs.php to Trust model

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -170,15 +170,6 @@
         <advanced>true</advanced>
     </field>
     <field>
-        <id>handle.PassiveHealthFailDuration</id>
-        <label>Upstream Fail Duration (s)</label>
-        <type>text</type>
-        <style>style_reverse_proxy</style>
-        <hint>off</hint>
-        <help><![CDATA[fail_duration enables a passive health check when multiple destinations in "Upstream Domain" are set. It is a value that defines how long to remember a failed request. A duration of 1 or more seconds enables passive health checking. A reasonable starting point might be 30s to balance error rates with responsiveness when bringing an unhealthy upstream back online.]]></help>
-        <advanced>true</advanced>
-    </field>
-    <field>
         <id>handle.lb_policy</id>
         <label>Load Balance Policy</label>
         <type>dropdown</type>
@@ -211,6 +202,51 @@
         <style>style_reverse_proxy</style>
         <hint>250</hint>
         <help><![CDATA[lb_try_interval is a duration value that defines how long to wait between selecting the next host from the pool. Only relevant when a request to an upstream host fails. Be aware that setting this to 0 with a non-zero lb_try_duration can cause the CPU to spin if all backends are down and latency is very low.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>handle.PassiveHealthFailDuration</id>
+        <label>Passive Health Fail Duration (s)</label>
+        <type>text</type>
+        <style>style_reverse_proxy</style>
+        <hint>off</hint>
+        <help><![CDATA[fail_duration enables a passive health check when multiple destinations in "Upstream Domain" are set. It is a value that defines how long to remember a failed request. A duration of 1 or more seconds enables passive health checking. A reasonable starting point might be 30s to balance error rates with responsiveness when bringing an unhealthy upstream back online.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>handle.PassiveHealthMaxFails</id>
+        <label>Passive Health Max Fails</label>
+        <type>text</type>
+        <style>style_reverse_proxy</style>
+        <hint>1</hint>
+        <help><![CDATA[max_fails is the maximum number of failed requests within fail_duration that are needed before considering an upstream to be down.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>handle.PassiveHealthUnhealthyStatus</id>
+        <label>Passive Health Unhealthy Status</label>
+        <type>text</type>
+        <style>style_reverse_proxy</style>
+        <hint>off</hint>
+        <help><![CDATA[unhealthy_status counts a request as failed if the response comes back with one of these status codes. Can be a 3-digit status code or a status code class ending in xx, for example: 404 or 5xx.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>handle.PassiveHealthUnhealthyLatency</id>
+        <label>Passive Health Unhealthy Latency (ms)</label>
+        <type>text</type>
+        <style>style_reverse_proxy</style>
+        <hint>off</hint>
+        <help><![CDATA[unhealthy_latency is a duration value in ms that counts a request as failed if it takes this long to get a response.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>handle.PassiveHealthUnhealthyRequestCount</id>
+        <label>Passive Health Unhealthy Request Count</label>
+        <type>text</type>
+        <style>style_reverse_proxy</style>
+        <hint>off</hint>
+        <help><![CDATA[unhealthy_request_count is the permissible number of simultaneous requests to a backend before marking it as down. In other words, if a particular backend is currently handling this many requests, then it is considered "overloaded" and other backends will be preferred instead. This should be a reasonably large number; configuring this means that the proxy will have a limit of unhealthy_request_count × upstreams_count total simultaneous requests, and any requests after that point will result in an error due to no upstreams being available.]]></help>
         <advanced>true</advanced>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -137,14 +137,6 @@
         <advanced>true</advanced>
     </field>
     <field>
-        <id>handle.PassiveHealthFailDuration</id>
-        <label>Upstream Fail Duration</label>
-        <type>text</type>
-        <style>style_reverse_proxy</style>
-        <help><![CDATA[Enables a passive health check when multiple destinations in "Upstream Domain" are set. "Fail Duration" is a value that defines how long to remember a failed request. A duration of 1 or more seconds enables passive health checking; the default is empty (off). A reasonable starting point might be 30s to balance error rates with responsiveness when bringing an unhealthy upstream back online.]]></help>
-        <advanced>true</advanced>
-    </field>
-    <field>
         <id>handle.HttpTlsInsecureSkipVerify</id>
         <label>TLS Insecure Skip Verify</label>
         <type>checkbox</type>
@@ -171,5 +163,54 @@
         <type>checkbox</type>
         <style>style_tls style_reverse_proxy</style>
         <help><![CDATA[Enable or disable NTLM. Needed to reverse proxy an Exchange Server. Warning: NTLM has been deprecated by Microsoft. This option will stay for as long as the optional http.reverse_proxy.transport.http_ntlm module can be compiled without errors.]]></help>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Load Balancing</label>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>handle.PassiveHealthFailDuration</id>
+        <label>Upstream Fail Duration (s)</label>
+        <type>text</type>
+        <style>style_reverse_proxy</style>
+        <hint>off</hint>
+        <help><![CDATA[fail_duration enables a passive health check when multiple destinations in "Upstream Domain" are set. It is a value that defines how long to remember a failed request. A duration of 1 or more seconds enables passive health checking. A reasonable starting point might be 30s to balance error rates with responsiveness when bringing an unhealthy upstream back online.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>handle.lb_policy</id>
+        <label>Load Balance Policy</label>
+        <type>dropdown</type>
+        <style>style_reverse_proxy</style>
+        <help><![CDATA[lb_policy is the name of the load balancing policy, along with any options. For policies that involve hashing, the highest-random-weight (HRW) algorithm is used to ensure that a client or request with the same hash key is mapped to the same upstream, even if the list of upstreams change.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>handle.lb_retries</id>
+        <label>Load Balance Retries</label>
+        <type>text</type>
+        <style>style_reverse_proxy</style>
+        <hint>off</hint>
+        <help><![CDATA[lb_retries is how many times to retry selecting available backends for each request if the next available host is down. If lb_try_duration is also configured, then retries may stop early if the duration is reached. In other words, the retry duration takes precedence over the retry count.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>handle.lb_try_duration</id>
+        <label>Load Balance Try Duration (s)</label>
+        <type>text</type>
+        <style>style_reverse_proxy</style>
+        <hint>0 </hint>
+        <help><![CDATA[lb_try_duration is a duration value that defines how long to try selecting available backends for each request if the next available host is down. Clients will wait for up to this long while the load balancer tries to find an available upstream host. A reasonable starting point might be 5s since the HTTP transport's default dial timeout is 3s, so that should allow for at least one retry if the first selected upstream cannot be reached.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>handle.lb_try_interval</id>
+        <label>Load Balance Try Interval (ms)</label>
+        <type>text</type>
+        <style>style_reverse_proxy</style>
+        <hint>250</hint>
+        <help><![CDATA[lb_try_interval is a duration value that defines how long to wait between selecting the next host from the pool. Only relevant when a request to an upstream host fails. Be aware that setting this to 0 with a non-zero lb_try_duration can cause the CPU to spin if all backends are down and latency is very low.]]></help>
+        <advanced>true</advanced>
     </field>
 </form>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -191,7 +191,7 @@
         <label>Load Balance Try Duration (s)</label>
         <type>text</type>
         <style>style_reverse_proxy</style>
-        <hint>0 </hint>
+        <hint>0</hint>
         <help><![CDATA[lb_try_duration is a duration value that defines how long to try selecting available backends for each request if the next available host is down. Clients will wait for up to this long while the load balancer tries to find an available upstream host. A reasonable starting point might be 5s since the HTTP transport's default dial timeout is 3s, so that should allow for at least one retry if the first selected upstream cannot be reached.]]></help>
         <advanced>true</advanced>
     </field>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogLayer4.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogLayer4.xml
@@ -120,18 +120,29 @@
         <advanced>true</advanced>
     </field>
     <field>
-        <id>layer4.PassiveHealthFailDuration</id>
-        <label>Upstream Fail Duration (s)</label>
-        <type>text</type>
-        <hint>off</hint>
-        <help><![CDATA[fail_duration enables a passive health check when multiple destinations in "Upstream Domain" are set. It is a value that defines how long to remember a failed request. A duration of 1 or more seconds enables passive health checking; the default is empty (off). A reasonable starting point might be 30s to balance error rates with responsiveness when bringing an unhealthy upstream back online.]]></help>
-        <advanced>true</advanced>
-    </field>
-    <field>
         <id>layer4.lb_policy</id>
         <label>Load Balance Policy</label>
         <type>dropdown</type>
+        <style>style_reverse_proxy</style>
         <help><![CDATA[lb_policy is the name of the load balancing policy, along with any options. For policies that involve hashing, the highest-random-weight (HRW) algorithm is used to ensure that a client or request with the same hash key is mapped to the same upstream, even if the list of upstreams change.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>layer4.PassiveHealthFailDuration</id>
+        <label>Passive Health Fail Duration (s)</label>
+        <type>text</type>
+        <style>style_reverse_proxy</style>
+        <hint>off</hint>
+        <help><![CDATA[fail_duration enables a passive health check when multiple destinations in "Upstream Domain" are set. It is a value that defines how long to remember a failed request. A duration of 1 or more seconds enables passive health checking. A reasonable starting point might be 30s to balance error rates with responsiveness when bringing an unhealthy upstream back online.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>layer4.PassiveHealthMaxFails</id>
+        <label>Passive Health Max Fails</label>
+        <type>text</type>
+        <style>style_reverse_proxy</style>
+        <hint>1</hint>
+        <help><![CDATA[max_fails is the maximum number of failed requests within fail_duration that are needed before considering an upstream to be down.]]></help>
         <advanced>true</advanced>
     </field>
     <field>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogLayer4.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogLayer4.xml
@@ -108,17 +108,30 @@
         <help><![CDATA[Choose a custom port for the upstream destination.]]></help>
     </field>
     <field>
-        <id>layer4.PassiveHealthFailDuration</id>
-        <label>Upstream Fail Duration</label>
-        <type>text</type>
-        <help><![CDATA[Enables a passive health check when multiple destinations in "Upstream Domain" are set. "Fail Duration" is a value that defines how long to remember a failed request. A duration of 1 or more seconds enables passive health checking; the default is empty (off). A reasonable starting point might be 30s to balance error rates with responsiveness when bringing an unhealthy upstream back online.]]></help>
-        <advanced>true</advanced>
-    </field>
-    <field>
         <id>layer4.ProxyProtocol</id>
         <label>Proxy Protocol</label>
         <type>dropdown</type>
         <help><![CDATA[Add the HA Proxy Protocol header. Either version 1 or 2 can be chosen. The default is off, since it is only needed when the upstream can use the Proxy Protocol header.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Load Balancing</label>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>layer4.PassiveHealthFailDuration</id>
+        <label>Upstream Fail Duration (s)</label>
+        <type>text</type>
+        <hint>off</hint>
+        <help><![CDATA[fail_duration enables a passive health check when multiple destinations in "Upstream Domain" are set. It is a value that defines how long to remember a failed request. A duration of 1 or more seconds enables passive health checking; the default is empty (off). A reasonable starting point might be 30s to balance error rates with responsiveness when bringing an unhealthy upstream back online.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>layer4.lb_policy</id>
+        <label>Load Balance Policy</label>
+        <type>dropdown</type>
+        <help><![CDATA[lb_policy is the name of the load balancing policy, along with any options. For policies that involve hashing, the highest-random-weight (HRW) algorithm is used to ensure that a client or request with the same hash key is mapped to the same upstream, even if the list of upstreams change.]]></help>
         <advanced>true</advanced>
     </field>
     <field>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -387,10 +387,6 @@
                     <Type>ca</Type>
                 </HttpTlsTrustedCaCerts>
                 <HttpTlsServerName type="HostnameField"/>
-                <PassiveHealthFailDuration type="IntegerField">
-                    <MinimumValue>1</MinimumValue>
-                    <ValidationMessage>Please enter a minimum value of 1 or leave empty for defaults.</ValidationMessage>
-                </PassiveHealthFailDuration>
                 <lb_policy type="OptionField">
                     <BlankDesc>random</BlankDesc>
                     <OptionValues>
@@ -411,6 +407,26 @@
                     <ValidationMessage>Please enter a minimum value of 1 or leave empty for defaults.</ValidationMessage>
                 </lb_try_duration>
                 <lb_try_interval type="IntegerField"/>
+                <PassiveHealthFailDuration type="IntegerField">
+                    <MinimumValue>1</MinimumValue>
+                    <ValidationMessage>Please enter a minimum value of 1 or leave empty for defaults.</ValidationMessage>
+                </PassiveHealthFailDuration>
+                <PassiveHealthMaxFails type="IntegerField">
+                    <MinimumValue>2</MinimumValue>
+                    <ValidationMessage>Please enter a minimum value of 2 or leave empty for defaults.</ValidationMessage>
+                </PassiveHealthMaxFails>
+                <PassiveHealthUnhealthyStatus type="TextField">
+                    <mask>/^(100|[1-5][0-9]{2}|[1-5]xx)$/u</mask>
+                    <ValidationMessage>Please enter a valid HTTP response code like 404 a status code class like 4xx.</ValidationMessage>
+                </PassiveHealthUnhealthyStatus>
+                <PassiveHealthUnhealthyLatency type="IntegerField">
+                    <MinimumValue>1</MinimumValue>
+                    <ValidationMessage>Please enter a minimum value of 1 or leave empty for defaults.</ValidationMessage>
+                </PassiveHealthUnhealthyLatency>
+                <PassiveHealthUnhealthyRequestCount type="IntegerField">
+                    <MinimumValue>1</MinimumValue>
+                    <ValidationMessage>Please enter a minimum value of 1 or leave empty for defaults.</ValidationMessage>
+                </PassiveHealthUnhealthyRequestCount>
                 <description type="DescriptionField"/>
             </handle>
             <accesslist type="ArrayField">
@@ -574,10 +590,6 @@
                         <v2>v2</v2>
                     </OptionValues>
                 </ProxyProtocol>
-                <PassiveHealthFailDuration type="IntegerField">
-                    <MinimumValue>1</MinimumValue>
-                    <ValidationMessage>Please enter a minimum value of 1 or leave empty for defaults.</ValidationMessage>
-                </PassiveHealthFailDuration>
                 <lb_policy type="OptionField">
                     <BlankDesc>random</BlankDesc>
                     <OptionValues>
@@ -589,6 +601,14 @@
                         <uri_hash>uri_hash</uri_hash>
                     </OptionValues>
                 </lb_policy>
+                <PassiveHealthFailDuration type="IntegerField">
+                    <MinimumValue>1</MinimumValue>
+                    <ValidationMessage>Please enter a minimum value of 1 or leave empty for defaults.</ValidationMessage>
+                </PassiveHealthFailDuration>
+                <PassiveHealthMaxFails type="IntegerField">
+                    <MinimumValue>2</MinimumValue>
+                    <ValidationMessage>Please enter a minimum value of 2 or leave empty for defaults.</ValidationMessage>
+                </PassiveHealthMaxFails>
                 <RemoteIp type="NetworkField">
                     <FieldSeparator>,</FieldSeparator>
                     <AsList>Y</AsList>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -344,11 +344,6 @@
                     <Mask>/^(\/.*)?$/u</Mask>
                     <ValidationMessage>Please enter a valid Path that starts with '/'.</ValidationMessage>
                 </ToPath>
-                <PassiveHealthFailDuration type="IntegerField">
-                    <MinimumValue>1</MinimumValue>
-                    <MaximumValue>100</MaximumValue>
-                    <ValidationMessage>Please enter a value between 1 to 100.</ValidationMessage>
-                </PassiveHealthFailDuration>
                 <ForwardAuth type="BooleanField"/>
                 <HttpTls type="OptionField">
                     <Required>Y</Required>
@@ -392,6 +387,30 @@
                     <Type>ca</Type>
                 </HttpTlsTrustedCaCerts>
                 <HttpTlsServerName type="HostnameField"/>
+                <PassiveHealthFailDuration type="IntegerField">
+                    <MinimumValue>1</MinimumValue>
+                    <ValidationMessage>Please enter a minimum value of 1 or leave empty for defaults.</ValidationMessage>
+                </PassiveHealthFailDuration>
+                <lb_policy type="OptionField">
+                    <BlankDesc>random</BlankDesc>
+                    <OptionValues>
+                        <first>first</first>
+                        <round_robin>round_robin</round_robin>
+                        <least_conn>least_conn</least_conn>
+                        <ip_hash>ip_hash</ip_hash>
+                        <client_ip_hash>client_ip_hash</client_ip_hash>
+                        <uri_hash>uri_hash</uri_hash>
+                    </OptionValues>
+                </lb_policy>
+                <lb_retries type="IntegerField">
+                    <MinimumValue>1</MinimumValue>
+                    <ValidationMessage>Please enter a minimum value of 1 or leave empty for defaults.</ValidationMessage>
+                </lb_retries>
+                <lb_try_duration type="IntegerField">
+                    <MinimumValue>1</MinimumValue>
+                    <ValidationMessage>Please enter a minimum value of 1 or leave empty for defaults.</ValidationMessage>
+                </lb_try_duration>
+                <lb_try_interval type="IntegerField"/>
                 <description type="DescriptionField"/>
             </handle>
             <accesslist type="ArrayField">
@@ -548,11 +567,6 @@
                 <ToPort type="PortField">
                     <Required>Y</Required>
                 </ToPort>
-                <PassiveHealthFailDuration type="IntegerField">
-                    <MinimumValue>1</MinimumValue>
-                    <MaximumValue>100</MaximumValue>
-                    <ValidationMessage>Please enter a value between 1 to 100.</ValidationMessage>
-                </PassiveHealthFailDuration>
                 <ProxyProtocol type="OptionField">
                     <BlankDesc>Off (default)</BlankDesc>
                     <OptionValues>
@@ -560,6 +574,21 @@
                         <v2>v2</v2>
                     </OptionValues>
                 </ProxyProtocol>
+                <PassiveHealthFailDuration type="IntegerField">
+                    <MinimumValue>1</MinimumValue>
+                    <ValidationMessage>Please enter a minimum value of 1 or leave empty for defaults.</ValidationMessage>
+                </PassiveHealthFailDuration>
+                <lb_policy type="OptionField">
+                    <BlankDesc>random</BlankDesc>
+                    <OptionValues>
+                        <first>first</first>
+                        <round_robin>round_robin</round_robin>
+                        <least_conn>least_conn</least_conn>
+                        <ip_hash>ip_hash</ip_hash>
+                        <client_ip_hash>client_ip_hash</client_ip_hash>
+                        <uri_hash>uri_hash</uri_hash>
+                    </OptionValues>
+                </lb_policy>
                 <RemoteIp type="NetworkField">
                     <FieldSeparator>,</FieldSeparator>
                     <AsList>Y</AsList>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/layer4.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/layer4.volt
@@ -148,6 +148,7 @@
                             <th data-column-id="FromPort" data-type="string" data-visible="false">{{ lang._('Local Port') }}</th>
                             <th data-column-id="Matchers" data-type="string">{{ lang._('Matchers') }}</th>
                             <th data-column-id="InvertMatchers" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('Invert Matchers') }}</th>
+                            <th data-column-id="TerminateTls" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('Terminate TLS') }}</th>
                             <th data-column-id="FromDomain" data-type="string">{{ lang._('Domain') }}</th>
                             <th data-column-id="FromOpenvpnModes" data-type="string" data-visible="false">{{ lang._('OpenVPN Modes') }}</th>
                             <th data-column-id="FromOpenvpnStaticKey" data-type="string" data-visible="false">{{ lang._('OpenVPN Static Key') }}</th>
@@ -155,6 +156,7 @@
                             <th data-column-id="ToPort" data-type="string">{{ lang._('Upstream Port') }}</th>
                             <th data-column-id="RemoteIp" data-type="string" data-visible="false">{{ lang._('Remote IP') }}</th>
                             <th data-column-id="PassiveHealthFailDuration" data-type="string" data-visible="false">{{ lang._('Fail Duration') }}</th>
+                            <th data-column-id="lb_policy" data-type="string" data-visible="false">{{ lang._('Load Balance Policy') }}</th>
                             <th data-column-id="ProxyProtocol" data-type="string" data-visible="false">{{ lang._('Proxy Protocol') }}</th>
                             <th data-column-id="description" data-type="string">{{ lang._('Description') }}</th>
                             <th data-column-id="commands" data-width="7em" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/layer4.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/layer4.volt
@@ -155,8 +155,9 @@
                             <th data-column-id="ToDomain" data-type="string">{{ lang._('Upstream Domain') }}</th>
                             <th data-column-id="ToPort" data-type="string">{{ lang._('Upstream Port') }}</th>
                             <th data-column-id="RemoteIp" data-type="string" data-visible="false">{{ lang._('Remote IP') }}</th>
-                            <th data-column-id="PassiveHealthFailDuration" data-type="string" data-visible="false">{{ lang._('Fail Duration') }}</th>
                             <th data-column-id="lb_policy" data-type="string" data-visible="false">{{ lang._('Load Balance Policy') }}</th>
+                            <th data-column-id="PassiveHealthFailDuration" data-type="string" data-visible="false">{{ lang._('Passive Health Fail Duration') }}</th>
+                            <th data-column-id="PassiveHealthMaxFails" data-type="string" data-visible="false">{{ lang._('Passive Health Max Fails') }}</th>
                             <th data-column-id="ProxyProtocol" data-type="string" data-visible="false">{{ lang._('Proxy Protocol') }}</th>
                             <th data-column-id="description" data-type="string">{{ lang._('Description') }}</th>
                             <th data-column-id="commands" data-width="7em" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -443,11 +443,15 @@
                             <th data-column-id="HttpTlsServerName" data-type="string" data-visible="false">{{ lang._('TLS Server Name') }}</th>
                             <th data-column-id="HttpNtlm" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('NTLM') }}</th>
                             <th data-column-id="HttpTlsInsecureSkipVerify" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('TLS Insecure Skip Verify') }}</th>
-                            <th data-column-id="PassiveHealthFailDuration" data-type="string" data-visible="false">{{ lang._('Upstream Fail Duration') }}</th>
                             <th data-column-id="lb_policy" data-type="string" data-visible="false">{{ lang._('Load Balance Policy') }}</th>
                             <th data-column-id="lb_retries" data-type="string" data-visible="false">{{ lang._('Load Balance Retries') }}</th>
                             <th data-column-id="lb_try_duration" data-type="string" data-visible="false">{{ lang._('Load Balance Try Duration') }}</th>
                             <th data-column-id="lb_try_interval" data-type="string" data-visible="false">{{ lang._('Load Balance Try Interval') }}</th>
+                            <th data-column-id="PassiveHealthFailDuration" data-type="string" data-visible="false">{{ lang._('Passive Health Fail Duration') }}</th>
+                            <th data-column-id="PassiveHealthMaxFails" data-type="string" data-visible="false">{{ lang._('Passive Health Max Fails') }}</th>
+                            <th data-column-id="PassiveHealthUnhealthyStatus" data-type="string" data-visible="false">{{ lang._('Passive Health Unhealthy Status') }}</th>
+                            <th data-column-id="PassiveHealthUnhealthyLatency" data-type="string" data-visible="false">{{ lang._('Passive Health Unhealthy Latency') }}</th>
+                            <th data-column-id="PassiveHealthUnhealthyRequestCount" data-type="string" data-visible="false">{{ lang._('Passive Health Unhealthy Request Count') }}</th>
                             <th data-column-id="description" data-type="string">{{ lang._('Description') }}</th>
                             <th data-column-id="commands" data-width="7em" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
                         </tr>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -435,7 +435,6 @@
                             <th data-column-id="ToDomain" data-type="string">{{ lang._('Upstream Domain') }}</th>
                             <th data-column-id="ToPort" data-type="string">{{ lang._('Upstream Port') }}</th>
                             <th data-column-id="ToPath" data-type="string" data-visible="false">{{ lang._('Upstream Path') }}</th>
-                            <th data-column-id="PassiveHealthFailDuration" data-type="string" data-visible="false">{{ lang._('Upstream Fail Duration') }}</th>
                             <th data-column-id="ForwardAuth" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('Forward Auth') }}</th>
                             <th data-column-id="accesslist" data-type="string" data-visible="false">{{ lang._('Access List') }}</th>
                             <th data-column-id="HttpVersion" data-type="string" data-visible="false">{{ lang._('HTTP Version') }}</th>
@@ -444,6 +443,11 @@
                             <th data-column-id="HttpTlsServerName" data-type="string" data-visible="false">{{ lang._('TLS Server Name') }}</th>
                             <th data-column-id="HttpNtlm" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('NTLM') }}</th>
                             <th data-column-id="HttpTlsInsecureSkipVerify" data-type="boolean" data-formatter="boolean" data-visible="false">{{ lang._('TLS Insecure Skip Verify') }}</th>
+                            <th data-column-id="PassiveHealthFailDuration" data-type="string" data-visible="false">{{ lang._('Upstream Fail Duration') }}</th>
+                            <th data-column-id="lb_policy" data-type="string" data-visible="false">{{ lang._('Load Balance Policy') }}</th>
+                            <th data-column-id="lb_retries" data-type="string" data-visible="false">{{ lang._('Load Balance Retries') }}</th>
+                            <th data-column-id="lb_try_duration" data-type="string" data-visible="false">{{ lang._('Load Balance Try Duration') }}</th>
+                            <th data-column-id="lb_try_interval" data-type="string" data-visible="false">{{ lang._('Load Balance Try Interval') }}</th>
                             <th data-column-id="description" data-type="string">{{ lang._('Description') }}</th>
                             <th data-column-id="commands" data-width="7em" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
                         </tr>

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -412,9 +412,6 @@ http://{{ domain }} {
         {% if handle.HandleDirective == "reverse_proxy" %}
         {{ handle.HandleDirective }} {{ formatted_domains | join(' ') }} {
             {{ header_manipulation(handle) }}
-            {% if handle.PassiveHealthFailDuration|default("") %}
-                fail_duration {{ handle.PassiveHealthFailDuration }}s
-            {% endif %}
             {% if handle.lb_policy|default("") %}
                 lb_policy {{ handle.lb_policy }}
             {% endif %}
@@ -426,6 +423,21 @@ http://{{ domain }} {
             {% endif %}
             {% if handle.lb_try_interval|default("") %}
                 lb_try_interval {{ handle.lb_try_interval }}ms
+            {% endif %}
+            {% if handle.PassiveHealthFailDuration|default("") %}
+                fail_duration {{ handle.PassiveHealthFailDuration }}s
+            {% endif %}
+            {% if handle.PassiveHealthMaxFails|default("") %}
+                max_fails {{ handle.PassiveHealthMaxFails }}
+            {% endif %}
+            {% if handle.PassiveHealthUnhealthyStatus|default("") %}
+                unhealthy_status {{ handle.PassiveHealthUnhealthyStatus }}
+            {% endif %}
+            {% if handle.PassiveHealthUnhealthyLatency|default("") %}
+                unhealthy_latency {{ handle.PassiveHealthUnhealthyLatency }}ms
+            {% endif %}
+            {% if handle.PassiveHealthUnhealthyRequestCount|default("") %}
+                unhealthy_request_count {{ handle.PassiveHealthUnhealthyRequestCount }}
             {% endif %}
             {% set has_transport_options =
                 handle.HttpVersion or

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -415,6 +415,18 @@ http://{{ domain }} {
             {% if handle.PassiveHealthFailDuration|default("") %}
                 fail_duration {{ handle.PassiveHealthFailDuration }}s
             {% endif %}
+            {% if handle.lb_policy|default("") %}
+                lb_policy {{ handle.lb_policy }}
+            {% endif %}
+            {% if handle.lb_retries|default("") %}
+                lb_retries {{ handle.lb_retries }}
+            {% endif %}
+            {% if handle.lb_try_duration|default("") %}
+                lb_try_duration {{ handle.lb_try_duration }}s
+            {% endif %}
+            {% if handle.lb_try_interval|default("") %}
+                lb_try_interval {{ handle.lb_try_interval }}ms
+            {% endif %}
             {% set has_transport_options =
                 handle.HttpVersion or
                 handle.HttpKeepalive or

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/includeLayer4
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/includeLayer4
@@ -30,11 +30,14 @@
         {% set is_ipv6 = (':' in domain) %}
         {{ layer4.Protocol }}/{{ '[' if is_ipv6 }}{{ domain }}{{ ']' if is_ipv6 }}:{{ layer4.ToPort }}{% if not loop.last %} {% endif %}
     {% endfor %} {
-    {% if layer4.PassiveHealthFailDuration %}
-        fail_duration {{ layer4.PassiveHealthFailDuration }}s
-    {% endif %}
     {% if layer4.lb_policy|default("") %}
         lb_policy {{ layer4.lb_policy }}
+    {% endif %}
+    {% if layer4.PassiveHealthFailDuration|default("") %}
+        fail_duration {{ layer4.PassiveHealthFailDuration }}s
+    {% endif %}
+    {% if layer4.PassiveHealthMaxFails|default("") %}
+        max_fails {{ layer4.PassiveHealthMaxFails }}
     {% endif %}
     {% if layer4.ProxyProtocol %}
         proxy_protocol {{ layer4.ProxyProtocol }}

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/includeLayer4
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/includeLayer4
@@ -22,35 +22,38 @@
 {# Sort the configurations based on 'Sequence' #}
 {% set layer4_configs = unsorted_layer4_configs | sort(attribute='Sequence') %}
 
-{% macro define_proxy(layer4, to_domains, to_port, fail_duration, proxy_protocol) %}
+{% macro define_proxy(layer4) %}
     {% if layer4.TerminateTls|default("0") == "1" %}
     tls
     {% endif %}
-    proxy {% for domain in to_domains.split(',') %}
+    proxy {% for domain in layer4.ToDomain.split(',') %}
         {% set is_ipv6 = (':' in domain) %}
-        {{ layer4.Protocol }}/{{ '[' if is_ipv6 }}{{ domain }}{{ ']' if is_ipv6 }}:{{ to_port }}{% if not loop.last %} {% endif %}
+        {{ layer4.Protocol }}/{{ '[' if is_ipv6 }}{{ domain }}{{ ']' if is_ipv6 }}:{{ layer4.ToPort }}{% if not loop.last %} {% endif %}
     {% endfor %} {
-    {% if fail_duration %}
-        fail_duration {{ fail_duration }}s
+    {% if layer4.PassiveHealthFailDuration %}
+        fail_duration {{ layer4.PassiveHealthFailDuration }}s
     {% endif %}
-    {% if proxy_protocol %}
-        proxy_protocol {{ proxy_protocol }}
+    {% if layer4.lb_policy|default("") %}
+        lb_policy {{ layer4.lb_policy }}
+    {% endif %}
+    {% if layer4.ProxyProtocol %}
+        proxy_protocol {{ layer4.ProxyProtocol }}
     {% endif %}
     }
 {% endmacro %}
 
-{% macro configure_proxy(layer4, to_domains, to_port, remote_ips, fail_duration, proxy_protocol) %}
+{% macro configure_proxy(layer4) %}
     {% set content %}
-        {% if remote_ips %}
-            {% set ip_list = remote_ips.split(',') %}
+        {% if layer4.RemoteIp %}
+            {% set ip_list = layer4.RemoteIp.split(',') %}
             subroute {
                 @allowed_ips remote_ip {{ ip_list|join(' ') }}
                 route @allowed_ips {
-                    {{ define_proxy(layer4, to_domains, to_port, fail_duration, proxy_protocol) }}
+                    {{ define_proxy(layer4) }}
                 }
             }
         {% else %}
-            {{ define_proxy(layer4, to_domains, to_port, fail_duration, proxy_protocol) }}
+            {{ define_proxy(layer4) }}
         {% endif %}
     {% endset %}
     {{ content|trim }}
@@ -144,7 +147,7 @@
             {% if layer4.Matchers != 'any' %}
                 @{{ layer4['@uuid'] }} {{ handle_special_matchers(layer4) }}
                 route @{{ layer4['@uuid'] }} {
-                    {{ configure_proxy(layer4, layer4.ToDomain, layer4.ToPort, layer4.RemoteIp, layer4.PassiveHealthFailDuration, layer4.ProxyProtocol) }}
+                    {{ configure_proxy(layer4) }}
                 }
             {% endif %}
         {% endif %}
@@ -157,11 +160,11 @@
                     {% if layer4.Matchers != 'any' %}
                         @{{ layer4['@uuid'] }} {{ handle_special_matchers(layer4) }}
                         route @{{ layer4['@uuid'] }} {
-                            {{ configure_proxy(layer4, layer4.ToDomain, layer4.ToPort, layer4.RemoteIp, layer4.PassiveHealthFailDuration, layer4.ProxyProtocol) }}
+                            {{ configure_proxy(layer4) }}
                         }
                     {% else %}
                         route {
-                            {{ configure_proxy(layer4, layer4.ToDomain, layer4.ToPort, layer4.RemoteIp, layer4.PassiveHealthFailDuration, layer4.ProxyProtocol) }}
+                            {{ configure_proxy(layer4) }}
                         }
                     {% endif %}
                 {% endif %}


### PR DESCRIPTION
Fixes: https://github.com/opnsense/plugins/issues/4378

Adds most of this: https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#load-balancing

`reverse_proxy` (HTTP Handler) can do `lb_policy`, `lb_retries`,`lb_try_duration`,`lb_try_interval`
`proxy` (Layer4) can only do `lb_policy`

Load balancing options that need further configuration have not been added.

Additionally all passive health check options have been added as well since they go habd in hand with the load balancing.

This hopefully exposed most options required for load balancing.

Since none of the options require a master/detail they all live in the existing forms.