### PR TITLE
www/caddy: Add persistent banner notification if custom imports are used

### DIFF
--- a/www/caddy/src/opnsense/mvc/app/library/OPNsense/System/Status/CaddyOverrideStatus.php
+++ b/www/caddy/src/opnsense/mvc/app/library/OPNsense/System/Status/CaddyOverrideStatus.php
@@ -1,0 +1,54 @@
+<?php
+/*
+ * Copyright (C) 2025 Cedrik Pischem
+ * Copyright (C) 2025 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\System\Status;
+
+use OPNsense\System\AbstractStatus;
+use OPNsense\System\SystemStatusCode;
+
+class CaddyOverrideStatus extends AbstractStatus
+{
+    public function __construct()
+    {
+        $this->internalPriority = 2;
+        $this->internalPersistent = true;
+        $this->internalIsBanner = true;
+        $this->internalTitle = gettext('Caddy config override');
+        $this->internalScope = [
+            '/ui/caddy/layer4',
+            '/ui/caddy/diagnostics',
+            '/ui/caddy/reverse_proxy',
+            '/ui/caddy/general'
+        ];
+
+        if (count(glob('/usr/local/etc/caddy/caddy.d/*.*'))) {
+            $this->internalMessage = gettext('Custom configuration imports exist in "/usr/local/etc/caddy/caddy.d/".');
+            $this->internalStatus = SystemStatusCode::NOTICE;
+        }
+    }
+}


### PR DESCRIPTION
Implements a banner like this when custom configuration imports are used:
https://github.com/opnsense/core/commit/fd39bafe7288689e39a4350188535428043981ad

Fixes: https://github.com/opnsense/plugins/issues/4244