### PR TITLE
dns/ddclient: Add support for altering IPv6 addresses in ddclient plugin

### DIFF
--- a/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/dialogAccount.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/dialogAccount.xml
@@ -93,10 +93,10 @@
     </field>
     <field>
         <id>account.dynipv6host</id>
-        <label>Dynamic ipv6 partial address</label>
+        <label>Dynamic ipv6 host</label>
         <type>text</type>
         <advanced>true</advanced>
-        <help>Swap the host part of the ipv6 address with the given partial ipv6 address</help>
+        <help>Swap the interface identifier of the ipv6 address with the given partial ipv6 address</help>
     </field>
     <field>
         <id>account.checkip_timeout</id>

--- a/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/dialogAccount.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/dialogAccount.xml
@@ -92,6 +92,13 @@
         <type>dropdown</type>
     </field>
     <field>
+        <id>account.dynipv6host</id>
+        <label>Dynamic ipv6 partial address</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>Swap the host part of the ipv6 address with the given partial ipv6 address</help>
+    </field>
+    <field>
         <id>account.checkip_timeout</id>
         <label>Check ip timeout</label>
         <type>text</type>

--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
@@ -165,6 +165,11 @@
                         </check001>
                     </Constraints>
                 </checkip>
+                <dynipv6host type="TextField">
+                    <Required>N</Required>
+                    <mask>/^::(([0-9a-fA-F]{1,4}:){0,3}[0-9a-fA-F]{1,4})?$/u</mask>
+                    <ValidationMessage>Entry is not a valid partial ipv6 address definition (e.g. ::1000).</ValidationMessage>
+                </dynipv6host>
                 <checkip_timeout type="IntegerField">
                     <Default>10</Default>
                     <Required>Y</Required>

--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/__init__.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/__init__.py
@@ -119,7 +119,7 @@ class BaseAccount:
             proto = 'https' if self.settings.get('force_ssl', False) else 'http',
             timeout = str(self.settings.get('checkip_timeout', '10')),
             interface = self.settings['interface'] if self.settings.get('interface' ,'').strip() != '' else None,
-            dynipv6host = self.settings.get('dynipv6host')
+            dynipv6host = self.settings['dynipv6host'] if self.settings.get('dynipv6host' ,'').strip() != '' else None
         )
 
         if self._current_address == None:

--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/__init__.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/__init__.py
@@ -118,7 +118,8 @@ class BaseAccount:
             service = self.settings.get('checkip'),
             proto = 'https' if self.settings.get('force_ssl', False) else 'http',
             timeout = str(self.settings.get('checkip_timeout', '10')),
-            interface = self.settings['interface'] if self.settings.get('interface' ,'').strip() != '' else None
+            interface = self.settings['interface'] if self.settings.get('interface' ,'').strip() != '' else None,
+            dynipv6host = self.settings.get('dynipv6host')
         )
 
         if self._current_address == None:

--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/address.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/address.py
@@ -67,11 +67,12 @@ def extract_address(host, txt):
     return ""
 
 
-def checkip(service, proto='https', timeout='10', interface=None):
+def checkip(service, proto='https', timeout='10', interface=None, dynipv6host=None):
     """ find ip address using external services defined in checkip_service_list
         :param proto: protocol
         :param timeout: timeout in seconds
         :param interface: bind to interface
+        :param dynipv6host: optional partial ipv6 address
         :return: str
     """
     if service.startswith('web_'):
@@ -95,6 +96,9 @@ def checkip(service, proto='https', timeout='10', interface=None):
                 if (parts[0] == 'inet' and service == 'if') or (parts[0] == 'inet6' and service == 'if6'):
                     try:
                         address = ipaddress.ip_address(parts[1])
+                        # alter dynamic ipv6 address
+                        if dynipv6host and isinstance(address, ipaddress.IPv6Address):
+                            address = ipaddress.ip_address(':'.join(parts[1].split(':')[:4]) + ':' + ':'.join(str(ipaddress.ip_address(dynipv6host).exploded).split(':')[4:]))
                         if address.is_global:
                             return str(address)
                     except ValueError:

--- a/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.json
+++ b/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.json
@@ -22,6 +22,7 @@
             "zone": "{{ account.zone }}",
             "checkip": "{{ account.checkip }}",
             "interface": "{% if account.interface %}{{physical_interface(account.interface)}}{% endif %}",
+            "dynipv6host": "{{ account.dynipv6host }}",
             "checkip_timeout": {{ account.checkip_timeout }},
             "force_ssl": {{ "true" if account.force_ssl == '1' else "false"}},
             "ttl": "{{ account.ttl }}",


### PR DESCRIPTION
When using the DynDNS client in combination with IPv6 addresses with a dynamic prefix, it is currently impossible to change the host part of the address to another host in the network. This pull request aims to fix this issue by adding the necessary functionality to the ddclient plugin.

A new field is added to the advanced view, where a partial IPv6 address (the host part) can be added. Validation is performed, so that the user can only enter a valid partial IPv6 address.

When this field is populated and the IP in question is an IPv6 (e.g. by using the "Interface [IPv6]" method), the IP for the DynDNS service will be altered so that the prefix stays and the host part is added.

Should resolve #4466

![grafik](https://github.com/user-attachments/assets/94b938d6-d5b9-49f0-af38-9f687ac38ba0)

![grafik](https://github.com/user-attachments/assets/23769ba8-0ae6-4075-bdf1-21fafd59ec6a)

![grafik](https://github.com/user-attachments/assets/5fa28b55-bd0f-453e-a8a7-077dc5926cbb)
