### PR TITLE
telegraf: fix internet speed tests saving mode

### DIFF
--- a/net-mgmt/telegraf/Makefile
+++ b/net-mgmt/telegraf/Makefile
@@ -1,6 +1,5 @@
 PLUGIN_NAME=		telegraf
-PLUGIN_VERSION=		1.12.12
-PLUGIN_REVISION=	1
+PLUGIN_VERSION=		1.12.13
 PLUGIN_COMMENT=		Agent for collecting metrics and data
 PLUGIN_DEPENDS=		telegraf
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net-mgmt/telegraf/pkg-descr
+++ b/net-mgmt/telegraf/pkg-descr
@@ -14,7 +14,7 @@ Plugin Changelog
 
 1.12.13
 
-* Fix and document memory_saving_mode formerly enable_file_download (contributed by sopex)
+* Implement memory_saving_mode formerly named enable_file_download (contributed by sopex)
 
 1.12.12
 

--- a/net-mgmt/telegraf/pkg-descr
+++ b/net-mgmt/telegraf/pkg-descr
@@ -14,7 +14,7 @@ Plugin Changelog
 
 1.12.13
 
-* Fix and document memory_saving_mode formerly enable_file_download (contribited by sopex)
+* Fix and document memory_saving_mode formerly enable_file_download (contributed by sopex)
 
 1.12.12
 

--- a/net-mgmt/telegraf/pkg-descr
+++ b/net-mgmt/telegraf/pkg-descr
@@ -14,7 +14,7 @@ Plugin Changelog
 
 1.12.13
 
-* Fix and document memory_saving_mode formerly enable_file_download (contribited by @sopex)
+* Fix and document memory_saving_mode formerly enable_file_download (contribited by sopex)
 
 1.12.12
 

--- a/net-mgmt/telegraf/pkg-descr
+++ b/net-mgmt/telegraf/pkg-descr
@@ -12,6 +12,10 @@ WWW: https://www.influxdata.com/time-series-platform/telegraf/
 Plugin Changelog
 ================
 
+1.12.13
+
+* Fix and document memory_saving_mode formerly enable_file_download (contribited by @sopex)
+
 1.12.12
 
 * Fix for mixed ping plugin config (contributed by Alex Baulé)

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/input.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/input.xml
@@ -56,10 +56,10 @@
         <help>Enable the collection of data about the internet speed on the system.</help>
     </field>
     <field>
-        <id>input.internet_speed_file</id>
-        <label>Internet Speed File Download</label>
+        <id>input.internet_speed_saving</id>
+        <label>Internet Speed Test saving mode</label>
         <type>checkbox</type>
-        <help>Enable the file download speed test.</help>
+        <help>Not recommended if speed tests work. Reduces memory and computation needs, but accuracy is compromised at connections above 30Mbps.</help>
     </field>
     <field>
         <id>input.internet_speed_interval</id>

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Input.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Input.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/telegraf/input</mount>
     <description>Telegraf inputs configuration</description>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
     <items>
         <cpu type="BooleanField">
             <Default>1</Default>

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Input.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Input.xml
@@ -39,10 +39,10 @@
             <Default>0</Default>
             <Required>N</Required>
         </internet_speed>
-        <internet_speed_file type="BooleanField">
+        <internet_speed_saving type="BooleanField">
             <Default>0</Default>
             <Required>N</Required>
-        </internet_speed_file>
+        </internet_speed_saving>
         <internet_speed_interval type="IntegerField">
             <Default>360</Default>
             <Required>N</Required>

--- a/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
+++ b/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
@@ -279,8 +279,8 @@
 
 {% if helpers.exists('OPNsense.telegraf.input.internet_speed') and OPNsense.telegraf.input.internet_speed == '1' %}
 [[inputs.internet_speed]]
-{% if helpers.exists('OPNsense.telegraf.input.internet_speed_file') and OPNsense.telegraf.input.internet_speed_file == '1' %}
-  enable_file_download = true
+{% if helpers.exists('OPNsense.telegraf.input.internet_speed_saving') and OPNsense.telegraf.input.internet_speed_saving == '1' %}
+  memory_saving_mode = true
 {% endif %}
 {% if helpers.exists('OPNsense.telegraf.input.internet_speed_interval') and OPNsense.telegraf.input.internet_speed_interval != '' %}
   interval = "{{ OPNsense.telegraf.input.internet_speed_interval }}s"


### PR DESCRIPTION
Fixes: https://github.com/opnsense/plugins/issues/4849

The telegraf team had mislabeled this option. The current version of this option has the same effects as before.

In contrast to the previous documentation by telegraf, this is not a recommended option due to its low accuracy and the already low resources required by the module.