### PR TITLE
www/caddy: Disable HTTP/3 to mitigate status 400 issue when reverse proxying the OPNsense WebGUI

### DIFF
--- a/www/caddy/Makefile
+++ b/www/caddy/Makefile
@@ -1,5 +1,6 @@
 PLUGIN_NAME=		caddy
 PLUGIN_VERSION=		1.8.0
+PLUGIN_REVISION=	1
 PLUGIN_DEPENDS=		caddy-custom
 PLUGIN_COMMENT=		Modern Reverse Proxy with Automatic HTTPS, Dynamic DNS and Layer4 Routing
 PLUGIN_MAINTAINER=	cedrik@pischem.com

--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -22,6 +22,7 @@ Plugin Changelog
          dinahosting, civo, easydns, hosttech; must be added via https://caddyserver.com/docs/command-line#caddy-add-package
 * Cleanup: Refactor caddy.inc and add syslog function, change name from Caddy Web Server to Caddy (opnsense/plugins/issues/4426)
 * Cleanup: Some small UI tweaks (opnsense/plugins/pull/4442)
+* Change: Disable HTTP/3 to mitigate status 400 issue when reverse proxying the OPNsense WebGUI (opnsense/plugins/issues/4471)
 
 1.7.6
 

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
@@ -33,10 +33,10 @@
             <help><![CDATA[Run this service as "www" user and group, instead of "root". This setting increases security, but comes with the hard restriction that the well-known port range can not be used anymore. After enabling and saving this setting, the service has to be totally restarted. For this, please disable Caddy and press Apply. Afterwards enable Caddy and press Apply. This setting is reversible by following the same steps.]]></help>
         </field>
         <field>
-            <id>caddy.general.HttpVersion</id>
-            <label>HTTP Version</label>
+            <id>caddy.general.HttpVersions</id>
+            <label>HTTP Versions</label>
             <type>select_multiple</type>
-            <help><![CDATA[Select the HTTP Version for the frontend listeners. By default, QUIC (HTTP/3) is enabled. This means, UDP/443 will be used by Caddy. To free this protocol port combination for a different service, choose a different combination of protocols that does not include HTTP/3.]]></help>
+            <help><![CDATA[Select the HTTP Versions for the frontend listeners. By default, QUIC (HTTP/3) is disabled.]]></help>
         </field>
         <field>
             <id>caddy.general.HttpPort</id>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
@@ -36,7 +36,7 @@
             <id>caddy.general.HttpVersions</id>
             <label>HTTP Versions</label>
             <type>select_multiple</type>
-            <help><![CDATA[Select the HTTP Versions for the frontend listeners. By default, QUIC (HTTP/3) is disabled.]]></help>
+            <help><![CDATA[Select the HTTP versions for the frontend listeners. By default, QUIC (HTTP/3) is disabled.]]></help>
         </field>
         <field>
             <id>caddy.general.HttpPort</id>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//Pischem/caddy</mount>
     <description>Caddy Reverse Proxy</description>
-    <version>1.3.3</version>
+    <version>1.3.4</version>
     <items>
         <general>
             <enabled type="BooleanField">
@@ -98,16 +98,16 @@
                 <ValidationMessage>Please enter a valid Grace Period between 1 and 20 seconds.</ValidationMessage>
                 <Required>Y</Required>
             </GracePeriod>
-            <HttpVersion type="OptionField">
+            <HttpVersions type="OptionField">
                 <Required>Y</Required>
-                <Default>h1,h2,h3</Default>
+                <Default>h1,h2</Default>
                 <Multiple>Y</Multiple>
                 <OptionValues>
                     <h1>HTTP/1.1</h1>
                     <h2>HTTP/2</h2>
                     <h3>HTTP/3</h3>
                 </OptionValues>
-            </HttpVersion>
+            </HttpVersions>
             <LogCredentials type="BooleanField"/>
             <LogAccessPlain type="BooleanField"/>
             <LogAccessPlainKeep type="IntegerField">

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -81,7 +81,7 @@
     {% endif %}
 
     servers {
-        protocols {{ generalSettings.HttpVersion.split(',') | join(' ') }}
+        protocols {{ generalSettings.HttpVersions.split(',') | join(' ') }}
         {% if accessList %}
             trusted_proxies static {{ accessList.clientIps.split(',') | join(' ') }}
         {% endif %}


### PR DESCRIPTION
It's an upstream issue but it could be mitigated with a hotfix.

Explanation here: https://github.com/opnsense/plugins/issues/4471#issuecomment-2599639355

Since this mitigation changes configuration via a forced migration, its a kinda dirty workaround. We do not /have/ to do this, but its a short term solution.

