### PR TITLE
www/c-icap: move to syslog

### DIFF
--- a/www/c-icap/src/etc/inc/plugins.inc.d/cicap.inc
+++ b/www/c-icap/src/etc/inc/plugins.inc.d/cicap.inc
@@ -26,6 +26,15 @@
     POSSIBILITY OF SUCH DAMAGE.
 */
 
+function cicap_syslog()
+{
+    return [
+        'cicap' => [
+            'facility' => ['c-icap']
+        ]
+    ];
+}
+
 function cicap_services()
 {
     global $config;

--- a/www/c-icap/src/opnsense/mvc/app/models/OPNsense/CICAP/Menu/Menu.xml
+++ b/www/c-icap/src/opnsense/mvc/app/models/OPNsense/CICAP/Menu/Menu.xml
@@ -2,7 +2,7 @@
   <Services>
     <C_ICAP VisibleName="C-ICAP" cssClass="fa fa-ambulance">
         <Configuration order="10" url="/ui/cicap/general/index"/>
-        <LogFile VisibleName="Log File" order="20" url="/ui/diagnostics/log/cicap/server"/>
+        <LogFile VisibleName="Log File" order="20" url="/ui/diagnostics/log/core/cicap"/>
     </C_ICAP>
   </Services>
 </menu>

--- a/www/c-icap/src/opnsense/scripts/OPNsense/CICAP/setup.sh
+++ b/www/c-icap/src/opnsense/scripts/OPNsense/CICAP/setup.sh
@@ -4,11 +4,5 @@ mkdir -p /var/run/c-icap
 chown -R c_icap:c_icap /var/run/c-icap
 chmod 750 /var/run/c-icap
 
-mkdir -p /var/log/c-icap
-chown -R c_icap:c_icap /var/log/c-icap
-chmod 750 /var/log/c-icap
-(cd /var/log && ln -s c-icap cicap)
-chown -R c_icap:c_icap /var/log/cicap
-
 mkdir -p /tmp/c-icap/templates/virus_scan/en
 chmod -R 755 /tmp/c-icap/

--- a/www/c-icap/src/opnsense/service/templates/OPNsense/CICAP/+TARGETS
+++ b/www/c-icap/src/opnsense/service/templates/OPNsense/CICAP/+TARGETS
@@ -1,6 +1,5 @@
 c_icap:/etc/rc.conf.d/c_icap
 c-icap.conf:/usr/local/etc/c-icap/c-icap.conf
-newsyslog.conf:/etc/newsyslog.conf.d/c-icap
 virus_scan.conf:/usr/local/etc/c-icap/virus_scan.conf
 VIRUS_FOUND:/tmp/c-icap/templates/virus_scan/en/VIRUS_FOUND
 VIR_MODE_HEAD:/tmp/c-icap/templates/virus_scan/en/VIR_MODE_HEAD

--- a/www/c-icap/src/opnsense/service/templates/OPNsense/CICAP/c-icap.conf
+++ b/www/c-icap/src/opnsense/service/templates/OPNsense/CICAP/c-icap.conf
@@ -46,7 +46,11 @@ ServerName {{ system.hostname }}
 {%      if helpers.exists('OPNsense.proxy.forward.icap.SendUsername') and OPNsense.proxy.forward.icap.SendUsername == '1' %}
 RemoteProxyUsers on
 acl AUTH auth *
-acl localserver srvip 127.0.0.1
+{%   if not helpers.empty('OPNsense.cicap.general.listenaddress') %}
+acl localserver srvip {{ OPNsense.cicap.general.listenaddress }}
+{%      else %}
+acl localserver srvip ::1
+{% endif %}
 icap_access allow AUTH localserver
 {%      else %}
 RemoteProxyUsers off
@@ -62,7 +66,11 @@ RemoteProxyUserHeader {{OPNsense.proxy.forward.icap.UsernameHeader}}
 {% else %}
 RemoteProxyUsers on
 acl AUTH auth *
-acl localserver srvip 127.0.0.1
+{%   if not helpers.empty('OPNsense.cicap.general.listenaddress') %}
+acl localserver srvip {{ OPNsense.cicap.general.listenaddress }}
+{%      else %}
+acl localserver srvip ::1
+{% endif %}
 icap_access allow AUTH localserver
 RemoteProxyUserHeaderEncoded on
 RemoteProxyUserHeader X-Authenticated-User
@@ -77,9 +85,11 @@ ServicesDir /usr/local/lib/c_icap
 TemplateDir /tmp/c-icap/templates/
 TemplateDefaultLanguage en
 LoadMagicFile /usr/local/etc/c-icap/c-icap.magic
-ServerLog /var/log/c-icap/server.log
-{% if helpers.exists('OPNsense.cicap.general.enable_accesslog') and OPNsense.cicap.general.enable_accesslog == '1' %}
-AccessLog /var/log/c-icap/access.log
+Module logger sys_logger.so
+Logger sys_logger
+sys_logger.Prefix "c-icap"
+{% if helpers.exists('OPNsense.cicap.general.enable_accesslog') and OPNsense.cicap.general.enable_accesslog == '0' %}
+sys_logger.access !localserver
 {% endif %}
 Service echo srv_echo.so
 Include virus_scan.conf

--- a/www/c-icap/src/opnsense/service/templates/OPNsense/CICAP/newsyslog.conf
+++ b/www/c-icap/src/opnsense/service/templates/OPNsense/CICAP/newsyslog.conf
@@ -1,7 +1,0 @@
-# logfilename                   [owner:group]   mode    count size      when    flags   [/pid_file]               [sig_num]
-{% if helpers.exists('OPNsense.cicap.general.enabled') and OPNsense.cicap.general.enabled|default("0") == "1" %}
-{% if helpers.exists('OPNsense.cicap.general.enable_accesslog') and OPNsense.cicap.general.enable_accesslog == '1' %}
-/var/log/c-icap/access.log    c_icap:c_icap     644     7       *       @T00     ZB      /var/run/c-icap/c-icap.pid
-{% endif %}
-/var/log/c-icap/server.log    c_icap:c_icap     644     7       *       @T00     ZB      /var/run/c-icap/c-icap.pid
-{% endif %}

--- a/www/c-icap/src/opnsense/service/templates/Syslog/local/cicap.conf
+++ b/www/c-icap/src/opnsense/service/templates/Syslog/local/cicap.conf
@@ -1,0 +1,6 @@
+###################################################################
+# Local syslog-ng configuration filter definition [cicap].
+###################################################################
+filter f_local_cicap {
+    program("c-icap");
+};


### PR DESCRIPTION
This commit changes the cicap log from logfile to syslog.
It also improves the previously static localserver acl with the correct serverip configured via the GUI.
Furthermore it flips the logic of the accesslog because it is enabled by default if sys_logger is enabled.