### PR TITLE
net/frr: Fix context of interface area for ospf6

### DIFF
--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospf6d.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospf6d.conf
@@ -12,6 +12,7 @@ agentx
 {% for interface in helpers.toList('OPNsense.quagga.ospf6.interfaces.interface') %}
 {%   if interface.enabled == '1' %}
 interface {{ physical_interface(interface.interfacename) }}
+  ipv6 ospf6 area {{ interface.area }}
 {%        if interface.bfd|default('') == '1' %}
   ipv6 ospf6 bfd
 {%        endif %}
@@ -65,13 +66,6 @@ router ospf6
  area {{ network.area }} filter-list prefix {{ prefixlist_data.name }} out
 {%         endif %}
 {%       endfor %}
-{%     endif %}
-{%   endfor %}
-{% endif %}
-{% if helpers.exists('OPNsense.quagga.ospf6.interfaces.interface') %}
-{%   for interface in helpers.toList('OPNsense.quagga.ospf6.interfaces.interface') %}
-{%     if interface.enabled == '1' %}
- interface {{ physical_interface(interface.interfacename) }} area {{ interface.area }}
 {%     endif %}
 {%   endfor %}
 {% endif %}


### PR DESCRIPTION
It was defined twice, the second time in the wrong context. frr10 seems more strict with this error and refuses to load the config.

Fixes: https://github.com/opnsense/plugins/issues/4840

