### PR TITLE
Update Sftp.php

### DIFF
--- a/sysutils/sftp-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Sftp.php
+++ b/sysutils/sftp-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Sftp.php
@@ -236,7 +236,7 @@ class Sftp extends Base implements IBackupProvider
                 $fileprefix = "config-";
             } else {
                 $config = $cnf->object();
-                $fileprefix = sprintf('%s.%s-', (string)$config->system->hostname, (string)$config->system->domain);
+                $fileprefix = strtolower(sprintf('%s.%s-', (string)$config->system->hostname, (string)$config->system->domain));
             }
             /**
              * Collect most recent backup, since /conf/backup/ always contains the latests, we can use the filename


### PR DESCRIPTION
Fixed an issue where SFTP backup would not be able to list remote backups if hostname was prefixed and hostname or domain had uppercase characters.

This closes issue #4819