### PR TITLE
security/acme-client: fix export of ca certs for SFTP upload automation

### DIFF
--- a/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/upload_sftp.php
+++ b/security/acme-client/src/opnsense/scripts/OPNsense/AcmeClient/upload_sftp.php
@@ -532,7 +532,7 @@ function exportCertificates(array $cert_refids): array
             $item["key"] = $_tmp["prv"];
             // check if a CA is linked
             if (!empty((string)$cert->caref)) {
-                $item['ca'] = $_tmp['ca'];
+                $item['ca'] = $_tmp['ca']['crt'];
 
                 // combine files to export a fullchain.pem
                 $item["fullchain"] = $item["cert"] . $item["ca"];


### PR DESCRIPTION
export correct array element for ca certs. fixes #4477