### PR TITLE
Add ZoneEdit settings for acme.sh

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -563,6 +563,21 @@
         <type>password</type>
     </field>
     <field>
+        <label>ZoneEdit</label>
+        <type>header</type>
+        <style>table_dns table_dns_zoneedit</style>
+    </field>
+    <field>
+        <id>validation.dns_zoneedit_id</id>
+        <label>ZONEEDIT_ID</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_zoneedit_token</id>
+        <label>ZONEEDIT_TOKEN</label>
+        <type>text</type>
+    </field>
+    <field>
         <label>Gandi LiveDNS</label>
         <type>header</type>
         <style>table_dns table_dns_gandi_livedns</style>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsZoneedit.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsZoneedit.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Copyright (C) 2020 Frank Wall
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\AcmeClient\LeValidation;
+
+use OPNsense\AcmeClient\LeValidationInterface;
+use OPNsense\Core\Config;
+
+/**
+ * FreeDNS API
+ * @package OPNsense\AcmeClient
+ */
+class DnsZoneedit extends Base implements LeValidationInterface
+{
+    public function prepare()
+    {
+        $this->acme_env['ZONEEDIT_ID'] = (string)$this->config->dns_zoneedit_id;
+        $this->acme_env['ZONEEDIT_Token'] = (string)$this->config->dns_zoneedit_token;
+    }
+}

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -530,6 +530,7 @@
                         <dns_zilore>Zilore</dns_zilore>
                         <dns_zone>Zone.eu</dns_zone>
                         <dns_zonomi>zonomi.com</dns_zonomi>
+                        <dns_zoneedit>ZoneEdit</dns_zoneedit>
                     </OptionValues>
                 </dns_service>
                 <dns_sleep type="IntegerField">
@@ -1311,6 +1312,12 @@
                 <dns_scaleway_token type="TextField">
                     <Required>N</Required>
                 </dns_scaleway_token>
+                <dns_zoneedit_id type="TextField">
+                    <Required>N</Required>
+                </dns_zoneedit_id>
+                <dns_zoneedit_token type="TextField">
+                    <Required>N</Required>
+                </dns_zoneedit_token>
             </validation>
         </validations>
         <actions>


### PR DESCRIPTION
The new acme.sh release [3.1.1](https://github.com/acmesh-official/acme.sh/tree/3.1.1) supports ZoneEdit DNS provider. 
This adds the necessary fields to support it.