### PR TITLE
Add support for deSEC.io as a ddclient target

### DIFF
--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.xml
@@ -46,6 +46,7 @@
                         <changeip>Changeip</changeip>
                         <cloudflare>Cloudflare</cloudflare>
                         <cloudns>ClouDNS</cloudns>
+                        <desecio>deSEC.io</desecio>
                         <digitalocean>Digitalocean</digitalocean>
                         <dinahosting>dinahosting</dinahosting>
                         <dnsmadeeasy>DNS Made Easy (digicert)</dnsmadeeasy>
@@ -145,6 +146,8 @@
                         <web_cloudflare>cloudflare</web_cloudflare>
                         <web_cloudflare_ipv4 value="cloudflare-ipv4">cloudflare-ipv4</web_cloudflare_ipv4>
                         <web_cloudflare_ipv6 value="cloudflare-ipv6">cloudflare-ipv6</web_cloudflare_ipv6>
+                        <web_desecio_ipv4 value="desecio-ipv4">desecio-ipv4</web_desecio_ipv4>
+                        <web_desecio_ipv6 value="desecio-ipv6">desecio-ipv6</web_desecio_ipv4>
                         <web_dynu_ipv4 value="dynu-ipv4">dynu-ipv4</web_dynu_ipv4>
                         <web_dynu_ipv6 value="dynu-ipv6">dynu-ipv6</web_dynu_ipv6>
                         <web_freedns>freedns</web_freedns>

--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/address.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/address.py
@@ -35,6 +35,8 @@ checkip_service_list = {
   'cloudflare': '%s://one.one.one.one/cdn-cgi/trace',
   'cloudflare-ipv4': '%s://1.1.1.1/cdn-cgi/trace',
   'cloudflare-ipv6': '%s://[2606:4700:4700::1111]/cdn-cgi/trace',
+  'desecio-ipv4': '%s://checkipv4.dedyn.io',
+  'desecio-ipv6': '%s://checkipv6.dedyn.io',
   'dynu-ipv4': '%s://ipcheck.dynu.com/',
   'dynu-ipv6': '%s://ipcheckv6.dynu.com/',
   'freedns': '%s://freedns.afraid.org/dynamic/check.php',

--- a/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
+++ b/dns/ddclient/src/opnsense/service/templates/OPNsense/ddclient/ddclient.conf
@@ -54,6 +54,9 @@ zone={{account.zone}}, \
 {%      elif account.service == 'dns-o-matic' %}
 protocol=dyndns2, \
 server=updates.dnsomatic.com, \
+{%      elif account.service == 'desecio' %}
+protocol=dyndns2, \
+server=update.dedyn.io, \
 {%      elif account.service == 'dynu' %}
 protocol=dyndns2, \
 server=api.dynu.com, \


### PR DESCRIPTION
Add support for deSEC.io (a not-for-profit german DNS service) which also uses dyndns2 for updating records dynamically.

It works fine with the 'other' selection, but this is a bit cleaner :)

Documentation:
https://desec.readthedocs.io/en/latest/dyndns/configure.html#manual-configuration-other-systems

Site: https://desec.io/