### PR TITLE
net/frr: Add bgp listen range to peer groups

### DIFF
--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPPeergroups.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPPeergroups.xml
@@ -34,6 +34,14 @@
     </grid_view>
   </field>
   <field>
+    <id>peergroup.listenranges</id>
+    <label>Listen Ranges</label>
+    <type>select_multiple</type>
+    <style>tokenize</style>
+    <allownew>true</allownew>
+    <help>Enter one or multiple IP networks in CIDR notation. Accept connections from any peers in the specified prefix.</help>
+  </field>
+  <field>
     <id>peergroup.updatesource</id>
     <label>Update-Source Interface</label>
     <type>dropdown</type>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
@@ -439,6 +439,13 @@
                                 <MinimumValue>1</MinimumValue>
                                 <MaximumValue>4294967295</MaximumValue>
                         </remoteas>
+                        <listenranges type="NetworkField">
+                                <FieldSeparator>,</FieldSeparator>
+                                <AsList>Y</AsList>
+                                <Strict>Y</Strict>
+                                <NetMaskRequired>Y</NetMaskRequired>
+                                <ValidationMessage>Please enter one or multiple valid IP networks in CIDR notation.</ValidationMessage>
+                        </listenranges>
                         <updatesource type="InterfaceField">
                                 <AllowDynamic>Y</AllowDynamic>
                                 <filters>

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -98,6 +98,11 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%           endif %}
 {%         endfor %}
 {%       endif %}
+{%       if peergroup.listenranges %}
+{%           for prefix in peergroup.listenranges.split(',') %}
+ bgp listen range {{ prefix }} peer-group {{ peergroup.name }}
+{%           endfor %}
+{%       endif %}
 {%     endif %}
 {%   endfor %}
 {%   if helpers.exists('OPNsense.quagga.bgp.neighbors.neighbor') %}


### PR DESCRIPTION
Fixes: https://github.com/opnsense/plugins/issues/4713
Fixes: https://github.com/opnsense/plugins/issues/4015

vtysh show running-config

```
router bgp 65551
 no bgp ebgp-requires-policy
 no bgp default ipv4-unicast
 neighbor testpeergroup peer-group
 neighbor testpeergroup remote-as 61222
 neighbor testpeergroup update-source hn0
 neighbor 192.168.1.1 remote-as 44444
 bgp listen range 192.168.1.0/24 peer-group testpeergroup
 bgp listen range 192.168.2.0/24 peer-group testpeergroup
 bgp listen range 172.16.0.0/24 peer-group testpeergroup
 !
 address-family ipv4 unicast
  neighbor testpeergroup activate
  neighbor 192.168.1.1 activate
 exit-address-family
exi
```