### PR TITLE
sysutils/git-backup Add ability to hide secret from git backup

### DIFF
--- a/sysutils/git-backup/src/etc/rc.syshook.d/config/10-git-backup
+++ b/sysutils/git-backup/src/etc/rc.syshook.d/config/10-git-backup
@@ -78,9 +78,10 @@ if len(sys.argv) > 1:
             try:
                 conf_tree = ET.parse('/conf/backup/git/config.xml')
                 conf_xmlroot = conf_tree.getroot()
-                password = conf_xmlroot.find('./system/backup/hasync/password')
-                password.text = ''
-                conf_tree.write
+                password = conf_xmlroot.find('./hasync/password')
+                if password is not None:
+                    password.text = ''
+                    conf_tree.write('/conf/backup/git/config.xml')
             except (FileNotFoundError, ET.ParseError):
                 syslog.syslog(syslog.LOG_ERR, 'Could not parse or open /conf/backup/git/config.xml')
                 sys.exit(1)

--- a/sysutils/git-backup/src/etc/rc.syshook.d/config/10-git-backup
+++ b/sysutils/git-backup/src/etc/rc.syshook.d/config/10-git-backup
@@ -67,9 +67,24 @@ if len(sys.argv) > 1:
             except AttributeError:
                 pass
 
+        hacred = bool(xmlroot.find('./system/backup/git/hacred').text)
+
         # snapshot provided config.xml into git staging and commit with extracted data
         os.chdir('/conf/backup/git/')
         subprocess.run(['cp', sys.argv[1], '/conf/backup/git/config.xml'])
+
+        # hide ha sync password if hacred
+        if (hacred):
+            try:
+                conf_tree = ET.parse('/conf/backup/git/config.xml')
+                conf_xmlroot = conf_tree.getroot()
+                password = conf_xmlroot.find('./system/backup/hasync/password')
+                password.text = ''
+                conf_tree.write
+            except (FileNotFoundError, ET.ParseError):
+                syslog.syslog(syslog.LOG_ERR, 'Could not parse or open /conf/backup/git/config.xml')
+                sys.exit(1)
+
         subprocess.run(['/usr/local/bin/git', 'add', 'config.xml'])
         message = "%s @ %s (%s)" % (metadata['./revision/description'], revdate, metadata['./revision/username'])
         subprocess.run(['/usr/local/bin/git', 'commit', '--author', "%s<%s>" % (fullname, user_email), '-m', message])

--- a/sysutils/git-backup/src/etc/rc.syshook.d/config/10-git-backup
+++ b/sysutils/git-backup/src/etc/rc.syshook.d/config/10-git-backup
@@ -67,7 +67,7 @@ if len(sys.argv) > 1:
             except AttributeError:
                 pass
 
-        hacred = bool(xmlroot.find('./system/backup/git/hacred').text)
+        hacred = bool(int(xmlroot.find('./system/backup/git/hacred').text))
 
         # snapshot provided config.xml into git staging and commit with extracted data
         os.chdir('/conf/backup/git/')

--- a/sysutils/git-backup/src/etc/rc.syshook.d/config/10-git-backup
+++ b/sysutils/git-backup/src/etc/rc.syshook.d/config/10-git-backup
@@ -67,21 +67,30 @@ if len(sys.argv) > 1:
             except AttributeError:
                 pass
 
-        hacred = bool(int(xmlroot.find('./system/backup/git/hacred').text))
+        hidesecrets = bool(int(xmlroot.find('./system/backup/git/hidesecrets').text))
 
         # snapshot provided config.xml into git staging and commit with extracted data
         os.chdir('/conf/backup/git/')
         subprocess.run(['cp', sys.argv[1], '/conf/backup/git/config.xml'])
 
-        # hide ha sync password if hacred
-        if (hacred):
+        # hide sensitive content if hidesecrets
+        if (hidesecrets):
             try:
                 conf_tree = ET.parse('/conf/backup/git/config.xml')
                 conf_xmlroot = conf_tree.getroot()
-                password = conf_xmlroot.find('./hasync/password')
-                if password is not None:
+                # Set password fields to ''
+                passwords = conf_xmlroot.iter('password')
+                for password in passwords:
                     password.text = ''
-                    conf_tree.write('/conf/backup/git/config.xml')
+                # Set certificates prv fields to ''
+                privkeys = conf_xmlroot.iter('prv')
+                for privkey in privkeys:
+                    privkey.text = ''
+                # Set ldap ldap_bindpw fields to ''
+                ldap_bindpws = conf_xmlroot.iter('ldap_bindpw')
+                for ldap_bindpw in ldap_bindpws:
+                    ldap_bindpw.text = ''
+                conf_tree.write('/conf/backup/git/config.xml')
             except (FileNotFoundError, ET.ParseError):
                 syslog.syslog(syslog.LOG_ERR, 'Could not parse or open /conf/backup/git/config.xml')
                 sys.exit(1)

--- a/sysutils/git-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Git.php
+++ b/sysutils/git-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Git.php
@@ -84,7 +84,14 @@ class Git extends Base implements IBackupProvider
              "type" => "password",
              "label" => gettext("Password"),
              "value" => null
-           ]
+           ],
+           [
+              "name" => "hacred",
+              "type" => "checkbox",
+              "label" => gettext("Hide HA Sync Credential"),
+              "help" => gettext("When enabled, HA sync password will be hidden from backup."),
+              "value" => null
+           ],
         ];
         $mdl = new GitSettings();
         foreach ($fields as &$field) {

--- a/sysutils/git-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Git.php
+++ b/sysutils/git-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Git.php
@@ -86,10 +86,10 @@ class Git extends Base implements IBackupProvider
              "value" => null
            ],
            [
-              "name" => "hacred",
+              "name" => "hidesecrets",
               "type" => "checkbox",
-              "label" => gettext("Hide HA Sync Credential"),
-              "help" => gettext("When enabled, HA sync password will be hidden from backup."),
+              "label" => gettext("Hide all secrets from backup"),
+              "help" => gettext("When enabled, all secrets will be hidden from backup."),
               "value" => null
            ]
         ];

--- a/sysutils/git-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Git.php
+++ b/sysutils/git-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Git.php
@@ -91,7 +91,7 @@ class Git extends Base implements IBackupProvider
               "label" => gettext("Hide HA Sync Credential"),
               "help" => gettext("When enabled, HA sync password will be hidden from backup."),
               "value" => null
-           ],
+           ]
         ];
         $mdl = new GitSettings();
         foreach ($fields as &$field) {

--- a/sysutils/git-backup/src/opnsense/mvc/app/models/OPNsense/Backup/GitSettings.xml
+++ b/sysutils/git-backup/src/opnsense/mvc/app/models/OPNsense/Backup/GitSettings.xml
@@ -49,5 +49,9 @@
         </user>
         <password type="TextField">
         </password>
+        <hacred type="BooleanField">
+          <Default>0</Default>
+          <Required>Y</Required>
+        </hacred>
     </items>
 </model>

--- a/sysutils/git-backup/src/opnsense/mvc/app/models/OPNsense/Backup/GitSettings.xml
+++ b/sysutils/git-backup/src/opnsense/mvc/app/models/OPNsense/Backup/GitSettings.xml
@@ -49,9 +49,9 @@
         </user>
         <password type="TextField">
         </password>
-        <hacred type="BooleanField">
+        <hidesecrets type="BooleanField">
           <Default>0</Default>
           <Required>Y</Required>
-        </hacred>
+        </hidesecrets>
     </items>
 </model>


### PR DESCRIPTION
Hello,

Since Git backups are not encrypted, they are useful for version control. However, it would be beneficial to have an option to remove sensitive information such as passwords and private keys.

Enabling this option would prevent users from fully restoring the backup, but it would allow for a clear history of changes outside of OPNsense without compromising security—especially considering that even GitLab has had significant CVEs.

Instead of a global option, I could implement a multi-select button to choose which types of sensitive data to hide. 
Additionally, I could restrict specific paths for certain fields, such as private keys for certificates instead of the global prv field.

While encrypting the entire file is an option, it would make it impossible to track differences between versions. Let me know your thoughts!