### PR TITLE
Caddy Widget Wildcard Fix

### DIFF
--- a/www/caddy/Makefile
+++ b/www/caddy/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		caddy
-PLUGIN_VERSION=		1.7.5
+PLUGIN_VERSION=		1.7.6
 PLUGIN_REVISION=	1
 PLUGIN_DEPENDS=		caddy-custom
 PLUGIN_COMMENT=		Modern Reverse Proxy with Automatic HTTPS, Dynamic DNS and Layer4 Routing

--- a/www/caddy/src/opnsense/www/js/widgets/CaddyCertificate.js
+++ b/www/caddy/src/opnsense/www/js/widgets/CaddyCertificate.js
@@ -61,7 +61,9 @@ export default class CaddyCertificate extends BaseTableWidget {
         const certificates = (await this.ajaxCall('/api/caddy/diagnostics/certificate')).content || [];
 
         // Display certificate if hostname in config and CN of stored cert on disk match
-        const matchingCertificates = certificates.filter(cert => domains.includes(cert.hostname));
+        const matchingCertificates = certificates.filter(cert =>
+            domains.some(domain => cert.hostname.replace('wildcard_', '*') === domain)
+        );
 
         if (matchingCertificates.length === 0) {
             this.displayError(`${this.translations.nocerts}`);


### PR DESCRIPTION
Currently the /api/caddy/reverse_proxy/get endpoint displays wildcard domains as '*.domain.com', however the  /api/caddy/diagnostics/certificate endpoint displays wildcard 'wildcard_.domain.com'. The net effect of this is the widget shows: 'Caddy does not manage any automatic certificates'.

The function responsible for this is https://github.com/opnsense/plugins/blob/06a28c3496eabdffc1216a8630b573a4f6c2df2b/www/caddy/src/opnsense/www/js/widgets/CaddyCertificate.js#L50

This PR adds the capability to match on 'wildcard_'

Linked Issue: https://github.com/opnsense/plugins/issues/4400