### PR TITLE
Clamav: fix DetectBrokenExecutables option

### DIFF
--- a/security/clamav/Makefile
+++ b/security/clamav/Makefile
@@ -1,6 +1,5 @@
 PLUGIN_NAME=		clamav
-PLUGIN_VERSION=		1.8
-PLUGIN_REVISION=	3
+PLUGIN_VERSION=		1.8.1
 PLUGIN_COMMENT=		Antivirus engine for detecting malicious threats
 PLUGIN_DEPENDS=		clamav
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/security/clamav/pkg-descr
+++ b/security/clamav/pkg-descr
@@ -9,6 +9,10 @@ database updates.
 Plugin Changelog
 ================
 
+1.8.1
+
+* Fixed detect broken executables option
+
 1.8
 
 * Use syslog for logging

--- a/security/clamav/pkg-descr
+++ b/security/clamav/pkg-descr
@@ -11,7 +11,7 @@ Plugin Changelog
 
 1.8.1
 
-* Fixed detect broken executables option
+* Fixed detect broken executables option (contributed by @sopex)
 
 1.8
 

--- a/security/clamav/src/opnsense/mvc/app/controllers/OPNsense/ClamAV/forms/general.xml
+++ b/security/clamav/src/opnsense/mvc/app/controllers/OPNsense/ClamAV/forms/general.xml
@@ -70,10 +70,10 @@
         <help>Executable and Linking Format is a standard format for UN*X executables.</help>
     </field>
     <field>
-        <id>general.detectbroken</id>
+        <id>general.alertbroken</id>
         <label>Detect broken executables</label>
         <type>checkbox</type>
-        <help>With this option clamav will try to detect broken executables (both PE and ELF) and mark them as Broken.</help>
+        <help>With this option ClamAV will alert on broken executables (both PE and ELF) and mark them as Broken.</help>
     </field>
     <field>
         <id>general.scanole2</id>

--- a/security/clamav/src/opnsense/mvc/app/controllers/OPNsense/ClamAV/forms/general.xml
+++ b/security/clamav/src/opnsense/mvc/app/controllers/OPNsense/ClamAV/forms/general.xml
@@ -70,7 +70,7 @@
         <help>Executable and Linking Format is a standard format for UN*X executables.</help>
     </field>
     <field>
-        <id>general.alertbroken</id>
+        <id>general.detectbroken</id>
         <label>Detect broken executables</label>
         <type>checkbox</type>
         <help>With this option ClamAV will alert on broken executables (both PE and ELF) and mark them as Broken.</help>

--- a/security/clamav/src/opnsense/mvc/app/models/OPNsense/ClamAV/General.xml
+++ b/security/clamav/src/opnsense/mvc/app/models/OPNsense/ClamAV/General.xml
@@ -51,10 +51,10 @@
             <Default>1</Default>
             <Required>N</Required>
         </scanelf>
-        <detectbroken type="BooleanField">
+        <alertbroken type="BooleanField">
             <Default>0</Default>
             <Required>N</Required>
-        </detectbroken>
+        </alertbroken>
         <scanole2 type="BooleanField">
             <Default>1</Default>
             <Required>N</Required>

--- a/security/clamav/src/opnsense/mvc/app/models/OPNsense/ClamAV/General.xml
+++ b/security/clamav/src/opnsense/mvc/app/models/OPNsense/ClamAV/General.xml
@@ -51,10 +51,10 @@
             <Default>1</Default>
             <Required>N</Required>
         </scanelf>
-        <alertbroken type="BooleanField">
+        <detectbroken type="BooleanField">
             <Default>0</Default>
             <Required>N</Required>
-        </alertbroken>
+        </detectbroken>
         <scanole2 type="BooleanField">
             <Default>1</Default>
             <Required>N</Required>

--- a/security/clamav/src/opnsense/service/templates/OPNsense/ClamAV/clamd.conf
+++ b/security/clamav/src/opnsense/service/templates/OPNsense/ClamAV/clamd.conf
@@ -37,8 +37,8 @@ ScanPE yes
 {% if helpers.exists('OPNsense.clamav.general.scanelf') and OPNsense.clamav.general.scanelf == '1' %}
 ScanELF yes
 {% endif %}
-{% if helpers.exists('OPNsense.clamav.general.detectbroken') and OPNsense.clamav.general.detectbroken == '1' %}
-DetectBrokenExecutables yes
+{% if helpers.exists('OPNsense.clamav.general.alertbroken') and OPNsense.clamav.general.alertbroken == '1' %}
+AlertBrokenExecutables yes
 {% endif %}
 {% if helpers.exists('OPNsense.clamav.general.scanole2') and OPNsense.clamav.general.scanole2 == '1' %}
 ScanOLE2 yes

--- a/security/clamav/src/opnsense/service/templates/OPNsense/ClamAV/clamd.conf
+++ b/security/clamav/src/opnsense/service/templates/OPNsense/ClamAV/clamd.conf
@@ -37,7 +37,7 @@ ScanPE yes
 {% if helpers.exists('OPNsense.clamav.general.scanelf') and OPNsense.clamav.general.scanelf == '1' %}
 ScanELF yes
 {% endif %}
-{% if helpers.exists('OPNsense.clamav.general.alertbroken') and OPNsense.clamav.general.alertbroken == '1' %}
+{% if helpers.exists('OPNsense.clamav.general.detectbroken') and OPNsense.clamav.general.detectbroken == '1' %}
 AlertBrokenExecutables yes
 {% endif %}
 {% if helpers.exists('OPNsense.clamav.general.scanole2') and OPNsense.clamav.general.scanole2 == '1' %}


### PR DESCRIPTION
Fixes: https://github.com/opnsense/plugins/issues/4833

This option was renamed for some reason and thus not working.
https://blog.clamav.net/2018/12/clamav-01010-has-been-released.html