### PR TITLE
feat(acme/pbs): implement certificate deployment to Proxmox Backup Server

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogAction.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogAction.xml
@@ -334,6 +334,47 @@
     <field>
         <label>Required Parameters</label>
         <type>header</type>
+        <style>method_table method_table_acme_proxmoxbs</style>
+    </field>
+    <field>
+        <id>action.acme_proxmoxbs_user</id>
+        <label>Proxmox BS user</label>
+        <type>text</type>
+        <help>The user who owns the API key. Defaults to root.</help>
+    </field>
+    <field>
+        <id>action.acme_proxmoxbs_server</id>
+        <label>Proxmox BS server</label>
+        <type>text</type>
+        <help>The hostname of the proxmox BS node.</help>
+    </field>
+    <field>
+        <id>action.acme_proxmoxbs_port</id>
+        <label>Proxmox BS server port</label>
+        <type>text</type>
+        <help>The port number the management interface is on. Defaults to 8007.</help>
+    </field>
+    <field>
+        <id>action.acme_proxmoxbs_realm</id>
+        <label>Proxmox BS realm</label>
+        <type>text</type>
+        <help>The authentication realm the user authenticates with. Defaults to pam.</help>
+    </field>
+    <field>
+        <id>action.acme_proxmoxbs_tokenid</id>
+        <label>Proxmox BS token name</label>
+        <type>text</type>
+        <help>The name of the API token created for the user account. Defaults to acme.</help>
+    </field>
+    <field>
+        <id>action.acme_proxmoxbs_tokenkey</id>
+        <label>Proxmox BS token key</label>
+        <type>text</type>
+        <help>The API token. Required.</help>
+    </field>
+    <field>
+        <label>Required Parameters</label>
+        <type>header</type>
         <style>method_table method_table_acme_truenas</style>
     </field>
     <field>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/AcmeProxmoxbs.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/AcmeProxmoxbs.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * Copyright (C) 2025 Yann Demoulin based on Jan Winkler's AcmeProxmoxve.php file
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\AcmeClient\LeAutomation;
+
+use OPNsense\AcmeClient\LeAutomationInterface;
+
+/**
+ * Run acme.sh deploy hook proxmoxbs
+ * @package OPNsense\AcmeClient
+ */
+class AcmeProxmoxbs extends Base implements LeAutomationInterface
+{
+    public function prepare()
+    {
+        $this->acme_env['DEPLOY_PROXMOXBS_USER'] = (string)$this->config->acme_proxmoxbs_user;
+        $this->acme_env['DEPLOY_PROXMOXBS_SERVER'] = (string)$this->config->acme_proxmoxbs_server;
+        $this->acme_env['DEPLOY_PROXMOXBS_SERVER_PORT'] = (string)$this->config->acme_proxmoxbs_port;
+        $this->acme_env['DEPLOY_PROXMOXBS_USER_REALM'] = (string)$this->config->acme_proxmoxbs_realm;
+        $this->acme_env['DEPLOY_PROXMOXBS_API_TOKEN_NAME'] = (string)$this->config->acme_proxmoxbs_tokenid;
+        $this->acme_env['DEPLOY_PROXMOXBS_API_TOKEN_KEY'] = (string)$this->config->acme_proxmoxbs_tokenkey;
+        $this->acme_args[] = '--deploy-hook proxmoxbs';
+        return true;
+    }
+}

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -1351,6 +1351,7 @@
                         <acme_fritzbox>Upload certificate to FRITZ!Box router</acme_fritzbox>
                         <acme_panos>Upload certificate to Palo Alto Networks Firewall</acme_panos>
                         <acme_proxmoxve>Upload certificate to Proxmox VE</acme_proxmoxve>
+                        <acme_proxmoxbs>Upload certificate to Proxmox Backup Environment</acme_proxmoxbs>
                         <acme_vault>Upload certificate to HashiCorp Vault</acme_vault>
                         <acme_synology_dsm>Upload certificate to Synology DSM</acme_synology_dsm>
                         <acme_truenas>Upload certificate to TrueNAS Core Server</acme_truenas>
@@ -1601,6 +1602,44 @@
                     <Mask>/^.{1,1024}$/u</Mask>
                     <ValidationMessage>Should be a string between 1 and 1024 characters.</ValidationMessage>
                 </acme_proxmoxve_tokenkey>
+                <acme_proxmoxbs_user type="TextField">
+                    <default>root</default>
+                    <Required>N</Required>
+                    <mask>/^.{1,1024}$/u</mask>
+                    <ValidationMessage>Should be a string between 1 and 1024 characters.</ValidationMessage>
+                </acme_proxmoxbs_user>
+                <acme_proxmoxbs_server type="TextField">
+                    <Required>N</Required>
+                    <mask>/^.{1,1024}$/u</mask>
+                    <ValidationMessage>Should be a string between 1 and 1024 characters.</ValidationMessage>
+                </acme_proxmoxbs_server>
+                <acme_proxmoxbs_port type="PortField">
+                    <default>8007</default>
+                    <Required>N</Required>
+                </acme_proxmoxbs_port>
+                <acme_proxmoxbs_nodename type="TextField">
+                    <Required>N</Required>
+                    <default>localhost</default>
+                    <mask>/^.{1,1024}$/u</mask>
+                    <ValidationMessage>Should be a string between 1 and 1024 characters.</ValidationMessage>
+                </acme_proxmoxbs_nodename>
+                <acme_proxmoxbs_realm type="TextField">
+                    <default>pam</default>
+                    <Required>N</Required>
+                    <mask>/^.{1,1024}$/u</mask>
+                    <ValidationMessage>Should be a string between 1 and 1024 characters.</ValidationMessage>
+                </acme_proxmoxbs_realm>
+                <acme_proxmoxbs_tokenid type="TextField">
+                    <default>acme</default>
+                    <Required>N</Required>
+                    <mask>/^.{1,1024}$/u</mask>
+                    <ValidationMessage>Should be a string between 1 and 1024 characters.</ValidationMessage>
+                </acme_proxmoxbs_tokenid>
+                <acme_proxmoxbs_tokenkey type="TextField">
+                    <Required>N</Required>
+                    <mask>/^.{1,1024}$/u</mask>
+                    <ValidationMessage>Should be a string between 1 and 1024 characters.</ValidationMessage>
+                </acme_proxmoxbs_tokenkey>
                 <acme_truenas_apikey type="TextField">
                     <Required>N</Required>
                     <Mask>/^.{1,1024}$/u</Mask>


### PR DESCRIPTION
Hello,

I would like to contribute to OPNsense by extending the ACME client plugin to support Proxmox Backup Server (PBS) as a deployment target.

**Motivation**
Proxmox Backup Server is widely used in conjunction with Proxmox VE and other infrastructure tools such as OPNsense. It benefits from using trusted certificates — particularly those issued automatically via Let's Encrypt.

Currently, deploying ACME certificates from OPNsense to PBS must be done manually. Integrating PBS into the ACME plugin would automate certificate deployment, improve security, and reduce administrative overhead.

**Proposed Features**
The ACME plugin would gain a new "Deployment Method" for PBS, supporting:
- Authentication via API token or username/password
- Deployment of the full certificate chain and private key to PBS
- Optional service restart of pbs-api (or another relevant service)
- Error handling and logs integrated into the ACME GUI

If possible, both API-based deployment and fallback via SSH/SCP could be offered, depending on PBS version and setup.

**Implementation Plan**
- Extend the ACME plugin’s deployment methods
- Add UI fields for PBS connection info (host, credentials/token, certificate target)

Please let me know if this proposal aligns with the plugin architecture and if there are any preferences or guidelines I should follow.

I’m looking forward to contributing!

Best regards,
HTDemony