### PR TITLE
net/frr: Migrate ospf passive interface from general to per interface

### DIFF
--- a/net/frr/Makefile
+++ b/net/frr/Makefile
@@ -1,5 +1,6 @@
 PLUGIN_NAME=		frr
 PLUGIN_VERSION=		1.43
+PLUGIN_REVISION=	1
 PLUGIN_COMMENT=		The FRRouting Protocol Suite
 PLUGIN_DEPENDS=		frr8-pythontools
 PLUGIN_MAINTAINER=	ad@opnsense.org

--- a/net/frr/pkg-descr
+++ b/net/frr/pkg-descr
@@ -19,6 +19,7 @@ Plugin Changelog
 * Delete per daemon and old watchfrr files (opnsense/plugins/issues/4551)
 * Add help texts to all options and expose them in grid as columns (opnsense/plugins/pull/4494)
 * Replace deprecated passive-interface directive in ospf (opnsense/plugins/issues/4534)
+* Migrate ospf passive interface from general to per interface (opnsense/plugins/issues/4590)
 * Style cleanup and unify forms (opnsense/plugins/pull/4450)
 * Implement base_apply_button (opnsense/plugins/pull/4542)
 

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditOSPFInterface.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditOSPFInterface.xml
@@ -16,6 +16,17 @@
     <help>Select an interface where this settings apply.</help>
   </field>
   <field>
+    <id>interface.passive</id>
+    <label>Passive Interface</label>
+    <type>checkbox</type>
+    <help>Disables OSPF Hello packets on the interface, preventing neighbor relationships (used for security or optimization).</help>
+    <grid_view>
+      <type>boolean</type>
+      <formatter>boolean</formatter>
+      <visible>false</visible>
+    </grid_view>
+  </field>
+  <field>
     <id>interface.authtype</id>
     <label>Authentication Type</label>
     <type>dropdown</type>

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/ospf.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/ospf.xml
@@ -26,12 +26,6 @@
         <help>Adjust the reference cost in Mbps for path calculation, useful when bundling interfaces for higher bandwidth.</help>
     </field>
     <field>
-        <id>ospf.passiveinterfaces</id>
-        <label>Passive Interfaces</label>
-        <type>select_multiple</type>
-        <help>Select the interfaces where no OSPF packets should be sent.</help>
-    </field>
-    <field>
         <id>ospf.redistribute</id>
         <label>Route Redistribution</label>
         <type>select_multiple</type>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/Migrations/M1_0_6.php
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/Migrations/M1_0_6.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * Copyright (C) 2025 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Quagga\Migrations;
+
+use OPNsense\Base\BaseModelMigration;
+use OPNsense\Core\Config;
+
+class M1_0_6 extends BaseModelMigration
+{
+    public function run($model)
+    {
+        $config = Config::getInstance()->object();
+
+        if (!isset($config->OPNsense->quagga->ospf)) {
+            return;
+        }
+        
+        if (!empty($config->OPNsense->quagga->ospf->passiveinterfaces)) {
+            $existingInterfaces = [];
+            foreach ($model->getNodeByReference('interfaces.interface')->iterateItems() as $interface) {
+                $existingInterfaces[(string)$interface->interfacename] = $interface;
+            }
+
+            $passiveInterfacesList = explode(',', (string)$config->OPNsense->quagga->ospf->passiveinterfaces);
+            foreach ($passiveInterfacesList as $passiveInterfaceName) {
+                $passiveInterfaceName = trim($passiveInterfaceName);
+                if (empty($passiveInterfaceName)) {
+                    continue;
+                }
+
+                if (isset($existingInterfaces[$passiveInterfaceName])) {
+                    $existingInterfaces[$passiveInterfaceName]->passive = '1';
+                } else {
+                    $newInterface = $model->getNodeByReference('interfaces.interface')->add();
+                    $newInterface->interfacename = $passiveInterfaceName;
+                    $newInterface->passive = '1';
+                }
+            }
+        }
+    }
+}

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/quagga/ospf</mount>
     <description>OSPF Routing configuration</description>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
     <items>
         <enabled type="BooleanField">
             <default>0</default>
@@ -40,15 +40,6 @@
             <MaximumValue>16777214</MaximumValue>
             <ValidationMessage>Must be a number between 0 and 16777214.</ValidationMessage>
         </originatemetric>
-        <passiveinterfaces type="InterfaceField">
-                <Required>N</Required>
-                <multiple>Y</multiple>
-                <default></default>
-                <AllowDynamic>Y</AllowDynamic>
-                <filters>
-                    <enable>/^(?!0).*$/</enable>
-                </filters>
-        </passiveinterfaces>
         <redistribute type="OptionField">
                 <Required>N</Required>
                 <multiple>Y</multiple>
@@ -143,6 +134,7 @@
                                          <enable>/^(?!0).*$/</enable>
                                  </filters>
                         </interfacename>
+                        <passive type="BooleanField"/>
                         <authtype type="OptionField">
                                 <Required>N</Required>
                                 <multiple>N</multiple>

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
@@ -9,21 +9,14 @@
 agentx
 {%   endif %}
 {% endif %}
-{% set passive_interfaces = [] %}
-{% if helpers.exists('OPNsense.quagga.ospf.passiveinterfaces') and OPNsense.quagga.ospf.passiveinterfaces != '' %}
-{%     for line in OPNsense.quagga.ospf.passiveinterfaces.split(',') %}
-{%         set iface = physical_interface(line) %}
-{%         set _ = passive_interfaces.append(iface) %}
-interface {{ iface }}
-  ip ospf passive
-{%     endfor %}
-{% endif %}
-{# Render only the enabled non-passive interfaces past this point #}
 {% if helpers.exists('OPNsense.quagga.ospf.interfaces.interface') %}
 {%     for interface in helpers.toList('OPNsense.quagga.ospf.interfaces.interface') %}
 {%         set iface = physical_interface(interface.interfacename) %}
-{%         if interface.enabled == '1' and iface not in passive_interfaces %}
+{%         if interface.enabled == '1' %}
 interface {{ iface }}
+{%             if interface.passive|default('0') == '1' %}
+  ip ospf passive
+{%             endif %}
 {%             if interface.bfd|default('') == '1' %}
   ip ospf bfd
 {%             endif %}


### PR DESCRIPTION
Fixes: https://github.com/opnsense/plugins/issues/4590

Example config after migration:

```
interface hn0
 ip ospf area 0.0.0.0
 ip ospf passive
exit
!
interface lo1
 ip ospf area 0.0.0.0
exit
!
interface lo2
 ip ospf passive
exit
```

This change brings OSPF in line with OSPF6, which does the same for passive interface.

https://github.com/opnsense/plugins/blob/931f2c5d7a73f4158748fdf14c1a1f8ba3c5d20e/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospf6d.conf#L21-L23


