### PR TITLE
Update dialogAccount.xml

### DIFF
--- a/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/dialogAccount.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/controllers/OPNsense/DynDNS/forms/dialogAccount.xml
@@ -87,6 +87,13 @@
         <help>How to determine the address to use for this host</help>
     </field>
     <field>
+        <id>account.rootdns</id>
+        <label>Root DNS Entry</label>
+        <type>checkbox</type>
+        <style>optional_setting service_porkbun</style>
+        <help>The configured host(s) entry to change is a Root DNS (A Record) entry.</help>
+    </field>
+    <field>
         <id>account.interface</id>
         <label>Interface to monitor</label>
         <type>dropdown</type>


### PR DESCRIPTION
This is to add a menu entry to ddclient when using Porkbun DNS specifically. It requires that "on-root-domain=yes" is explicitly added to the ddclient.conf file in order to update the root DNS entry.