### PR TITLE
Allow http (i.e non https) git repository to be used in `os-git-backup` plugin

### DIFF
--- a/sysutils/git-backup/src/opnsense/mvc/app/models/OPNsense/Backup/GitSettings.xml
+++ b/sysutils/git-backup/src/opnsense/mvc/app/models/OPNsense/Backup/GitSettings.xml
@@ -17,7 +17,7 @@
         </enabled>
         <url type="TextField">
             <Required>N</Required>
-            <mask>/^((https)|(ssh))?:\/\/.*[^\/]$/</mask>
+            <mask>/^((https?)|(ssh))?:\/\/.*[^\/]$/</mask>
             <ValidationMessage>A valid git location must be provided. e.g. ssh://server/project.git, https://server/project.git</ValidationMessage>
             <Constraints>
                 <check001>


### PR DESCRIPTION
Apply fix described in [Issue #3834](https://github.com/opnsense/plugins/issues/3834)