### PR TITLE
security/crowdsec: Fix alert time not showing in grid

### DIFF
--- a/security/crowdsec/src/opnsense/mvc/app/views/OPNsense/CrowdSec/alerts.volt
+++ b/security/crowdsec/src/opnsense/mvc/app/views/OPNsense/CrowdSec/alerts.volt
@@ -52,7 +52,7 @@
             <th data-column-id="country">Country</th>
             <th data-column-id="as">AS</th>
             <th data-column-id="decisions">Decisions</th>
-            <th data-column-id="created_at" data-formatter="created">Created</th>
+            <th data-column-id="created" data-formatter="created">Created</th>
         </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
Fixes: https://github.com/opnsense/plugins/issues/4837

@fichtner Not our fault in terms of framework but an easy fix so I quickly did it.