### PR TITLE
security/acme-client: release 4.8

### DIFF
--- a/security/acme-client/Makefile
+++ b/security/acme-client/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		acme-client
-PLUGIN_VERSION=		4.7
+PLUGIN_VERSION=		4.8
 PLUGIN_COMMENT=		ACME Client
 PLUGIN_MAINTAINER=	opnsense@moov.de
 PLUGIN_DEPENDS=		acme.sh py${PLUGIN_PYTHON}-dns-lexicon

--- a/security/acme-client/pkg-descr
+++ b/security/acme-client/pkg-descr
@@ -10,6 +10,13 @@ Plugin Changelog
 
 4.8
 
+BREAKING CHANGE: Let's Encrypt ends support for the OCSP Must Staple
+extension on 30.01.2025. Issuance requests will fail if this option is
+still enabled past this date.
+
+Changed:
+* Add note regarding the support of OCSP
+
 Fixed:
 * SFTP automation unable to transfer certs (#4477)
 

--- a/security/acme-client/pkg-descr
+++ b/security/acme-client/pkg-descr
@@ -8,6 +8,11 @@ WWW: https://github.com/acmesh-official/acme.sh
 Plugin Changelog
 ================
 
+4.8
+
+Fixed:
+* SFTP automation unable to transfer certs (#4477)
+
 4.7
 
 Added:

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogCertificate.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogCertificate.xml
@@ -69,10 +69,14 @@
         <help><![CDATA[Specify the domain key length: 2048, 3072, 4096, 8192 or ec-256, ec-384.]]></help>
     </field>
     <field>
+        <label><![CDATA[NOTE: OCSP is not supported by all CAs.]]></label>
+        <type>info</type>
+    </field>
+    <field>
         <id>certificate.ocsp</id>
         <label>OCSP Must Staple</label>
         <type>checkbox</type>
-        <help>Generate and add OCSP Must Staple extension to the certificate.</help>
+        <help>Generate and add OCSP Must Staple extension to the certificate. When this option is enabled and issueance/renewal requests fail, then this extension is probably not supported by the CA.</help>
     </field>
     <field>
         <label>Advanced Settings</label>


### PR DESCRIPTION
@fichtner Let's Encrypt is going to make a huge change later this month. This will probably affect many users (and may cause a lot support requests). Is there a chance that you could add a note to the OPNsense 25.1 release notes? Something like this may be sufficient:

> BREAKING CHANGE: Let's Encrypt [ends support](https://letsencrypt.org/2024/12/05/ending-ocsp/) for the OCSP Must Staple
> extension on 30.01.2025. Issuance requests will fail if this option is
> still enabled past this date.

This note is also in the plugin changelog, but it's too easy to miss this important change.