### PR TITLE
Fixing non-existing path in maltrail.conf

### DIFF
--- a/security/maltrail/src/opnsense/service/templates/OPNsense/Maltrail/maltrail.conf
+++ b/security/maltrail/src/opnsense/service/templates/OPNsense/Maltrail/maltrail.conf
@@ -36,7 +36,7 @@ SYSLOG_SERVER {{ OPNsense.maltrail.sensor.syslogserver }}:{{ OPNsense.maltrail.s
 {% endif %}
 
 SENSOR_NAME $HOSTNAME
-CUSTOM_TRAILS_DIR /usr/local/maltrail/trails/custom/
+CUSTOM_TRAILS_DIR /usr/local/share/maltrail/trails/custom/
 PROCESS_COUNT $CPU_CORES
 DISABLE_CPU_AFFINITY false
 USE_FEED_UPDATES true


### PR DESCRIPTION
This hard-coded path does not exist on OPNsense at all