### PR TITLE
os-dnscrypt-proxy: Allow for ip:port lists for DNS forwarders

### DIFF
--- a/dns/dnscrypt-proxy/src/opnsense/mvc/app/controllers/OPNsense/Dnscryptproxy/forms/dialogEditDnscryptproxyForward.xml
+++ b/dns/dnscrypt-proxy/src/opnsense/mvc/app/controllers/OPNsense/Dnscryptproxy/forms/dialogEditDnscryptproxyForward.xml
@@ -13,8 +13,10 @@
     </field>
     <field>
         <id>forward.dnsserver</id>
-        <label>DNS Server</label>
-        <type>text</type>
+        <label>DNS Server(s)</label>
+        <style>tokenize</style>
+        <type>select_multiple</type>
+        <allownew>true</allownew>
         <help>Set the IP addresses to forward the domain.</help>
     </field>
 </form>

--- a/dns/dnscrypt-proxy/src/opnsense/mvc/app/models/OPNsense/Dnscryptproxy/Forward.xml
+++ b/dns/dnscrypt-proxy/src/opnsense/mvc/app/models/OPNsense/Dnscryptproxy/Forward.xml
@@ -12,7 +12,7 @@
                 <domain type="HostnameField">
                     <Required>Y</Required>
                 </domain>
-                <dnsserver type="HostnameField">
+                <dnsserver type="CSVListField">
                     <Required>Y</Required>
                 </dnsserver>
             </forward>


### PR DESCRIPTION
Allow for ip_port lists for DNS forwarders instead of just one server.

See issue: https://github.com/opnsense/plugins/issues/4697