### PR TITLE
net/frr: add neighbor config to ospf

### DIFF
--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/Api/OspfsettingsController.php
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/Api/OspfsettingsController.php
@@ -37,6 +37,31 @@ class OspfsettingsController extends ApiMutableModelControllerBase
     protected static $internalModelName = 'ospf';
     protected static $internalModelClass = '\OPNsense\Quagga\OSPF';
 
+    public function searchNeighborAction()
+    {
+        return $this->searchBase('neighbors.neighbor');
+    }
+
+    public function getNeighborAction($uuid = null)
+    {
+        return $this->getBase('neighbor', 'neighbors.neighbor', $uuid);
+    }
+
+    public function addNeighborAction()
+    {
+        return $this->addBase('neighbor', 'neighbors.neighbor');
+    }
+
+    public function delNeighborAction($uuid)
+    {
+        return $this->delBase('neighbors.neighbor', $uuid);
+    }
+
+    public function setNeighborAction($uuid)
+    {
+        return $this->setBase('neighbor', 'neighbors.neighbor', $uuid);
+    }
+
     public function searchNetworkAction()
     {
         return $this->searchBase('networks.network');
@@ -116,6 +141,10 @@ class OspfsettingsController extends ApiMutableModelControllerBase
     public function setRoutemapAction($uuid)
     {
         return $this->setBase('routemap', 'routemaps.routemap', $uuid);
+    }
+    public function toggleNeighborAction($uuid)
+    {
+        return $this->toggleBase('neighbors.neighbor', $uuid);
     }
     public function toggleNetworkAction($uuid)
     {

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/OspfController.php
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/OspfController.php
@@ -34,6 +34,9 @@ class OspfController extends \OPNsense\Base\IndexController
     {
         $this->view->generalForm = $this->getForm("ospf");
 
+        $this->view->formDialogEditOSPFNeighbor = $this->getForm("dialogEditOSPFNeighbor");
+        $this->view->formGridEditOSPFNeighbor = $this->getFormGrid("dialogEditOSPFNeighbor");
+
         $this->view->formDialogEditNetwork = $this->getForm("dialogEditOSPFNetwork");
         $this->view->formGridEditNetwork = $this->getFormGrid("dialogEditOSPFNetwork");
 

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditOSPFNeighbor.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditOSPFNeighbor.xml
@@ -1,0 +1,36 @@
+<form>
+  <field>
+    <id>neighbor.enabled</id>
+    <label>Enabled</label>
+    <type>checkbox</type>
+    <grid_view>
+      <width>6em</width>
+      <type>boolean</type>
+      <formatter>rowtoggle</formatter>
+    </grid_view>
+  </field>
+  <field>
+    <id>neighbor.description</id>
+    <label>Description</label>
+    <type>text</type>
+    <help>Optional description for the neighbor.</help>
+  </field>
+  <field>
+    <id>neighbor.address</id>
+    <label>Peer-IP</label>
+    <type>text</type>
+    <help>Specify the IP address of the OSPF neighbor.</help>
+  </field>
+  <field>
+    <id>neighbor.pollinterval</id>
+    <label>Poll-Interval</label>
+    <type>text</type>
+    <help>The poll-interval specifies the rate for sending hello packets to neighbors that are not active. When the configured neighbor is discovered, hello packets will be sent at the rate of the hello-interval. The default poll-interval is 60 seconds.</help>
+  </field>
+  <field>
+    <id>neighbor.priority</id>
+    <label>Priority</label>
+    <type>text</type>
+    <help>The priority is used to for the Designated Router (DR) election on non-broadcast multi-access networks.</help>
+  </field>
+</form>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF.xml
@@ -103,6 +103,30 @@
                         </linkedPrefixlistOut>
                 </network>
         </networks>
+        <neighbors>
+                <neighbor type="ArrayField">
+                        <enabled type="BooleanField">
+                                <default>1</default>
+                                <Required>Y</Required>
+                        </enabled>
+                        <description type="DescriptionField">
+                                <Required>N</Required>
+                        </description>
+                        <address type="NetworkField">
+                                <Required>Y</Required>
+                        </address>
+                        <pollinterval type="IntegerField">
+                                <Required>N</Required>
+                                <MinimumValue>1</MinimumValue>
+                                <MaximumValue>65535</MaximumValue>
+                        </pollinterval>
+                        <priority type="IntegerField">
+                                <Required>N</Required>
+                                <MinimumValue>0</MinimumValue>
+                                <MaximumValue>255</MaximumValue>
+                        </priority>
+                </neighbor>
+        </neighbors>
         <interfaces>
                 <interface type="ArrayField">
                         <enabled type="BooleanField">

--- a/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/ospf.volt
+++ b/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/ospf.volt
@@ -51,6 +51,14 @@ POSSIBILITY OF SUCH DAMAGE.
             }
         });
 
+        $("#{{formGridEditOSPFNeighbor['table_id']}}").UIBootgrid({
+            'search':'/api/quagga/ospfsettings/search_neighbor',
+            'get':'/api/quagga/ospfsettings/get_neighbor/',
+            'set':'/api/quagga/ospfsettings/set_neighbor/',
+            'add':'/api/quagga/ospfsettings/add_neighbor/',
+            'del':'/api/quagga/ospfsettings/del_neighbor/',
+            'toggle':'/api/quagga/ospfsettings/toggle_neighbor/'
+        });
         $("#{{formGridEditNetwork['table_id']}}").UIBootgrid({
             'search':'/api/quagga/ospfsettings/searchNetwork',
             'get':'/api/quagga/ospfsettings/getNetwork/',
@@ -122,6 +130,7 @@ POSSIBILITY OF SUCH DAMAGE.
 <!-- Navigation bar -->
 <ul class="nav nav-tabs" data-tabs="tabs" id="maintabs">
     <li class="active"><a data-toggle="tab" href="#general">{{ lang._('General') }}</a></li>
+    <li><a data-toggle="tab" href="#neighbors">{{ lang._('Neighbors') }}</a></li>
     <li><a data-toggle="tab" href="#networks">{{ lang._('Networks') }}</a></li>
     <li><a data-toggle="tab" href="#interfaces">{{ lang._('Interfaces') }}</a></li>
     <li><a data-toggle="tab" href="#prefixlists">{{ lang._('Prefix Lists') }}</a></li>
@@ -132,6 +141,10 @@ POSSIBILITY OF SUCH DAMAGE.
     <div id="general" class="tab-pane fade in active">
         {{ partial("layout_partials/base_form",['fields':generalForm,'id':'frm_ospf_settings'])}}
         {{ partial('layout_partials/base_bootgrid_table', formGridEditRedistribution)}}
+    </div>
+    <!-- Tab: Neighbors -->
+    <div id="neighbors" class="tab-pane fade in">
+        {{ partial('layout_partials/base_bootgrid_table', formGridEditOSPFNeighbor)}}
     </div>
     <!-- Tab: Networks -->
     <div id="networks" class="tab-pane fade in">
@@ -151,6 +164,7 @@ POSSIBILITY OF SUCH DAMAGE.
     </div>
 </div>
 {{ partial('layout_partials/base_apply_button', {'data_endpoint': '/api/quagga/service/reconfigure', 'data_service_widget': 'quagga'}) }}
+{{ partial("layout_partials/base_dialog",['fields':formDialogEditOSPFNeighbor,'id':formGridEditOSPFNeighbor['edit_dialog_id'],'label':lang._('Edit Neighbor')])}}
 {{ partial("layout_partials/base_dialog",['fields':formDialogEditNetwork,'id':formGridEditNetwork['edit_dialog_id'],'label':lang._('Edit Network')])}}
 {{ partial("layout_partials/base_dialog",['fields':formDialogEditInterface,'id':formGridEditInterface['edit_dialog_id'],'label':lang._('Edit Interface')])}}
 {{ partial("layout_partials/base_dialog",['fields':formDialogEditPrefixLists,'id':formGridEditPrefixLists['edit_dialog_id'],'label':lang._('Edit Prefix Lists')])}}

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
@@ -58,6 +58,13 @@ router ospf
  redistribute {{ redistribution.redistribute }}{% if redistribution.linkedRoutemap %} route-map {{ helpers.getUUID(redistribution.linkedRoutemap).name }}{% endif +%}
 {%   endif %}
 {% endfor %}
+{%   if helpers.exists('OPNsense.quagga.ospf.neighbors.neighbor') %}
+{%     for neighbor in helpers.toList('OPNsense.quagga.ospf.neighbors.neighbor') %}
+{%       if neighbor.enabled == '1' %}
+ neighbor {{ neighbor.address }}{% if 'pollinterval' in neighbor and neighbor.pollinterval != '' %} poll-interval {{ neighbor.pollinterval }} {% endif %}{% if 'priority' in neighbor and neighbor.priority != '' %} priority {{ neighbor.priority }} {% endif +%}
+{%       endif %}
+{%     endfor %}
+{%   endif %}
 {% if helpers.exists('OPNsense.quagga.ospf.networks.network') %}
 {%   for network in helpers.toList('OPNsense.quagga.ospf.networks.network') %}
 {%     if network.enabled == '1' %}


### PR DESCRIPTION
This commit adds the possibility to configure OSPF neighbors for non-broadcast multi-access (NBMA) networks and point-to-multipoint non-broadcast networks.
The feature was also requested in the past: https://forum.opnsense.org/index.php?topic=22543.0