### PR TITLE
nginx: fix PHP 8.2+ deprecation warnings

### DIFF
--- a/www/nginx/Makefile
+++ b/www/nginx/Makefile
@@ -1,6 +1,6 @@
 PLUGIN_NAME=		nginx
 PLUGIN_VERSION=		1.34
-PLUGIN_REVISION=	7
+PLUGIN_REVISION=	8
 PLUGIN_COMMENT=		Nginx HTTP server and reverse proxy
 PLUGIN_DEPENDS=		nginx
 PLUGIN_MAINTAINER=	franz.fabian.94@gmail.com

--- a/www/nginx/src/opnsense/scripts/nginx/ngx_autoblock.php
+++ b/www/nginx/src/opnsense/scripts/nginx/ngx_autoblock.php
@@ -76,7 +76,7 @@ function modify_blocklist($tablename, array $allIps, $operation = "add"): void
     foreach (array_chunk($allIps, $chunkSize) as $ips) {
         $escapedIps = join(" ", array_map("escapeshellarg", $ips));
 
-        exec_hidden("/sbin/pfctl -t ${tablename} -T ${operation} ${escapedIps}");
+        exec_hidden("/sbin/pfctl -t {$tablename} -T {$operation} {$escapedIps}");
     }
 }
 
@@ -89,7 +89,7 @@ function read_all_from_blocklist($tablename)
         2 => ['file', "/dev/null", "w"],
     ];
 
-    $process = proc_open("/sbin/pfctl -t ${tablename} -T show", $descriptorspec, $pipes);
+    $process = proc_open("/sbin/pfctl -t {$tablename} -T show", $descriptorspec, $pipes);
     if (is_resource($process)) {
         $ips = [];
         while ($ip = fgets($pipes[1], 96)) {


### PR DESCRIPTION
What the title says, cleans up the PHP errors noise in the crash reporter.

From ${var} to {$var}