### PR TITLE
Add support for Zabbix 7.4 (Agent & Proxy)

### DIFF
--- a/net-mgmt/zabbix-agent/Makefile
+++ b/net-mgmt/zabbix-agent/Makefile
@@ -1,14 +1,17 @@
 PLUGIN_NAME=		zabbix-agent
-PLUGIN_VERSION=		1.16
+PLUGIN_VERSION=		1.17
 PLUGIN_COMMENT=		Zabbix monitoring agent
 PLUGIN_MAINTAINER=	opnsense@moov.de
-PLUGIN_VARIANTS=	zabbix7 zabbix72 zabbix6
+PLUGIN_VARIANTS=	zabbix7 zabbix72 zabbix74 zabbix6
 
 zabbix7_NAME=		zabbix7-agent
 zabbix7_DEPENDS=	zabbix7-agent
 
 zabbix72_NAME=		zabbix72-agent
 zabbix72_DEPENDS=	zabbix72-agent
+
+zabbix74_NAME=		zabbix74-agent
+zabbix74_DEPENDS=	zabbix74-agent
 
 zabbix6_NAME=		zabbix6-agent
 zabbix6_DEPENDS=	zabbix6-agent

--- a/net-mgmt/zabbix-agent/pkg-descr
+++ b/net-mgmt/zabbix-agent/pkg-descr
@@ -12,6 +12,11 @@ WWW: https://www.zabbix.com/
 Plugin Changelog
 ----------------
 
+1.17
+
+Added:
+* Plugin variant for Zabbix Agent 7.4
+
 1.16
 
 Changed:

--- a/net-mgmt/zabbix-proxy/Makefile
+++ b/net-mgmt/zabbix-proxy/Makefile
@@ -1,14 +1,17 @@
 PLUGIN_NAME=		zabbix-proxy
-PLUGIN_VERSION=		1.13
+PLUGIN_VERSION=		1.14
 PLUGIN_COMMENT=		Zabbix monitoring proxy
 PLUGIN_MAINTAINER=	m.muenz@gmail.com
-PLUGIN_VARIANTS=	zabbix7 zabbix72 zabbix6
+PLUGIN_VARIANTS=	zabbix7 zabbix72 zabbix74 zabbix6
 
 zabbix7_NAME=		zabbix7-proxy
 zabbix7_DEPENDS=	zabbix7-proxy
 
 zabbix72_NAME=		zabbix72-proxy
 zabbix72_DEPENDS=	zabbix72-proxy
+
+zabbix74_NAME=		zabbix74-proxy
+zabbix74_DEPENDS=	zabbix74-proxy
 
 zabbix6_NAME=		zabbix6-proxy
 zabbix6_DEPENDS=	zabbix6-proxy

--- a/net-mgmt/zabbix-proxy/pkg-descr
+++ b/net-mgmt/zabbix-proxy/pkg-descr
@@ -12,6 +12,10 @@ WWW: https://www.zabbix.com/
 Plugin Changelog
 ----------------
 
+1.14
+
+* Add plugin variant for Zabbix Proxy 7.4
+
 1.13
 
 * Removed plugin variant for Zabbox Proxy 5.0 which is EoL


### PR DESCRIPTION
Currently, OPNSense only supports up to version 7.2 of Zabbix's agent and proxy. This PR adds support for Zabbix 7.4 for both the agent and proxy packages. This is required as the latest versions of Zabbix server institute a minimum version of 7.4 for both agents and proxies.