### PR TITLE
net/frr: watchfrr service handling

### DIFF
--- a/net/frr/src/opnsense/scripts/frr/frr_restart.sh
+++ b/net/frr/src/opnsense/scripts/frr/frr_restart.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Service wrapper for restarting frr service
+# This wrapper is needed to react on specific service interactions through watchfrr.
+# Startup details with watchfrr enabled (default):
+# 1. "service frr start" calls "service frr start watchfrr"
+# 2. watchfrr once started calls "service frr restart all"
+# 3. "restart all" need to loop the list of $frr_daemons to start each
+#    of then
+# 4. vtysh -b is executed to load boot startup configuration
+
+/usr/sbin/service frr restart $1
+
+# If started service is ospfd, e.g. process error
+if [ "$1" = "ospfd" ]; then
+    logger -t frr_wrapper "WATCHFRR - OSPFD - Starting CARP event handler now"
+    /usr/local/opnsense/scripts/frr/carp_event_handler
+fi
+# If frr starts up
+if [ "$1" = "all" ]; then
+    /usr/bin/logger -t frr_wrapper "WATCHFRR - STARTUP - Starting CARP event handler in 1 sec."
+    (
+        sleep 1
+        /usr/bin/logger -t frr_wrapper "WATCHFRR - STARTUP - Starting CARP event handler now"
+        /usr/local/opnsense/scripts/frr/carp_event_handler
+    ) &
+fi
+exit $?

--- a/net/frr/src/opnsense/scripts/frr/frr_start.sh
+++ b/net/frr/src/opnsense/scripts/frr/frr_start.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Service wrapper for starting frr service
+# This wrapper is needed to react on specific service interactions through watchfrr.
+# Startup details with watchfrr enabled (default):
+# 1. "service frr start" calls "service frr start watchfrr"
+# 2. watchfrr once started calls "service frr restart all"
+# 3. "restart all" need to loop the list of $frr_daemons to start each
+#    of then
+# 4. vtysh -b is executed to load boot startup configuration
+
+/usr/sbin/service frr start $1
+
+# If started service is ospfd, e.g. process error
+if [ "$1" = "ospfd" ]; then
+    logger -t frr_wrapper "WATCHFRR - OSPFD - Starting CARP event handler now"
+    /usr/local/opnsense/scripts/frr/carp_event_handler
+fi
+# If frr starts up
+if [ "$1" = "all" ]; then
+    /usr/bin/logger -t frr_wrapper "WATCHFRR - STARTUP - Starting CARP event handler in 1 sec."
+    (
+        sleep 1
+        /usr/bin/logger -t frr_wrapper "WATCHFRR - STARTUP - Starting CARP event handler now"
+        /usr/local/opnsense/scripts/frr/carp_event_handler
+    ) &
+fi
+exit $?

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/frr
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/frr
@@ -18,15 +18,7 @@ frr_carp_demote="{%
     if not helpers.empty('OPNsense.quagga.ospf.carp_demote') %} ospfd{% endif %}{%
     if not helpers.empty('OPNsense.quagga.ospf6.carp_demote') %} ospf6d{% endif
 %}"
-start_postcmd='
-	# XXX rc.d/frr declares its own post command we need to hook first
-	start_postcmd
-	# XXX rc.d/frr iterates through daemons so we need to hook last one
-	if [ "${frr_daemons}" != "${frr_daemons% ${name}}" ]; then
-		echo "Starting CARP event handler now"
-		/usr/local/opnsense/scripts/frr/carp_event_handler
-	fi
-'
+watchfrr_flags="-r /usr/local/opnsense/scripts/frr/frr_restart.shbB%s -s /usr/local/opnsense/scripts/frr/frr_start.shbB%s -k /usr/sbin/servicebBfrrbBstopbB%s -b bB -t 30"
 {% if OPNsense.quagga.general.enablesnmp == '1' %}
 zebra_flags="${zebra_flags} -M snmp"
 bgpd_flags="${bgpd_flags} -M snmp"


### PR DESCRIPTION
This commit fixes CARP event handler integration with FRR service startup.
It resolves issues with triggering the CARP event handler during service startup, particularly in setups where route costs depend on CARP status.
- Removes the "start_postcmd" override, as routing deamon lifecycle management is now handled by watchfrr.
- Introduces two service wrapper scripts to hook into watchfrr's startup and restart procedures.

Tested Scenarios:
✓ Stopping / Starting FRR
✓ Killing ospfd process
✓ Reboot

Resolves https://github.com/opnsense/plugins/issues/4702