### PR TITLE
enforce --auth-key param in template preventing prompt for auth on boot

### DIFF
--- a/security/tailscale/Makefile
+++ b/security/tailscale/Makefile
@@ -1,5 +1,6 @@
 PLUGIN_NAME=       tailscale
 PLUGIN_VERSION=    1.0.d
+PLUGIN_REVISION=   1
 PLUGIN_DEVEL=      yes
 PLUGIN_COMMENT=    Tailscale makes creating software-defined networks easy
 PLUGIN_DEPENDS=    tailscale

--- a/security/tailscale/pkg-descr
+++ b/security/tailscale/pkg-descr
@@ -9,3 +9,8 @@ Plugin Changelog
 1.0
 
 * initial development release
+
+1.0_1
+
+* fixes to template to prevent auth key prompt when empty
+

--- a/security/tailscale/src/opnsense/mvc/app/views/OPNsense/Tailscale/status.volt
+++ b/security/tailscale/src/opnsense/mvc/app/views/OPNsense/Tailscale/status.volt
@@ -8,7 +8,6 @@
             return (str + '').replace(/([^>\r\n]?)(\r\n|\n\r|\r|\n)/g, '$1' + breakTag + '$2');
         }
 
-
 	function updateNetInfo() {
             ajaxGet(url = "/api/tailscale/status/net/", sendData={},
                 callback = function (data, status) {
@@ -44,7 +43,6 @@
             });
         }
 
-
         function updateStatusInfo() {
             ajaxGet(url = "/api/tailscale/status/status/", sendData={},
                 callback = function (data, status) {
@@ -78,14 +76,14 @@
                     } else {
                         $('#statusList > tbody').append('<tr><td colspan=2>Unable to fetch status, is Tailscale running?</td></tr>');
                     }
+
+                    updateServiceControlUI('tailscale');
                 }
             );
         }
 
-
         updateNetInfo();
         updateStatusInfo();
-
     });
 </script>
 

--- a/security/tailscale/src/opnsense/service/templates/OPNsense/Tailscale/rc.conf.d
+++ b/security/tailscale/src/opnsense/service/templates/OPNsense/Tailscale/rc.conf.d
@@ -30,6 +30,8 @@ tailscaled_port="{{ OPNsense.tailscale.settings.listenPort }}"
 {%    endif %}
 {%    if helpers.exists('OPNsense.tailscale.authentication.preAuthKey') %}
 {%      do up_args.append("--auth-key=" + OPNsense.tailscale.authentication.preAuthKey) %}
+{%    else %}
+{%      do up_args.append("--auth-key=non-specified") %}
 {%    endif %}
 {#  loop through subnets to build list #}
 {%    if helpers.exists('OPNsense.tailscale.settings.subnets.subnet4') %}


### PR DESCRIPTION
Update security/tailscale template to enforce presence of "--auth-key" attribute in Tailscale up_args - fixes #4394