### PR TITLE
security/acme-client: add support for AzureDNS System Assigned Managed Identity

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -227,6 +227,12 @@
         <type>text</type>
     </field>
     <field>
+        <id>validation.dns_azuredns_managedidentity</id>
+        <label>Use System Assigned Managed Identity</label>
+        <type>checkbox</type>
+        <help><![CDATA[When System Assigned Managed Identity is enabled the Tenant ID, APP ID and Client Secret settings are ignored by the acme client. Access tokens are obtained using the Azure Instance Metadata Service for the System Assigned Managed Identity. See <a target="_blank" href="https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/how-to-use-vm-token">documentation</a>.]]></help>
+    </field>
+    <field>
         <label>Bunny</label>
         <type>header</type>
         <style>table_dns table_dns_bunny</style>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsAzure.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsAzure.php
@@ -43,5 +43,9 @@ class DnsAzure extends Base implements LeValidationInterface
         $this->acme_env['AZUREDNS_TENANTID'] = (string)$this->config->dns_azuredns_tenantid;
         $this->acme_env['AZUREDNS_APPID'] = (string)$this->config->dns_azuredns_appid;
         $this->acme_env['AZUREDNS_CLIENTSECRET'] = (string)$this->config->dns_azuredns_clientsecret;
+        
+        if ($this->config->dns_azuredns_managedidentity == '1') {
+            $this->acme_env['AZUREDNS_MANAGEDIDENTITY'] = 'true';
+        }
     }
 }

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -579,6 +579,10 @@
                 <dns_azuredns_clientsecret type="TextField">
                     <Required>N</Required>
                 </dns_azuredns_clientsecret>
+                <dns_azuredns_managedidentity type="BooleanField">
+                    <Default>0</Default>
+                    <Required>N</Required>
+                </dns_azuredns_managedidentity>
                 <dns_bunny_api_key type="TextField">
                     <Required>N</Required>
                 </dns_bunny_api_key>


### PR DESCRIPTION
Adding support for Azure System Assigned Managed Identities to enable zero-secret integration for DNS01 verifications using Azure DNS.

For workloads hosted in Azure the Azure Metadata Instance Service can be used for obtaining access tokens on behalf of the workload identity. This requires no configuration of client id's or secrets.

This method has been supported in acme.sh since version 3.0.5.