### PR TITLE
net/freeradius: Change TLS max version to 1.3

### DIFF
--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-eap
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-eap
@@ -454,7 +454,7 @@ eap {
                 #  The values must be in quotes.
                 #
                 tls_min_version = "{{ OPNsense.freeradius.eap.tls_min_version }}"
-                tls_max_version = "1.2"
+                tls_max_version = "1.3"
 
                 #  Elliptical cryptography configuration
                 #


### PR DESCRIPTION
The TLS max version is currently hard-coded to 1.2, but clients like Android support already version 1.3. Change the eap configuration file to allow TLS 1.3 if the client supports it.