### PR TITLE
www/caddy: Change em into px, fix key/value display in formatter

### DIFF
--- a/www/caddy/Makefile
+++ b/www/caddy/Makefile
@@ -1,5 +1,6 @@
 PLUGIN_NAME=		caddy
 PLUGIN_VERSION=		2.0.2
+PLUGIN_REVISION=	1
 PLUGIN_DEPENDS=		caddy-custom
 PLUGIN_COMMENT=		Modern Reverse Proxy with Automatic HTTPS, Dynamic DNS and Layer4 Routing
 PLUGIN_MAINTAINER=	cedrik@pischem.com

--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -11,6 +11,7 @@ Plugin Changelog
 Add: Global server timeout options (opnsense/plugins/pull/4778)
 Cleanup: Change all camelCase to snake_case in api notations (opnsense/plugins/pull/4767,4768,4776)
 Cleanup: Use SimpleActionButton in general.volt (opnsense/plugins/pull/4779)
+Cleanup: Change em into px, fix key/value display in formatter (opnsense/plugins/pull/4807)
 
 2.0.1
 

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogAccessList.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogAccessList.xml
@@ -50,6 +50,9 @@
         <type>dropdown</type>
         <help><![CDATA[Set the request matcher that will be applied to this access list.]]></help>
         <advanced>true</advanced>
+        <grid_view>
+            <visible>false</visible>
+        </grid_view>
     </field>
     <field>
         <id>accesslist.description</id>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogBasicAuth.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogBasicAuth.xml
@@ -10,6 +10,9 @@
         <label>Password</label>
         <type>text</type>
         <help><![CDATA[Enter a password. It will be hashed with bcrypt. It can only be set and changed but will not be visible anymore.]]></help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
     </field>
     <field>
         <id>basicauth.description</id>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHandle.xml
@@ -5,7 +5,7 @@
         <type>checkbox</type>
         <help><![CDATA[Enable this handler.]]></help>
         <grid_view>
-            <width>2em</width>
+            <width>100</width>
             <type>boolean</type>
             <formatter>rowtoggle</formatter>
         </grid_view>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHeader.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogHeader.xml
@@ -4,6 +4,9 @@
         <label>Header</label>
         <type>dropdown</type>
         <help><![CDATA["header_up" sets, adds (with the "+" prefix), deletes (with the "-" prefix), or performs a replacement (by using two arguments, a search and replacement) in a request header going upstream to the backend. "header_down" sets, adds (with the "+" prefix), deletes (with the "-" prefix), or performs a replacement (by using two arguments, a search and replacement) in a response header coming downstream from the backend. For more information: https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#headers]]></help>
+        <grid_view>
+            <width>120</width>
+        </grid_view>
     </field>
     <field>
         <id>header.HeaderType</id>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogLayer4.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogLayer4.xml
@@ -5,7 +5,7 @@
         <type>checkbox</type>
         <help><![CDATA[Enable this Layer4 route.]]></help>
         <grid_view>
-            <width>2em</width>
+            <width>100</width>
             <type>boolean</type>
             <formatter>rowtoggle</formatter>
         </grid_view>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
@@ -5,7 +5,7 @@
         <type>checkbox</type>
         <help><![CDATA[Enable this domain.]]></help>
         <grid_view>
-            <width>2em</width>
+            <width>100</width>
             <type>boolean</type>
             <formatter>rowtoggle</formatter>
         </grid_view>

--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogSubdomain.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogSubdomain.xml
@@ -5,7 +5,7 @@
         <type>checkbox</type>
         <help><![CDATA[Enable this subdomain.]]></help>
         <grid_view>
-            <width>2em</width>
+            <width>100</width>
             <type>boolean</type>
             <formatter>rowtoggle</formatter>
         </grid_view>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -174,7 +174,6 @@
                                     return request;
                                 },
                                 headerFormatters: {
-                                    enabled: function (column) { return "" },
                                     ToDomain: function (column) { return labels.upstream; },
                                     FromDomain: function (column) {
                                         if (grid_id === "subdomain") {
@@ -207,14 +206,14 @@
                                     },
                                     from_domain: function (column, row) {
                                         return (
-                                            (row["DisableTls"] || "") +
+                                            (row["$DisableTls"] || "") +
                                             (row["FromDomain"] || "") +
                                             (row["FromPort"] ? `:${row["FromPort"]}` : "")
                                         );
                                     },
                                     to_domain: function (column, row) {
                                         return (
-                                            (row["HttpTls"] || "") +
+                                            (row["$HttpTls"] || "") +
                                             (row["ToDomain"] || "") +
                                             (row["ToPort"] ? `:${row["ToPort"]}` : "") +
                                             (row["ToPath"] || "")
@@ -501,7 +500,7 @@
             <!-- Reverse Proxy -->
             <h1 class="custom-header">{{ lang._('Domains') }}</h1>
             <div style="display: block;">
-                {{ partial('layout_partials/base_bootgrid_table', formGridReverseProxy + {'command_width': '11em'})}}
+                {{ partial('layout_partials/base_bootgrid_table', formGridReverseProxy + {'command_width': '160'})}}
             </div>
         </div>
 
@@ -509,7 +508,7 @@
         <div style="padding-left: 16px;">
             <h1 class="custom-header">{{ lang._('Subdomains') }}</h1>
             <div style="display: block;">
-                {{ partial('layout_partials/base_bootgrid_table', formGridSubdomain + {'command_width': '11em'})}}
+                {{ partial('layout_partials/base_bootgrid_table', formGridSubdomain + {'command_width': '160'})}}
             </div>
         </div>
     </div>

--- a/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
+++ b/www/caddy/src/opnsense/mvc/app/views/OPNsense/Caddy/reverse_proxy.volt
@@ -206,14 +206,14 @@
                                     },
                                     from_domain: function (column, row) {
                                         return (
-                                            (row["$DisableTls"] || "") +
+                                            (row["%DisableTls"] || "") +
                                             (row["FromDomain"] || "") +
                                             (row["FromPort"] ? `:${row["FromPort"]}` : "")
                                         );
                                     },
                                     to_domain: function (column, row) {
                                         return (
-                                            (row["$HttpTls"] || "") +
+                                            (row["%HttpTls"] || "") +
                                             (row["ToDomain"] || "") +
                                             (row["ToPort"] ? `:${row["ToPort"]}` : "") +
                                             (row["ToPath"] || "")


### PR DESCRIPTION
Some small display fixes, use pixel instead of em values.

Also uses $field instead of field for some option fields in the formatter for after this commit:
https://github.com/opnsense/core/commit/f17bd8ef05f18ffaffd4509d19803fb47f2e0fea