### PR TITLE
security/intrusion-detection-content-pt-open: (Re-)Add PT IDS-rules plugin

### DIFF
--- a/security/intrusion-detection-content-pt-open/LICENSE
+++ b/security/intrusion-detection-content-pt-open/LICENSE
@@ -1,0 +1,24 @@
+(C) 2024 JSC Positive Technologies. All rights reserved.
+
+Definitions
+
+“Program” refers to any copyrightable work (including rule sets for open source network threat detection engine Suricata) and associated documentation files licensed under this License, accessible at: https://rules.ptsecurity.com “License” means the terms of this license agreement which apply to the Program.
+“Licensee” refers to individuals or legal entities accessing and/or using the Program.
+“Modify” a work (part of the work) means to make any change, including translation of the Program from one language into another, except for adaptation.
+“Copyright holder” means JSС Positive Technologies as the holder of the exclusive right to the Program.
+
+Legal Usage
+
+The Licensee is hereby granted free of charge the rights to use, copy, publish, distribute, sublicense, and/or sell copies of the Program for non-commercial and commercial use subject to the following conditions:
+· The above copyright notice shall be included in all copies or substantial portions of the Program.
+· Neither the name of the Copyright holder nor the names of its contributors may be used to endorse or promote programs in which the Program was integrated without specific prior written permission.
+· Redistributions of the Program must retain the above copyright notice and the full text of the License.
+No permission is hereby granted to the Licensee to modify the Program and distribute the modified Program. However, for the avoidance of doubt, the Licensee is granted the right to integrate the original Program into other programs and distribute such programs.
+
+Applicable law
+
+This License is governed by the laws of the Russian Federation. The rules of the article 1286.1 of the Civil Code of the Russian Federation are applicable to this License.
+
+Disclaimer
+
+THIS PROGRAM IS PROVIDED BY THE COPYRIGHT HOLDER “AS IS”. UNDER NO CIRCUMSTANCES THE COPYRIGHT HOLDER IS LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES RESULTING FROM (I) THE LICENSEE'S USE OF THE PROGRAM; (II) THE LICENSEE'S INTERPRETATION AND APPLICATION OF ANY FILES, METHODS, OR ANY OTHER INFORMATION PROVIDED ON OR THROUGH THE PROGRAM; (III) THE FAILURE OF THE PROGRAM TO MEET THE LICENSEE'S EXPECTATIONS. IF, NOTWITHSTANDING THE OTHER PROVISIONS OF THIS LISENCE, THE COPYRIGHT HOLDER IS FORCED TO BEAR RESPONSIBILITY TO THE LICENSEE FOR ANY LOSSES RELATED TO THE LICENSEE'S USE OF THE PROGRAM, THE COPYRIGHT HOLDER’S LIABILITY SHALL IN NO CASE EXCEED THE EQUIVALENT OF 10 (TEN) U.S. DOLLARS.

--- a/security/intrusion-detection-content-pt-open/Makefile
+++ b/security/intrusion-detection-content-pt-open/Makefile
@@ -1,0 +1,6 @@
+PLUGIN_NAME=		intrusion-detection-content-ptopen
+PLUGIN_VERSION=		1.0
+PLUGIN_COMMENT=		IDS Positive Technologies ESC ruleset
+PLUGIN_MAINTAINER=	kulikov.a@gmail.com
+PLUGIN_WWW=		https://rules.ptsecurity.com
+.include "../../Mk/plugins.mk"

--- a/security/intrusion-detection-content-pt-open/pkg-descr
+++ b/security/intrusion-detection-content-pt-open/pkg-descr
@@ -1,0 +1,12 @@
+IDS PT ESC open ruleset designed to detect a variety of network threats,
+including those communicated under TLS.
+PT Rules is an open-source project focused on enhancing network security
+through proactive threat detection. As the PT Expert Security Center attack
+detection team, we are a dedicated group of cybersecurity experts committed
+to improve network security through open-source initiatives.
+
+Don't forget to define the $DC_SERVERS rule-variable if you want to use the
+protection rules against DCShadow/DCSync attacks.
+
+LICENSE: https://rules.ptsecurity.com/view/LICENSE.txt
+WWW: https://rules.ptsecurity.com/

--- a/security/intrusion-detection-content-pt-open/src/opnsense/scripts/suricata/metadata/rules/pt-open.xml
+++ b/security/intrusion-detection-content-pt-open/src/opnsense/scripts/suricata/metadata/rules/pt-open.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<ruleset documentation_url="https://rules.ptsecurity.com/">
+    <location url="https://rules.ptsecurity.com/files/ptopen.rules.tar.gz" prefix="PT open"/>
+    <files>
+        <file description="attacks" url="inline::rules/ptopen-attacks.rules">ptopen-attacks.rules</file>
+        <file description="info" url="inline::rules/ptopen-info.rules">ptopen-info.rules</file>
+        <file description="malware" url="inline::rules/ptopen-malware.rules">ptopen-malware.rules</file>
+        <file description="tools" url="inline::rules/ptopen-tools.rules">ptopen-tools.rules</file>
+        <file description="windows" url="inline::rules/ptopen-windows.rules">ptopen-windows.rules</file>
+    </files>
+</ruleset>


### PR DESCRIPTION
Hi!
The rather interesting IDS rules from Positive Technologies are available again.
It would be great to add the ability to install them in OPNsense.
Thanks!