### PR TITLE
security/tor: add bridge transports to relay

### DIFF
--- a/security/tor/src/opnsense/mvc/app/controllers/OPNsense/Tor/forms/relay.xml
+++ b/security/tor/src/opnsense/mvc/app/controllers/OPNsense/Tor/forms/relay.xml
@@ -89,6 +89,13 @@
     <help>A bridge is a private relay. It is not visible in the public directory. Uncheck this if you want to become a public relay.</help>
   </field>
   <field>
+    <id>relay.bridge_type</id>
+    <label>Bridge Transport</label>
+    <type>dropdown</type>
+    <style>dropdownstyle</style>
+    <help>If the relay type is a bridge, select the type of bridge transport.</help>
+  </field>
+  <field>
     <id>relay.publish</id>
     <label>Publish Server Descriptor</label>
     <type>checkbox</type>

--- a/security/tor/src/opnsense/mvc/app/controllers/OPNsense/Tor/forms/relay.xml
+++ b/security/tor/src/opnsense/mvc/app/controllers/OPNsense/Tor/forms/relay.xml
@@ -101,6 +101,11 @@
     <type>text</type>
   </field>
   <field>
+    <id>relay.webtunnel_site</id>
+    <label>Webtunnel URL</label>
+    <type>text</type>
+  </field>
+  <field>
     <id>relay.publish</id>
     <label>Publish Server Descriptor</label>
     <type>checkbox</type>

--- a/security/tor/src/opnsense/mvc/app/controllers/OPNsense/Tor/forms/relay.xml
+++ b/security/tor/src/opnsense/mvc/app/controllers/OPNsense/Tor/forms/relay.xml
@@ -96,6 +96,11 @@
     <help>If the relay type is a bridge, select the type of bridge transport.</help>
   </field>
   <field>
+    <id>relay.obfs4_port</id>
+    <label>Obfs4 Port</label>
+    <type>text</type>
+  </field>
+  <field>
     <id>relay.publish</id>
     <label>Publish Server Descriptor</label>
     <type>checkbox</type>

--- a/security/tor/src/opnsense/mvc/app/models/OPNsense/Tor/Relay.xml
+++ b/security/tor/src/opnsense/mvc/app/models/OPNsense/Tor/Relay.xml
@@ -69,6 +69,17 @@
         <default>0</default>
         <Required>Y</Required>
     </relay>
+    <bridge_type type="OptionField">
+      <Required>Y</Required>
+      <multiple>N</multiple>
+      <default>none</default>
+      <OptionValues>
+        <none>None</none>
+        <webtunnel>Webtunnel</webtunnel>
+        <obfs4>Obfs4</obfs4>
+        <snowflake>Snowflake</snowflake>
+      </OptionValues>
+    </bridge_type>
     <exitrejectprivateip type="BooleanField">
         <default>1</default>
         <Required>Y</Required>

--- a/security/tor/src/opnsense/mvc/app/models/OPNsense/Tor/Relay.xml
+++ b/security/tor/src/opnsense/mvc/app/models/OPNsense/Tor/Relay.xml
@@ -77,7 +77,6 @@
         <none>None</none>
         <webtunnel>Webtunnel</webtunnel>
         <obfs4>Obfs4</obfs4>
-        <snowflake>Snowflake</snowflake>
       </OptionValues>
     </bridge_type>
     <obfs4_port type="IntegerField">

--- a/security/tor/src/opnsense/mvc/app/models/OPNsense/Tor/Relay.xml
+++ b/security/tor/src/opnsense/mvc/app/models/OPNsense/Tor/Relay.xml
@@ -86,6 +86,10 @@
       <MaximumValue>65535</MaximumValue>
       <ValidationMessage>A valid Port number must be specified.</ValidationMessage>
     </obfs4_port>
+    <webtunnel_site type="TextField">
+      <Required>N</Required>
+      <mask>/^https?:\/\/([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}\/?$/</mask>
+    </webtunnel_site>
     <exitrejectprivateip type="BooleanField">
         <default>1</default>
         <Required>Y</Required>

--- a/security/tor/src/opnsense/mvc/app/models/OPNsense/Tor/Relay.xml
+++ b/security/tor/src/opnsense/mvc/app/models/OPNsense/Tor/Relay.xml
@@ -80,6 +80,12 @@
         <snowflake>Snowflake</snowflake>
       </OptionValues>
     </bridge_type>
+    <obfs4_port type="IntegerField">
+      <MinimumValue>0</MinimumValue>
+      <Required>N</Required>
+      <MaximumValue>65535</MaximumValue>
+      <ValidationMessage>A valid Port number must be specified.</ValidationMessage>
+    </obfs4_port>
     <exitrejectprivateip type="BooleanField">
         <default>1</default>
         <Required>Y</Required>

--- a/security/tor/src/opnsense/service/templates/OPNsense/Tor/torrc
+++ b/security/tor/src/opnsense/service/templates/OPNsense/Tor/torrc
@@ -254,6 +254,17 @@ ExitPolicy {{ policy.action }} {% if policy.network == 'any' %}*{% if 'v' in pol
 ExitPolicy reject *:*
 ExitPolicy reject6 *:*
 
+{% if helpers.exists('OPNsense.tor.relay.relay') and OPNsense.tor.relay.relay == '1' %}
+{%   if helpers.exists('OPNsense.tor.relay.bridge_types') and OPNsense.tor.relay.bridge_types != "None" %}
+{%     if OPNsense.tor.relay.bridge_types ==  "Obfs4" %}
+{%       if helpers.exists('OPNsense.tor.relay.obfs4_port') and OPNsense.tor.relay.obfs4_port != '' %}
+ServerTransportPlugin obfs4 exec /usr/local/bin/obfs4proxy
+ServerTransportListenAddr obfs4 0.0.0.0:{{ OPNsense.tor.relay.obfs4_port }}
+{%       endif %}
+{%     endif %}
+ExtORPort auto
+{%   endif %}
+{% endif %}
 
 BridgeRelay {{ OPNsense.tor.relay.relay|default('1') }}
 PublishServerDescriptor {{ OPNsense.tor.relay.publish|default('0') }}

--- a/security/tor/src/opnsense/service/templates/OPNsense/Tor/torrc
+++ b/security/tor/src/opnsense/service/templates/OPNsense/Tor/torrc
@@ -141,11 +141,13 @@ HiddenServicePort {{ acl.port}} {{ acl.target_host }}:{{ acl.target_port }}
 {%   endif %}
 {% endif %}
 
-{% if helpers.exists('OPNsense.tor.relay.enabled') and OPNsense.tor.relay.enabled == '1' %}
+{%   if helpers.exists('OPNsense.tor.relay.enabled') and OPNsense.tor.relay.enabled == '1' %}
+{% if OPNsense.tor.relay.relay == '1' and OPNsense.tor.relay.bridge_types != 'Webtunnel' %}
 ORPort {% if helpers.exists('OPNsense.tor.relay.host') and OPNsense.tor.relay.host != '' %}{{ OPNsense.tor.relay.host }}:{% endif%}{{ OPNsense.tor.relay.port|default('9001') }}
-{% if helpers.exists('OPNsense.tor.relay.hostv6') and OPNsense.tor.relay.hostv6 != '' %}
+{%   if helpers.exists('OPNsense.tor.relay.hostv6') and OPNsense.tor.relay.hostv6 != '' %}
 ORPort [{{ OPNsense.tor.relay.hostv6 }}]:{{ OPNsense.tor.relay.port|default('9001') }}
-{% endif%}
+{%   endif %}
+{% endif %}
 
 {% if helpers.exists('OPNsense.tor.relay.address') and OPNsense.tor.relay.address != '' %}
 Address {{ OPNsense.tor.relay.address }}
@@ -256,10 +258,18 @@ ExitPolicy reject6 *:*
 
 {% if helpers.exists('OPNsense.tor.relay.relay') and OPNsense.tor.relay.relay == '1' %}
 {%   if helpers.exists('OPNsense.tor.relay.bridge_types') and OPNsense.tor.relay.bridge_types != "None" %}
-{%     if OPNsense.tor.relay.bridge_types ==  "Obfs4" %}
+{%     if OPNsense.tor.relay.bridge_types == "Obfs4" %}
 {%       if helpers.exists('OPNsense.tor.relay.obfs4_port') and OPNsense.tor.relay.obfs4_port != '' %}
 ServerTransportPlugin obfs4 exec /usr/local/bin/obfs4proxy
 ServerTransportListenAddr obfs4 0.0.0.0:{{ OPNsense.tor.relay.obfs4_port }}
+{%       endif %}
+{%     if OPNsense.tor.relay.bridge_types == "Webtunnel" %}
+{%       if helpers.exists('OPNsense.tor.relay.webtunnel_site') and OPNsense.tor.relay.webtunnel_site != '' %}
+ORPort 127.0.0.1:auto
+AssumeReachable 1
+ServerTransportPlugin webtunnel exec /usr/local/bin/webtunnel
+ServerTransportListenAddr webtunnel 127.0.0.1:15000
+ServerTransportOptions webtunnel url={{ OPNsense.tor.relay.webtunnel_site }}
 {%       endif %}
 {%     endif %}
 ExtORPort auto


### PR DESCRIPTION
In the plugin, it allows for the relay to be a bridge relay, but doesn't have the ability to select the bridge transport: obfs4, webtunnel, and snowflake (completely seperate from the tor service).
This would add the obfs4 and webtunnel transports to the tor plugin.

The biggest problem I see with this is that no package managers offer the webtunnel binary, including FreeBSD. Tor's guide for webtunnel is to manually compile the binary. For obfs4, the FreeBSD security/obfs4proxy-tor port would need to be added to the plugin's dependencies and opnsense's binary repository.