### PR TITLE
net/frr: Fix wrong route redistribution option for ospf (bgp missing)

### DIFF
--- a/net/frr/Makefile
+++ b/net/frr/Makefile
@@ -1,5 +1,6 @@
 PLUGIN_NAME=		frr
 PLUGIN_VERSION=		1.44
+PLUGIN_REVISION=	1
 PLUGIN_COMMENT=		The FRRouting Protocol Suite
 PLUGIN_DEPENDS=		frr8-pythontools
 PLUGIN_MAINTAINER=	ad@opnsense.org

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF.xml
@@ -297,7 +297,7 @@
                                 <Required>Y</Required>
                                 <Default>connected</Default>
                                 <OptionValues>
-                                        <ospf>Open Shortest Path First (OSPF)</ospf>
+                                        <bgp>Border Gateway Protocol (BGP)</bgp>
                                         <connected>Connected routes (directly attached subnet or host)</connected>
                                         <kernel>Kernel routes (not installed via the zebra RIB)</kernel>
                                         <rip>Routing Information Protocol (RIP)</rip>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF6.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF6.xml
@@ -216,7 +216,7 @@
                                 <Required>Y</Required>
                                 <Default>connected</Default>
                                 <OptionValues>
-                                        <ospf>Open Shortest Path First (OSPF)</ospf>
+                                        <bgp>Border Gateway Protocol (BGP)</bgp>
                                         <connected>Connected routes (directly attached subnet or host)</connected>
                                         <kernel>Kernel routes (not installed via the zebra RIB)</kernel>
                                         <rip>Routing Information Protocol (RIP)</rip>


### PR DESCRIPTION
@fichtner I made a small oopsy here while copy pasting.

Fixes: https://github.com/opnsense/plugins/issues/4580#issuecomment-2767842030

Compare to here: https://github.com/opnsense/plugins/blob/7bbd4557995c77f6668c8b5f97401a98a634f005/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF.xml#L56-L62