### PR TITLE
Added AccountingServer options

### DIFF
--- a/net/radsecproxy/src/opnsense/service/templates/OPNsense/RadSecProxy/radsecproxy.conf
+++ b/net/radsecproxy/src/opnsense/service/templates/OPNsense/RadSecProxy/radsecproxy.conf
@@ -221,6 +221,12 @@ realm {{ realm.realm }} {
   Server {{ server.identifier }}
 {% endfor %}
 {% endif %}
+{% if realm.accountingServer is defined and realm.accountingServer != "" %}
+{% for serverUuid in realm.accountingServer.split(',') %}
+{% set accountingServer = helpers.getUUID(serverUuid) %}
+  AccountingServer {{ accountingServer.identifier }}
+{% endfor %}
+{% endif %}
 {% if realm.replyMessage is defined and realm.replyMessage != "" %}
   ReplyMessage "{{ realm.replyMessage }}"
 {% endif %}


### PR DESCRIPTION
While playing around with OPNsense and my new access points I was trying to get radius accounting working with OPNsense / RadSecProxy / Freeradius.
However, no matter what settings I tried, I couldn't get it to work.

Looks like the "AccountingServer" option is missing, so I copied the "Server" section and things started working.