### PR TITLE
security/netbird: Fix service startup failure

### DIFF
--- a/security/netbird/Makefile
+++ b/security/netbird/Makefile
@@ -1,5 +1,6 @@
 PLUGIN_NAME=		netbird
-PLUGIN_VERSION=		0.2.1
+PLUGIN_VERSION=		0.2
+PLUGIN_REVISION=		1
 PLUGIN_DEPENDS=		netbird
 PLUGIN_COMMENT=		Peer-to-peer VPN that seamlessly connects your devices
 PLUGIN_MAINTAINER=	dev@netbird.io

--- a/security/netbird/Makefile
+++ b/security/netbird/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		netbird
-PLUGIN_VERSION=		0.2
+PLUGIN_VERSION=		0.2.1
 PLUGIN_DEPENDS=		netbird
 PLUGIN_COMMENT=		Peer-to-peer VPN that seamlessly connects your devices
 PLUGIN_MAINTAINER=	dev@netbird.io

--- a/security/netbird/src/opnsense/service/templates/OPNsense/Netbird/netbird
+++ b/security/netbird/src/opnsense/service/templates/OPNsense/Netbird/netbird
@@ -1,4 +1,4 @@
-{% if OPNsense.netbird.general.enable == '1' %}
+{% if OPNsense.Netbird.settings.general.enable == '1' %}
 netbird_enable="YES"
 {% else %}
 netbird_enable="NO"

--- a/security/netbird/src/opnsense/service/templates/OPNsense/Netbird/netbird
+++ b/security/netbird/src/opnsense/service/templates/OPNsense/Netbird/netbird
@@ -1,4 +1,4 @@
-{% if OPNsense.Netbird.settings.general.enable == '1' %}
+{% if OPNsense.netbird.settings.general.enable == '1' %}
 netbird_enable="YES"
 {% else %}
 netbird_enable="NO"


### PR DESCRIPTION
This change fixes an issue that prevented the NetBird service from starting normally using `service netbird start`.

### Problem

The configuration template was incorrectly referencing the service enable flag using:

```jinja
{% if OPNsense.netbird.general.enable == '1' %}
```
This resulted in `netbird_enable="NO"` always being rendered, regardless of the actual enabled state in the UI settings. Consequently, the service could not be started using:

```
service netbird start
```

and instead required manual invocation via:

```
service netbird onestart
```

### Fix

The template has been corrected to:

```jinja
{% if OPNsense.netbird.settings.general.enable == '1' %}
```

This ensures the `netbird_enable` flag correctly reflects the enabled state, allowing the service to be started normally.

Closes: https://github.com/opnsense/plugins/issues/4853
