### PR TITLE
www/squid: change cache_dir from ufs to rock

### DIFF
--- a/www/squid/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
+++ b/www/squid/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
@@ -148,17 +148,24 @@
                 <advanced>true</advanced>
             </field>
             <field>
-                <id>proxy.general.cache.local.l1</id>
-                <label>Number of first-level subdirectories</label>
+                <id>proxy.general.cache.local.swap_timeout</id>
+                <label>Disk I/O Timeout for Swap Operations (msec)</label>
                 <type>text</type>
-                <help>Enter the number of first-level subdirectories for the local cache (default is 16).</help>
+                <help>Prevents Squid from reading/writing to disk if the operation exceeds the specified timelimit in milliseconds (default 0 = disable when left empty).</help>
                 <advanced>true</advanced>
             </field>
             <field>
-                <id>proxy.general.cache.local.l2</id>
-                <label>Number of second-level subdirectories</label>
+                <id>proxy.general.cache.local.max_swap_rate</id>
+                <label>Disk I/O Timeout for Swap Operations (swaps/sec)</label>
                 <type>text</type>
-                <help>Enter the number of second-level subdirectories for the local cache (default is 256).</help>
+                <help>Limits disk access by setting a maximum I/O rate in swaps per second (default 0 = disable when left empty).</help>
+                <advanced>true</advanced>
+            </field>
+            <field>
+                <id>proxy.general.cache.local.slot_size</id>
+                <label>Cache Database-Record Size (bytes)</label>
+                <type>text</type>
+                <help>Defines the size of a database record used to store cached responses. Value should be a multiple of the OS I/O page size (default 16384 when left empty).</help>
                 <advanced>true</advanced>
             </field>
             <field>

--- a/www/squid/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
+++ b/www/squid/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
@@ -124,18 +124,21 @@
                         <ValidationMessage>Specify a positive cache size. (number of MB's)</ValidationMessage>
                         <Required>Y</Required>
                     </size>
-                    <l1 type="IntegerField">
-                        <Default>16</Default>
-                        <MinimumValue>1</MinimumValue>
-                        <ValidationMessage>Specify a positive number of first-level subdirectories.</ValidationMessage>
-                        <Required>Y</Required>
-                    </l1>
-                    <l2 type="IntegerField">
-                        <Default>256</Default>
-                        <MinimumValue>1</MinimumValue>
-                        <ValidationMessage>Specify a positive number of second-level subdirectories.</ValidationMessage>
-                        <Required>Y</Required>
-                    </l2>
+                    <swap_timeout type="IntegerField">
+                        <MinimumValue>0</MinimumValue>
+                        <ValidationMessage>Specify a valid swap-timeout.</ValidationMessage>
+                        <Required>N</Required>
+                    </swap_timeout>
+                    <max_swap_rate type="IntegerField">
+                        <MinimumValue>0</MinimumValue>
+                        <ValidationMessage>Specify a valid swap-rate.</ValidationMessage>
+                        <Required>N</Required>
+                    </max_swap_rate>
+                    <slot_size type="IntegerField">
+                        <MinimumValue>4096</MinimumValue>
+                        <ValidationMessage>Specify a multiple of operating system I/O page size.</ValidationMessage>
+                        <Required>N</Required>
+                    </slot_size>
                     <cache_linux_packages type="BooleanField">
                         <Default>0</Default>
                         <Required>Y</Required>

--- a/www/squid/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
+++ b/www/squid/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
@@ -320,7 +320,7 @@ maximum_object_size_in_memory {{OPNsense.proxy.general.cache.local.maximum_objec
 memory_cache_mode {{OPNsense.proxy.general.cache.local.memory_cache_mode}}
 {%  endif %}
 {%   if OPNsense.proxy.general.cache.local.enabled == '1' %}
-cache_dir ufs {{OPNsense.proxy.general.cache.local.directory}} {{OPNsense.proxy.general.cache.local.size}} {{OPNsense.proxy.general.cache.local.l1}} {{OPNsense.proxy.general.cache.local.l2}}
+cache_dir rock {{OPNsense.proxy.general.cache.local.directory}} {{OPNsense.proxy.general.cache.local.size}}{% if not helpers.empty('OPNsense.proxy.general.cache.local.swap_timeout') %} swap-timeout={{OPNsense.proxy.general.cache.local.swap_timeout}}{% endif %}{% if not helpers.empty('OPNsense.proxy.general.cache.local.max_swap_rate') %} max-swap-rate={{OPNsense.proxy.general.cache.local.max_swap_rate}}{% endif %}{% if not helpers.empty('OPNsense.proxy.general.cache.local.slot_size') %} slot-size={{OPNsense.proxy.general.cache.local.slot_size}}{% endif %}
 {%   endif %}
 {%  endif %}
 {% endif %}


### PR DESCRIPTION
This pull-request changes the type of the squid cache_dir from ufs to rock.
We already included the workers in https://github.com/opnsense/plugins/pull/4393 for smp-mode and should also move to rock as the cach_dir type, as rock is currently the only SMP-aware cache_dir type.

Testing happened on OPNSense 24.7.12 with enabled local ufs cache.
Switched to rock and it initialises the rock db in /var/squid/cache.
The pre-rock ufs data stays there until a reset via Squid Web Proxy --> Administration -->  Support --> Reset is done.

More information: http://www.squid-cache.org/Doc/config/cache_dir/