### PR TITLE
www/squid: Regex + hint

### DIFF
--- a/www/squid/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
+++ b/www/squid/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
@@ -343,7 +343,8 @@
                 <id>proxy.forward.workers</id>
                 <label>Number of squid workers</label>
                 <type>text</type>
-                <help>Start N main Squid process daemons (i.e., SMP mode). Requires Restart. Do not enable when using local cache! Default: 1</help>
+                <help>Start N main Squid process daemons (i.e., SMP mode). Requires Restart. Do not enable when using local cache.</help>
+                <hint>1</hint>
                 <advanced>true</advanced>
             </field>
             <field>

--- a/www/squid/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
+++ b/www/squid/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
@@ -343,7 +343,7 @@
                 <id>proxy.forward.workers</id>
                 <label>Number of squid workers</label>
                 <type>text</type>
-                <help>Start N main Squid process daemons (i.e., SMP mode). Requires Restart. Default: 1</help>
+                <help>Start N main Squid process daemons (i.e., SMP mode). Requires Restart. Do not enable when using local cache! Default: 1</help>
                 <advanced>true</advanced>
             </field>
             <field>

--- a/www/squid/src/opnsense/service/templates/OPNsense/Syslog/local/squid_access.conf
+++ b/www/squid/src/opnsense/service/templates/OPNsense/Syslog/local/squid_access.conf
@@ -2,5 +2,5 @@
 # Local syslog-ng configuration filter definition [squid_access].
 ###################################################################
 filter f_local_squid_access {
-    program("^(squid-|squid-coord-)\\d+");
+    program("squid-*");
 };


### PR DESCRIPTION
Sorry, i somehow messed up the regex in squid_access.conf..
Also it is necessary to drop a note about not using local cache in combination with multiple workers as our cache_dir is of the type ufs and is not smp-aware.  Rock is currently the only smp-aware cache_dir type.