### PR TITLE
security/acme-client: add support for selectel.ru V2 API

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -1234,6 +1234,39 @@
         <type>text</type>
     </field>
     <field>
+        <label>Selectel V2</label>
+        <type>header</type>
+        <style>table_dns table_dns_selectelv2</style>
+    </field>
+    <field>
+        <id>validation.dns_selectelv2_token_lifetime</id>
+        <label>Token lifetime</label>
+        <type>text</type>
+        <help>Token lifetime in minutes (0-1440)</help>
+    </field>
+    <field>
+        <id>validation.dns_selectelv2_account_id</id>
+        <label>Account ID</label>
+        <type>text</type>
+        <help>Account number, can be seen in the upper right corner on the provider's website</help>
+    </field>
+    <field>
+        <id>validation.dns_selectelv2_project_name</id>
+        <label>Project name</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_selectelv2_login_name</id>
+        <label>Service username</label>
+        <type>text</type>
+        <help>Service username, can be seen in the <a href="https://my.selectel.ru/iam/users_management/users?type=service">control panel</a></help>
+    </field>
+    <field>
+        <id>validation.dns_selectelv2_password</id>
+        <label>Password</label>
+        <type>password</type>
+    </field>
+    <field>
         <label>Selfhost</label>
         <type>header</type>
         <style>table_dns table_dns_selfhost</style>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsSelectelV2.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsSelectelV2.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * Copyright (C) 2025 Renat Gorbushin
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\AcmeClient\LeValidation;
+
+use OPNsense\AcmeClient\LeValidationInterface;
+use OPNsense\Core\Config;
+
+/**
+ * Selectel DNS API V2
+ * @package OPNsense\AcmeClient
+ */
+class DnsSelectelV2 extends Base implements LeValidationInterface
+{
+    public function prepare()
+    {
+        $this->acme_env['SL_Ver'] = 'v2';
+        $this->acme_env['SL_Expire'] = (string)$this->config->dns_selectelv2_token_lifetime;
+        $this->acme_env['SL_Login_ID'] = (string)$this->config->dns_selectelv2_account_id;
+        $this->acme_env['SL_Project_Name'] = (string)$this->config->dns_selectelv2_project_name;
+        $this->acme_env['SL_Login_Name'] = (string)$this->config->dns_selectelv2_login_name;
+        $this->acme_env['SL_Pswd'] = (string)$this->config->dns_selectelv2_password;
+    }
+}

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -516,6 +516,7 @@
                         <dns_scaleway>Scaleway</dns_scaleway>
                         <dns_schlundtech>SchlundTech</dns_schlundtech>
                         <dns_selectel>selectel.com / selectel.ru</dns_selectel>
+                        <dns_selectel_v2>selectel.com V2 / selectel.ru V2</dns_selectel_v2>
                         <dns_selfhost>Selfhost</dns_selfhost>
                         <dns_servercow>Servercow</dns_servercow>
                         <dns_simply>Simply.com</dns_simply>
@@ -1050,6 +1051,21 @@
                 <dns_sl_key type="TextField">
                     <Required>N</Required>
                 </dns_sl_key>
+                <dns_selectelv2_token_lifetime type="TextField">
+                    <Required>N</Required>
+                </dns_selectelv2_token_lifetime>
+                <dns_selectelv2_account_id type="TextField">
+                    <Required>N</Required>
+                </dns_selectelv2_account_id>
+                <dns_selectelv2_project_name type="TextField">
+                    <Required>N</Required>
+                </dns_selectelv2_project_name>
+                <dns_selectelv2_login_name type="TextField">
+                    <Required>N</Required>
+                </dns_selectelv2_login_name>
+                <dns_selectelv2_password type="TextField">
+                    <Required>N</Required>
+                </dns_selectelv2_password>
                 <dns_selfhost_user type="TextField">
                     <Required>N</Required>
                 </dns_selfhost_user>


### PR DESCRIPTION
The provider currently supports two API versions: v1 (legacy) and v2 (actual). Legacy version is supported in a limited way and will be disabled from 09.2025. This PR adds support for v2 API