### PR TITLE
dns/ddclient: empty ip send to dns provider & replace dyndns by dynu

### DIFF
--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
@@ -142,7 +142,8 @@
                         <web_cloudflare>cloudflare</web_cloudflare>
                         <web_cloudflare_ipv4 value="cloudflare-ipv4">cloudflare-ipv4</web_cloudflare_ipv4>
                         <web_cloudflare_ipv6 value="cloudflare-ipv6">cloudflare-ipv6</web_cloudflare_ipv6>
-                        <web_dyndns>dyndns</web_dyndns>
+                        <web_dynu_ipv4 value="dynu-ipv4">dynu-ipv4</web_dynu_ipv4>
+                        <web_dynu_ipv6 value="dynu-ipv6">dynu-ipv6</web_dynu_ipv6>
                         <web_freedns>freedns</web_freedns>
                         <web_he>he</web_he>
                         <web_icanhazip>icanhazip</web_icanhazip>

--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/__init__.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/__init__.py
@@ -121,7 +121,7 @@ class BaseAccount:
             interface = self.settings['interface'] if self.settings.get('interface' ,'').strip() != '' else None
         )
 
-        if self._current_address == None or self._current_address == "":
+        if not self._current_address:
             syslog.syslog(
                 syslog.LOG_WARNING,
                 "Account %s no global IP address detected, check config if warning persists" % (self.description)

--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/__init__.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/__init__.py
@@ -121,7 +121,7 @@ class BaseAccount:
             interface = self.settings['interface'] if self.settings.get('interface' ,'').strip() != '' else None
         )
 
-        if self._current_address == None or self._current_address == "":
+        if self._current_address == None:
             syslog.syslog(
                 syslog.LOG_WARNING,
                 "Account %s no global IP address detected, check config if warning persists" % (self.description)

--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/__init__.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/__init__.py
@@ -121,7 +121,7 @@ class BaseAccount:
             interface = self.settings['interface'] if self.settings.get('interface' ,'').strip() != '' else None
         )
 
-        if self._current_address == None:
+        if self._current_address == None or self._current_address == "":
             syslog.syslog(
                 syslog.LOG_WARNING,
                 "Account %s no global IP address detected, check config if warning persists" % (self.description)

--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/address.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/address.py
@@ -32,7 +32,8 @@ checkip_service_list = {
   'cloudflare': '%s://one.one.one.one/cdn-cgi/trace',
   'cloudflare-ipv4': '%s://1.1.1.1/cdn-cgi/trace',
   'cloudflare-ipv6': '%s://[2606:4700:4700::1111]/cdn-cgi/trace',
-  'dyndns': '%s://checkip.dyndns.org/',
+  'dynu-ipv4': '%s://ipcheck.dynu.com/',
+  'dynu-ipv6': '%s://ipcheckv6.dynu.com/',
   'freedns': '%s://freedns.afraid.org/dynamic/check.php',
   'he': '%s://checkip.dns.he.net/',
   'icanhazip': '%s://icanhazip.com/',
@@ -64,7 +65,7 @@ def extract_address(host, txt):
                     return match.group()
                 except ValueError:
                     pass
-    return ""
+    return None
 
 
 def checkip(service, proto='https', timeout='10', interface=None):

--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/address.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/address.py
@@ -65,7 +65,7 @@ def extract_address(host, txt):
                     return match.group()
                 except ValueError:
                     pass
-    return None
+    return ""
 
 
 def checkip(service, proto='https', timeout='10', interface=None):


### PR DESCRIPTION
**Important notices**
Before you add a new report, we ask you kindly to acknowledge the following:

- [X] I have read the contributing guide lines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [X] I have searched the existing issues, open and closed, and I'm convinced that mine is new.
- [X] The title contains the plugin to which this issue belongs

**Describe the bug**
The current service to lookup external ip (   https://github.com/opnsense/plugins/blob/master/dns/ddclient/src/opnsense/scripts/ddclient/lib/address.py#L35) for dyndns times out (and has been doing so for ages):

```
curl https://checkip.dyndns.com/
curl: (28) Failed to connect to checkip.dyndns.com port 443 after 300103 ms: Timeout was reached
```
Subsequently no IP is displayed in GUI and no IP is send to the DNS provider.

The PR resolves the dyndns ip lookup by removing the deprentied service dyndns and add dynu ipv4 and ipv6. This will "break" lookup for some, and they will need to revist their dDNS config.

**To Reproduce**
Steps to reproduce the behavior:
1. Go to Dynamic DNS
2. Configure DDNS and use dynu as  "Check ip method"
3. "See error in logs and gui"

**Expected behavior**
DDNS lookup and population of IP working in GUI.

**Environment**
OPNsense 25.1.7-amd64
Plugin: os-ddclient (installed)	1.27_2
