### PR TITLE
www/caddy: Change and fix ACL privileges

### DIFF
--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -16,6 +16,7 @@ Plugin Changelog
 1.8.5
 
 * Add: basic_auth per handler (opnsense/plugins/issues/4619)
+* Change: the ACL has been changed to "page-caddy" in "System: Access: Privileges". Privilege must be reassigned if used. (opnsense/plugins/issues/4623)
 
 1.8.4
 

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/ACL/ACL.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/ACL/ACL.xml
@@ -1,34 +1,10 @@
 <acl>
-    <page-caddy-general>
-        <name>Services: Caddy Web Server: General Settings</name>
-        <description>Allow access to Caddy General Settings</description>
+    <page-caddy>
+        <name>Services: Caddy</name>
+        <description>Allow access to Caddy</description>
         <patterns>
-            <pattern>ui/caddy/general/*</pattern>
-            <pattern>api/caddy/general/*</pattern>
+            <pattern>ui/caddy/*</pattern>
+            <pattern>api/caddy/*</pattern>
         </patterns>
-    </page-caddy-general>
-    <page-caddy-reverse-proxy>
-        <name>Services: Caddy Web Server: Reverse Proxy</name>
-        <description>Allow access to Caddy Reverse Proxy</description>
-        <patterns>
-            <pattern>ui/caddy/reverse_proxy/*</pattern>
-            <pattern>api/caddy/reverse_proxy/*</pattern>
-        </patterns>
-    </page-caddy-reverse-proxy>
-    <page-caddy-layer4-routes>
-        <name>Services: Caddy Web Server: Layer4 Proxy</name>
-        <description>Allow access to Caddy Layer4 Proxy</description>
-        <patterns>
-            <pattern>ui/caddy/layer4/*</pattern>
-            <pattern>api/caddy/reverse_proxy/*</pattern>
-        </patterns>
-    </page-caddy-layer4-routes>
-    <page-caddy-diagnostics>
-        <name>Services: Caddy Web Server: Diagnostics</name>
-        <description>Allow access to Caddy Diagnostics</description>
-        <patterns>
-            <pattern>ui/caddy/diagnostics/*</pattern>
-            <pattern>api/caddy/diagnostics/*</pattern>
-        </patterns>
-    </page-caddy-diagnostics>
+    </page-caddy>
 </acl>


### PR DESCRIPTION
Fixes: https://github.com/opnsense/plugins/issues/4623

As multiple ACLs were mostly smoke and mirrors, there is just a single ACL now that matches the whole plugin.

The ACL from before is dysfunct due to non matching api paths.