### PR TITLE
HAProxy: Fix frontend client cert 'required' casing

### DIFF
--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -642,7 +642,7 @@
                     <OptionValues>
                         <none>none</none>
                         <optional>optional</optional>
-                        <Required>required</Required>
+                        <required>required</required>
                     </OptionValues>
                 </ssl_clientAuthVerify>
                 <ssl_clientAuthCAs type="CertificateField">


### PR DESCRIPTION
'Required' --> 'required'

Using the OpnSense web interface to set a client certificate as 'required' results in the error below. Fixing the casing of the XML tags to align with HAProxy https://www.haproxy.com/documentation/haproxy-configuration-tutorials/security/authentication/client-certificate-authentication/#verify-client-certificates

[NOTICE] (18212) : haproxy version is 3.0.11-9e587df
[NOTICE] (18212) : path to executable is /usr/local/sbin/haproxy
[ALERT] (18212) : config : parsing [/usr/local/etc/haproxy.conf.staging:66] : 'bind 0.0.0.0:123' in section 'frontend' : 'verify' : unknown verify method 'Required', only 'none', 'optional', and 'required' are supported
[ALERT] (18212) : config : Error(s) found in configuration file : /usr/local/etc/haproxy.conf.staging
[ALERT] (18212) : config : Fatal errors found in configuration.