### PR TITLE
Add support for mijn.host DNS challenge.

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -1924,4 +1924,14 @@
         <label>Token</label>
         <type>password</type>
     </field>
+    <field>
+        <label>mijn.host</label>
+        <type>header</type>
+        <style>table_dns table_dns_mijnhost</style>
+    </field>
+    <field>
+        <id>validation.dns_mijnhost_api_key</id>
+        <label>API Key</label>
+        <type>text</type>
+    </field>
 </form>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsMijnHost.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsMijnHost.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Copyright (C) 2022 Nikolaj Brinch Jørgensen
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\AcmeClient\LeValidation;
+
+use OPNsense\AcmeClient\LeValidationInterface;
+use OPNsense\Core\Config;
+
+/**
+ * mijn.hosty DNS API
+ * @package OPNsense\AcmeClient
+ */
+class DnsMijnHost extends Base implements LeValidationInterface
+{
+    public function prepare()
+    {
+        $this->acme_env['MIJNHOST_API_KEY'] = (string)$this->config->dns_mijnhost_api_key;
+    }
+}

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -529,6 +529,7 @@
                         <dns_zilore>Zilore</dns_zilore>
                         <dns_zone>Zone.eu</dns_zone>
                         <dns_zonomi>zonomi.com</dns_zonomi>
+                        <dns_mijnhost>mijn.host</dns_mijnhost>
                     </OptionValues>
                 </dns_service>
                 <dns_sleep type="IntegerField">
@@ -1307,6 +1308,9 @@
                 <dns_rage4_user type="TextField">
                     <Required>N</Required>
                 </dns_rage4_user>
+                <dns_mijnhost_api_key type="TextField">
+                    <Required>N</Required>
+                </dns_mijnhost_api_key>
             </validation>
         </validations>
         <actions>


### PR DESCRIPTION
Support for mijn.host DNS challenge was merged into dev for acme.sh. Once released, this pull request adds support for mijn.host to the acme client plugin. Not sure how timing of this is supposed to work, but here you go.