### PR TITLE
net-mgmt/zabbix-proxy: Add VMware parameters

### DIFF
--- a/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/controllers/OPNsense/Zabbixproxy/forms/general.xml
+++ b/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/controllers/OPNsense/Zabbixproxy/forms/general.xml
@@ -154,6 +154,34 @@
         <help>IP address of host allowed to retrieve proxy statistics.</help>
     </field>
     <field>
+        <id>general.vmwarecachesize</id>
+        <label>VMware Cache Size</label>
+        <type>text</type>
+        <help>Shared memory size for storing VMware data.</help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>general.vmwarefrequency</id>
+        <label>VMware Frequency</label>
+        <type>text</type>
+        <help>Delay in seconds between data gathering from a single VMware service.</help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>general.vmwareperffrequency</id>
+        <label>VMwarePerfFrequency</label>
+        <type>text</type>
+        <help>Delay in seconds between performance counter statistics retrieval from a single VMware service.</help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>general.vmwaretimeout</id>
+        <label>VMware Timeout</label>
+        <type>text</type>
+        <help>The maximum number of seconds vmware collector will wait for a response from VMware service.</help>
+        <advanced>true</advanced>
+    </field>
+    <field>
         <id>general.syslogEnable</id>
         <label>Log To Syslog</label>
         <type>checkbox</type>

--- a/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/models/OPNsense/Zabbixproxy/General.xml
+++ b/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/models/OPNsense/Zabbixproxy/General.xml
@@ -107,7 +107,7 @@
             <Required>N</Required>
         </statsip>
         <vmwarecachesize type="TextField">
-            <default>8M</default>
+            <Mask>/^\d+[KMG]$/</Mask>
         </vmwarecachesize>
         <vmwarefrequency type="IntegerField">
             <MinimumValue>10</MinimumValue>

--- a/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/models/OPNsense/Zabbixproxy/General.xml
+++ b/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/models/OPNsense/Zabbixproxy/General.xml
@@ -118,7 +118,6 @@
             <MaximumValue>86400</MaximumValue>
         </vmwareperffrequency>
         <vmwaretimeout type="IntegerField">
-            <default></default>
             <MinimumValue>1</MinimumValue>
             <MaximumValue>300</MaximumValue>
             <Required>N</Required>

--- a/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/models/OPNsense/Zabbixproxy/General.xml
+++ b/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/models/OPNsense/Zabbixproxy/General.xml
@@ -111,7 +111,6 @@
             <Required>N</Required>
         </vmwarecachesize>
         <vmwarefrequency type="IntegerField">
-            <default></default>
             <MinimumValue>10</MinimumValue>
             <MaximumValue>86400</MaximumValue>
             <Required>N</Required>

--- a/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/models/OPNsense/Zabbixproxy/General.xml
+++ b/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/models/OPNsense/Zabbixproxy/General.xml
@@ -108,7 +108,6 @@
         </statsip>
         <vmwarecachesize type="TextField">
             <default>8M</default>
-            <Required>N</Required>
         </vmwarecachesize>
         <vmwarefrequency type="IntegerField">
             <MinimumValue>10</MinimumValue>

--- a/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/models/OPNsense/Zabbixproxy/General.xml
+++ b/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/models/OPNsense/Zabbixproxy/General.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/zabbixproxy/general</mount>
     <description>Zabbix Proxy configuration</description>
-    <version>2.0.4</version>
+    <version>2.0.5</version>
     <items>
         <enabled type="BooleanField">
             <default>0</default>
@@ -106,6 +106,28 @@
             <asList>Y</asList>
             <Required>N</Required>
         </statsip>
+        <vmwarecachesize type="TextField">
+            <default>8M</default>
+            <Required>N</Required>
+        </vmwarecachesize>
+        <vmwarefrequency type="IntegerField">
+            <default></default>
+            <MinimumValue>10</MinimumValue>
+            <MaximumValue>86400</MaximumValue>
+            <Required>N</Required>
+        </vmwarefrequency>
+        <vmwareperffrequency type="IntegerField">
+            <default></default>
+            <MinimumValue>10</MinimumValue>
+            <MaximumValue>86400</MaximumValue>
+            <Required>N</Required>
+        </vmwareperffrequency>
+        <vmwaretimeout type="IntegerField">
+            <default></default>
+            <MinimumValue>1</MinimumValue>
+            <MaximumValue>300</MaximumValue>
+            <Required>N</Required>
+        </vmwaretimeout>
         <syslogEnable type="BooleanField">
             <default>0</default>
             <Required>Y</Required>

--- a/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/models/OPNsense/Zabbixproxy/General.xml
+++ b/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/models/OPNsense/Zabbixproxy/General.xml
@@ -114,7 +114,6 @@
             <MaximumValue>86400</MaximumValue>
         </vmwarefrequency>
         <vmwareperffrequency type="IntegerField">
-            <default></default>
             <MinimumValue>10</MinimumValue>
             <MaximumValue>86400</MaximumValue>
             <Required>N</Required>

--- a/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/models/OPNsense/Zabbixproxy/General.xml
+++ b/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/models/OPNsense/Zabbixproxy/General.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/zabbixproxy/general</mount>
     <description>Zabbix Proxy configuration</description>
-    <version>2.0.5</version>
+    <version>2.0.4</version>
     <items>
         <enabled type="BooleanField">
             <default>0</default>
@@ -120,7 +120,6 @@
         <vmwaretimeout type="IntegerField">
             <MinimumValue>1</MinimumValue>
             <MaximumValue>300</MaximumValue>
-            <Required>N</Required>
         </vmwaretimeout>
         <syslogEnable type="BooleanField">
             <default>0</default>

--- a/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/models/OPNsense/Zabbixproxy/General.xml
+++ b/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/models/OPNsense/Zabbixproxy/General.xml
@@ -112,7 +112,6 @@
         <vmwarefrequency type="IntegerField">
             <MinimumValue>10</MinimumValue>
             <MaximumValue>86400</MaximumValue>
-            <Required>N</Required>
         </vmwarefrequency>
         <vmwareperffrequency type="IntegerField">
             <default></default>

--- a/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/models/OPNsense/Zabbixproxy/General.xml
+++ b/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/models/OPNsense/Zabbixproxy/General.xml
@@ -116,7 +116,6 @@
         <vmwareperffrequency type="IntegerField">
             <MinimumValue>10</MinimumValue>
             <MaximumValue>86400</MaximumValue>
-            <Required>N</Required>
         </vmwareperffrequency>
         <vmwaretimeout type="IntegerField">
             <default></default>

--- a/net-mgmt/zabbix-proxy/src/opnsense/service/templates/OPNsense/Zabbixproxy/zabbix_proxy.conf.in
+++ b/net-mgmt/zabbix-proxy/src/opnsense/service/templates/OPNsense/Zabbixproxy/zabbix_proxy.conf.in
@@ -84,6 +84,18 @@ HistoryCacheSize={{ OPNsense.zabbixproxy.general.historycachesize }}
 {% if helpers.exists('OPNsense.zabbixproxy.general.historyindexcachesize') and OPNsense.zabbixproxy.general.historyindexcachesize != '' %}
 HistoryIndexCacheSize={{ OPNsense.zabbixproxy.general.historyindexcachesize }}
 {% endif %}
+{% if helpers.exists('OPNsense.zabbixproxy.general.vmwarecachesize') and OPNsense.zabbixproxy.general.vmwarecachesize != '' %}
+VMwareCacheSize={{ OPNsense.zabbixproxy.general.vmwarecachesize }}
+{% endif %}
+{% if helpers.exists('OPNsense.zabbixproxy.general.vmwarefrequency') and OPNsense.zabbixproxy.general.vmwarefrequency != '' %}
+VMwareFrequency={{ OPNsense.zabbixproxy.general.vmwarefrequency }}
+{% endif %}
+{% if helpers.exists('OPNsense.zabbixproxy.general.vmwareperffrequency') and OPNsense.zabbixproxy.general.vmwareperffrequency != '' %}
+VMwarePerfFrequency={{ OPNsense.zabbixproxy.general.vmwareperffrequency }}
+{% endif %}
+{% if helpers.exists('OPNsense.zabbixproxy.general.vmwaretimeout') and OPNsense.zabbixproxy.general.vmwaretimeout != '' %}
+VMwareTimeout={{ OPNsense.zabbixproxy.general.vmwaretimeout }}
+{% endif %}
 {% if helpers.exists('OPNsense.zabbixproxy.general.timeout') and OPNsense.zabbixproxy.general.timeout != '' %}
 Timeout={{ OPNsense.zabbixproxy.general.timeout }}
 {% endif %}


### PR DESCRIPTION
Zabbix Proxy was crashing because of lacking of VMwareCacheSize on my setup and manually adding that option to config at every change was painful, so I implemented it with other VMware options. I would appreciate it if this could be merged into the main repository.