### PR TITLE
dns/bind (os-bind) Custom Directives

### DIFF
--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/general.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/general.xml
@@ -195,4 +195,17 @@
         <advanced>true</advanced>
         <help>The base64-encoded RNDC key. This requires a restart of the Bind Service.</help>
     </field>
+    <field>
+        <type>header</type>
+        <label>Custom Directives</label>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>general.customdirectives</id>
+        <label>Custom Directives</label>
+        <type>textbox</type>
+        <style>height:100px</style>
+        <advanced>true</advanced>
+        <help>Additional BIND configuration directives that will be appended to named.conf. Use this for advanced configurations not available in the GUI (e.g., "server 192.168.1.1 { edns no; };").</help>
+    </field>
 </form>

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/General.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/General.xml
@@ -172,5 +172,11 @@
             <Required>Y</Required>
             <Default>VxtIzJevSQXqnr7h2qerrcwjnZlMWSGGFBndKeNIDfw=</Default>
         </rndcsecret>
+        <customdirectives type="TextField">
+            <Required>N</Required>
+            <default></default>
+            <mask>/^.{0,2048}$/u</mask>
+            <ValidationMessage>Custom directives should not exceed 2048 characters.</ValidationMessage>
+        </customdirectives>
     </items>
 </model>

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/General.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/General.xml
@@ -175,7 +175,7 @@
         <customdirectives type="TextField">
             <Required>N</Required>
             <default></default>
-            <mask>/^.{0,2048}$/u</mask>
+            <mask>/^[\s\S]{0,2048}$/u</mask>
             <ValidationMessage>Custom directives should not exceed 2048 characters.</ValidationMessage>
         </customdirectives>
     </items>

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
@@ -112,6 +112,10 @@ controls {
 };
 {% endif %}
 
+{% if helpers.exists('OPNsense.bind.general.customdirectives') and OPNsense.bind.general.customdirectives != '' %}
+{{ OPNsense.bind.general.customdirectives }}
+{% endif %}
+
 zone "." { type hint; file "/usr/local/etc/namedb/named.root"; };
 
 zone "localhost"        { type primary; file "/usr/local/etc/namedb/primary/localhost-forward.db"; };


### PR DESCRIPTION
Adds a "Custom Directives" field in the BIND Configuration "General" tab, which adds whatever text you put in the "Custom Directives" into the `named.conf` configuration file.

Addresses https://github.com/opnsense/plugins/issues/4773