### PR TITLE
Add ddclient TTL configuration in Gandi and GoDaddy

### DIFF
--- a/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/dialogAccount.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/dialogAccount.xml
@@ -77,7 +77,7 @@
         <id>account.ttl</id>
         <label>TTL</label>
         <type>text</type>
-        <style>optional_setting service_aws service_netcup</style>
+        <style>optional_setting service_aws service_netcup service_gandi service_godaddy</style>
         <help>Time to Live for the DNS entry</help>
     </field>
     <field>

--- a/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
+++ b/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
@@ -44,7 +44,7 @@ protocol={{account.service}}, \
 dynurl=https://ipv4.cloudns.net/api/dynamicURL/?q={{account.password}}, \
 {%      elif account.service == 'hosting1984' %}
 protocol=1984, \
-{%      elif account.service == 'godaddy' %}
+{%      elif account.service in ['godaddy', 'gandi'] %}
 protocol={{account.service}}, \
 zone={{account.zone}}, \
 ttl={{account.ttl}}, \
@@ -57,10 +57,6 @@ server=updates.dnsomatic.com, \
 {%      elif account.service == 'dynu' %}
 protocol=dyndns2, \
 server=api.dynu.com, \
-{%      elif account.service == 'gandi' %}
-protocol={{account.service}}, \
-zone={{account.zone}}, \
-ttl={{account.ttl}}, \
 {%      elif account.service == 'he-net' %}
 protocol=dyndns2, \
 server=dyn.dns.he.net, \

--- a/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
+++ b/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
@@ -47,6 +47,7 @@ protocol=1984, \
 {%      elif account.service == 'godaddy' %}
 protocol={{account.service}}, \
 zone={{account.zone}}, \
+ttl={{account.ttl}}, \
 {%      elif account.service == 'hetzner' %}
 protocol={{account.service}}, \
 zone={{account.zone}}, \
@@ -59,6 +60,7 @@ server=api.dynu.com, \
 {%      elif account.service == 'gandi' %}
 protocol={{account.service}}, \
 zone={{account.zone}}, \
+ttl={{account.ttl}}, \
 {%      elif account.service == 'he-net' %}
 protocol=dyndns2, \
 server=dyn.dns.he.net, \


### PR DESCRIPTION
Gandi and GoDaddy both support setting the TTL using the ddclient tool.

Not setting pose an issue at least for Gandi which set the value to 18000 seconds, which is too high.
Letting the user to set 300 for example helps reducing service interruption when the IP changes.