### PR TITLE
security/tailscale: make login timeout (tailscale up --timeout parameter) configurable

### DIFF
--- a/security/tailscale/src/opnsense/mvc/app/controllers/OPNsense/Tailscale/forms/settings.xml
+++ b/security/tailscale/src/opnsense/mvc/app/controllers/OPNsense/Tailscale/forms/settings.xml
@@ -6,6 +6,13 @@
         <help>This will activate the Tailscale service.</help>
     </field>
     <field>
+        <id>settings.loginTimeout</id>
+        <label>Login timeout</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>Maximum time to wait for successful login, in seconds. Set to 0 to wait indefinitely, however this may prevent OPNsense booting completely if the Tailscale control plane is unavailable. Default is 10 seconds.</help>
+    </field>
+    <field>
         <id>settings.listenPort</id>
         <label>Listen Port</label>
         <type>text</type>
@@ -28,12 +35,5 @@
         <label>Accept Subnet Routes</label>
         <type>checkbox</type>
         <help>Accept subnet routes that other nodes advertise.</help>
-    </field>
-    <field>
-        <id>settings.loginTimeout</id>
-        <label>Login timeout</label>
-        <type>text</type>
-        <help>Maximum time to wait for successful login, in seconds.  Set to 0 to wait indefinitely, however this may prevent
-            OPNsense booting completely if the Tailscale control plane is unavailable.  Default is 10 seconds.</help>
     </field>
 </form>

--- a/security/tailscale/src/opnsense/mvc/app/controllers/OPNsense/Tailscale/forms/settings.xml
+++ b/security/tailscale/src/opnsense/mvc/app/controllers/OPNsense/Tailscale/forms/settings.xml
@@ -8,7 +8,7 @@
     <field>
         <id>settings.listenPort</id>
         <label>Listen Port</label>
-	<type>text</type>
+        <type>text</type>
         <help>UDP port to listen on for WireGuard and peer-to-peer traffic.</help>
     </field>
     <field>
@@ -28,5 +28,12 @@
         <label>Accept Subnet Routes</label>
         <type>checkbox</type>
         <help>Accept subnet routes that other nodes advertise.</help>
+    </field>
+    <field>
+        <id>settings.loginTimeout</id>
+        <label>Login timeout</label>
+        <type>text</type>
+        <help>Maximum time to wait for successful login, in seconds.  Set to 0 to wait indefinitely, however this may prevent
+            OPNsense booting completely if the Tailscale control plane is unavailable.  Default is 10 seconds.</help>
     </field>
 </form>

--- a/security/tailscale/src/opnsense/mvc/app/models/OPNsense/Tailscale/Settings.xml
+++ b/security/tailscale/src/opnsense/mvc/app/models/OPNsense/Tailscale/Settings.xml
@@ -6,6 +6,10 @@
             <default>0</default>
             <Required>Y</Required>
         </enabled>
+        <loginTimeout type="IntegerField">
+            <default>10</default>
+            <Required>Y</Required>
+        </loginTimeout>
         <listenPort type="PortField">
             <default>41641</default>
             <Required>Y</Required>
@@ -32,9 +36,5 @@
                 <description type="DescriptionField"/>
             </subnet4>
         </subnets>
-        <loginTimeout type="IntegerField">
-            <default>10</default>
-            <Required>Y</Required>
-        </loginTimeout>
     </items>
 </model>

--- a/security/tailscale/src/opnsense/mvc/app/models/OPNsense/Tailscale/Settings.xml
+++ b/security/tailscale/src/opnsense/mvc/app/models/OPNsense/Tailscale/Settings.xml
@@ -32,5 +32,9 @@
                 <description type="DescriptionField"/>
             </subnet4>
         </subnets>
+        <loginTimeout type="IntegerField">
+            <default>10</default>
+            <Required>Y</Required>
+        </loginTimeout>
     </items>
 </model>

--- a/security/tailscale/src/opnsense/service/templates/OPNsense/Tailscale/rc.conf.d
+++ b/security/tailscale/src/opnsense/service/templates/OPNsense/Tailscale/rc.conf.d
@@ -10,11 +10,7 @@ tailscaled_enable="YES"
 tailscaled_port="{{ OPNsense.tailscale.settings.listenPort }}"
 {%    endif %}
 {%    set up_args = [] %}
-{%    if helpers.exists('OPNsense.tailscale.settings.loginTimeout') %}
 {%      do up_args.append("--timeout=" + OPNsense.tailscale.settings.loginTimeout + "s") %}
-{%    else %}
-{%      do up_args.append("--timeout=10s") %}
-{%    endif %}
 {%    if helpers.exists('OPNsense.tailscale.settings.advertiseExitNode') and OPNsense.tailscale.settings.advertiseExitNode|default("0") == "1" %}
 {%      do up_args.append("--advertise-exit-node") %}
 {%    else %}

--- a/security/tailscale/src/opnsense/service/templates/OPNsense/Tailscale/rc.conf.d
+++ b/security/tailscale/src/opnsense/service/templates/OPNsense/Tailscale/rc.conf.d
@@ -9,7 +9,12 @@ tailscaled_enable="YES"
 {%    if helpers.exists('OPNsense.tailscale.settings.listenPort') %}
 tailscaled_port="{{ OPNsense.tailscale.settings.listenPort }}"
 {%    endif %}
-{%    set up_args = ["--timeout=10s"] %}
+{%    set up_args = [] %}
+{%    if helpers.exists('OPNsense.tailscale.settings.loginTimeout') %}
+{%      do up_args.append("--timeout=" + OPNsense.tailscale.settings.loginTimeout + "s") %}
+{%    else %}
+{%      do up_args.append("--timeout=10s") %}
+{%    endif %}
 {%    if helpers.exists('OPNsense.tailscale.settings.advertiseExitNode') and OPNsense.tailscale.settings.advertiseExitNode|default("0") == "1" %}
 {%      do up_args.append("--advertise-exit-node") %}
 {%    else %}

--- a/security/tailscale/src/opnsense/service/templates/OPNsense/Tailscale/rc.conf.d
+++ b/security/tailscale/src/opnsense/service/templates/OPNsense/Tailscale/rc.conf.d
@@ -9,7 +9,7 @@ tailscaled_enable="YES"
 {%    if helpers.exists('OPNsense.tailscale.settings.listenPort') %}
 tailscaled_port="{{ OPNsense.tailscale.settings.listenPort }}"
 {%    endif %}
-{%    set up_args = [] %}
+{%    set up_args = ["--timeout=10s"] %}
 {%    if helpers.exists('OPNsense.tailscale.settings.advertiseExitNode') and OPNsense.tailscale.settings.advertiseExitNode|default("0") == "1" %}
 {%      do up_args.append("--advertise-exit-node") %}
 {%    else %}


### PR DESCRIPTION
If the Tailscale (or Headscale) control plane is unavailable at OPNsense boot time then the boot will stall because `tailscale up` by default will wait indefinitely to connect.  This seems undesirable, even in my case where I use Tailscale rather than a self hosted instance, an outage may be unlikely but I would still rather OPNsense didn't get stuck booting up if I rebooted during some Tailscale outage, or even if my Internet connection were simply down and I was rebooting as part of diagnosing that.

I've made the timeout configurable, defaulting to 10 seconds, which feels like it should be long enough to connect in the majority of cases.  If timeout does occur, the daemon still runs, and will reconnect on its own once the control plane is available again.

ref forum thread: https://forum.opnsense.org/index.php?topic=45309.0 