### PR TITLE
opnsense/plugins#4402: configure custom permissions on caddy.sock

### DIFF
--- a/www/caddy/Makefile
+++ b/www/caddy/Makefile
@@ -1,6 +1,5 @@
 PLUGIN_NAME=		caddy
 PLUGIN_VERSION=		1.7.6
-PLUGIN_REVISION=	1
 PLUGIN_DEPENDS=		caddy-custom
 PLUGIN_COMMENT=		Modern Reverse Proxy with Automatic HTTPS, Dynamic DNS and Layer4 Routing
 PLUGIN_MAINTAINER=	cedrik@pischem.com

--- a/www/caddy/Makefile
+++ b/www/caddy/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		caddy
-PLUGIN_VERSION=		1.7.5
+PLUGIN_VERSION=		1.7.6
 PLUGIN_REVISION=	1
 PLUGIN_DEPENDS=		caddy-custom
 PLUGIN_COMMENT=		Modern Reverse Proxy with Automatic HTTPS, Dynamic DNS and Layer4 Routing

--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -15,7 +15,7 @@ Plugin Changelog
 
 1.7.6
 
-* Fix: Web UI can still restart/stop Caddy when running as `www` user
+* Fix: Web UI can still restart/stop Caddy when running as `www` user (opnsense/plugins#4402)
 
 1.7.5
 

--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -13,6 +13,10 @@ DOC: https://docs.opnsense.org/manual/how-tos/caddy.html
 Plugin Changelog
 ================
 
+1.7.6
+
+* Fix: Web UI can still restart/stop Caddy when running as `www` user
+
 1.7.5
 
 * Add: Load Balancing options to Layer 4 Proxy and HTTP Handle

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/rc.conf.d/caddy
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/rc.conf.d/caddy
@@ -3,6 +3,7 @@
 {% set generalSettings = helpers.getNodeByTag('Pischem.caddy.general') %}
 {% if generalSettings.enabled|default("0") == "1" %}
 caddy_enable="YES"
+caddy_admin="unix//var/run/caddy/caddy.sock|0220"
 caddy_setup="/usr/local/opnsense/scripts/OPNsense/Caddy/setup.sh"
 {% if generalSettings.DisableSuperuser|default("0") == "1" %}
 caddy_user=www


### PR DESCRIPTION
Fixes: opnsense/plugins#4402

When Caddy is given a Unix socket for its admin interface, and no permissions are supplied, the permissions become `0200` by default ([link](https://github.com/caddyserver/caddy/blob/v2.8.4/internal/sockets.go#L34-L55)).

As part of applying changes, OPNsense ends up running a script which results in the owner of `/var/run/caddy/caddy.sock` becoming `root`, thus when Caddy is running under the `www` user it can no longer perform admin operations like stop/restart.

This proposed change would provide custom permissions to Caddy, which is already catered for in the upstream code, to make sure that no matter who the **owner** of `caddy.sock` is, the `www` **group** can write to this socket. This way, whether Caddy is running under the `root` user or the `www` user, it can still use the admin API via this Unix socket.