### PR TITLE
net/frr: Activate peergroup in address family

### DIFF
--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -59,7 +59,6 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%       if peergroup.updatesource %}
  neighbor {{ peergroup.name }} update-source {{ physical_interface(peergroup.updatesource) }}
 {%       endif %}
- neighbor {{ peergroup.name }} activate
 {%       if  peergroup.nexthopself|default('0') == '1' %}
  neighbor {{ peergroup.name }} next-hop-self
 {%       endif %}
@@ -162,6 +161,11 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%   endfor %}
 {%   for network in networks[addressFamily] %}
   network {{ network }}
+{%   endfor %}
+{%   for peergroup in helpers.toList('OPNsense.quagga.bgp.peergroups.peergroup') %}
+{%     if peergroup.enabled == '1' %}
+  neighbor {{ peergroup.name }} activate
+{%     endif %}
 {%   endfor %}
 {%   for neighbor in neighbors[addressFamily] %}
   neighbor {{ neighbor.address }} activate


### PR DESCRIPTION
Fixes: https://github.com/opnsense/plugins/issues/4762

I asked OP to test, so lets wait first, but when looking at the frr documentation its indeed at the wrong spot.