### PR TITLE
Update ddclient.conf

### DIFF
--- a/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
+++ b/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
@@ -4,6 +4,9 @@ pid=/var/run/ddclient.pid   # record PID in file.
 {% if not helpers.empty('OPNsense.DynDNS.general.verbose') %}
 verbose=yes
 {% endif %}
+{%      if account.rootdns|default('0') == '1' %}
+on-root-domain=yes, \
+{%      endif %}
 {%  set accounts = [] %}
 {%  set force_ssl = [] %}
 {%  if helpers.exists('OPNsense.DynDNS.accounts.account') and OPNsense.DynDNS.general.backend == 'ddclient' %}


### PR DESCRIPTION
In order to change the Root DNS entry — when using Porkbun —  "on-root-domain=yes" must be explicitly added to the ddclient.conf file.  I have tested that this works to update the Root DNS entry by manually adding this to the file and reloading the ddclient service. It works for a few minutes and then the file is overwritten due to how OPNSense works.

**DISCLAIMER:** I am **NOT** a developer. I am not even sure that this is the part of the plugin that updates the config file.