### PR TITLE
dns/ddclient: Fix Netcup host/domain recognition

### DIFF
--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/netcup.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/netcup.py
@@ -65,7 +65,7 @@ class Netcup(BaseAccount):
                 return False
 
             self.domain = self.settings['hostnames'].split('.', self.settings['hostnames'].count('.')-1)[-1]
-            self.hostname = self.settings['hostnames'].rsplit('.', 2)[0] if self.domain is not self.settings['hostnames'] else '@'
+            self.hostname = self.settings['hostnames'].rsplit('.', 2)[0] if self.domain != self.settings['hostnames'] else '@'
 
             if self.settings['password'].count('|') == 1:
                 self.settings['APIPassword'], self.settings['APIKey'] = self.settings['password'].split('|')


### PR DESCRIPTION
The current implementation of the Netcup DynDNS provider only correctly updates single level subdomains (e.g. "sub.example.com"). When using the main domain (e.g. "example.com") or further levels of subdomains (e.g. "sub.sub.example.com"), the Netcup API responds with error messages.

The API expects a domainname and a hostname to correctly process the request. These two variables are generated by the hostnames input field in the OPNsense webgui by splitting using the "." symbol and using the part before the first split as the hostname and the part after the first split as the domainname. This will result in wrong assignments for hostname and/or domain if more than 2 or less than 2 dots are used in the input.

This PR resolves this issue by using the idea of @Sduniii in #3966. Additionally, "@" is used for the hostname if the main domain is entered as input (according to API specification).

Examples:

|            |                 |                     |             |
| ---------- | --------------- | ------------------- | ----------- |
| Input      | sub.example.com | sub.sub.example.com | example.com |
| Hostname   | sub             | sub.sub             | @           |
| Domainname | example.com     | example.com         | example.com |

References:
[Netcup API description](https://ccp.netcup.net/run/webservice/servers/endpoint.php)
[Netcup domain check regex](https://ccp.netcup.net/run/webservice/xsd/simpletypes.xsd)

Should resolve #3966