### PR TITLE
www/squid: Don't reject no-bump sites when certificate validation fails

### DIFF
--- a/www/squid/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
+++ b/www/squid/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
@@ -84,6 +84,7 @@ ssl_bump peek bump_step2 bump_nobumpsites
 ssl_bump splice bump_step3 bump_nobumpsites
 ssl_bump stare bump_step2
 ssl_bump bump bump_step3
+sslproxy_cert_error allow bump_nobumpsites
 {% endif %}
 
 sslproxy_cert_error deny all


### PR DESCRIPTION
These days I'm in a project to migrate from Sophos Proxy to OPNsense, nearly 1000 users, explicit proxy with ssl decryption and ClamAV/C-ICAP. There a couple of misconfigured site where certificate chain is incomplete and also not in OPNsense default stack. The only solution is to import by hand or ask website owner to fix it.

Now I had a new case where also importing missin certificates doesn't work and only option was this one.

To me it's fine as it says don't block connections when certificate validation fails, but we ignore this only for no-bump sites, so it shouldn't be a problem either.

Screenshot of the error:
![image](https://github.com/user-attachments/assets/dbc51c21-eec9-4daa-aeaa-898406f09aab)
