### PR TITLE
www/squid: correct bannedhosts acl

### DIFF
--- a/www/squid/src/opnsense/service/templates/OPNsense/Proxy/squid.acl.conf
+++ b/www/squid/src/opnsense/service/templates/OPNsense/Proxy/squid.acl.conf
@@ -14,6 +14,20 @@ adaptation_access request_mod allow unrestricted
 http_access allow unrestricted
 {% endif %}
 
+{% if helpers.exists('OPNsense.proxy.forward.acl.bannedHosts') %}
+
+# ACL list (Deny) banned hosts
+{% if helpers.exists('OPNsense.proxy.forward.icap.enable') and OPNsense.proxy.forward.icap.enable == '1' %}
+{%   if helpers.exists('OPNsense.proxy.forward.icap.ResponseURL') %}
+adaptation_access response_mod deny bannedHosts
+{%   endif %}
+{%   if helpers.exists('OPNsense.proxy.forward.icap.RequestURL') %}
+adaptation_access request_mod deny bannedHosts
+{%   endif %}
+{% endif %}
+http_access deny bannedHosts
+{% endif %}
+
 {% if helpers.exists('OPNsense.proxy.forward.acl.whiteList') %}
 
 # ACL list (Allow) whitelist
@@ -138,18 +152,6 @@ adaptation_access request_mod deny CONNECT !SSL_ports {% if helpers.exists('OPNs
 {% endif %}
 
 http_access deny CONNECT !SSL_ports {% if helpers.exists('OPNsense.proxy.forward.acl.unrestricted') %}!unrestricted{% endif %}
-
-{% if helpers.exists('OPNsense.proxy.forward.acl.bannedHosts') %}
-{% if helpers.exists('OPNsense.proxy.forward.icap.enable') and OPNsense.proxy.forward.icap.enable == '1' %}
-{%   if helpers.exists('OPNsense.proxy.forward.icap.ResponseURL') %}
-adaptation_access response_mod deny bannedHosts
-{%   endif %}
-{%   if helpers.exists('OPNsense.proxy.forward.icap.RequestURL') %}
-adaptation_access request_mod deny bannedHosts
-{%   endif %}
-{% endif %}
-http_access deny bannedHosts
-{% endif %}
 
 # Only allow cachemgr access from localhost
 http_access allow localhost manager


### PR DESCRIPTION
The bannedhosts ACL, which is used to deny access for a source address, is currently evaluated after the destination-based whitelist. As a result, access from banned hosts is denied except for URLs that are whitelisted. 
However, the intended behavior for bannedhosts is to block all access for certain clients, regardless of destination. 
This commit corrects this by moving the bannedhosts acl to its proper position and ensures that the access is blocked for these.