### PR TITLE
security/acme-client: Add support for Scaleway DNS challenge

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -1924,4 +1924,14 @@
         <label>Token</label>
         <type>password</type>
     </field>
+    <field>
+        <label>scaleway</label>
+        <type>header</type>
+        <style>table_dns table_dns_scaleway</style>
+    </field>
+    <field>
+        <id>validation.dns_scaleway_token</id>
+        <label>API Key</label>
+        <type>text</type>
+    </field>
 </form>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsScaleway.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsScaleway.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Copyright (C) 2025 Yann Bayart
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\AcmeClient\LeValidation;
+
+use OPNsense\AcmeClient\LeValidationInterface;
+use OPNsense\Core\Config;
+
+/**
+ * scaleway DNS API
+ * @package OPNsense\AcmeClient
+ */
+class DnsScaleway extends Base implements LeValidationInterface
+{
+    public function prepare()
+    {
+        $this->acme_env['SCALEWAY_API_TOKEN'] = (string)$this->config->dns_scaleway_token;
+    }
+}

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -513,6 +513,7 @@
                         <dns_rackspace>Rackspace</dns_rackspace>
                         <dns_rage4>rage4</dns_rage4>
                         <dns_regru>RegRu</dns_regru>
+                        <dns_scaleway>Scaleway</dns_scaleway>
                         <dns_schlundtech>SchlundTech</dns_schlundtech>
                         <dns_selectel>selectel.com / selectel.ru</dns_selectel>
                         <dns_selfhost>Selfhost</dns_selfhost>
@@ -1307,6 +1308,9 @@
                 <dns_rage4_user type="TextField">
                     <Required>N</Required>
                 </dns_rage4_user>
+                <dns_scaleway_token type="TextField">
+                    <Required>N</Required>
+                </dns_scaleway_token>
             </validation>
         </validations>
         <actions>


### PR DESCRIPTION
Support for Scaleway DNS challenge, available in acme.sh since 2020: https://github.com/acmesh-official/acme.sh/blob/master/dnsapi/dns_scaleway.sh

Displays `API Key` to match Scaleway UI:
<img width="619" alt="image" src="https://github.com/user-attachments/assets/e90bda3b-f68f-4d2d-8a0a-5e8c9d3afe1e" />
but using `SCALEWAY_API_TOKEN` as this is the name of the value in acme.sh