### PR TITLE
www/caddy: Mark DNS Providers optional that are not included per default

### DIFF
--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
@@ -98,7 +98,7 @@
             <id>caddy.general.TlsDnsProvider</id>
             <label>DNS Provider</label>
             <type>dropdown</type>
-            <help><![CDATA[Select the DNS provider for the DNS-01 Challenge and Dynamic DNS. This is mostly needed for Wildcard Certificates, and for Dynamic DNS. To use, enable the checkbox in a "Domain" or "Subdomain". For more information, visit https://github.com/caddy-dns where each module is community maintained.]]></help>
+            <help><![CDATA[Select the DNS Provider for the DNS-01 Challenge and Dynamic DNS. Providers marked as "optional" must be installed manually, see https://caddyserver.com/docs/command-line#caddy-add-package. For more information, visit https://github.com/caddy-dns where each module is community maintained.]]></help>
         </field>
         <field>
             <id>caddy.general.TlsDnsApiKey</id>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -26,42 +26,41 @@
                 <OptionValues>
                     <cloudflare>Cloudflare</cloudflare>
                     <duckdns>Duck DNS</duckdns>
-                    <digitalocean>DigitalOcean</digitalocean>
                     <gandi>Gandi</gandi>
                     <ionos>IONOS</ionos>
                     <desec>Desec</desec>
                     <porkbun>Porkbun</porkbun>
-                    <route53>Route53</route53>
                     <acmedns>ACME-DNS</acmedns>
-                    <googleclouddns>Google Cloud DNS</googleclouddns>
                     <azure>Azure</azure>
                     <ovh>OVH</ovh>
                     <namecheap>Namecheap</namecheap>
-                    <netlify>Netlify</netlify>
                     <powerdns>PowerDNS</powerdns>
-                    <ddnss>DDNSS</ddnss>
-                    <njalla>Njalla</njalla>
                     <linode>Linode</linode>
-                    <tencentcloud>Tencent Cloud</tencentcloud>
-                    <dinahosting>Dinahosting</dinahosting>
                     <hexonet>Hexonet</hexonet>
                     <mailinabox>Mail-in-a-Box</mailinabox>
-                    <netcup>Netcup</netcup>
                     <rfc2136>RFC2136</rfc2136>
                     <dnsmadeeasy>DNS Made Easy</dnsmadeeasy>
                     <bunny>Bunny</bunny>
-                    <civo>Civo</civo>
                     <scaleway>Scaleway</scaleway>
                     <acmeproxy>ACME Proxy</acmeproxy>
                     <inwx>INWX</inwx>
                     <netcup>Netcup</netcup>
                     <namedotcom>Name.com</namedotcom>
-                    <easydns>EasyDNS</easydns>
                     <infomaniak>Infomaniak</infomaniak>
                     <directadmin>DirectAdmin</directadmin>
-                    <hosttech>Hosttech</hosttech>
                     <vultr>Vultr</vultr>
                     <hetzner>Hetzner</hetzner>
+                    <digitalocean>DigitalOcean (optional)</digitalocean>
+                    <route53>Route53 (optional)</route53>
+                    <googleclouddns>Google Cloud DNS (optional)</googleclouddns>
+                    <netlify>Netlify (optional)</netlify>
+                    <ddnss>DDNSS (optional)</ddnss>
+                    <njalla>Njalla (optional)</njalla>
+                    <tencentcloud>Tencent Cloud (optional)</tencentcloud>
+                    <dinahosting>Dinahosting (optional)</dinahosting>
+                    <civo>Civo (optional)</civo>
+                    <easydns>EasyDNS (optional)</easydns>
+                    <hosttech>Hosttech (optional)</hosttech>
                 </OptionValues>
             </TlsDnsProvider>
             <TlsDnsApiKey type="TextField"/>


### PR DESCRIPTION
These modules must be added on demand on the command line with caddy add-package. This lowers maintainance burden and deflates the binary of big unused structs and sdks, since providers like route53 or googleclouddns alone pull around 16MB into the binary. Remove duplicate Netcup.

Increases security, maintainability and stability since the remaining providers do not pull in any external dependencies or include unused structs.

For: https://github.com/opnsense/plugins/issues/4437