### PR TITLE
Theme Cicada: Make disabled items more visible

### DIFF
--- a/misc/theme-cicada/src/opnsense/www/themes/cicada/assets/stylesheets/main.scss
+++ b/misc/theme-cicada/src/opnsense/www/themes/cicada/assets/stylesheets/main.scss
@@ -10631,6 +10631,10 @@ ul.jqtree-tree {
   border: 1px solid #191919 !important;
 }
 
+.rule.text-muted {
+  background-color: #3b2b1a !important;
+}
+
 .rule.text-muted > td {
   &:nth-child(1n+3) {
     text-decoration: line-through;

--- a/misc/theme-cicada/src/opnsense/www/themes/cicada/build/css/main.css
+++ b/misc/theme-cicada/src/opnsense/www/themes/cicada/build/css/main.css
@@ -6617,6 +6617,10 @@ ul.jqtree-tree .jqtree-title {
   border: 1px solid #191919 !important;
 }
 
+.rule.text-muted {
+  background-color: #3b2b1a !important;
+}
+
 .rule.text-muted > td:nth-child(1n+3) {
   text-decoration: line-through;
 }


### PR DESCRIPTION
The goal of this PR is to make disabled entries more visible in a long list of entries for the Cicada theme.

## Current

![grafik](https://github.com/user-attachments/assets/62d7040e-a808-4a7c-9ee9-104640238004)


## After this PR

![grafik](https://github.com/user-attachments/assets/2b093da1-0142-4525-be7d-781ff46131e5)
