### PR TITLE
dns/bind: allow to specify primaryip's port for secondary zone

### DIFF
--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Domain.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Domain.xml
@@ -17,9 +17,9 @@
                         <secondary>secondary</secondary>
                     </OptionValues>
                 </type>
-                <primaryip type="NetworkField">
-                    <FieldSeparator>,</FieldSeparator>
-                    <asList>Y</asList>
+                <primaryip type="CSVListField">
+                    <mask>/^(([0-9a-fA-F.:\[\]]+(:+[0-9])?([,]){0,1}))*/u</mask>
+                    <ValidationMessage>Please provide a valid ip address and optional port, i.e. 192.168.0.33, 10.0.0.99:53530, 2001:0db8:0000:0000:0000:ff00:0042:8329 or [::1]:53530.</ValidationMessage>
                 </primaryip>
                 <transferkeyalgo type="OptionField">
                     <OptionValues>

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
@@ -153,9 +153,10 @@ zone "{{ domain.domainname }}" {
         type {{ domain.type }};
 {%       if domain.type == 'secondary' %}
 {%         if domain.transferkey is defined %}
-        primaries { {{ domain.primaryip.replace(',', ' key "' ~ domain.transferkeyname ~ '"; ') }} key "{{ domain.transferkeyname }}"; };
+        primaries { {{ domain.primaryip | regex_replace('(?<!:)(?<!:[0-9A-Fa-f]{1})(?<!:[0-9A-Fa-f]{2})(?<!:[0-9A-Fa-f]{3})(?<!:[0-9A-Fa-f]{4}):([0-9]+)((,)|$)', ' port \\1\\2') |
+ regex_replace ('\[|\]', '') |  replace(',', ' key "' ~ domain.transferkeyname ~ '"; ') }} key "{{ domain.transferkeyname }}"; };
 {%         else %}
-        primaries { {{ domain.primaryip.replace(',', '; ') }}; };
+        primaries { {{ domain.primaryip | regex_replace('(?<!:)(?<!:[0-9A-Fa-f]{1})(?<!:[0-9A-Fa-f]{2})(?<!:[0-9A-Fa-f]{3})(?<!:[0-9A-Fa-f]{4}):([0-9]+)((,)|$)', ' port \\1\\2') | regex_replace ('\[|\]', '') | replace(',', '; ') }}; };
 {%         endif %}
 {%         if domain.allownotifysecondary is defined %}
         allow-notify { {{ domain.allownotifysecondary.replace(',', '; ') }}; };


### PR DESCRIPTION
Closes: #4444 

Notes on proposed solution

Bind/Domain.xml:
- change field type to CSVListField, adopted from net/haproxy HAProxy.xml to allow port specification

Bind/named.conf
- adjust jinja2 template instead of introducing new fields to avoid have to deal with config migrations of previous opnsense versions
- if specifying a port for a ipv6 address the following notion has to be used: [address]:port (https://en.wikipedia.org/wiki/IPv6#Address_representation)
- using negative lookbehind in regular expression to avoid matching ipv6 addresses without port
- using multiple lookbehind regular expressions since quantifiers are not allowed and ipv6 addresses can be shortened