### PR TITLE
Update squid workers helptext.

### DIFF
--- a/www/squid/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
+++ b/www/squid/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
@@ -350,7 +350,7 @@
                 <id>proxy.forward.workers</id>
                 <label>Number of squid workers</label>
                 <type>text</type>
-                <help>Start N main Squid process daemons (i.e., SMP mode). Requires Restart. Do not enable when using local cache.</help>
+                <help>Start N main Squid process daemons (i.e., SMP mode). Requires Restart.</help>
                 <hint>1</hint>
                 <advanced>true</advanced>
             </field>


### PR DESCRIPTION
Removes the hint introduced by https://github.com/opnsense/plugins/pull/4470 as we now have https://github.com/opnsense/plugins/pull/4487 which supports cache in combination with workers.