### PR TITLE
feat: Added the ability to override SNI for streams

### DIFF
--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/streams.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/streams.conf
@@ -93,6 +93,10 @@
         proxy_ssl_certificate_key /usr/local/etc/nginx/key/{{ upstream.tls_client_certificate }}.key;
         proxy_ssl_certificate /usr/local/etc/nginx/key/{{ upstream.tls_client_certificate }}.pem;
 {%         endif %}
+{%         if upstream.tls_name_override is defined and upstream.tls_name_override != '' %}
+        proxy_ssl_server_name on;
+        proxy_ssl_name {{ upstream.tls_name_override }};
+{%         endif %}
 {%       endif %}
         proxy_ssl {% if upstream.tls_enable == '1' %}on{% else %}off{% endif %};
         proxy_pass upstream{{ server.upstream.replace('-','') }};


### PR DESCRIPTION
While the option is available in the interface, overriding the SNI does nothing when used from NGINX streams. However, [the option still exists in this situation](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ssl_server_name).

_This PR i here to fix that._

---

For the record, this missing feature was problematic when I wanted to set up mutual TLS authentication between an OPNSense router and a Kubernetes cluster, without loosing PROXY headers. It seems that Nginx was not providing any certificate to the client without this directive...