### PR TITLE
security/tailscale: fix display of 'exit node' status

### DIFF
--- a/security/tailscale/src/opnsense/www/js/widgets/Tailscale.js
+++ b/security/tailscale/src/opnsense/www/js/widgets/Tailscale.js
@@ -78,7 +78,7 @@ export default class Tailscale extends BaseTableWidget {
         result['online'] = (data.Self.Online === true) ?
           this.translations.yes : this.translations.no;
 
-        result['exitNode'] = (data.Self.ExitNode === true) ?
+        result['exitNode'] = (data.Self.ExitNodeOption === true) ?
           this.translations.yes : this.translations.no;
 
         result['peerCount'] = Object.keys(data.Peer).length;


### PR DESCRIPTION
Determine the exit node status from 'ExitNodeOption' instead of 'ExitNode'.

I believe from some experimenting that 'ExitNode' set on an entry under Peers means 'this peer is my current exit node', and 'ExitNodeOption' on Self or under Peers means 'this peer (or self) offers an exit node'.  Therefore for the dashboard display I think Self.ExitNodeOption is correct, and I'm not sure that Self.ExitNode can ever be true, since a machine would never be its own exit node.  From some testing on OPNsense and a Linux based exit node I haven't seen Self.ExitNode true on either of them.

ref forum thread: https://forum.opnsense.org/index.php?topic=45368.0
