### PR TITLE
www/caddy: Fix wildcard certificate extraction for widget

### DIFF
--- a/www/caddy/Makefile
+++ b/www/caddy/Makefile
@@ -1,5 +1,6 @@
 PLUGIN_NAME=		caddy
 PLUGIN_VERSION=		1.7.5
+PLUGIN_REVISION=	1
 PLUGIN_DEPENDS=		caddy-custom
 PLUGIN_COMMENT=		Modern Reverse Proxy with Automatic HTTPS, Dynamic DNS and Layer4 Routing
 PLUGIN_MAINTAINER=	cedrik@pischem.com

--- a/www/caddy/src/opnsense/scripts/OPNsense/Caddy/caddy_diagnostics.py
+++ b/www/caddy/src/opnsense/scripts/OPNsense/Caddy/caddy_diagnostics.py
@@ -101,6 +101,8 @@ async def extract_certificate_info(cert_path):
 
         # Extract the hostname from the filename
         hostname = os.path.basename(cert_path).replace('.crt', '').lower()
+        if hostname.startswith("wildcard_"):
+            hostname = hostname.replace("wildcard_", "*")
 
         return {'hostname': hostname, 'expiration_date': expiration_date_str, 'remaining_days': remaining_days}
     except asyncio.TimeoutError as e:


### PR DESCRIPTION
Wildcard certificates are `wildcard_.example.com` in the filesystem, but the widget requires `*.example.com`.

This little patch should fix it.

PR: https://forum.opnsense.org/index.php?topic=44440.0