### PR TITLE
www/caddy: Fix setup.sh script interaction with files and directories in caddy storage

### DIFF
--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -9,8 +9,9 @@ Plugin Changelog
 2.0.3
 
 Add: Tabulator groupBy of domain and subdomain (opnsense/plugins/pull/4909)
-Fix: Tabulator 'Data Load Response Blocked' warning
 Cleanup: Grid HTML and style
+Fix: Tabulator 'Data Load Response Blocked' warning
+Fix: setup.sh interaction with caddy storage and permissions (opnsense/plugins/pull/4911)
 
 2.0.2
 

--- a/www/caddy/src/opnsense/scripts/OPNsense/Caddy/caddy_certs.php
+++ b/www/caddy/src/opnsense/scripts/OPNsense/Caddy/caddy_certs.php
@@ -43,7 +43,7 @@ $writeFileIfChanged = function ($filePath, $content) {
     }
 };
 
-$tempDir = '/var/db/caddy/data/caddy/certificates/temp/';
+$tempDir = '/usr/local/etc/caddy/certificates/';
 
 // leaf certificate chain
 $certificateRefs = [];

--- a/www/caddy/src/opnsense/scripts/OPNsense/Caddy/caddy_certs.php
+++ b/www/caddy/src/opnsense/scripts/OPNsense/Caddy/caddy_certs.php
@@ -43,7 +43,7 @@ $writeFileIfChanged = function ($filePath, $content) {
     }
 };
 
-$tempDir = '/usr/local/etc/caddy/certificates/';
+$tempDir = '/usr/local/etc/caddy/certificates';
 
 // leaf certificate chain
 $certificateRefs = [];

--- a/www/caddy/src/opnsense/scripts/OPNsense/Caddy/setup.sh
+++ b/www/caddy/src/opnsense/scripts/OPNsense/Caddy/setup.sh
@@ -27,14 +27,12 @@
 #
 
 # Detect configured caddy_user/group (defaults)
-CADDY_USER=root
-CADDY_GROUP=wheel
-[ -r /etc/rc.conf.d/caddy ] && . /etc/rc.conf.d/caddy
-[ -n "$caddy_user" ]  && CADDY_USER="$caddy_user"
-[ -n "$caddy_group" ] && CADDY_GROUP="$caddy_group"
+. /etc/rc.conf.d/caddy
+CADDY_USER="${caddy_user:-root}"
+CADDY_GROUP="${caddy_group:-wheel}"
 
 # Canary to detect root->www switch (disable superuser) permission issues
-# The storage instance will always exist, its a good assumption
+# The storage instance will always exist, it's a good assumption
 CANARY="/var/db/caddy/data/caddy/instance.uuid"
 
 # Define directories
@@ -66,7 +64,7 @@ if [ -f "$CANARY" ]; then
     CANARY_USER="$(stat -f '%Su' "$CANARY")"
     CANARY_GROUP="$(stat -f '%Sg' "$CANARY")"
 
-    if [ "$CANARY_USER" = "$EXPECTED_USER" ] && [ "$CANARY_GROUP" = "$EXPECTED_GROUP" ]; then
+    if [ "$CANARY_USER" = "$EXPECTED_USER" -a "$CANARY_GROUP" = "$EXPECTED_GROUP" ]; then
         exit 0
     fi
 fi

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -312,7 +312,7 @@ http://{{ domain }} {
     tlsDnsPropagationResolvers=""
 ) %}
     {% if customCert or (dnsChallenge == "1" and dnsProvider) or clientAuthTrustPool %}
-        tls {% if customCert %}/var/db/caddy/data/caddy/certificates/temp/{{ customCert }}.pem /var/db/caddy/data/caddy/certificates/temp/{{ customCert }}.key{% endif %} {
+        tls {% if customCert %}/usr/local/etc/caddy/certificates/{{ customCert }}.pem /usr/local/etc/caddy/certificates/{{ customCert }}.key{% endif %} {
             {% if not customCert and (dnsChallenge == "1" and dnsProvider) %}
             issuer acme {
                 dns {{ dnsProvider }} {{ dnsApiKey }}
@@ -334,7 +334,7 @@ http://{{ domain }} {
             {% if clientAuthTrustPool %}
                 client_auth {
                     {% for ca in clientAuthTrustPool.split(',') %}
-                    trust_pool file /var/db/caddy/data/caddy/certificates/temp/{{ ca.strip() }}.pem
+                    trust_pool file /usr/local/etc/caddy/certificates/{{ ca.strip() }}.pem
                     {% endfor %}
                     {% if clientAuthMode %}
                     mode {{ clientAuthMode }}
@@ -508,7 +508,7 @@ http://{{ domain }} {
                             tls_insecure_skip_verify
                         {% endif %}
                         {% if handle.HttpTlsTrustedCaCerts %}
-                            tls_trust_pool file /var/db/caddy/data/caddy/certificates/temp/{{ handle.HttpTlsTrustedCaCerts }}.pem
+                            tls_trust_pool file /usr/local/etc/caddy/certificates/{{ handle.HttpTlsTrustedCaCerts }}.pem
                         {% endif %}
                         {% if handle.HttpTlsServerName %}
                             tls_server_name {{ handle.HttpTlsServerName }}

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/includeLayer4
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/includeLayer4
@@ -99,7 +99,7 @@
                 {% if layer4.FromOpenvpnStaticKey %}
                     group_key_direction {{ direction }}
                     {% for key_uuid in key_list %}
-                    group_key_file /var/db/caddy/data/caddy/certificates/temp/{{ key_uuid.strip() }}.key
+                    group_key_file /usr/local/etc/caddy/certificates/{{ key_uuid.strip() }}.key
                     {% endfor %}
                 {% endif %}
                 }
@@ -111,7 +111,7 @@
                     modes crypt
                 {% if layer4.FromOpenvpnStaticKey %}
                     {% for key_uuid in key_list %}
-                    group_key_file /var/db/caddy/data/caddy/certificates/temp/{{ key_uuid.strip() }}.key
+                    group_key_file /usr/local/etc/caddy/certificates/{{ key_uuid.strip() }}.key
                     {% endfor %}
                 {% endif %}
                 }
@@ -121,7 +121,7 @@
                     modes crypt2
                     {% if layer4.FromOpenvpnStaticKey %}
                         {% for key_uuid in key_list %}
-                    client_key_file /var/db/caddy/data/caddy/certificates/temp/{{ key_uuid.strip() }}.key
+                    client_key_file /usr/local/etc/caddy/certificates/{{ key_uuid.strip() }}.key
                         {% endfor %}
                     {% endif %}
                 }
@@ -133,7 +133,7 @@
                     modes crypt2
                     {% if layer4.FromOpenvpnStaticKey %}
                         {% for key_uuid in key_list %}
-                    server_key_file /var/db/caddy/data/caddy/certificates/temp/{{ key_uuid.strip() }}.key
+                    server_key_file /usr/local/etc/caddy/certificates/{{ key_uuid.strip() }}.key
                         {% endfor %}
                     {% endif %}
                 }


### PR DESCRIPTION
This fixes multiple things:
- When running as www:www user, the interaction with the admin socket could fail, now we do not touch /var/run/caddy and let it be handled by the permissions set in the rc.d script

```
2025-08-24T11:39:27Errorcaddy"error","ts":"2025-08-24T09:39:27Z","logger":"admin.api","msg":"request error","error":"loading config: loading new config: starting caddy administration endpoint: unable to set permissions (--w--w----) on /var/run/caddy/caddy.sock: chmod /var/run/caddy/caddy.sock: operation not permitted","status_code":400}
```

Fixes: https://github.com/opnsense/plugins/issues/4402

- When restarting/reloading caddy, permissions and ownerships would be changed every time, possibly breaking the storage if caddy writes at the same time
- The custom certificates are now stored outside the scope of the caddy storage, ensuring caddy has atomic write guarantee on /var/db/caddy/data...

Fixes: https://github.com/opnsense/plugins/issues/4905