### PR TITLE
siproxd: add commonly used username characters

### DIFF
--- a/net/siproxd/Makefile
+++ b/net/siproxd/Makefile
@@ -1,6 +1,6 @@
 PLUGIN_NAME=		siproxd
 PLUGIN_VERSION=		1.3
-PLUGIN_REVISION=	2
+PLUGIN_REVISION=	3
 PLUGIN_COMMENT=		Siproxd is a proxy daemon for the SIP protocol
 PLUGIN_DEPENDS=		siproxd
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net/siproxd/src/opnsense/mvc/app/models/OPNsense/Siproxd/User.xml
+++ b/net/siproxd/src/opnsense/mvc/app/models/OPNsense/Siproxd/User.xml
@@ -12,7 +12,7 @@
                 <username type="TextField">
                     <Default></Default>
                     <Required>Y</Required>
-                    <Mask>/^([0-9a-zA-Z._\-]){1,128}$/u</Mask>
+                    <Mask>/^([0-9a-zA-Z._\-\+\@]){1,128}$/u</Mask>
                 </username>
                 <password type="TextField">
                     <Default></Default>


### PR DESCRIPTION
Fix: https://github.com/opnsense/plugins/issues/4599

siproxd supports those, and I don't think they would break anything on the opnsense side.