### PR TITLE
www/caddy: Add bind to loopback interface option

### DIFF
--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/general.xml
@@ -65,6 +65,12 @@
             <label>Server Settings</label>
         </field>
         <field>
+            <id>caddy.general.BindLoopback</id>
+            <label>Bind to loopback interface</label>
+            <type>checkbox</type>
+            <help><![CDATA[Bind the service to the default loopback interface instead of binding to all interfaces. Use destination NAT rules to redirect packets to this socket.]]></help>
+        </field>
+        <field>
             <id>caddy.general.accesslist</id>
             <label>Trusted Proxies</label>
             <type>dropdown</type>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -11,6 +11,7 @@
             <EnableLayer4 type="BooleanField"/>
             <HttpPort type="PortField"/>
             <HttpsPort type="PortField"/>
+            <BindLoopback type="BooleanField"/>
             <TlsEmail type="EmailField"/>
             <TlsAutoHttps type="OptionField">
                 <BlankDesc>On (default)</BlankDesc>

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -35,6 +35,9 @@
 # caddy_user=root
 {% endif %}
 
+{# Used in Caddyfile and includeLayer4 #}
+{% set loopback_on = generalSettings.BindLoopback|default("0") == "1" %}
+
 # Global Options
 {
     {#
@@ -69,6 +72,9 @@
     {% endif %}
     {% if httpsPort %}
         https_port {{ httpsPort }}
+    {% endif %}
+    {% if loopback_on %}
+        default_bind ::1 127.0.0.1
     {% endif %}
 
     {#
@@ -241,29 +247,29 @@
 # Reverse Proxy Configuration
 
 {#
-#   When Layer4 is active, set default ports.
-#   Caddy does not set them up automatically under certain conditions.
-#   For example when AutoHTTPS would be off, or no domains have been configured.
-#   There are no regressions to set these ports up.
+#   Always set default HTTP/HTTPS listeners as catch-all.
+#   Loopback bind is optional, default is binding to all interfaces.
 #}
-
-{% if generalSettings.EnableLayer4|default("0") == "1" %}
-    # Layer4 default HTTP port
-    {% if httpPort %}
-        :{{ httpPort }} {
-        }
-    {% else %}
-        :80 {
-        }
-    {% endif %}
-    # Layer4 default HTTPS port
-    {% if httpsPort %}
-        :{{ httpsPort }} {
-        }
-    {% else %}
-        :443 {
-        }
-    {% endif %}
+{% set loopback_on = (generalSettings.BindLoopback|default("0") == "1") %}
+# Default HTTP port
+{% if httpPort %}
+    :{{ httpPort }} {
+        {% if loopback_on %}bind ::1 127.0.0.1{% endif %}
+    }
+{% else %}
+    :80 {
+        {% if loopback_on %}bind ::1 127.0.0.1{% endif %}
+    }
+{% endif %}
+# Default HTTPS port
+{% if httpsPort %}
+    :{{ httpsPort }} {
+        {% if loopback_on %}bind ::1 127.0.0.1{% endif %}
+    }
+{% else %}
+    :443 {
+        {% if loopback_on %}bind ::1 127.0.0.1{% endif %}
+    }
 {% endif %}
 
 {#
@@ -608,6 +614,9 @@ http://{{ domain }} {
 {% for reverse in helpers.toList('Pischem.caddy.reverseproxy.reverse') %}
     {% if reverse.enabled|default("0") == "1" %}
         {% if reverse.DisableTls|default("0") == "1" %}http://{% endif %}{{ reverse.FromDomain|default("") }}{% if reverse.FromPort %}:{{ reverse.FromPort }}{% endif %} {
+            {% if loopback_on %}
+                bind ::1 127.0.0.1
+            {% endif %}
             {% if reverse.AccessLog|default("0") == "1" %}
                 {% if generalSettings.LogAccessPlain|default("0") == "0" %}
                     log {{ reverse['@uuid'] }}
@@ -645,6 +654,9 @@ http://{{ domain }} {
         {% set reverse = helpers.toList('Pischem.caddy.reverseproxy.reverse') | selectattr('@uuid', 'equalto', subdomain.reverse) | first %}
         {% if reverse and reverse.enabled|default("0") == "1" %}
             {% if reverse.DisableTls|default("0") == "1" %}http://{% endif %}{{ subdomain.FromDomain|default("") }}{% if reverse.FromPort %}:{{ reverse.FromPort }}{% endif %} {
+                {% if loopback_on %}
+                    bind ::1 127.0.0.1
+                {% endif %}
                 {% if reverse.AccessLog|default("0") == "1" %}
                     {% if generalSettings.LogAccessPlain|default("0") == "0" %}
                         log {{ subdomain['@uuid'] }}

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/includeLayer4
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/includeLayer4
@@ -65,7 +65,12 @@
 {% set grouped_configs = {} %}
 {% for layer4 in layer4_configs %}
     {% if layer4.FromPort and layer4.Protocol and layer4.enabled == "1"  %}
-        {% set key = layer4.Protocol ~ '/:' ~ layer4.FromPort %}
+        {% if loopback_on %}
+            {% set key = layer4.Protocol ~ '/127.0.0.1:' ~ layer4.FromPort
+                ~ ' ' ~ layer4.Protocol ~ '/[::1]:' ~ layer4.FromPort %}
+        {% else %}
+            {% set key = layer4.Protocol ~ '/:' ~ layer4.FromPort %}
+        {% endif %}
         {% if not key in grouped_configs %}
             {% set _ = grouped_configs.update({key: []}) %}
         {% endif %}


### PR DESCRIPTION
This binds all ports that caddy opens to the default loopback interfaces IPv4 and IPv6 addresses.

This way, you can use DNAT to forward traffic from specific receiving interfaces only, and it is more safe than allowing to bind to a specific interface.

Kinda the best of both worlds if you need it.

