### PR TITLE
www/caddy: Add Request Matcher option to Access List

### DIFF
--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogAccessList.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogAccessList.xml
@@ -45,6 +45,13 @@
         </grid_view>
     </field>
     <field>
+        <id>accesslist.RequestMatcher</id>
+        <label>Request Matcher</label>
+        <type>dropdown</type>
+        <help><![CDATA[Set the request matcher that will be applied to this access list.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
         <id>accesslist.description</id>
         <label>Description</label>
         <type>text</type>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -530,6 +530,14 @@
                     <ValidationMessage>Please enter a valid HTTP response code between 100 and 599</ValidationMessage>
                 </HttpResponseCode>
                 <HttpResponseMessage type="DescriptionField"/>
+                <RequestMatcher type="OptionField">
+                    <Required>Y</Required>
+                    <Default>client_ip</Default>
+                    <OptionValues>
+                        <client_ip>client_ip</client_ip>
+                        <remote_ip>remote_ip</remote_ip>
+                    </OptionValues>
+                </RequestMatcher>
                 <description type="DescriptionField"/>
             </accesslist>
             <basicauth type="ArrayField">

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//Pischem/caddy</mount>
     <description>Caddy Reverse Proxy</description>
-    <version>1.3.5</version>
+    <version>1.3.6</version>
     <items>
         <general>
             <enabled type="BooleanField">

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -524,7 +524,7 @@ http://{{ domain }} {
             {% set client_ips = accesslist_obj.clientIps.split(',') | join(' ') %}
             {{ unique_identifier }} {
                 {# Non-inverted access lists have "not" as default, inverted ones '' #}
-                {{ 'not' if accesslist_obj.accesslistInvert|default("0") == "0" else '' }} client_ip {{ client_ips }}
+                {{ 'not' if accesslist_obj.accesslistInvert|default("0") == "0" else '' }} {{ accesslist_obj.RequestMatcher }} {{ client_ips }}
             }
             {# When IP is matched, abort or send response code. This will end processing and drop the request #}
             handle {{ unique_identifier }} {


### PR DESCRIPTION
This PR adds a dropdown to Access List form to choose Request Matcher between `client_ip` and `remote_ip`.

Close #4666