### PR TITLE
www/nginx: Add basic support for forced caching

### DIFF
--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/location.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/location.xml
@@ -97,6 +97,13 @@
     <help>Enter how often the resource must be hit before adding it to the cache.</help>
   </field>
   <field>
+    <id>location.cache_valid</id>
+    <label>Cache: Force caching time</label>
+    <type>text</type>
+    <advanced>true</advanced>
+    <help>Force caching of 200, 301 and 302 responses according to the request methods enabled for caching. Given in minutes; leave empty to rely on request/response headers from client and upstream.</help>
+  </field>
+  <field>
     <id>location.cache_background_update</id>
     <label>Cache: Background Update</label>
     <type>checkbox</type>

--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
@@ -349,6 +349,9 @@
         <Required>Y</Required>
         <default>1</default>
       </cache_min_uses>
+      <cache_valid type="IntegerField">
+        <Required>N</Required>
+      </cache_valid>
       <cache_background_update type="BooleanField">
         <Required>Y</Required>
         <default>0</default>

--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/location.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/location.conf
@@ -143,6 +143,9 @@ location {{ location.matchtype }} {{ location.urlpattern }} {
 {%   if location.cache_use_stale is defined and location.cache_use_stale != '' %}
     proxy_cache_use_stale  {{ location.cache_use_stale.replace(',', ' ') }};
 {%   endif %}
+{%   if location.cache_valid is defined and location.cache_valid != '' %}
+    proxy_cache_valid  {{ location.cache_valid }}m;
+{%   endif %}
     proxy_cache_min_uses {{ location.cache_min_uses|default('1') }};
     proxy_cache_background_update {% if location.cache_background_update is defined and location.cache_background_update == '1' %}on{% else %}off{% endif %};
     proxy_cache_lock {% if location.cache_lock is defined and location.cache_lock == '1'%}on{% else %}off{% endif %};


### PR DESCRIPTION
Fixes #4475 by adding an optional, advanced field for locations, which uses the simples variant of the [proxy_cache_valid](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_valid) statement. By default, this will set the given cache validity for results with HTTP 200, 301 or 302 response codes.

Making sure caching only happens for objects that should be cached remains an exercise for the user. This helps the cases where upstreams don't set cache headers at all, in which case nginx will not cache.