### PR TITLE
net/ndproxy: Disable promiscuous mode forced by port

### DIFF
--- a/net/ndproxy/src/opnsense/service/templates/OPNsense/Ndproxy/rc.conf.d/ndproxy
+++ b/net/ndproxy/src/opnsense/service/templates/OPNsense/Ndproxy/rc.conf.d/ndproxy
@@ -17,3 +17,5 @@ ndproxy_uplink_ipv6_addresses="{{ generalSettings.ndproxy_uplink_ipv6_addresses 
 {% else %}
 ndproxy_enable="NO"
 {% endif %}
+{# Always disable promiscuous mode forced by port since it should be controlled via interface settings if needed. #}
+ndproxy_promisc_enable="NO"


### PR DESCRIPTION
We do not need this since our most common setup has "uplink_interface" and "downlink_mac_address" on the same interface, ndproxy and CPE router are same device.

Promiscuous mode would be needed if the "downlink_mac_address" is on a different device, e.g. a separate CPE router. If that is the case, users can enable it via interface settings.