### PR TITLE
Add error page file extension support

### DIFF
--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/errorpage.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/errorpage.xml
@@ -19,6 +19,13 @@
         <help>The HTML page content to display.</help>
     </field>
     <field>
+        <id>errorpage.extension</id>
+        <label>File Extension</label>
+        <type>text</type>
+        <help>Allow to change error file extension to, i.e. json</help>
+        <advanced>true</advanced>
+    </field>
+    <field>
         <id>errorpage.redirect</id>
         <label>Redirect Target</label>
         <type>text</type>

--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
@@ -1841,6 +1841,10 @@
           </check001>
         </Constraints>
       </pagecontent>
+      <extension type="TextField">
+        <default>html</default>
+        <Required>Y</Required>
+      </extension>
       <redirect type="UrlField">
         <Required>N</Required>
         <Constraints>

--- a/www/nginx/src/opnsense/scripts/nginx/setup.php
+++ b/www/nginx/src/opnsense/scripts/nginx/setup.php
@@ -296,7 +296,7 @@ foreach ($nginx->location->iterateItems() as $location) {
 foreach ($nginx->errorpage->iterateItems() as $errorpage) {
     $uuid = str_replace('-', '', $errorpage->getAttributes()['uuid']);
     if (in_array($uuid, $used_errorpages)) {
-        $filename = "error_$uuid.html";
+        $filename = "error_$uuid.$errorpage->extension";
         $content = base64_decode((string)$errorpage->pagecontent);
         // Does error page have a content?
         if (strlen($content) > 0) {

--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/http.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/http.conf
@@ -219,9 +219,9 @@ server {
 {%   for errorpage_uuid in server.errorpages.split(',') %}
 {%     do used_errorpages.append(errorpage_uuid) %}
 {%     set errorpage = helpers.getUUID(errorpage_uuid) %}
-    error_page {{ errorpage.statuscodes.replace(',', ' ') }} {% if errorpage.response is defined and errorpage.response != '' %}={{ errorpage.response }} {% endif %}{% if errorpage.redirect is defined and errorpage.redirect != '' %}{{ errorpage.redirect }}{% else %}/error_{{ errorpage_uuid.replace('-', '') }}.html{% endif %};
+    error_page {{ errorpage.statuscodes.replace(',', ' ') }} {% if errorpage.response is defined and errorpage.response != '' %}={{ errorpage.response }} {% endif %}{% if errorpage.redirect is defined and errorpage.redirect != '' %}{{ errorpage.redirect }}{% else %}/error_{{ errorpage_uuid.replace('-', '') }}.{{ errorpage.extension }}{% endif %};
 {%     if errorpage.redirect is not defined or errorpage.redirect == '' %}
-    location = /error_{{ errorpage_uuid.replace('-', '') }}.html {
+    location = /error_{{ errorpage_uuid.replace('-', '') }}.{{ errorpage.extension }} {
         internal;
         root /usr/local/etc/nginx/views;
     }
@@ -382,7 +382,7 @@ server {
 {%       if errorpage_uuid not in used_errorpages %}
 {%         set errorpage = helpers.getUUID(errorpage_uuid) %}
 {%         if errorpage.redirect is not defined or errorpage.redirect == '' %}
-location = /error_{{ errorpage_uuid.replace('-', '') }}.html {
+location = /error_{{ errorpage_uuid.replace('-', '') }}.{{ errorpage.extension }}}} {
     internal;
     root /usr/local/etc/nginx/views;
 }

--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/location.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/location.conf
@@ -44,7 +44,7 @@ location {{ location.matchtype }} {{ location.urlpattern }} {
 {% if location.errorpages is defined and location.errorpages != '' %}
 {%   for errorpage_uuid in location.errorpages.split(',') %}
 {%     set errorpage = helpers.getUUID(errorpage_uuid) %}
-    error_page {{ errorpage.statuscodes.replace(',', ' ') }} {% if errorpage.response is defined and errorpage.response != '' %}={{ errorpage.response }} {% endif %}{% if errorpage.redirect is defined and errorpage.redirect != '' %}{{ errorpage.redirect }}{% else %}/error_{{ errorpage_uuid.replace('-', '') }}.html{% endif %};
+    error_page {{ errorpage.statuscodes.replace(',', ' ') }} {% if errorpage.response is defined and errorpage.response != '' %}={{ errorpage.response }} {% endif %}{% if errorpage.redirect is defined and errorpage.redirect != '' %}{{ errorpage.redirect }}{% else %}/error_{{ errorpage_uuid.replace('-', '') }}.{{ errorpage.extension }}{% endif %};
 {%    endfor %}
 {% endif %}
 {% if location.force_https is defined and location.force_https == '1' %}


### PR DESCRIPTION
this address https://github.com/opnsense/plugins/issues/4684
Allow users to change the extension of the error file so we can now set it to i.e. json to make it well read for app that require json
These changes were made on a running Opnsense so perhaps I did miss to report some modifications here, so, please, review it carefully ^^
As I don't know Opnsense code at all so I did a "just working" change
see you :) 