### PR TITLE
fix wrong key in greylist.conf template for whitelisted ips

### DIFF
--- a/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/greylist.conf
+++ b/mail/rspamd/src/opnsense/service/templates/OPNsense/Rspamd/greylist.conf
@@ -11,5 +11,5 @@
   action = "soft reject"; # default greylisted action
   ipv4_mask = {{ OPNsense.Rspamd.graylist.ipv4mask|default('19') }};
   ipv6_mask = {{ OPNsense.Rspamd.graylist.ipv6mask|default('64') }};
-  whitelist_ip = "/usr/local/etc/rspamd/local.d/greylist_ip.wl";
+  whitelisted_ip = "/usr/local/etc/rspamd/local.d/greylist_ip.wl";
 {% endif %}


### PR DESCRIPTION
Hi,

this Bug ist still exist in rspamd plugin

https://forum.opnsense.org/index.php?topic=30204.0

https://forum.opnsense.org/index.php?topic=21665.0
