### PR TITLE
dns/ddclient: Add __IPV6PREFIX__ replace for custom urls

### DIFF
--- a/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/dialogAccount.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/dialogAccount.xml
@@ -30,6 +30,7 @@
         <help>DynDNS Server hostname or uri to use (depending on the protocol).
          When a URI is provided, the tag __MYIP__ will be replaced with the current detected address for this service
          and __HOSTNAME__ will contain the (comma separated) list of hostnames provided.
+         If the current address is an IPv6 the tag __IPV6PREFIX__ will be replaced with the /64 prefix of the current address.
          </help>
         <style>optional_setting service_custom</style>
     </field>

--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/dyndns2.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/dyndns2.py
@@ -23,6 +23,7 @@
     ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
     POSSIBILITY OF SUCH DAMAGE.
 """
+import ipaddress
 import syslog
 import requests
 from requests.auth import HTTPBasicAuth
@@ -71,6 +72,8 @@ class DynDNS2(BaseAccount):
                 url = self.settings.get('server')
                 url = url.replace('__MYIP__', self.current_address)
                 url = url.replace('__HOSTNAME__', self.settings.get('hostnames'))
+                if self.current_address.find(':') > 0:
+                    url = url.replace('__IPV6PREFIX__', str(ipaddress.ip_network("%s/64" % self.current_address, strict=False)))
                 req = requests.request(
                     method=protocol,
                     url=url,


### PR DESCRIPTION
Some of the DynDNS providers allow setting an IPv6 prefix. So you can have multiple hosts updated at the same time, if they are within the same network/prefix.

For example:
https://ipv64.net/dyndns_updater_api
https://dynv6.com/docs/apis#update

Currently I am using the DYNDNS2 custom URL/custom GET to update the IPv6 prefix at my DNS provider. The API offers parameters like **ipv6prefix=auto** to auto detect the IPv6 prefix. Unfortunately I can not use the "auto" parameter because I have different prefixes on WAN and LAN. I assume these are called IA_PD and IA_NA. But probably there are multiple use cases to this, for example if you have multiple LAN segments with different prefixes. So I want to explicitly define the prefix which shall be used.

The idea is to add an replacement tag __IPV6PREFIX__ for custom URLs. Just like __MYIP__ which is already present.
As the __MYIP__ is taken from the "Interface to track" this should use IP address of the interface to determine the correct IPv6 prefix.

The replacement will only be done, if the IP address is IPv6.

This relates to #3558 and will add the possibility to add IPv6 Prefix updates. Unfortunately the update will only work using custom URLs with this change.