### PR TITLE
net/frr: Fix passive interface generation in ospf

### DIFF
--- a/net/frr/Makefile
+++ b/net/frr/Makefile
@@ -1,5 +1,6 @@
 PLUGIN_NAME=		frr
 PLUGIN_VERSION=		1.43
+PLUGIN_REVISION=	1
 PLUGIN_COMMENT=		The FRRouting Protocol Suite
 PLUGIN_DEPENDS=		frr8-pythontools
 PLUGIN_MAINTAINER=	ad@opnsense.org

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
@@ -9,20 +9,17 @@
 agentx
 {%   endif %}
 {% endif %}
-{% set passive_interfaces = [] %}
-{% if helpers.exists('OPNsense.quagga.ospf.passiveinterfaces') and OPNsense.quagga.ospf.passiveinterfaces != '' %}
-{%     for line in OPNsense.quagga.ospf.passiveinterfaces.split(',') %}
-{%         set iface = physical_interface(line) %}
-{%         set _ = passive_interfaces.append(iface) %}
-interface {{ iface }}
+{% if OPNsense.quagga.ospf.passiveinterfaces %}
+{%     for iface in OPNsense.quagga.ospf.passiveinterfaces.split(',') %}
+interface {{ helpers.physical_interface(iface) }}
   ip ospf passive
 {%     endfor %}
 {% endif %}
-{# Render only the enabled non-passive interfaces past this point #}
+{# vtysh automatically merges passive interfaces with interfaces below #}
 {% if helpers.exists('OPNsense.quagga.ospf.interfaces.interface') %}
 {%     for interface in helpers.toList('OPNsense.quagga.ospf.interfaces.interface') %}
 {%         set iface = physical_interface(interface.interfacename) %}
-{%         if interface.enabled == '1' and iface not in passive_interfaces %}
+{%         if interface.enabled == '1' %}
 interface {{ iface }}
 {%             if interface.bfd|default('') == '1' %}
   ip ospf bfd


### PR DESCRIPTION
Fixes: https://github.com/opnsense/plugins/issues/4590

It looks like its allowed to set this in frr.conf:

```
interface hn0
    ip ospf passive
interface hn0
    ip ospf area 0.0.0.0
```

And it will be automatically merged in vtysh running-config:

```
interface hn0
 ip ospf area 0.0.0.0
 ip ospf passive
exit
!
```

So this is the most simple fix.