### PR TITLE
security/clamav: Fix typo in freshclam.sh

### DIFF
--- a/security/clamav/src/opnsense/scripts/OPNsense/ClamAV/freshclam.sh
+++ b/security/clamav/src/opnsense/scripts/OPNsense/ClamAV/freshclam.sh
@@ -37,7 +37,7 @@ elif pgrep -qF ${PIDFILE} 2> /dev/null; then
 elif [ -z "${COMMAND}" ]; then
 	echo "missing"
 else
-       daemon -f -p ${PIDFILE} /usr/local/etc/rc.d/clamav-freshclam restart
+       daemon -f -p ${PIDFILE} /usr/local/etc/rc.d/clamav_freshclam restart
        echo "starting"
 fi
 


### PR DESCRIPTION
This one was forgotten to rename.