### PR TITLE
Set SNMPD SMUX socket to localhost

### DIFF
--- a/net-mgmt/net-snmp/src/opnsense/service/templates/OPNsense/Netsnmp/snmpd.conf
+++ b/net-mgmt/net-snmp/src/opnsense/service/templates/OPNsense/Netsnmp/snmpd.conf
@@ -18,6 +18,8 @@ agentxsocket /var/agentx/master
 agentxperms 777 777
 {% endif %}
 
+smuxsocket 127.0.0.1
+
 {% if OPNsense.netsnmp.general.enableobservium == '1' %}
 extend .1.3.6.1.4.1.2021.7890.1 distro /usr/local/opnsense/scripts/OPNsense/Netsnmp/distro.sh
 extend .1.3.6.1.4.1.2021.7890.2 hardware /bin/kenv smbios.planar.product


### PR DESCRIPTION
I recently switched to OPNsense and noticed an exposed service when reviewing all services listening on all interfaces.

`smuxsocket` defaults to all IPv4 interfaces ([manpage](https://www.net-snmp.org/docs/man/snmpd.conf.html#:~:text=smuxsocket,-%3CIPv4%2Daddress)) and it isn't needed at all. Setting it to the loopback address disables the outdated feature as much as possible.