### PR TITLE
net/frr: ospfd add point-to-multipoint options

### DIFF
--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditOSPFInterface.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditOSPFInterface.xml
@@ -135,4 +135,14 @@
     <type>dropdown</type>
     <help>Defines the OSPF network type, impacting adjacency and LSA flooding methods. "Broadcast Multi-Access": Assumes networks supporting multiple routers with broadcast capability (e.g., Ethernet). "Non-Broadcast Multi-Access (NBMA)"": For networks without broadcast support (e.g., Frame Relay); requires manual neighbor setup. "Point-to-Multipoint": Connects multiple routers over a single interface, treating each as a point-to-point link. "Point-to-Point": Directly connects two routers, simplifying adjacency and LSA transmission.</help>
   </field>
+  <field>
+    <id>interface.p2mpoptions</id>
+    <label>P2MP options</label>
+    <type>dropdown</type>
+    <style>selectpicker style_networktype</style>
+    <help>Only for point-to-multipoint network type! non-broadcast: Disables multicast/broadcast, OSPF neighbors must be manually configured. delay-reflood: Delays LSA flooding until retransmission timer expires if no ACK received.</help>
+    <grid_view>
+      <visible>false</visible>
+    </grid_view>
+  </field>
 </form>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF.xml
@@ -236,6 +236,12 @@
                                         <point-to-point>Point-to-point network</point-to-point>
                                 </OptionValues>
                         </networktype>
+                        <p2mpoptions type="OptionField">
+                                <OptionValues>
+                                        <delay-reflood>Delay reflood</delay-reflood>
+                                        <non-broadcast>Non-broadcast</non-broadcast>
+                                </OptionValues>
+                        </p2mpoptions>
                 </interface>
         </interfaces>
         <prefixlists>

--- a/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/ospf.volt
+++ b/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/ospf.volt
@@ -110,6 +110,29 @@ POSSIBILITY OF SUCH DAMAGE.
             );
         }
 
+        $("#interface\\.networktype").on("keyup change", function () {
+
+            const networktype = String($("#interface\\.networktype").val() || "")
+ 
+            const styleVisibility = [
+                {
+                    class: "style_networktype",
+                    visible: networktype === "point-to-multipoint"
+                },
+            ];
+
+            styleVisibility.forEach(style => {
+                // hide/show rows with the class
+                const elements = $("." + style.class).closest("tr");
+                style.visible ? elements.show() : elements.hide();
+
+                // hide/show thead only if its parent container has the same class
+                $(".table-responsive." + style.class).find("thead").each(function () {
+                    style.visible ? $(this).show() : $(this).hide();
+                });
+            });
+        });
+
     });
 </script>
 

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospfd.conf
@@ -25,7 +25,15 @@ interface {{ iface }}
   ip ospf bfd
 {%             endif %}
 {%             if interface.networktype %}
+{%                 if interface.networktype == 'point-to-multipoint' %}
+{%                     if interface.p2mpoptions %}
+  {{ cline("network", "point-to-multipoint " ~ interface.p2mpoptions) }}
+{%                     else %}
+  {{ cline("network", "point-to-multipoint") }}
+{%                     endif %}
+{%                 else %}
   {{ cline("network", interface.networktype) }}
+{%                 endif %}
 {%             endif %}
 {%             if interface.authtype and interface.authtype == 'message-digest' %}
   {{ cline("authentication", interface.authtype) }}


### PR DESCRIPTION
This PR adds support for specifying the additional arguments delay-reflood and non-broadcast for the point-to-multipoint network type. These options are now available: https://docs.frrouting.org/en/latest/ospfd.html#clicmd-ip-ospf-network-broadcast-non-broadcast-point-to-multipoint-delay-reflood-non-broadcast-point-to-point-dmvpn 