### PR TITLE
www/caddy: Fix redirect regression

### DIFF
--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -399,11 +399,13 @@ http://{{ domain }} {
         {% if handle.HandleDirective == "reverse_proxy" and handle.ToPath|default("") != "" %}
             rewrite * {{ handle.ToPath }}{uri}
         {% endif %}
-        {% set protocol = {
-            "0": "http://",
-            "1": "https://",
-            "2": "h2c://"
-        }.get(handle.HttpTls, '') %}
+        {# http:// is the empty default for reverse_proxy #}
+        {% set protocol = (
+            "http://" if handle.HttpTls == "0" and handle.HandleDirective == "redir" else
+            "https://" if handle.HttpTls == "1" else
+            "h2c://" if handle.HttpTls == "2" else
+            ''
+        ) %}
         {% set formatted_domains = [] -%}
         {% for domain in handle.ToDomain.split(',') -%}
             {% set is_ipv6 = (':' in domain and domain.count(':') >= 2) -%}

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -399,8 +399,11 @@ http://{{ domain }} {
         {% if handle.HandleDirective == "reverse_proxy" and handle.ToPath|default("") != "" %}
             rewrite * {{ handle.ToPath }}{uri}
         {% endif %}
-        {# http:// is the empty default #}
-        {% set protocol = 'https://' if handle.HttpTls == "1" else 'h2c://' if handle.HttpTls == "2" else '' -%}
+        {% set protocol = {
+            "0": "http://",
+            "1": "https://",
+            "2": "h2c://"
+        }.get(handle.HttpTls, '') %}
         {% set formatted_domains = [] -%}
         {% for domain in handle.ToDomain.split(',') -%}
             {% set is_ipv6 = (':' in domain and domain.count(':') >= 2) -%}


### PR DESCRIPTION
Long story short:

`reverse_proxy` implies it is "http://" when it is empty default
`redir` implies it is an URI when it is an empty default

So, gotta attach http:// to redir again to fix regression introduced here: https://github.com/opnsense/plugins/pull/4369

PR: https://forum.opnsense.org/index.php?topic=44542.0