### PR TITLE
dns/bind: Added options to control recursion

### DIFF
--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/general.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/general.xml
@@ -109,10 +109,27 @@
         <help>How much memory in percent the cache can use from the system. Default is 80%.</help>
     </field>
     <field>
-        <id>general.recursion</id>
+        <type>header</type>
         <label>Recursion</label>
+    </field>
+    <field>
+        <id>general.enablerecursion</id>
+        <label>Enable Recursive Resolution</label>
+        <type>checkbox</type>
+        <help>This will enable recursive resolution (default). Disable for public authoritative DNS servers.</help>
+    </field>
+    <field>
+        <id>general.recursion</id>
+        <label>Recursion ACLs</label>
         <type>select_multiple</type>
-        <help>Define an ACL where you allow which clients can resolve via this service. Usually use your local LAN.</help>
+        <help>Select ACLs for which you wish to enable recursive resolution. For public authoritative DNS servers, recursion should be disabled and this field left empty. For private recursive DNS servers, this is usually an ACL representing your local LAN. When recursion is enabled and no ACL is defined here or for "Cache Query ACLs" or "Allow Query", the default will be the local address list. Otherwise this field will default to the value found in "Cache Query ACLs", or failing that, "Allow Query".</help>
+    </field>
+    <field>
+        <id>general.allowcachequeries</id>
+        <label>Cache Query ACLs</label>
+        <advanced>true</advanced>
+        <type>select_multiple</type>
+        <help>Select ACLs for which you wish to enable cache access. For private recursive DNS servers, use this field to override the defaults. When "Recursion ACLs" is set, the default will be the same ACL. Otherwise, the default will be the local address list.</help>
     </field>
     <field>
         <id>general.allowtransfer</id>

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/General.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/General.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/bind/general</mount>
     <description>BIND configuration</description>
-    <version>1.0.12</version>
+    <version>1.0.13</version>
     <items>
         <enabled type="BooleanField">
             <Default>0</Default>
@@ -86,6 +86,10 @@
             <MaximumValue>99</MaximumValue>
             <ValidationMessage>Choose a value between 1 and 99.</ValidationMessage>
         </maxcachesize>
+        <enablerecursion type="BooleanField">
+            <Default>1</Default>
+            <Required>Y</Required>
+        </enablerecursion>
         <recursion type="ModelRelationField">
             <Model>
                 <template>
@@ -97,6 +101,17 @@
             <Multiple>Y</Multiple>
             <ValidationMessage>Choose an ACL.</ValidationMessage>
         </recursion>
+        <allowcachequeries type="ModelRelationField">
+            <Model>
+                <template>
+                    <source>OPNsense.Bind.Acl</source>
+                    <items>acls.acl</items>
+                    <display>name</display>
+                </template>
+            </Model>
+            <Multiple>Y</Multiple>
+            <ValidationMessage>Choose an ACL.</ValidationMessage>
+        </allowcachequeries>
         <allowtransfer type="ModelRelationField">
             <Model>
                 <template>

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
@@ -46,14 +46,26 @@ options {
         response-policy { {% if helpers.exists('OPNsense.bind.dnsbl.type') and OPNsense.bind.dnsbl.type != '' %}zone "whitelist.localdomain"; zone "blacklist.localdomain";{% endif %}{% if helpers.exists('OPNsense.bind.dnsbl.forcesafegoogle') and OPNsense.bind.dnsbl.forcesafegoogle == '1' %}zone "rpzgoogle";{% endif %}{% if helpers.exists('OPNsense.bind.dnsbl.forcesafeduckduckgo') and OPNsense.bind.dnsbl.forcesafeduckduckgo == '1' %}zone "rpzduckduckgo";{% endif %}{% if helpers.exists('OPNsense.bind.dnsbl.forcesafeyoutube') and OPNsense.bind.dnsbl.forcesafeyoutube == '1' %}zone "rpzyoutube";{% endif %}{% if helpers.exists('OPNsense.bind.dnsbl.forcestrictbing') and OPNsense.bind.dnsbl.forcestrictbing == '1' %}zone "rpzbing";{% endif %} };
 {% endif %}
 
-{% if helpers.exists('OPNsense.bind.general.recursion') and OPNsense.bind.general.recursion != '' %}
+{% if helpers.exists('OPNsense.bind.general.enablerecursion') and OPNsense.bind.general.enablerecursion == '1' %}
         recursion          yes;
+{%   if helpers.exists('OPNsense.bind.general.recursion') and OPNsense.bind.general.recursion != '' %}
         allow-recursion {
 {%              for acl in OPNsense.bind.general.recursion.split(',') %}
 {%              set recursion_acl = helpers.getUUID(acl) %}
                 {{ recursion_acl.name }};
 {%              endfor %}
         };
+{%   endif %}
+{%   if helpers.exists('OPNsense.bind.general.allowcachequeries') and OPNsense.bind.general.allowcachequeries != '' %}
+        allow-query-cache {
+{%              for acl in OPNsense.bind.general.allowcachequeries.split(',') %}
+{%              set allowcachequeries_acl = helpers.getUUID(acl) %}
+                {{ allowcachequeries_acl.name }};
+{%              endfor %}
+        };
+{%   endif %}
+{% else %}
+        recursion          no;
 {% endif %}
 
 {% if helpers.exists('OPNsense.bind.general.allowtransfer') and OPNsense.bind.general.allowtransfer != '' %}


### PR DESCRIPTION
Adds options to control recursion:

1. Adds an option to explicitly enable recursion, when unchecked sets recursion=no
2. Adds an option for allow-query-cache, which effectively controls recursion
3. Updated help and reformatted

Split from PR #4892.

Resolves #4887