### PR TITLE
net/vnstat: Handle multiple interfaces better

### DIFF
--- a/net/vnstat/src/opnsense/mvc/app/controllers/OPNsense/Vnstat/Api/ServiceController.php
+++ b/net/vnstat/src/opnsense/mvc/app/controllers/OPNsense/Vnstat/Api/ServiceController.php
@@ -99,7 +99,7 @@ class ServiceController extends ApiMutableServiceControllerBase
 
         if (!isset($config['OPNsense']['vnstat']['general']['interface_display'])) {
             // no interface configured, use script default (i.e. don't specify interface)
-            $response = $backend->configdRun("vnstat $type");
+            $response = $backend->configdpRun("vnstat", [ $type ]);
             return array("response" => $response);
         }
 

--- a/net/vnstat/src/opnsense/mvc/app/controllers/OPNsense/Vnstat/Api/ServiceController.php
+++ b/net/vnstat/src/opnsense/mvc/app/controllers/OPNsense/Vnstat/Api/ServiceController.php
@@ -114,5 +114,3 @@ class ServiceController extends ApiMutableServiceControllerBase
         return array("response" => $result);
     }
 }
-
-// vim:set ts=4 sw=4 et:

--- a/net/vnstat/src/opnsense/mvc/app/controllers/OPNsense/Vnstat/forms/general.xml
+++ b/net/vnstat/src/opnsense/mvc/app/controllers/OPNsense/Vnstat/forms/general.xml
@@ -7,8 +7,14 @@
     </field>
     <field>
         <id>general.interface</id>
-        <label>Interface</label>
+        <label>Default interface</label>
         <type>dropdown</type>
-        <help>Set the interface to listen on.</help>
+        <help>Set the default interface.</help>
+    </field>
+    <field>
+        <id>general.interface_display</id>
+        <label>Interfaces to display</label>
+        <type>select_multiple</type>
+        <help>Set the interface(s) to display stats for.</help>
     </field>
 </form>

--- a/net/vnstat/src/opnsense/mvc/app/controllers/OPNsense/Vnstat/forms/general.xml
+++ b/net/vnstat/src/opnsense/mvc/app/controllers/OPNsense/Vnstat/forms/general.xml
@@ -8,7 +8,7 @@
     <field>
         <id>general.interface</id>
         <label>Interface</label>
-        <type>select_multiple</type>
+        <type>dropdown</type>
         <help>Set the interface to listen on.</help>
     </field>
 </form>

--- a/net/vnstat/src/opnsense/mvc/app/models/OPNsense/Vnstat/General.xml
+++ b/net/vnstat/src/opnsense/mvc/app/models/OPNsense/Vnstat/General.xml
@@ -11,5 +11,9 @@
             <Required>N</Required>
             <multiple>N</multiple>
         </interface>
+        <interface_display type="InterfaceField">
+            <Required>N</Required>
+            <multiple>Y</multiple>
+        </interface_display>
     </items>
 </model>

--- a/net/vnstat/src/opnsense/mvc/app/models/OPNsense/Vnstat/General.xml
+++ b/net/vnstat/src/opnsense/mvc/app/models/OPNsense/Vnstat/General.xml
@@ -9,7 +9,7 @@
         </enabled>
         <interface type="InterfaceField">
             <Required>N</Required>
-            <multiple>Y</multiple>
+            <multiple>N</multiple>
         </interface>
     </items>
 </model>

--- a/net/vnstat/src/opnsense/scripts/OPNsense/Vnstat/stats.sh
+++ b/net/vnstat/src/opnsense/scripts/OPNsense/Vnstat/stats.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+type="$1"
+interface="$2"
+
+if [ -z "$interface" ]; then
+	# Interface not specified, use default interface for backward compatibility
+	interface=`awk '/^Interface/ { print $2 }' < /usr/local/etc/vnstat.conf`
+fi
+
+vnstat -$type $interface

--- a/net/vnstat/src/opnsense/service/conf/actions.d/actions_vnstat.conf
+++ b/net/vnstat/src/opnsense/service/conf/actions.d/actions_vnstat.conf
@@ -23,26 +23,26 @@ type:script_output
 message:request Vnstat status
 
 [hourly]
-command:/usr/local/bin/vnstat -h
-parameters:
+command:/usr/local/opnsense/scripts/OPNsense/Vnstat/stats.sh h
+parameters:%s
 type:script_output
 message:request Vnstat hourly status
 
 [daily]
-command:/usr/local/bin/vnstat -d
-parameters:
+command:/usr/local/opnsense/scripts/OPNsense/Vnstat/stats.sh d
+parameters:%s
 type:script_output
 message:request Vnstat daily status
 
 [monthly]
-command:/usr/local/bin/vnstat -m
-parameters:
+command:/usr/local/opnsense/scripts/OPNsense/Vnstat/stats.sh m
+parameters:%s
 type:script_output
 message:request Vnstat monthly status
 
 [yearly]
-command:/usr/local/bin/vnstat -y
-parameters:
+command:/usr/local/opnsense/scripts/OPNsense/Vnstat/stats.sh y
+parameters:%s
 type:script_output
 message:request Vnstat yearly status
 

--- a/net/vnstat/src/opnsense/service/templates/OPNsense/Vnstat/vnstat.conf
+++ b/net/vnstat/src/opnsense/service/templates/OPNsense/Vnstat/vnstat.conf
@@ -9,6 +9,8 @@
 Interface {{ interfaces|join('+') }}
 {%   endif %}
 
+# scan for new interfaces and add to DB
+AlwaysAddNewInterfaces 1
 
 # location of the database directory
 DatabaseDir "/var/lib/vnstat"


### PR DESCRIPTION
I tried using vnstat to report on multiple interfaces (to see how much traffic is going over a backup LTE connection I'm experimenting with) and it didn't really work.

* Selecting two interfaces was allowed but resulted in `Interface foo+bar` in `vnstat.conf` which appears to be a config directive only supporting one interface.
* `vnstat` was not configured to pick up new interfaces added after it was first installed.
* The stat in the UI only show the interface configured on the general tab, and as noted, configuring more than one there doesn't work.

To improve this I have:

* Restricted the interface option to one interface only, and renamed it to Default interface
* I've added a second 'Interfaces to display' option, which allows more than one to be selected
* The stats pages in the UI now show stats for all interfaces specified under 'Interfaces to display'
* The vnstat config contains `AlwaysAddNewInterfaces` to make it notice new interfaces added.
