### PR TITLE
www/caddy: Add buttons below model relation fields for improved UX, fix wizard buttons

### DIFF
--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/general.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/general.volt
@@ -113,7 +113,35 @@
                 setSpinner(generalId, 'stop');
             });
         });
+
+        // Add buttons that redirect users to the correct model relation fields for better UX
+        const addButton = $(`
+            <button data-action="add" type="button" class="btn btn-xs btn-primary" style="margin-top: 5px;">
+                <span class="fa fa-plus"></span>
+            </button>
+        `);
+
+        function appendButton(selectors, idPrefix) {
+            $(selectors).each(function(index) {
+                $(this).after(addButton.clone().attr("id", idPrefix + index));
+            });
+        }
+
+        appendButton("#select_caddy\\.general\\.accesslist", "btnAddAccessList");
+        appendButton("#select_caddy\\.general\\.ClientIpHeaders, #select_caddy\\.general\\.AuthCopyHeaders", "btnAddHeader");
+
+        $(document).on("click", "[id^='btnAddAccessList']", function(e) {
+            e.preventDefault();
+            window.location.href = "/ui/caddy/reverse_proxy#btnAddAccessList";
+        });
+
+        $(document).on("click", "[id^='btnAddHeader']", function(e) {
+            e.preventDefault();
+            window.location.href = "/ui/caddy/reverse_proxy#btnAddHeader";
+        });
+
     });
+
 </script>
 
 <!-- General Tab -->

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/general.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/general.volt
@@ -116,10 +116,14 @@
 
         // Add buttons that redirect users to the correct model relation fields for better UX
         const addButton = $(`
-            <button data-action="add" type="button" class="btn btn-xs btn-secondary" style="margin-top: 5px;">
+            <button data-action="add" type="button" class="btn btn-xs btn-secondary" style="margin-top: 5px;" data-toggle="tooltip" title="{{ lang._('Create Item') }}">
                 <span class="fa fa-plus"></span>
             </button>
         `);
+
+        $(function () {
+            $('[data-toggle="tooltip"]').tooltip();
+        });
 
         function appendButton(selectors, idPrefix) {
             $(selectors).each(function(index) {

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/general.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/general.volt
@@ -121,10 +121,6 @@
             </button>
         `);
 
-        $(function () {
-            $('[data-toggle="tooltip"]').tooltip();
-        });
-
         function appendButton(selectors, idPrefix) {
             $(selectors).each(function(index) {
                 $(this).after(addButton.clone().attr("id", idPrefix + index));
@@ -143,6 +139,8 @@
             e.preventDefault();
             window.location.href = "/ui/caddy/reverse_proxy#btnAddHeader";
         });
+
+        $('[data-toggle="tooltip"]').tooltip();
 
     });
 

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/general.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/general.volt
@@ -116,7 +116,7 @@
 
         // Add buttons that redirect users to the correct model relation fields for better UX
         const addButton = $(`
-            <button data-action="add" type="button" class="btn btn-xs btn-primary" style="margin-top: 5px;">
+            <button data-action="add" type="button" class="btn btn-xs btn-secondary" style="margin-top: 5px;">
                 <span class="fa fa-plus"></span>
             </button>
         `);

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -274,7 +274,7 @@
          */
 
         const addButton = $(`
-            <button data-action="add" type="button" class="btn btn-xs btn-primary" style="margin-top: 5px;">
+            <button data-action="add" type="button" class="btn btn-xs btn-secondary" style="margin-top: 5px;">
                 <span class="fa fa-plus"></span>
             </button>
         `);
@@ -291,12 +291,15 @@
             "btnAddBasicAuth": { tab: "#accessTab", tableId: "{{formGridBasicAuth['table_id']}}" },
             "btnAddHeader": { tab: "#headerTab", tableId: "{{formGridHeader['table_id']}}" },
             "btnAddHandle": { tab: "#handlesTab", tableId: "{{formGridHandle['table_id']}}" },
-            "btnAddDomain": { tab: "#domainsTab", tableId: "{{formGridReverseProxy['table_id']}}" }
+            "btnAddDomain": { tab: "#domainsTab", tableId: "{{formGridReverseProxy['table_id']}}" },
+            "btnAddSubdomain": { tab: "#domainsTab", tableId: "{{formGridSubdomain['table_id']}}" }
         };
 
         appendButton("#select_reverse\\.accesslist, #select_subdomain\\.accesslist, #select_handle\\.accesslist", "btnAddAccessList");
         appendButton("#select_reverse\\.basicauth, #select_subdomain\\.basicauth", "btnAddBasicAuth");
         appendButton("#select_handle\\.header", "btnAddHeader");
+        appendButton("#select_handle\\.reverse", "btnAddDomain");
+        appendButton("#select_handle\\.subdomain", "btnAddSubdomain")
 
         // The same buttons can be triggered via URL hash from the "General Settings" page
         const hash = window.location.hash.substring(1);
@@ -308,6 +311,7 @@
         }
 
         $(document).on("click", "[id^='btnAdd']", function() {
+            // XXX: Close all open modals first. Overlapping modals seem to work but they are not used anywhere else.
             $(".modal").each(function() {
                 let closeButton = $(this).find("[data-dismiss='modal']");
                 if (closeButton.length) {

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -262,10 +262,6 @@
             }
         });
 
-        // Service Actions
-        updateServiceControlUI('caddy');
-        loadDomainFilters();
-
         /**
          * These "+" buttons are added below their respective selectpicker fields inside the modals.
          * The button's ID is generated based on the prefix provided.
@@ -278,10 +274,6 @@
                 <span class="fa fa-plus"></span>
             </button>
         `);
-
-        $(function () {
-            $('[data-toggle="tooltip"]').tooltip();
-        });
 
         function appendButton(selectors, idPrefix) {
             $(selectors).each(function(index) {
@@ -336,6 +328,10 @@
                 }
             }
         });
+
+        updateServiceControlUI('caddy');
+        loadDomainFilters();
+        $('[data-toggle="tooltip"]').tooltip();
 
     });
 

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -229,10 +229,10 @@
         // Add click event listener for "Add Handler" button
         $("#addHandleBtn").on("click", function() {
             if ($('#maintabs .active a').attr('href') === "#handlesTab") {
-                $("#addReverseHandleBtn").click();
+                $(`#{{formGridHandle['table_id']}} button[data-action="add"]`).click();
             } else {
-                $('#maintabs a[href="#handlesTab"]').tab('show').one('shown.bs.tab', function(e) {
-                    $("#addReverseHandleBtn").click();
+                $('#maintabs a[href="#handlesTab"]').tab('show').one('shown.bs.tab', function() {
+                    $(`#{{formGridHandle['table_id']}} button[data-action="add"]`).click();
                 });
             }
         });
@@ -240,10 +240,10 @@
         // Add click event listener for "Add Domain" button
         $("#addDomainBtn").on("click", function() {
             if ($('#maintabs .active a').attr('href') === "#domainsTab") {
-                $("#addReverseProxyBtn").click();
+                $(`#{{formGridReverseProxy['table_id']}} button[data-action="add"]`).click();
             } else {
-                $('#maintabs a[href="#domainsTab"]').tab('show').one('shown.bs.tab', function(e) {
-                    $("#addReverseProxyBtn").click();
+                $('#maintabs a[href="#domainsTab"]').tab('show').one('shown.bs.tab', function() {
+                    $(`#{{formGridReverseProxy['table_id']}} button[data-action="add"]`).click();
                 });
             }
         });
@@ -332,7 +332,7 @@
         </div>
         <!-- Selectpicker and Clear All on the right -->
         <div class="filter-actions" style="display: flex; flex-direction: column; align-items: flex-end;">
-            <select id="reverseFilter" class="selectpicker form-control" multiple data-live-search="true" data-width="348px" data-size="7" title="{{ lang._('Filter by Domain') }}">
+            <select id="reverseFilter" class="selectpicker form-control" multiple data-live-search="true" data-width="334px" data-size="7" title="{{ lang._('Filter by Domain') }}">
             </select>
             <a href="#" class="text-danger" id="clearDomains" style="margin-top: 5px;">
                 <i class="fa fa-times-circle"></i> <small>Clear All</small>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -273,11 +273,15 @@
          * An event listener can trigger the same buttons from other pages, e.g. from the General Settings.
          */
 
-        const addButton = $(`
-            <button data-action="add" type="button" class="btn btn-xs btn-secondary" style="margin-top: 5px;">
+         const addButton = $(`
+            <button data-action="add" type="button" class="btn btn-xs btn-secondary" style="margin-top: 5px;" data-toggle="tooltip" title="{{ lang._('Create Item') }}">
                 <span class="fa fa-plus"></span>
             </button>
         `);
+
+        $(function () {
+            $('[data-toggle="tooltip"]').tooltip();
+        });
 
         function appendButton(selectors, idPrefix) {
             $(selectors).each(function(index) {


### PR DESCRIPTION
Fixes: https://github.com/opnsense/plugins/issues/4509

The new buttons appear below /all/ model relation field selectpickers. Upon press the redirect the user to the correct ui page, tab and modal to add a new entry.