### PR TITLE
www/squid: authenticate before blacklist

### DIFF
--- a/www/squid/src/opnsense/service/templates/OPNsense/Proxy/squid.acl.conf
+++ b/www/squid/src/opnsense/service/templates/OPNsense/Proxy/squid.acl.conf
@@ -28,6 +28,10 @@ adaptation_access request_mod allow whiteList
 http_access allow whiteList
 {% endif %}
 
+{%   if not helpers.empty('OPNsense.proxy.forward.authentication.method') %}
+http_access deny !local_auth
+{% endif %}
+
 {% if helpers.exists('OPNsense.proxy.forward.acl.blackList') %}
 
 #


### PR DESCRIPTION
This commit ensures user authentication before blacklist evaluation.
Previously, Squid denied access to blacklisted sites before triggering authentication.
As a result, blocked requests were logged without a username, making it difficult to trace user actions, especially in terminalserver environments.
The commit extends the current behavior if proxy authentication is enabled.

Example: Access of blocked website "www.reddit.com"

Logs before:
`May  1 13:51:30 fw.example.org (squid-2)[9549]: 1746100290.093     19 172.20.2.3 TCP_DENIED/200 0 CONNECT www.reddit.com:443 - HIER_NONE/- -`

Logs after:
`May 1 14:52:11 fw.example.org (squid-3)[8990]: 1746103931.825     54 172.20.2.3 TCP_DENIED/200 0 CONNECT www.reddit.com:443 user01@EXAMPLE.ORG HIER_NONE/- -`