### PR TITLE
www/caddy: Add missing selectpicker style to dropdowns which have other styles attached

### DIFF
--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -16,6 +16,7 @@ Plugin Changelog
 1.8.4
 
 * Add: Client Auth (mTLS) to domains (opnsense/plugins/issues/4089)
+* Fix: Some selectpickers had incorrect style (opnsense/plugins/pull/4616)
 
 1.8.3
 

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -116,7 +116,7 @@
         <type>dropdown</type>
         <type>select_multiple</type>
         <size>5</size>
-        <style>style_reverse_proxy selectpicker</style>
+        <style>selectpicker style_reverse_proxy</style>
         <help><![CDATA[Select one or multiple headers. Caddy sets "X-Forwarded-For", "X-Forwarded-Proto" and "X-Forwarded-Host" by default, adding them here is not needed. Setting a wrong configuration can be a security risk or break functionality.]]></help>
         <advanced>true</advanced>
         <grid_view>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -181,7 +181,7 @@
         <id>handle.HttpTlsTrustedCaCerts</id>
         <label>TLS Trust Pool</label>
         <type>dropdown</type>
-        <style>style_tls style_reverse_proxy</style>
+        <style>selectpicker style_tls style_reverse_proxy</style>
         <help><![CDATA[Choose a CA or self-signed certificate to trust from "System - Trust - Authorities". Useful if the upstream destination only accepts TLS connections and offers a self signed certificate. Adding that certificate here will allow for the encrypted connection to succeed.]]></help>
         <grid_view>
             <visible>false</visible>
@@ -218,7 +218,7 @@
         <id>handle.lb_policy</id>
         <label>Load Balance Policy</label>
         <type>dropdown</type>
-        <style>style_reverse_proxy</style>
+        <style>selectpicker style_reverse_proxy</style>
         <help><![CDATA[lb_policy is the name of the load balancing policy, along with any options. For policies that involve hashing, the highest-random-weight (HRW) algorithm is used to ensure that a client or request with the same hash key is mapped to the same upstream, even if the list of upstreams change.]]></help>
         <advanced>true</advanced>
         <grid_view>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogLayer4.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogLayer4.xml
@@ -74,7 +74,7 @@
         <id>layer4.FromOpenvpnModes</id>
         <label>OpenVPN Mode</label>
         <type>dropdown</type>
-        <style>style_matchers selectpicker matchers_openvpn</style>
+        <style>selectpicker style_matchers matchers_openvpn</style>
         <help><![CDATA[Select the mode matching the OpenVPN Server or Client.]]></help>
         <grid_view>
             <visible>false</visible>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogLayer4.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogLayer4.xml
@@ -39,7 +39,7 @@
         <id>layer4.Protocol</id>
         <label>Protocol</label>
         <type>dropdown</type>
-        <style>style_type</style>
+        <style>selectpicker style_type</style>
         <help><![CDATA[Match the received traffic on OSI Layer 4, either TCP or UDP. When "Routing Type" is "listener_wrappers", currently only TCP will match.]]></help>
     </field>
     <field>
@@ -74,7 +74,7 @@
         <id>layer4.FromOpenvpnModes</id>
         <label>OpenVPN Mode</label>
         <type>dropdown</type>
-        <style>style_matchers matchers_openvpn</style>
+        <style>style_matchers selectpicker matchers_openvpn</style>
         <help><![CDATA[Select the mode matching the OpenVPN Server or Client.]]></help>
         <grid_view>
             <visible>false</visible>
@@ -84,7 +84,7 @@
         <id>layer4.FromOpenvpnStaticKey</id>
         <label>OpenVPN Static Key</label>
         <type>select_multiple</type>
-        <style>style_matchers selectpicker matchers_openvpn</style>
+        <style>selectpicker style_matchers matchers_openvpn</style>
         <hint>Any</hint>
         <size>5</size>
         <help><![CDATA[Select a Static Key to match. Multiple Static Keys are only supported for tls-crypt2_client mode.]]></help>
@@ -153,7 +153,7 @@
         <id>layer4.lb_policy</id>
         <label>Load Balance Policy</label>
         <type>dropdown</type>
-        <style>style_reverse_proxy</style>
+        <style>selectpicker style_reverse_proxy</style>
         <help><![CDATA[lb_policy is the name of the load balancing policy, along with any options. For policies that involve hashing, the highest-random-weight (HRW) algorithm is used to ensure that a client or request with the same hash key is mapped to the same upstream, even if the list of upstreams change.]]></help>
         <advanced>true</advanced>
         <grid_view>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
@@ -42,7 +42,7 @@
         <id>reverse.CustomCertificate</id>
         <label>Certificate</label>
         <type>dropdown</type>
-        <style>style_tls</style>
+        <style>selectpicker style_tls</style>
         <help><![CDATA[Choose ACME to get automatic certificates with the built in ACME client; no additional plugin required. The "HTTP-01", "TLS-ALPN-01" or "DNS-01" challenge will be used to get automatic "Let's Encrypt" or "ZeroSSL" certificates. Alternatively, choose a custom certificate from "System - Trust - Certificates" for this domain. Make sure the full chain has been imported.]]></help>
         <grid_view>
             <visible>false</visible>


### PR DESCRIPTION
I didn't notice this for quite a while.