### PR TITLE
security/tailscale: Allow use of an exit node

### DIFF
--- a/security/tailscale/src/opnsense/mvc/app/controllers/OPNsense/Tailscale/forms/settings.xml
+++ b/security/tailscale/src/opnsense/mvc/app/controllers/OPNsense/Tailscale/forms/settings.xml
@@ -24,6 +24,13 @@
         <help>Offer to be an exit node for outbound internet traffic from the Tailscale network.</help>
     </field>
     <field>
+        <id>settings.useExitNode</id>
+        <label>Use Exit Node</label>
+        <type>dropdown</type>
+        <help>Route traffic to the specified exit node.  Note that this only affects traffic routed into your Tailscale interface,
+          which you will have to configure separately.</help>
+    </field>
+    <field>
         <id>settings.acceptSubnetRoutes</id>
         <label>Accept Subnet Routes</label>
         <type>checkbox</type>

--- a/security/tailscale/src/opnsense/mvc/app/controllers/OPNsense/Tailscale/forms/settings.xml
+++ b/security/tailscale/src/opnsense/mvc/app/controllers/OPNsense/Tailscale/forms/settings.xml
@@ -27,8 +27,7 @@
         <id>settings.useExitNode</id>
         <label>Use Exit Node</label>
         <type>dropdown</type>
-        <help>Route traffic to the specified exit node.  Note that this only affects traffic routed into your Tailscale interface,
-          which you will have to configure separately using firewall rules and hybrid outbound NAT rules.</help>
+        <help>Route traffic to the specified exit node. Note that this only affects traffic routed into your Tailscale interface, which you will have to configure separately using firewall rules and hybrid outbound NAT rules.</help>
     </field>
     <field>
         <id>settings.acceptSubnetRoutes</id>

--- a/security/tailscale/src/opnsense/mvc/app/controllers/OPNsense/Tailscale/forms/settings.xml
+++ b/security/tailscale/src/opnsense/mvc/app/controllers/OPNsense/Tailscale/forms/settings.xml
@@ -28,7 +28,7 @@
         <label>Use Exit Node</label>
         <type>dropdown</type>
         <help>Route traffic to the specified exit node.  Note that this only affects traffic routed into your Tailscale interface,
-          which you will have to configure separately.</help>
+          which you will have to configure separately using firewall rules and hybrid outbound NAT rules.</help>
     </field>
     <field>
         <id>settings.acceptSubnetRoutes</id>

--- a/security/tailscale/src/opnsense/mvc/app/models/OPNsense/Tailscale/FieldTypes/ExitNodeField.php
+++ b/security/tailscale/src/opnsense/mvc/app/models/OPNsense/Tailscale/FieldTypes/ExitNodeField.php
@@ -17,7 +17,7 @@ class ExitNodeField extends BaseListField
             $exitNodes = [];
             $exitNodes[''] = 'None';
 
-            if (is_array($response) && array_key_exists('Peer', $response)) {
+            if (is_array($response) && array_key_exists('Peer', $response) && is_array($response['Peer'])) {
                 foreach ($response['Peer'] as $peer) {
                     if ($peer['ExitNodeOption']) {
                         $exitNodes[$peer['TailscaleIPs'][0]] = $peer['HostName'];

--- a/security/tailscale/src/opnsense/mvc/app/models/OPNsense/Tailscale/FieldTypes/ExitNodeField.php
+++ b/security/tailscale/src/opnsense/mvc/app/models/OPNsense/Tailscale/FieldTypes/ExitNodeField.php
@@ -18,7 +18,7 @@ class ExitNodeField extends BaseListField
             $exitNodes[''] = 'None';
             foreach ($response['Peer'] as $peer) {
                 if ($peer['ExitNodeOption']) {
-                    $exitNodes[$peer['HostName']] = $peer['HostName'];
+                    $exitNodes[$peer['TailscaleIPs'][0]] = $peer['HostName'];
                 }
             }
 

--- a/security/tailscale/src/opnsense/mvc/app/models/OPNsense/Tailscale/FieldTypes/ExitNodeField.php
+++ b/security/tailscale/src/opnsense/mvc/app/models/OPNsense/Tailscale/FieldTypes/ExitNodeField.php
@@ -14,8 +14,7 @@ class ExitNodeField extends BaseListField
     {
         if (empty(self::$internalCacheOptionList)) {
             $response = json_decode(trim((new Backend())->configdRun('tailscale tailscale-status')), true);
-            $exitNodes = [];
-            $exitNodes[''] = 'None';
+            $exitNodes = ['' => gettext('None')];
 
             if (is_array($response) && array_key_exists('Peer', $response) && is_array($response['Peer'])) {
                 foreach ($response['Peer'] as $peer) {

--- a/security/tailscale/src/opnsense/mvc/app/models/OPNsense/Tailscale/FieldTypes/ExitNodeField.php
+++ b/security/tailscale/src/opnsense/mvc/app/models/OPNsense/Tailscale/FieldTypes/ExitNodeField.php
@@ -17,7 +17,7 @@ class ExitNodeField extends BaseListField
             $exitNodes = [];
             $exitNodes[''] = 'None';
 
-            if (array_key_exists('Peer', $response)) {
+            if (is_array($response) && array_key_exists('Peer', $response)) {
                 foreach ($response['Peer'] as $peer) {
                     if ($peer['ExitNodeOption']) {
                         $exitNodes[$peer['TailscaleIPs'][0]] = $peer['HostName'];

--- a/security/tailscale/src/opnsense/mvc/app/models/OPNsense/Tailscale/FieldTypes/ExitNodeField.php
+++ b/security/tailscale/src/opnsense/mvc/app/models/OPNsense/Tailscale/FieldTypes/ExitNodeField.php
@@ -15,12 +15,12 @@ class ExitNodeField extends BaseListField
         if (empty(self::$internalCacheOptionList)) {
             $response = json_decode(trim((new Backend())->configdRun('tailscale tailscale-status')), true);
             $exitNodes = [];
+            $exitNodes[''] = 'None';
             foreach ($response['Peer'] as $peer) {
                 if ($peer['ExitNodeOption']) {
                     $exitNodes[$peer['HostName']] = $peer['HostName'];
                 }
             }
-            $exitNodes['foo'] = 'bar';
 
             self::$internalCacheOptionList = $exitNodes;
         }

--- a/security/tailscale/src/opnsense/mvc/app/models/OPNsense/Tailscale/FieldTypes/ExitNodeField.php
+++ b/security/tailscale/src/opnsense/mvc/app/models/OPNsense/Tailscale/FieldTypes/ExitNodeField.php
@@ -27,5 +27,3 @@ class ExitNodeField extends BaseListField
         $this->internalOptionList = self::$internalCacheOptionList;
     }
 }
-
-# vim:ts=4 sw=4 et:

--- a/security/tailscale/src/opnsense/mvc/app/models/OPNsense/Tailscale/FieldTypes/ExitNodeField.php
+++ b/security/tailscale/src/opnsense/mvc/app/models/OPNsense/Tailscale/FieldTypes/ExitNodeField.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace OPNsense\Tailscale\FieldTypes;
+
+use OPNsense\Base\FieldTypes\BaseListField;
+use OPNsense\Core\Backend;
+
+class ExitNodeField extends BaseListField
+{
+    private static array $internalCacheOptionList = [];
+    protected $internalIsContainer = false;
+
+    protected function actionPostLoadingEvent()
+    {
+        if (empty(self::$internalCacheOptionList)) {
+            $response = json_decode(trim((new Backend())->configdRun('tailscale tailscale-status')), true);
+            $exitNodes = [];
+            foreach ($response['Peer'] as $peer) {
+                if ($peer['ExitNodeOption']) {
+                    $exitNodes[$peer['HostName']] = $peer['HostName'];
+                }
+            }
+            $exitNodes['foo'] = 'bar';
+
+            self::$internalCacheOptionList = $exitNodes;
+        }
+        $this->internalOptionList = self::$internalCacheOptionList;
+    }
+}
+
+# vim:ts=4 sw=4 et:

--- a/security/tailscale/src/opnsense/mvc/app/models/OPNsense/Tailscale/FieldTypes/ExitNodeField.php
+++ b/security/tailscale/src/opnsense/mvc/app/models/OPNsense/Tailscale/FieldTypes/ExitNodeField.php
@@ -16,9 +16,12 @@ class ExitNodeField extends BaseListField
             $response = json_decode(trim((new Backend())->configdRun('tailscale tailscale-status')), true);
             $exitNodes = [];
             $exitNodes[''] = 'None';
-            foreach ($response['Peer'] as $peer) {
-                if ($peer['ExitNodeOption']) {
-                    $exitNodes[$peer['TailscaleIPs'][0]] = $peer['HostName'];
+
+            if (array_key_exists('Peer', $response)) {
+                foreach ($response['Peer'] as $peer) {
+                    if ($peer['ExitNodeOption']) {
+                        $exitNodes[$peer['TailscaleIPs'][0]] = $peer['HostName'];
+                    }
                 }
             }
 

--- a/security/tailscale/src/opnsense/mvc/app/models/OPNsense/Tailscale/Settings.xml
+++ b/security/tailscale/src/opnsense/mvc/app/models/OPNsense/Tailscale/Settings.xml
@@ -18,6 +18,10 @@
             <default>0</default>
             <Required>Y</Required>
         </advertiseExitNode>
+        <useExitNode type=".\ExitNodeField">
+            <default></default>
+            <Required>N</Required>
+        </useExitNode>
         <acceptSubnetRoutes type="BooleanField">
             <default>0</default>
             <Required>Y</Required>

--- a/security/tailscale/src/opnsense/mvc/app/models/OPNsense/Tailscale/Settings.xml
+++ b/security/tailscale/src/opnsense/mvc/app/models/OPNsense/Tailscale/Settings.xml
@@ -18,10 +18,7 @@
             <default>0</default>
             <Required>Y</Required>
         </advertiseExitNode>
-        <useExitNode type=".\ExitNodeField">
-            <default></default>
-            <Required>N</Required>
-        </useExitNode>
+        <useExitNode type=".\ExitNodeField"/>
         <acceptSubnetRoutes type="BooleanField">
             <default>0</default>
             <Required>Y</Required>

--- a/security/tailscale/src/opnsense/mvc/app/views/OPNsense/Tailscale/settings.volt
+++ b/security/tailscale/src/opnsense/mvc/app/views/OPNsense/Tailscale/settings.volt
@@ -1,6 +1,7 @@
 <script type="text/javascript">
     $( document ).ready(function() {
         mapDataToFormUI({'frmSettings':"/api/tailscale/settings/get"}).done(function(data) {
+            $('.selectpicker').selectpicker('refresh');
             updateServiceControlUI('tailscale');
         });
 

--- a/security/tailscale/src/opnsense/mvc/app/views/OPNsense/Tailscale/status.volt
+++ b/security/tailscale/src/opnsense/mvc/app/views/OPNsense/Tailscale/status.volt
@@ -76,6 +76,16 @@
                                 return true;
                             }
 
+                            if (key == 'ExitNodeStatus') {
+                                var newValue = value.TailscaleIPs[0];
+                                if (value.Online) {
+                                    newValue += ' (online)';
+                                } else {
+                                    newValue += ' (offline)';
+                                }
+                                value = newValue;
+                            }
+
                             $('#statusList > tbody').append('<tr><td>' + key + '</td>' +
                             '<td>' + value + '</td></tr>');
                         });

--- a/security/tailscale/src/opnsense/service/templates/OPNsense/Tailscale/rc.conf.d
+++ b/security/tailscale/src/opnsense/service/templates/OPNsense/Tailscale/rc.conf.d
@@ -18,7 +18,7 @@ tailscaled_port="{{ OPNsense.tailscale.settings.listenPort }}"
 {%    if helpers.exists('OPNsense.tailscale.settings.useExitNode') %}
 {%      do up_args.append("--exit-node=" + OPNsense.tailscale.settings.useExitNode) %}
 {%    else %}
-{%      do up_args.append("--exit-node=''") %}
+{%      do up_args.append("--exit-node=") %}
 {%    endif %}
 {%    if helpers.exists('OPNsense.tailscale.settings.acceptSubnetRoutes') and OPNsense.tailscale.settings.acceptSubnetRoutes|default("0") == "1" %}
 {%      do up_args.append("--accept-routes") %}

--- a/security/tailscale/src/opnsense/service/templates/OPNsense/Tailscale/rc.conf.d
+++ b/security/tailscale/src/opnsense/service/templates/OPNsense/Tailscale/rc.conf.d
@@ -17,8 +17,6 @@ tailscaled_port="{{ OPNsense.tailscale.settings.listenPort }}"
 {%    endif %}
 {%    if helpers.exists('OPNsense.tailscale.settings.useExitNode') %}
 {%      do up_args.append("--exit-node=" + OPNsense.tailscale.settings.useExitNode) %}
-{%    else %}
-{%      do up_args.append("--exit-node=") %}
 {%    endif %}
 {%    if helpers.exists('OPNsense.tailscale.settings.acceptSubnetRoutes') and OPNsense.tailscale.settings.acceptSubnetRoutes|default("0") == "1" %}
 {%      do up_args.append("--accept-routes") %}

--- a/security/tailscale/src/opnsense/service/templates/OPNsense/Tailscale/rc.conf.d
+++ b/security/tailscale/src/opnsense/service/templates/OPNsense/Tailscale/rc.conf.d
@@ -15,6 +15,11 @@ tailscaled_port="{{ OPNsense.tailscale.settings.listenPort }}"
 {%    else %}
 {%      do up_args.append("--advertise-exit-node=false") %}
 {%    endif %}
+{%    if helpers.exists('OPNsense.tailscale.settings.useExitNode') %}
+{%      do up_args.append("--exit-node=" + OPNsense.tailscale.settings.useExitNode) %}
+{%    else %}
+{%      do up_args.append("--exit-node=''") %}
+{%    endif %}
 {%    if helpers.exists('OPNsense.tailscale.settings.acceptSubnetRoutes') and OPNsense.tailscale.settings.acceptSubnetRoutes|default("0") == "1" %}
 {%      do up_args.append("--accept-routes") %}
 {%    else %}


### PR DESCRIPTION
I've been playing around with Tailscale since the new plugin was added and I was looking at getting OPNsense to use a remote exit node.  This achieves the Tailscale part of doing that - the rest needs doing separately with NAT/Firewall rules.

Would this be useful for inclusion in the plugin at all?