### PR TITLE
Rename master to main in git-backup, and fix the shell arg

### DIFF
--- a/sysutils/git-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Git.php
+++ b/sysutils/git-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Git.php
@@ -162,7 +162,7 @@ class Git extends Base implements IBackupProvider
         exec("cd {$targetdir} && {$git} remote remove origin");
         exec("cd {$targetdir} && {$git} remote add origin " . escapeshellarg($url));
         $pushtxt = shell_exec(
-            "(cd {$targetdir} && {$git} push origin " . escapeshellarg("{$mdl->branch}:{$mdl->branch}") .
+            "(cd {$targetdir} && {$git} push origin " . escapeshellarg("main:{$mdl->branch}") .
             " && echo '__exit_ok__') 2>&1"
         );
         if (strpos($pushtxt, '__exit_ok__')) {

--- a/sysutils/git-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Git.php
+++ b/sysutils/git-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Git.php
@@ -162,7 +162,7 @@ class Git extends Base implements IBackupProvider
         exec("cd {$targetdir} && {$git} remote remove origin");
         exec("cd {$targetdir} && {$git} remote add origin " . escapeshellarg($url));
         $pushtxt = shell_exec(
-            "(cd {$targetdir} && {$git} push origin " . escapeshellarg("master:{$mdl->branch}") .
+            "(cd {$targetdir} && {$git} push origin " . escapeshellarg("{$mdl->branch}:{$mdl->branch}") .
             " && echo '__exit_ok__') 2>&1"
         );
         if (strpos($pushtxt, '__exit_ok__')) {

--- a/sysutils/git-backup/src/opnsense/mvc/app/models/OPNsense/Backup/GitSettings.xml
+++ b/sysutils/git-backup/src/opnsense/mvc/app/models/OPNsense/Backup/GitSettings.xml
@@ -30,7 +30,7 @@
             </Constraints>
         </url>
         <branch type="TextField">
-          <Default>master</Default>
+          <Default>main</Default>
           <Required>Y</Required>
         </branch>
         <privkey type="TextField">


### PR DESCRIPTION
This change defaults things to `main` instead of `master` in git-backup, as well as changing `escapeshellarg("master:{$mdl->branch}")` to `escapeshellarg("{$mdl->branch}:{$mdl->branch}")` which I believe should correct the syncing issues found when using a UI-configured `main` branch.
