### PR TITLE
net/udpbroadcastrelay: support SSDP M-SEARCH special handling

### DIFF
--- a/net/udpbroadcastrelay/src/opnsense/mvc/app/controllers/OPNsense/UDPBroadcastRelay/forms/dialogEdit.xml
+++ b/net/udpbroadcastrelay/src/opnsense/mvc/app/controllers/OPNsense/UDPBroadcastRelay/forms/dialogEdit.xml
@@ -44,6 +44,12 @@
       <help><![CDATA[Use the ID to set the TTL Value of the packet (Original method) rather than DSCP, default is not ticked]]></help>
    </field>
    <field>
+      <id>udpbroadcastrelay.msearch_dial</id>
+      <label>SSDP M-SEARCH 'dial' mode</label>
+      <type>checkbox</type>
+      <help>Perform full DIAL protocol processing on M-SEARCH request. Create proxies for M-SEARCH, Locator and REST services.</help>
+   </field>
+   <field>
       <id>udpbroadcastrelay.description</id>
       <label>Description</label>
       <type>text</type>

--- a/net/udpbroadcastrelay/src/opnsense/mvc/app/controllers/OPNsense/UDPBroadcastRelay/forms/dialogEdit.xml
+++ b/net/udpbroadcastrelay/src/opnsense/mvc/app/controllers/OPNsense/UDPBroadcastRelay/forms/dialogEdit.xml
@@ -50,6 +50,13 @@
       <help>Perform full DIAL protocol processing on M-SEARCH request. Create proxies for M-SEARCH, Locator and REST services.</help>
    </field>
    <field>
+      <id>udpbroadcastrelay.msearch_proxy</id>
+      <label>SSDP M-SEARCH 'proxy' mode</label>
+      <type>checkbox</type>
+      <help>Create a local proxy for the M-SEARCH request, send request out with subnet local address and proxy port.
+         Received responses are sent back to original requester with no processing.</help>
+   </field>
+   <field>
       <id>udpbroadcastrelay.description</id>
       <label>Description</label>
       <type>text</type>

--- a/net/udpbroadcastrelay/src/opnsense/mvc/app/models/OPNsense/UDPBroadcastRelay/UDPBroadcastRelay.xml
+++ b/net/udpbroadcastrelay/src/opnsense/mvc/app/models/OPNsense/UDPBroadcastRelay/UDPBroadcastRelay.xml
@@ -50,6 +50,10 @@
             <default>0</default>
             <Required>Y</Required>
          </RevertTTL>
+         <msearch_dial type="BooleanField">
+            <default>0</default>
+            <Required>N</Required>
+         </msearch_dial>
          <description type="TextField">
             <Required>N</Required>
             <mask>/^([\t\n\v\f\r 0-9a-zA-Z.,_\x{00A0}-\x{FFFF}]){1,255}$/u</mask>

--- a/net/udpbroadcastrelay/src/opnsense/mvc/app/models/OPNsense/UDPBroadcastRelay/UDPBroadcastRelay.xml
+++ b/net/udpbroadcastrelay/src/opnsense/mvc/app/models/OPNsense/UDPBroadcastRelay/UDPBroadcastRelay.xml
@@ -54,6 +54,10 @@
             <default>0</default>
             <Required>N</Required>
          </msearch_dial>
+         <msearch_proxy type="BooleanField">
+            <default>0</default>
+            <Required>N</Required>
+         </msearch_proxy>
          <description type="TextField">
             <Required>N</Required>
             <mask>/^([\t\n\v\f\r 0-9a-zA-Z.,_\x{00A0}-\x{FFFF}]){1,255}$/u</mask>

--- a/net/udpbroadcastrelay/src/opnsense/service/templates/OPNsense/UDPBroadcastRelay/rc.conf.d
+++ b/net/udpbroadcastrelay/src/opnsense/service/templates/OPNsense/UDPBroadcastRelay/rc.conf.d
@@ -24,6 +24,9 @@ osudpbroadcastrelay_enable="YES"
 {%    if osudpbroadcastrelay.sourceaddress %}
 {%     do Parameters.append("-s " ~ osudpbroadcastrelay.sourceaddress) %}
 {%    endif %}
+{%    if osudpbroadcastrelay.msearch_dial|default('0') == '1' %}
+{%     do Parameters.append("--msearch dial ") %}
+{%    endif %}
 {%    if osudpbroadcastrelay.RevertTTL|default('0') == '1' %}
 {%     do Parameters.append("-t ") %}
 {%    endif %}

--- a/net/udpbroadcastrelay/src/opnsense/service/templates/OPNsense/UDPBroadcastRelay/rc.conf.d
+++ b/net/udpbroadcastrelay/src/opnsense/service/templates/OPNsense/UDPBroadcastRelay/rc.conf.d
@@ -27,6 +27,9 @@ osudpbroadcastrelay_enable="YES"
 {%    if osudpbroadcastrelay.msearch_dial|default('0') == '1' %}
 {%     do Parameters.append("--msearch dial ") %}
 {%    endif %}
+{%    if osudpbroadcastrelay.msearch_proxy|default('0') == '1' %}
+{%     do Parameters.append("--msearch proxy ") %}
+{%    endif %}
 {%    if osudpbroadcastrelay.RevertTTL|default('0') == '1' %}
 {%     do Parameters.append("-t ") %}
 {%    endif %}


### PR DESCRIPTION
I've been experimentally separating some devices onto a separate VLAN and while mDNS 'just works' with the mdns-repeater plugin, SSDP seems to be a bit more fussy.  I've found adding both the special 'dial' and 'proxy' M-SEARCH modes seems to help, at least for my devices.

This could be extended to be more sophisticated as the daemon does support other modes, and optional filters to these modes, but adding these might be a start at least.  I also don't fully know the use cases for other modes so wouldn't be able to personally see if they make any difference.  Perhaps a future enhancement.