### PR TITLE
www/caddy: Add client_ip_headers

### DIFF
--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -84,6 +84,17 @@
                     </reverseproxy>
                 </Model>
             </accesslist>
+            <ClientIpHeaders type="ModelRelationField">
+                <Model>
+                    <reverseproxy>
+                        <source>OPNsense.Caddy.Caddy</source>
+                        <items>reverseproxy.header</items>
+                        <display>HeaderType,description</display>
+                        <display_format>%s %s</display_format>
+                    </reverseproxy>
+                </Model>
+                <Multiple>Y</Multiple>
+            </ClientIpHeaders>
             <DisableSuperuser type="OptionField">
                 <Required>Y</Required>
                 <Default>0</Default>
@@ -168,26 +179,16 @@
                 <Mask>/^(\/.*)?$/u</Mask>
                 <ValidationMessage>Please enter a valid 'URI' that starts with '/'.</ValidationMessage>
             </AuthToUri>
-            <AuthCopyHeaders type="OptionField">
+            <AuthCopyHeaders type="ModelRelationField">
+                <Model>
+                    <reverseproxy>
+                        <source>OPNsense.Caddy.Caddy</source>
+                        <items>reverseproxy.header</items>
+                        <display>HeaderType,description</display>
+                        <display_format>%s %s</display_format>
+                    </reverseproxy>
+                </Model>
                 <Multiple>Y</Multiple>
-                <OptionValues>
-                    <Authorization>Authorization</Authorization>
-                    <Remote-User>Remote-User</Remote-User>
-                    <Remote-Groups>Remote-Groups</Remote-Groups>
-                    <Remote-Name>Remote-Name</Remote-Name>
-                    <Remote-Email>Remote-Email</Remote-Email>
-                    <X-Authentik-Username>X-Authentik-Username</X-Authentik-Username>
-                    <X-Authentik-Groups>X-Authentik-Groups</X-Authentik-Groups>
-                    <X-Authentik-Email>X-Authentik-Email</X-Authentik-Email>
-                    <X-Authentik-Name>X-Authentik-Name</X-Authentik-Name>
-                    <X-Authentik-Uid>X-Authentik-Uid</X-Authentik-Uid>
-                    <X-Authentik-Jwt>X-Authentik-Jwt</X-Authentik-Jwt>
-                    <X-Authentik-Meta-Jwks>X-Authentik-Meta-Jwks</X-Authentik-Meta-Jwks>
-                    <X-Authentik-Meta-Outpost>X-Authentik-Meta-Outpost</X-Authentik-Meta-Outpost>
-                    <X-Authentik-Meta-Provider>X-Authentik-Meta-Provider</X-Authentik-Meta-Provider>
-                    <X-Authentik-Meta-App>X-Authentik-Meta-App</X-Authentik-Meta-App>
-                    <X-Authentik-Meta-Version>X-Authentik-Meta-Version</X-Authentik-Meta-Version>
-                </OptionValues>
             </AuthCopyHeaders>
         </general>
         <reverseproxy>

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -85,6 +85,14 @@
         {% if accessList %}
             trusted_proxies static {{ accessList.clientIps.split(',') | join(' ') }}
         {% endif %}
+        {% if generalSettings.ClientIpHeaders %}
+            {% for header_uuid in generalSettings.ClientIpHeaders.split(',') %}
+                {% set header = helpers.toList('Pischem.caddy.reverseproxy.header') | selectattr('@uuid', 'equalto', header_uuid) | first %}
+                {% if header and header.HeaderType %}
+                    client_ip_headers {{ header.HeaderType }}
+                {% endif %}
+            {% endfor %}
+        {% endif %}
         {% if generalSettings.LogCredentials|default("0") == "1" %}
             log_credentials
         {% endif %}

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/includeAuthProvider
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/includeAuthProvider
@@ -7,16 +7,26 @@
     {% set is_ipv6 = (':' in generalSettings.AuthToDomain and generalSettings.AuthToDomain.count(':') >= 2) %}
     {% set auth_url = (generalSettings.AuthToTls|default("0") == "1" and 'https://' or 'http://') + (is_ipv6 and '[' or '') + generalSettings.AuthToDomain|default("") + (is_ipv6 and ']' or '') + (generalSettings.AuthToPort and ':' + generalSettings.AuthToPort or '') %}
 {% endif %}
+{% macro generate_copy_headers() %}
+    {% if generalSettings.AuthCopyHeaders %}
+        {% for header_uuid in generalSettings.AuthCopyHeaders.split(',') %}
+            {% set header = helpers.toList('Pischem.caddy.reverseproxy.header') | selectattr('@uuid', 'equalto', header_uuid) | first %}
+            {% if header and header.HeaderType %}
+                copy_headers {{ header.HeaderType }}
+            {% endif %}
+        {% endfor %}
+    {% endif %}
+{% endmacro %}
 {% if generalSettings.AuthProvider == 'authelia' %}
     forward_auth {{ auth_url }} {
     {% if generalSettings.AuthToUri %}
         uri {{ generalSettings.AuthToUri|default("") }}
     {% endif %}
-    {% if generalSettings.AuthCopyHeaders|default("") == "" %}
-        copy_headers Remote-User Remote-Groups Remote-Name Remote-Email
-    {% else %}
-        copy_headers {{ generalSettings.AuthCopyHeaders.split(',') | join(' ') }}
-    {% endif %}
+        copy_headers Remote-User
+        copy_headers Remote-Groups
+        copy_headers Remote-Name
+        copy_headers Remote-Email
+        {{ generate_copy_headers() }}
     }
 {% elif generalSettings.AuthProvider == 'authentik' %}
     reverse_proxy /outpost.goauthentik.io/* {{ auth_url }} {
@@ -28,10 +38,17 @@
     {% if generalSettings.AuthToUri %}
         uri {{ generalSettings.AuthToUri|default("") }}
     {% endif %}
-    {% if generalSettings.AuthCopyHeaders|default("") == "" %}
-        copy_headers X-Authentik-Username X-Authentik-Groups X-Authentik-Email X-Authentik-Name X-Authentik-Uid X-Authentik-Jwt X-Authentik-Meta-Jwks X-Authentik-Meta-Outpost X-Authentik-Meta-Provider X-Authentik-Meta-App X-Authentik-Meta-Version
-    {% else %}
-       copy_headers {{ generalSettings.AuthCopyHeaders.split(',') | join(' ') }}
-    {% endif %}
+        copy_headers X-Authentik-Username
+        copy_headers X-Authentik-Groups
+        copy_headers X-Authentik-Email
+        copy_headers X-Authentik-Name
+        copy_headers X-Authentik-Uid
+        copy_headers X-Authentik-Jwt
+        copy_headers X-Authentik-Meta-Jwks
+        copy_headers X-Authentik-Meta-Outpost
+        copy_headers X-Authentik-Meta-Provider
+        copy_headers X-Authentik-Meta-App
+        copy_headers X-Authentik-Meta-Version
+        {{ generate_copy_headers() }}
     }
 {% endif %}


### PR DESCRIPTION
Fixes: https://github.com/opnsense/plunsins/issues/4517

Rewrite copy_headers logic from https://github.com/opnsense/plugins/issues/4488

Since headers are used in multiple parts of the configuration this creates a single point of truth to ease maintenance burden.

Will synergize with the new buttons that redirect users (in this case the add headers modal):
https://github.com/opnsense/plugins/pull/4512
