### PR TITLE
www/squid: select behavior for banned hosts

### DIFF
--- a/www/squid/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
+++ b/www/squid/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
@@ -422,6 +422,12 @@
                 <allownew>true</allownew>
             </field>
             <field>
+                <id>proxy.forward.acl.allowWhitelistBannedHosts</id>
+                <label>Whitelist access for banned hosts</label>
+                <type>checkbox</type>
+                <help>Allows banned hosts to access domains listed in whitelist.</help>
+            </field>
+            <field>
                 <id>proxy.forward.acl.whiteList</id>
                 <label>Whitelist</label>
                 <type>select_multiple</type>

--- a/www/squid/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
+++ b/www/squid/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
@@ -355,6 +355,10 @@
                 <bannedHosts type="CSVListField">
                     <Mask>/^([\/0-9a-fA-F.:,])*/u</Mask>
                 </bannedHosts>
+                <allowWhitelistBannedHosts type="BooleanField">
+                    <Default>1</Default>
+                    <Required>N</Required>
+                </allowWhitelistBannedHosts>
                 <whiteList type="CSVListField"/>
                 <blackList type="CSVListField"/>
                 <browser type="CSVListField"/>

--- a/www/squid/src/opnsense/service/templates/OPNsense/Proxy/squid.acl.conf
+++ b/www/squid/src/opnsense/service/templates/OPNsense/Proxy/squid.acl.conf
@@ -14,6 +14,20 @@ adaptation_access request_mod allow unrestricted
 http_access allow unrestricted
 {% endif %}
 
+{% if helpers.exists('OPNsense.proxy.forward.acl.bannedHosts') and OPNsense.proxy.forward.acl.allowWhitelistBannedHosts|default('1') == '0' %}
+
+# ACL list (Deny) banned hosts
+{% if helpers.exists('OPNsense.proxy.forward.icap.enable') and OPNsense.proxy.forward.icap.enable == '1' %}
+{%   if helpers.exists('OPNsense.proxy.forward.icap.ResponseURL') %}
+adaptation_access response_mod deny bannedHosts
+{%   endif %}
+{%   if helpers.exists('OPNsense.proxy.forward.icap.RequestURL') %}
+adaptation_access request_mod deny bannedHosts
+{%   endif %}
+{% endif %}
+http_access deny bannedHosts
+{% endif %}
+
 {% if helpers.exists('OPNsense.proxy.forward.acl.whiteList') %}
 
 # ACL list (Allow) whitelist
@@ -139,7 +153,9 @@ adaptation_access request_mod deny CONNECT !SSL_ports {% if helpers.exists('OPNs
 
 http_access deny CONNECT !SSL_ports {% if helpers.exists('OPNsense.proxy.forward.acl.unrestricted') %}!unrestricted{% endif %}
 
-{% if helpers.exists('OPNsense.proxy.forward.acl.bannedHosts') %}
+{% if helpers.exists('OPNsense.proxy.forward.acl.bannedHosts') and OPNsense.proxy.forward.acl.allowWhitelistBannedHosts|default('1')  == '1' %}
+
+# ACL list (Deny) banned hosts
 {% if helpers.exists('OPNsense.proxy.forward.icap.enable') and OPNsense.proxy.forward.icap.enable == '1' %}
 {%   if helpers.exists('OPNsense.proxy.forward.icap.ResponseURL') %}
 adaptation_access response_mod deny bannedHosts


### PR DESCRIPTION
This PR supersedes https://github.com/opnsense/plugins/pull/4686.
It introduces a selectable bahavior for the banned hosts acl.
It allows to switch access to whitelisted domains for banned hosts as suggested by @mimugmail in https://github.com/opnsense/plugins/pull/4686#issuecomment-2862783499.