### PR TITLE
net/zerotier: Configure ZeroTier network options

### DIFF
--- a/net/zerotier/src/opnsense/mvc/app/controllers/OPNsense/Zerotier/forms/dialogNetwork.xml
+++ b/net/zerotier/src/opnsense/mvc/app/controllers/OPNsense/Zerotier/forms/dialogNetwork.xml
@@ -11,4 +11,48 @@
         <type>text</type>
         <help>Local Description to help identify this network</help>
     </field>
+    <field>
+        <id>network.allowManaged</id>
+        <label>Allow Managed</label>
+        <type>checkbox</type>
+        <help>Allow ZeroTier to set IP Addresses and Routes (local/private ranges only)</help>
+        <grid_view>
+            <visible>false</visible>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+        </grid_view>
+    </field>
+    <field>
+        <id>network.allowGlobal</id>
+        <label>Allow Global</label>
+        <type>checkbox</type>
+        <help>Allow ZeroTier to set Global/Public/Not-Private range IPs and Routes</help>
+        <grid_view>
+            <visible>false</visible>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+        </grid_view>
+    </field>
+    <field>
+        <id>network.allowDefault</id>
+        <label>Allow Default</label>
+        <type>checkbox</type>
+        <help>Allow ZeroTier to set the Default Route on the system</help>
+        <grid_view>
+            <visible>false</visible>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+        </grid_view>
+    </field>
+    <field>
+        <id>network.allowDNS</id>
+        <label>Allow DNS</label>
+        <type>checkbox</type>
+        <help>Allow ZeroTier to set DNS servers</help>
+        <grid_view>
+            <visible>false</visible>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+        </grid_view>
+    </field>
 </form>

--- a/net/zerotier/src/opnsense/mvc/app/models/OPNsense/Zerotier/Zerotier.xml
+++ b/net/zerotier/src/opnsense/mvc/app/models/OPNsense/Zerotier/Zerotier.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/zerotier</mount>
     <description>Zerotier configuration</description>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
     <items>
         <enabled type="BooleanField">
             <Default>0</Default>
@@ -19,6 +19,22 @@
                     <Required>Y</Required>
                 </networkId>
                 <description type="TextField"/>
+                <allowManaged type="BooleanField">
+                    <Default>1</Default>
+                    <Required>Y</Required>
+                </allowManaged>
+                <allowGlobal type="BooleanField">
+                    <Default>0</Default>
+                    <Required>Y</Required>
+                </allowGlobal>
+                <allowDefault type="BooleanField">
+                    <Default>0</Default>
+                    <Required>Y</Required>
+                </allowDefault>
+                <allowDNS type="BooleanField">
+                    <Default>0</Default>
+                    <Required>Y</Required>
+                </allowDNS>
             </network>
         </networks>
     </items>

--- a/net/zerotier/src/opnsense/service/conf/actions.d/actions_zerotier.conf
+++ b/net/zerotier/src/opnsense/service/conf/actions.d/actions_zerotier.conf
@@ -34,6 +34,12 @@ parameters: leave %s
 type:script_output
 message:Leaving Zerotier Network
 
+[set]
+command:/usr/local/bin/zerotier-cli
+parameters: set %s %s=%s
+type:script_output
+message:Setting Zerotier Network
+
 [info]
 command:/usr/local/bin/zerotier-cli info
 parameters:

--- a/net/zerotier/src/opnsense/service/templates/OPNsense/zerotier/+TARGETS
+++ b/net/zerotier/src/opnsense/service/templates/OPNsense/zerotier/+TARGETS
@@ -1,2 +1,3 @@
 zerotier:/etc/rc.conf.d/zerotier
 local.conf:/var/db/zerotier-one/local.conf
+networks-local.conf:/var/db/zerotier-one/networks.d/[OPNsense.zerotier.networks.network.%.networkId].local.conf

--- a/net/zerotier/src/opnsense/service/templates/OPNsense/zerotier/networks-local.conf
+++ b/net/zerotier/src/opnsense/service/templates/OPNsense/zerotier/networks-local.conf
@@ -1,0 +1,10 @@
+{% if helpers.exists('OPNsense.zerotier.networks') %}
+{%   for network in helpers.toList('OPNsense.zerotier.networks.network') %}
+{%     if TARGET_FILTERS['OPNsense.zerotier.networks.network.' ~ loop.index0] or TARGET_FILTERS['OPNsense.zerotier.networks.network'] %}
+allowManaged={{ network.allowManaged }}
+allowGlobal={{ network.allowGlobal }}
+allowDefault={{ network.allowDefault }}
+allowDNS={{ network.allowDNS }}
+{%     endif %}
+{%   endfor %}
+{% endif %}


### PR DESCRIPTION
This pull requests adds in the four configurable options for Zerotier networks: allowManaged, allowGlobal, allowDefault, allowDNS.   

Zerotier defaults are used for these options.

Referenced in: https://github.com/opnsense/plugins/issues/4011


