### PR TITLE
security/tailscale: Fix subnet router dialog help text

### DIFF
--- a/security/tailscale/src/opnsense/mvc/app/controllers/OPNsense/Tailscale/forms/dialogSubnet4.xml
+++ b/security/tailscale/src/opnsense/mvc/app/controllers/OPNsense/Tailscale/forms/dialogSubnet4.xml
@@ -3,7 +3,7 @@
         <id>subnet4.subnet</id>
         <label>Subnet</label>
         <type>text</type>
-        <help>Subnet to use, should be large enough to hold the specified pools and reservations</help>
+        <help>Local subnet to route to your tailnet in CIDR notation (e.g. 192.168.1.0/24).</help>
     </field>
     <field>
         <id>subnet4.description</id>


### PR DESCRIPTION
The original help text appears to be a potential copy-and-paste leftover from an unrelated subnet field for some kind of DHCP configuration dialog.

Changes the help text so that it is contextually relevant to the plugin.