### PR TITLE
dns/bind: Allow negation in ACL definitions (#4435)

### DIFF
--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/Api/AclController.php
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/Api/AclController.php
@@ -34,6 +34,7 @@ class AclController extends ApiMutableModelControllerBase
 {
     protected static $internalModelName = 'acl';
     protected static $internalModelClass = '\OPNsense\Bind\Acl';
+    protected static $internalModelUseSafeDelete = true;
 
     public function searchAclAction()
     {
@@ -63,5 +64,10 @@ class AclController extends ApiMutableModelControllerBase
     public function toggleAclAction($uuid)
     {
         return $this->toggleBase('acls.acl', $uuid);
+    }
+
+    protected function checkAndThrowValueInUse($token, $contains = true, $only_mvc = false, $exclude_refs = [])
+    {
+        parent::checkAndThrowValueInUse($token, $contains, $only_mvc, $exclude_refs);
     }
 }

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindAcl.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindAcl.xml
@@ -14,9 +14,7 @@
     <field>
         <id>acl.networks</id>
         <label>Network List</label>
-        <style>tokenize</style>
-        <type>select_multiple</type>
-        <allownew>true</allownew>
-        <help>List of networks for this ACL.</help>
+        <type>textbox</type>
+        <help>List of addresses and network prefixes, one address or prefix per line. Use a leading exclamation mark (!) for negation. These built in ACLs may also be used: any, none, localhost, and localnets. If more than one element in an ACL is found to match a given IP address or prefix, preference is given to the one that came first in the ACL definition.</help>
     </field>
 </form>

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/general.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/general.xml
@@ -84,10 +84,8 @@
     <field>
         <id>general.filteraaaaacl</id>
         <label>ACL for filter-aaaa</label>
-        <style>tokenize</style>
-        <type>select_multiple</type>
-        <allownew>true</allownew>
-        <help>Specifies a list of client addresses for which AAAA filtering is to be applied.</help>
+        <type>textbox</type>
+        <help>Specifies a list of client addresses, one per line, for which AAAA filtering is to be applied.</help>
     </field>
     <field>
         <id>general.logsize</id>

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Acl.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Acl.xml
@@ -20,10 +20,8 @@
                         </check001>
                     </Constraints>
                 </name>
-                <networks type="NetworkField">
-                    <FieldSeparator>,</FieldSeparator>
+                <networks type=".\BindAddressMatchField">
                     <Required>Y</Required>
-                    <asList>Y</asList>
                 </networks>
             </acl>
         </acls>

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/FieldTypes/BindAddressMatchField.php
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/FieldTypes/BindAddressMatchField.php
@@ -1,0 +1,158 @@
+<?php
+
+/*
+ * Copyright (C) 2015-2025 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Bind\FieldTypes;
+
+use OPNsense\Base\FieldTypes\BaseField;
+use OPNsense\Bind\Validators\BindAddressMatchValidator;
+
+/**
+ * @package OPNsense\Bind\FieldTypes
+ */
+class BindAddressMatchField extends BaseField
+{
+    /**
+     * @var bool marks if this is a data node or a container
+     */
+    protected $internalIsContainer = false;
+
+    /**
+     * @var bool marks if net mask is required
+     */
+    protected $internalNetMaskRequired = false;
+
+    /**
+     * @var bool marks if net mask is (dis)allowed
+     */
+    protected $internalNetMaskAllowed = true;
+
+    /**
+     * @var string when multiple values could be provided at once, specify the split character
+     */
+    protected $internalFieldSeparator = ',';
+
+    /**
+     * @var string Network family (ipv4, ipv6)
+     */
+    protected $internalAddressFamily = null;
+
+    /**
+     * @var bool when set, host bits with a value other than zero are not allowed in the notation if a mask is provided
+     */
+    private $internalStrict = false;
+
+    /**
+     * always lowercase / trim networks
+     * @param string $value
+     */
+    public function setValue($value)
+    {
+        parent::setValue(join($this->internalFieldSeparator, array_map('trim', explode("\n", trim(strtolower($value))))));
+    }
+
+    /**
+     * setter for net mask required
+     * @param integer $value
+     */
+    public function setNetMaskRequired($value)
+    {
+        if (trim(strtoupper($value)) == "Y") {
+            $this->internalNetMaskRequired = true;
+        } else {
+            $this->internalNetMaskRequired = false;
+        }
+    }
+
+    /**
+     * setter for net mask required
+     * @param integer $value
+     */
+    public function setNetMaskAllowed($value)
+    {
+        $this->internalNetMaskAllowed = (trim(strtoupper($value)) == "Y");
+    }
+
+    /**
+     * setter for address family
+     * @param $value address family [ipv4, ipv6, empty for all]
+     */
+    public function setAddressFamily($value)
+    {
+        $this->internalAddressFamily = trim(strtolower($value));
+    }
+
+    /**
+     * select if host bits are allowed in the notation
+     * @param $value
+     */
+    public function setStrict($value)
+    {
+        if (trim(strtoupper($value)) == "Y") {
+            $this->internalStrict = true;
+        } else {
+            $this->internalStrict = false;
+        }
+    }
+
+    /**
+     * get valid options, descriptions and selected value
+     * @return array
+     */
+    public function getNodeData()
+    {
+        return join("\n", array_map('trim', explode($this->internalFieldSeparator, $this->internalValue)));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function defaultValidationMessage()
+    {
+        return gettext('Please specify a valid network segment or IP address.');
+    }
+
+    /**
+     * retrieve field validators for this field type
+     * @return array returns Text/regex validator
+     */
+    public function getValidators()
+    {
+        $validators = parent::getValidators();
+        if ($this->internalValue != null) {
+            $validators[] = new BindAddressMatchValidator([
+                'message' => $this->getValidationMessage(),
+                'split' => $this->internalFieldSeparator,
+                'netMaskRequired' => $this->internalNetMaskRequired,
+                'netMaskAllowed' => $this->internalNetMaskAllowed,
+                'version' => $this->internalAddressFamily,
+                'strict' => $this->internalStrict
+            ]);
+        }
+        return $validators;
+    }
+}

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/General.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/General.xml
@@ -59,10 +59,7 @@
             <Default>0</Default>
             <Required>Y</Required>
         </filteraaaav6>
-        <filteraaaaacl type="NetworkField">
-            <FieldSeparator>,</FieldSeparator>
-            <asList>Y</asList>
-        </filteraaaaacl>
+        <filteraaaaacl type=".\BindAddressMatchField"/>
         <logsize type="IntegerField">
             <Default>5</Default>
             <Required>Y</Required>

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Validators/BindAddressMatchValidator.php
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Validators/BindAddressMatchValidator.php
@@ -1,0 +1,149 @@
+<?php
+
+/*
+ * Copyright (C) 2015-2025 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Bind\Validators;
+
+use OPNsense\Base\BaseValidator;
+use OPNsense\Firewall\Util;
+use OPNsense\Base\Messages\Message;
+
+/**
+ * Class NetworkValidator validate networks and ip addresses
+ * @package OPNsense\Base\Validators
+ */
+class BindAddressMatchValidator extends BaseValidator
+{
+    /**
+     * @var array List of built in ACLs
+     */
+    protected $builtinAcls = ['any','none','localhost','localnets'];
+
+    /**
+     * Executes network / ip validation for a subset of Bind Address Match Lists
+     *      version         : ipv4, ipv6, all (default)
+     *      netMaskAllowed  : true (default), false)
+     *      netMaskRequired : true, false (default)
+     *      strict:         : true, false (default)
+     *
+     * Address match list elements which are supported:
+     *  - ip_address: an IP address (IPv4 or IPv6)
+     *  - netprefix: an IP prefix (in / notation)
+     *  - negation with a leading exclamation mark (!)
+     *  - built in ACL names of: any, none, localhost, and localnets
+     *
+     * Address match list elements which are NOT supported:
+     *  - server_key: a key ID, as defined by the key statement
+     *  - acl_name: the name of an address match list defined with the acl statement
+     *  - a nested address match list enclosed in braces
+     *
+     * Reference: https://bind9.readthedocs.io/en/v9.20.4/reference.html#address-match-lists
+     *
+     * @param $validator
+     * @param string $attribute
+     * @return boolean
+     */
+    public function validate($validator, $attribute): bool
+    {
+        $result = true;
+        $msg = $this->getOption('message');
+        $fieldSplit = $this->getOption('split', null);
+        if ($fieldSplit == null) {
+            $values = array($validator->getValue($attribute));
+        } else {
+            $values = explode($fieldSplit, $validator->getValue($attribute));
+        }
+        foreach ($values as $value) {
+            // strip off negation before address validation
+            $value = ltrim($value, '!');
+
+            // short-circuit on built-in ACLs
+            if (in_array($value, $this->builtinAcls)) {
+                continue;
+            }
+
+            // parse filter options
+            $filterOpt = 0;
+            switch (strtolower($this->getOption('version') ?? '')) {
+                case "ipv4":
+                    $filterOpt |= FILTER_FLAG_IPV4;
+                    break;
+                case "ipv6":
+                    $filterOpt |= FILTER_FLAG_IPV6;
+                    break;
+                default:
+                    $filterOpt |= FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6;
+            }
+
+            // split network
+            if (strpos($value, "/") !== false) {
+                if ($this->getOption('netMaskAllowed') === false) {
+                    $result = false;
+                } else {
+                    $cidr = $value;
+                    $parts = explode("/", $value);
+                    if (count($parts) > 2 || !ctype_digit($parts[1])) {
+                        // more parts then expected or second part is not numeric
+                        $result = false;
+                    } else {
+                        $mask = $parts[1];
+                        $value = $parts[0];
+                        if (strpos($parts[0], ":") !== false) {
+                            // probably ipv6, mask must be between 0..128
+                            if ($mask < 0 || $mask > 128) {
+                                $result = false;
+                            }
+                        } else {
+                            // most likely ipv4 address, mask must be between 0..32
+                            if ($mask < 0 || $mask > 32) {
+                                $result = false;
+                            }
+                        }
+                    }
+
+                    if ($this->getOption('strict') === true && !Util::isSubnetStrict($cidr)) {
+                        $result = false;
+                    }
+                }
+            } elseif ($this->getOption('netMaskRequired') === true) {
+                $result = false;
+            }
+
+
+            if (filter_var($value, FILTER_VALIDATE_IP, $filterOpt) === false) {
+                $result = false;
+            }
+
+            if (!$result) {
+                // append validation message
+                $validator->appendMessage(new Message($msg, $attribute, 'BindAddressMatchValidator'));
+            }
+        }
+
+        return $result;
+    }
+}

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
@@ -8,6 +8,36 @@ acl "{{ acl_list.name }}" { {{ acl_list.networks.replace(',', '; ') }}; };
 {%   endfor %}
 {% endif %}
 
+{#
+Given a comma separated list of ACL UUIDs, if any named ACLs in the list are enabled,
+evaluate the call block, otherwise skip. Use this to wrap configuration block that don't
+make sense to include if there are no enabled ACLs.
+#}
+{% macro ACLListEnabled(aclList) %}
+{% if aclList is defined and aclList != '' %}
+{% set ns = namespace() %}
+{% set ns.found = 0 %}
+{% for aclUUID in aclList.split(',') if helpers.getUUID(aclUUID).enabled == '1' %}
+{% set ns.found  = ns.found + 1 %}
+{% endfor %}
+{% if ns.found > 0 %}
+{{ caller() }}
+{% endif %}
+{% endif %}
+{% endmacro %}
+
+{#
+Given a comma separated list of ACL UUIDs, return a semicolon separated
+list of the enabled ACL names for use in a an address match field context.
+#}
+{% macro ACLNames(aclList, joiner = "; ") %}
+{% set ns = namespace() %}
+{% set ns.names = [] %}
+{% if aclList is defined and aclList != '' %}
+{%   for aclUUID in aclList.split(',') %}{% do ns.names.append(helpers.getUUID(aclUUID)) %}{% endfor %}
+{% endif %}
+{{ ns.names | selectattr("enabled", "eq", "1") | map(attribute="name") | join(joiner) }}{% endmacro %}
+
 options {
 
         directory       "/usr/local/etc/namedb/working";
@@ -46,33 +76,24 @@ options {
         response-policy { {% if helpers.exists('OPNsense.bind.dnsbl.type') and OPNsense.bind.dnsbl.type != '' %}zone "whitelist.localdomain"; zone "blacklist.localdomain";{% endif %}{% if helpers.exists('OPNsense.bind.dnsbl.forcesafegoogle') and OPNsense.bind.dnsbl.forcesafegoogle == '1' %}zone "rpzgoogle";{% endif %}{% if helpers.exists('OPNsense.bind.dnsbl.forcesafeduckduckgo') and OPNsense.bind.dnsbl.forcesafeduckduckgo == '1' %}zone "rpzduckduckgo";{% endif %}{% if helpers.exists('OPNsense.bind.dnsbl.forcesafeyoutube') and OPNsense.bind.dnsbl.forcesafeyoutube == '1' %}zone "rpzyoutube";{% endif %}{% if helpers.exists('OPNsense.bind.dnsbl.forcestrictbing') and OPNsense.bind.dnsbl.forcestrictbing == '1' %}zone "rpzbing";{% endif %} };
 {% endif %}
 
-{% if helpers.exists('OPNsense.bind.general.recursion') and OPNsense.bind.general.recursion != '' %}
+{% if helpers.exists('OPNsense.bind.general.recursion') %}
+{%   call ACLListEnabled(OPNsense.bind.general.recursion) %}
         recursion          yes;
-        allow-recursion {
-{%              for acl in OPNsense.bind.general.recursion.split(',') %}
-{%              set recursion_acl = helpers.getUUID(acl) %}
-                {{ recursion_acl.name }};
-{%              endfor %}
-        };
-{% endif %}
+        allow-recursion { {{ ACLNames(OPNsense.bind.general.recursion) }}; };
+{%   endcall %}
+{% endif -%}
 
-{% if helpers.exists('OPNsense.bind.general.allowtransfer') and OPNsense.bind.general.allowtransfer != '' %}
-        allow-transfer {
-{%              for acl in OPNsense.bind.general.allowtransfer.split(',') %}
-{%              set transfer_acl = helpers.getUUID(acl) %}
-                {{ transfer_acl.name }};
-{%              endfor %}
-        };
-{% endif %}
+{% if helpers.exists('OPNsense.bind.general.allowtransfer') %}
+{%   call ACLListEnabled(OPNsense.bind.general.allowtransfer) %}
+        allow-transfer { {{ ACLNames(OPNsense.bind.general.allowtransfer) }}; };
+{%   endcall %}
+{% endif -%}
 
-{% if helpers.exists('OPNsense.bind.general.allowquery') and OPNsense.bind.general.allowquery != '' %}
-        allow-query {
-{%              for acl in OPNsense.bind.general.allowquery.split(',') %}
-{%              set query_acl = helpers.getUUID(acl) %}
-                {{ query_acl.name }};
-{%              endfor %}
-        };
-{% endif %}
+{% if helpers.exists('OPNsense.bind.general.allowquery') %}
+{%   call ACLListEnabled(OPNsense.bind.general.allowquery) %}
+        allow-query { {{ ACLNames(OPNsense.bind.general.allowquery) }}; };
+{%   endcall %}
+{% endif -%}
 
 {% if helpers.exists('OPNsense.bind.general.maxcachesize') and OPNsense.bind.general.maxcachesize != '' %}
         max-cache-size    {{ OPNsense.bind.general.maxcachesize }}%;
@@ -91,7 +112,7 @@ options {
 {% endif %}
 {% if helpers.exists('OPNsense.bind.general.enableratelimiting') and OPNsense.bind.general.enableratelimiting == '1' %}
 {%   if helpers.exists('OPNsense.bind.general.ratelimitcount') and OPNsense.bind.general.ratelimitcount != '' %}
-	rate-limit {
+        rate-limit {
                 responses-per-second {{ OPNsense.bind.general.ratelimitcount }};
 {%     if helpers.exists('OPNsense.bind.general.ratelimitexcept') and OPNsense.bind.general.ratelimitexcept != '' %}
                 exempt-clients { {{ OPNsense.bind.general.ratelimitexcept.replace(',', '; ') }}; };
@@ -108,7 +129,7 @@ key "rndc-key" {
 };
 controls {
         inet 127.0.0.1 port 9530
-                allow { 127.0.0.1; } keys { "rndc-key"; };
+        allow { 127.0.0.1; } keys { "rndc-key"; };
 };
 {% endif %}
 
@@ -164,30 +185,24 @@ zone "{{ domain.domainname }}" {
 {%       else %}
         file "/usr/local/etc/namedb/primary/{{ domain.domainname }}.db";
 {%       endif %}
-{%      if domain.allowtransfer is defined or (domain.allowrndctransfer is defined and domain.allowrndctransfer == "1") %}
+{%      if domain.allowrndctransfer is defined and domain.allowrndctransfer == "1" %}
         allow-transfer {
-{%          if domain.allowrndctransfer is defined and domain.allowrndctransfer == "1" %}
-                key "rndc-key";
-{%          endif %}
-{%          if domain.allowtransfer is defined %}
-{%              for acl in domain.allowtransfer.split(',') %}
-{%              set transfer_acl = helpers.getUUID(acl) %}
-                {{ transfer_acl.name }};
-{%              endfor %}
-{%          endif %}
+            key "rndc-key";
+{%          call ACLListEnabled(domain.allowtransfer) %}
+            {{ ACLNames(domain.allowtransfer) }};
+{%          endcall %}
         };
+{%      else %}
+{%      call ACLListEnabled(domain.allowtransfer) %}
+        allow-transfer { {{ ACLNames(domain.allowtransfer) }}; };
+{%      endcall %}
 {%      endif %}
-{%      if domain.allowquery is defined %}
-        allow-query {
-{%              for acl in domain.allowquery.split(',') %}
-{%              set query_acl = helpers.getUUID(acl) %}
-                {{ query_acl.name }};
-{%              endfor %}
-        };
-{%      endif %}
+{%      call ACLListEnabled(domain.allowquery) %}
+        allow-query { {{ ACLNames(domain.allowquery) }}; };
+{%      endcall %}
 {%      if domain.allowrndcupdate is defined and domain.allowrndcupdate == "1" and domain.type != 'secondary' %}
         update-policy {
-		grant rndc-key zonesub ANY;
+            grant rndc-key zonesub ANY;
         };
 {%      endif %}
 };
@@ -244,20 +259,20 @@ logging {
 plugin query "/usr/local/lib/bind/filter-aaaa.so" {
 {% if helpers.exists('OPNsense.bind.general.filteraaaav4') and OPNsense.bind.general.filteraaaav4 == '1' %}
 {%   if OPNsense.bind.general.dnssecvalidation == 'no' %}
-                   filter-aaaa-on-v4 break-dnssec;
+        filter-aaaa-on-v4 break-dnssec;
 {%   else %}
-                   filter-aaaa-on-v4 yes;
+        filter-aaaa-on-v4 yes;
 {%   endif %}
 {% endif %}
 {% if helpers.exists('OPNsense.bind.general.filteraaaav6') and OPNsense.bind.general.filteraaaav6 == '1' %}
 {%   if OPNsense.bind.general.dnssecvalidation == 'no' %}
-                   filter-aaaa-on-v6 break-dnssec;
+        filter-aaaa-on-v6 break-dnssec;
 {%   else %}
-                   filter-aaaa-on-v6 yes;
+        filter-aaaa-on-v6 yes;
 {%   endif %}
 {% endif %}
 {% if helpers.exists('OPNsense.bind.general.filteraaaaacl') and OPNsense.bind.general.filteraaaaacl != '' %}
         filter-aaaa    { {{ OPNsense.bind.general.filteraaaaacl.replace(',', '; ') }}; };
 {% endif %}
-           };
+};
 {% endif %}


### PR DESCRIPTION
This adds a `BindAddressMatchField` and matching validator as a better match to the fairly ubiquitous [address match list](https://bind9.readthedocs.io/en/v9.20.4/reference.html#address-match-lists) construct in the bind configuration.  It allows ACLs to contain negation (!) and reference built-in ACLs.  It does not (yet) support referencing other user defined ACLs, keys, or nested address match lists.

Since introducing negation makes ACL entry order critical, the user interface is updated from the tokenized address list to a textbox with one entry per line, which provides a better experience for controlling the entry order.

Lastly, this now blocks deletion of ACLs that are referenced elsewhere in the configuration, and better handles ACLs that are disabled when generating named.conf.  Previously, deleting or disabling ACLs would typically cause an invalid configuration to be generated.

The BindAddressMatchField and validator implementation is based on (read: copied and modified) the core NetworkField type and validator to the extent that leaving the Deciso copyright seems appropriate.

There are no model or stored configuration changes, so no migration is needed.