### PR TITLE
www/squid: Add SMP support

### DIFF
--- a/www/squid/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
+++ b/www/squid/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
@@ -340,6 +340,13 @@
                 <help>Create a list of sites which may not be inspected, for example bank sites. Prefix the domain with a . to accept all subdomains (e.g. .google.com).</help>
             </field>
             <field>
+                <id>proxy.forward.workers</id>
+                <label>Number of squid workers</label>
+                <type>text</type>
+                <help>Start N main Squid process daemons (i.e., SMP mode). Requires Restart. Default: 1</help>
+                <advanced>true</advanced>
+            </field>
+            <field>
                 <id>proxy.forward.ssl_crtd_storage_max_size</id>
                 <label>SSL cache size</label>
                 <type>text</type>

--- a/www/squid/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
+++ b/www/squid/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
@@ -282,6 +282,12 @@
               <Mask>/^([a-zA-Z0-9\.:\[\]\s\-]*?,)*([a-zA-Z0-9\.:\[\]\s\-]*)$/</Mask>
               <ValidationMessage>Please enter ip addresses or domain names here</ValidationMessage>
             </sslnobumpsites>
+            <workers type="IntegerField">
+              <Default>1</Default>
+              <MinimumValue>1</MinimumValue>
+              <MaximumValue>100</MaximumValue>
+              <ValidationMessage>worker number needs to be an integer value between 1 and 100</ValidationMessage>
+            </workers>
             <ssl_crtd_storage_max_size type="IntegerField">
               <Required>Y</Required>
               <Default>4</Default>

--- a/www/squid/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
+++ b/www/squid/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
@@ -53,6 +53,10 @@
 {%     endfor %}
 {% endif %}
 
+{%   if not helpers.empty('OPNsense.proxy.forward.workers') %}
+workers {{ OPNsense.proxy.forward.workers }}
+{%   endif %}
+
 {% if helpers.exists('OPNsense.proxy.forward.sslbump') and OPNsense.proxy.forward.sslbump == '1' %}
 # setup ssl re-cert
 sslcrtd_program /usr/local/libexec/squid/security_file_certgen -s /var/squid/ssl_crtd -M {{ OPNsense.proxy.forward.ssl_crtd_storage_max_size|default('4') }}MB


### PR DESCRIPTION
This pull-request enables the squid "workers" configuration-directive (https://www.squid-cache.org/Doc/config/workers/) which gives the user the possibility to set squid workers according to their needs.
The default value of 1 represents one main process, which is the current default.
For more information regarding scaling see https://wiki.squid-cache.org/Features/SmpScale