### PR TITLE
net/freeradius: EAP-TLS with multiple CAs

### DIFF
--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/eap.xml
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/eap.xml
@@ -20,7 +20,7 @@
     <field>
         <id>eap.ca</id>
         <label>Root Certificate</label>
-        <type>dropdown</type>
+        <type>select_multiple</type>
         <help>Choose the Root CA. This CA will be trusted to issue client certificates for authentication.</help>
     </field>
     <field>

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Eap.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Eap.xml
@@ -31,6 +31,7 @@
         <ca type="CertificateField">
             <Type>ca</Type>
             <Required>N</Required>
+            <multiple>Y</multiple>
         </ca>
         <certificate type="CertificateField">
             <Type>cert</Type>

--- a/net/freeradius/src/opnsense/scripts/Freeradius/generate_certs.php
+++ b/net/freeradius/src/opnsense/scripts/Freeradius/generate_certs.php
@@ -80,17 +80,21 @@ if (isset($configObj->OPNsense->freeradius)) {
         $cert_refid = (string)$find_cert->ca;
         // if eap has a ca-certificate attached, search for its contents
         if ($cert_refid != "") {
-            foreach ($configObj->ca as $ca) {
-                if ($cert_refid == (string)$ca->refid) {
-                    // generate cert pem file
-                    $pem_content = trim(str_replace("\n\n", "\n", str_replace(
-                        "\r",
-                        "",
-                        base64_decode((string)$ca->crt)
-                    )));
-
-                    $pem_content .= "\n";
-                    $ca_pem_content .= $pem_content;
+            // multiple comma-separated refid values are possible
+            $cert_refids = explode(',', $cert_refid);
+            foreach ($cert_refids as $current_refid) {
+                foreach ($configObj->ca as $ca) {
+                    if ($current_refid == (string)$ca->refid) {
+                        // generate cert pem file
+                        $pem_content = trim(str_replace("\n\n", "\n", str_replace(
+                            "\r",
+                            "",
+                            base64_decode((string)$ca->crt)
+                        )));
+    
+                        $pem_content .= "\n";
+                        $ca_pem_content .= $pem_content;
+                    }
                 }
             }
         }


### PR DESCRIPTION
**Description:**  
This PR enables the configuration of multiple CA certificates for EAP-TLS authentication in FreeRADIUS. This is useful for environments where client devices (e.g., laptops, desktops) use certificates from an internal private CA, while devices like VoIP phones and printers use certificates issued by their vendor's CA.

The configuration aligns with the FreeRADIUS documentation regarding the "ca_file" directive, which supports multiple CA certificates:  
[[FreeRADIUS Documentation - ca_file](https://networkradius.com/doc/current/raddb/tls/tls-config_tls-common.html)](https://networkradius.com/doc/current/raddb/tls/tls-config_tls-common.html)

To implement this, the controller and model for eap was modified. And the "generate_certs.php" script was updated to handle and process multiple `refid` values when provided.

**Changes:**  
- Modified "generate_certs.php" to support multiple CA references.  
- Updated logic to accommodate additional CA certificates for EAP-TLS configurations.
- Modified the UI for multiple CA input.

**Testing:**  
- Verified functionality with multiple CAs in test environments for both internal and vendor-supplied certificates.  
- Ensured backward compatibility for single CA setups.  

Let me know if additional tests or refinements are needed!