### PR TITLE
dns/bind: Fix zone_test and grid-primary-domains

### DIFF
--- a/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/general.volt
+++ b/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/general.volt
@@ -99,8 +99,8 @@
                         <th data-column-id="retry" data-type="string" data-visible="true">{{ lang._('Retry') }}</th>
                         <th data-column-id="expire" data-type="string" data-visible="true">{{ lang._('Expire') }}</th>
                         <th data-column-id="negative" data-type="string" data-visible="true">{{ lang._('Negative TTL') }}</th>
-                        <th data-column-id="commands" data-width="9em" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
                         <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
+                        <th data-column-id="commands" data-width="9em" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
                     </tr>
                 </thead>
                 <tbody>


### PR DESCRIPTION
Contains the following fixes:

1. Fixes zone_test empty zonename variable
2. Fixes command truncation in grid-primary-domains

Split from PR #4892.
