### PR TITLE
security/acme-client: Fix DNS validation failures - missing prepare() call

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/Base.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/Base.php
@@ -139,6 +139,9 @@ abstract class Base extends \OPNsense\AcmeClient\LeCommon
 
         LeUtils::log('using challenge type: ' . (string)$this->config->name);
 
+        // Prepare validation (sets environment variables)
+        $this->prepare();
+
         // Issue or renew
         $acme_action = $renew == true ? 'renew' : 'issue';
 


### PR DESCRIPTION
## Description
This PR fixes a critical bug in the ACME client where DNS validations fail because environment variables (API credentials) are not being passed to acme.sh.

## The Problem
The `prepare()` method in DNS validation classes (like `DnsCf.php` for Cloudflare) sets environment variables with API credentials:
```php
public function prepare()
{
    $this->acme_env['CF_Token'] = (string)$this->config->dns_cf_token;
    $this->acme_env['CF_Zone_ID'] = (string)$this->config->dns_cf_zone_id;
    // etc...
}
```

However, the `Base::run()` method never calls `prepare()`, so these environment variables are never set, causing DNS validations to fail with exit code 3.

## The Solution
Add a call to `$this->prepare();` in the `run()` method before the environment variables are used.

## Testing
Tested with Cloudflare DNS validation on OPNsense 25.1:
- Before fix: Validation fails with "domain validation failed (dns01)" and exit code 3
- After fix: Certificate successfully issued

## Impact
This bug affects ALL DNS validation providers (Cloudflare, Route53, Azure DNS, etc.) as none of them can pass their credentials to acme.sh.