### PR TITLE
sysutils/nut(fix): IPv6 addresses in Netclient

### DIFF
--- a/sysutils/nut/src/opnsense/service/templates/OPNsense/Nut/upsmon.conf
+++ b/sysutils/nut/src/opnsense/service/templates/OPNsense/Nut/upsmon.conf
@@ -7,7 +7,7 @@ SHUTDOWNCMD "/usr/local/etc/rc.halt"
 POWERDOWNFLAG /etc/killpower
 {% endif %}
 {% if helpers.exists('OPNsense.Nut.netclient.enable') and OPNsense.Nut.netclient.enable == '1' %}
-MONITOR {{ OPNsense.Nut.general.name }}@{{ helpers.get_host_port_from_tag('OPNsense.Nut.netclient.address', 'OPNsense.Nut.netclient.port') }} 1 {{ OPNsense.Nut.netclient.user }} {{ OPNsense.Nut.netclient.password }} slave
+MONITOR {{ OPNsense.Nut.general.name }}@{{ helpers.get_host_port('OPNsense.Nut.netclient.address', 'OPNsense.Nut.netclient.port') }} 1 {{ OPNsense.Nut.netclient.user }} {{ OPNsense.Nut.netclient.password }} slave
 SHUTDOWNCMD "/usr/local/etc/rc.halt"
 POWERDOWNFLAG /etc/killpower
 {% endif %}

--- a/sysutils/nut/src/opnsense/service/templates/OPNsense/Nut/upsmon.conf
+++ b/sysutils/nut/src/opnsense/service/templates/OPNsense/Nut/upsmon.conf
@@ -7,7 +7,7 @@ SHUTDOWNCMD "/usr/local/etc/rc.halt"
 POWERDOWNFLAG /etc/killpower
 {% endif %}
 {% if helpers.exists('OPNsense.Nut.netclient.enable') and OPNsense.Nut.netclient.enable == '1' %}
-MONITOR {{ OPNsense.Nut.general.name }}@{{ OPNsense.Nut.netclient.address }}{% if helpers.exists('OPNsense.Nut.netclient.port') %}:{{ OPNsense.Nut.netclient.port }}{% endif %} 1 {{ OPNsense.Nut.netclient.user }} {{ OPNsense.Nut.netclient.password }} slave
+MONITOR {{ OPNsense.Nut.general.name }}@{{ helpers.get_bracketed_ip(OPNsense.Nut.netclient.address) }}{% if helpers.exists('OPNsense.Nut.netclient.port') %}:{{ OPNsense.Nut.netclient.port }}{% endif %} 1 {{ OPNsense.Nut.netclient.user }} {{ OPNsense.Nut.netclient.password }} slave
 SHUTDOWNCMD "/usr/local/etc/rc.halt"
 POWERDOWNFLAG /etc/killpower
 {% endif %}

--- a/sysutils/nut/src/opnsense/service/templates/OPNsense/Nut/upsmon.conf
+++ b/sysutils/nut/src/opnsense/service/templates/OPNsense/Nut/upsmon.conf
@@ -7,7 +7,7 @@ SHUTDOWNCMD "/usr/local/etc/rc.halt"
 POWERDOWNFLAG /etc/killpower
 {% endif %}
 {% if helpers.exists('OPNsense.Nut.netclient.enable') and OPNsense.Nut.netclient.enable == '1' %}
-MONITOR {{ OPNsense.Nut.general.name }}@{{ helpers.get_host_port('OPNsense.Nut.netclient.address', 'OPNsense.Nut.netclient.port') }} 1 {{ OPNsense.Nut.netclient.user }} {{ OPNsense.Nut.netclient.password }} slave
+MONITOR {{ OPNsense.Nut.general.name }}@{{ helpers.host_with_port('OPNsense.Nut.netclient.address', 'OPNsense.Nut.netclient.port') }} 1 {{ OPNsense.Nut.netclient.user }} {{ OPNsense.Nut.netclient.password }} slave
 SHUTDOWNCMD "/usr/local/etc/rc.halt"
 POWERDOWNFLAG /etc/killpower
 {% endif %}

--- a/sysutils/nut/src/opnsense/service/templates/OPNsense/Nut/upsmon.conf
+++ b/sysutils/nut/src/opnsense/service/templates/OPNsense/Nut/upsmon.conf
@@ -1,8 +1,3 @@
-{% if helpers.exists('OPNsense.Nut.netclient.port') %}
-{% set port = OPNsense.Nut.netclient.port %}
-{% else %}
-{% set port = -1 %}
-{% endif %}
 # Please don't modify this file as your changes might be overwritten with
 # the next update.
 #
@@ -12,7 +7,7 @@ SHUTDOWNCMD "/usr/local/etc/rc.halt"
 POWERDOWNFLAG /etc/killpower
 {% endif %}
 {% if helpers.exists('OPNsense.Nut.netclient.enable') and OPNsense.Nut.netclient.enable == '1' %}
-MONITOR {{ OPNsense.Nut.general.name }}@{{ helpers.get_host_port(OPNsense.Nut.netclient.address, port) }} 1 {{ OPNsense.Nut.netclient.user }} {{ OPNsense.Nut.netclient.password }} slave
+MONITOR {{ OPNsense.Nut.general.name }}@{{ helpers.get_host_port_from_tag('OPNsense.Nut.netclient.address', 'OPNsense.Nut.netclient.port') }} 1 {{ OPNsense.Nut.netclient.user }} {{ OPNsense.Nut.netclient.password }} slave
 SHUTDOWNCMD "/usr/local/etc/rc.halt"
 POWERDOWNFLAG /etc/killpower
 {% endif %}

--- a/sysutils/nut/src/opnsense/service/templates/OPNsense/Nut/upsmon.conf
+++ b/sysutils/nut/src/opnsense/service/templates/OPNsense/Nut/upsmon.conf
@@ -1,3 +1,8 @@
+{% if helpers.exists('OPNsense.Nut.netclient.port') %}
+{% set port = OPNsense.Nut.netclient.port %}
+{% else %}
+{% set port = -1 %}
+{% endif %}
 # Please don't modify this file as your changes might be overwritten with
 # the next update.
 #
@@ -7,7 +12,7 @@ SHUTDOWNCMD "/usr/local/etc/rc.halt"
 POWERDOWNFLAG /etc/killpower
 {% endif %}
 {% if helpers.exists('OPNsense.Nut.netclient.enable') and OPNsense.Nut.netclient.enable == '1' %}
-MONITOR {{ OPNsense.Nut.general.name }}@{{ helpers.get_bracketed_ip(OPNsense.Nut.netclient.address) }}{% if helpers.exists('OPNsense.Nut.netclient.port') %}:{{ OPNsense.Nut.netclient.port }}{% endif %} 1 {{ OPNsense.Nut.netclient.user }} {{ OPNsense.Nut.netclient.password }} slave
+MONITOR {{ OPNsense.Nut.general.name }}@{{ helpers.get_host_port(OPNsense.Nut.netclient.address, port) }} 1 {{ OPNsense.Nut.netclient.user }} {{ OPNsense.Nut.netclient.password }} slave
 SHUTDOWNCMD "/usr/local/etc/rc.halt"
 POWERDOWNFLAG /etc/killpower
 {% endif %}


### PR DESCRIPTION
this PR relies on opnsense/core/pull/8948 

according to #4513 nut's netclient option needs IPv6 to be in brackets
considering the line in `/usr/local/etc/nut/upsmon.conf`
is `UPSName@[2001:db8::1]:3493` with a port and all it's probably save to assume it does need brackets

Closes #4513