### PR TITLE
bootgrid: Sweep rowcount as default has been increased

### DIFF
--- a/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/logs.volt
+++ b/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/logs.volt
@@ -34,7 +34,6 @@
               sorting:false,
               rowSelect: false,
               selection: false,
-              rowCount:[20,50,100,200,500,1000,-1],
           },
           search:'/api/diagnostics/log/named/query'
       });
@@ -45,7 +44,6 @@
               sorting:false,
               rowSelect: false,
               selection: false,
-              rowCount:[20,50,100,200,500,1000,-1],
           },
           search:'/api/diagnostics/log/named/rpz'
       });

--- a/net-mgmt/zabbix-agent/src/opnsense/mvc/app/views/OPNsense/ZabbixAgent/index.volt
+++ b/net-mgmt/zabbix-agent/src/opnsense/mvc/app/views/OPNsense/ZabbixAgent/index.volt
@@ -48,7 +48,6 @@ $( document ).ready(function() {
             del:'/api/zabbixagent/settings/del_userparameter/',
             toggle:'/api/zabbixagent/settings/toggle_userparameter/',
             options: {
-                rowCount:[10,25,50,100,500,1000]
             }
         }
     );
@@ -61,7 +60,6 @@ $( document ).ready(function() {
             del:'/api/zabbixagent/settings/del_alias/',
             toggle:'/api/zabbixagent/settings/toggle_alias/',
             options: {
-                rowCount:[10,25,50,100,500,1000]
             }
         }
     );

--- a/net/freeradius/src/opnsense/mvc/app/views/OPNsense/Freeradius/proxy.volt
+++ b/net/freeradius/src/opnsense/mvc/app/views/OPNsense/Freeradius/proxy.volt
@@ -50,7 +50,6 @@ $( document ).ready(function() {
                 'del':'/api/freeradius/proxy/del_homeserver/',
                 'toggle':'/api/freeradius/proxy/toggle_homeserver/',
             options: {
-                rowCount:[10,25,50,100,500,1000]
                 }
             }
         );
@@ -62,7 +61,6 @@ $( document ).ready(function() {
                 'del':'/api/freeradius/proxy/del_homeserverpool/',
                 'toggle':'/api/freeradius/proxy/toggle_homeserverpool/',
             options: {
-                rowCount:[10,25,50,100,500,1000]
                 }
             }
         );
@@ -74,7 +72,6 @@ $( document ).ready(function() {
                 'del':'/api/freeradius/proxy/del_realm/',
                 'toggle':'/api/freeradius/proxy/toggle_realm/',
             options: {
-                rowCount:[10,25,50,100,500,1000]
                 }
             }
         );

--- a/net/haproxy/src/opnsense/mvc/app/views/OPNsense/HAProxy/index.volt
+++ b/net/haproxy/src/opnsense/mvc/app/views/OPNsense/HAProxy/index.volt
@@ -56,7 +56,6 @@ POSSIBILITY OF SUCH DAMAGE.
                 del:'/api/haproxy/settings/del_frontend/',
                 toggle:'/api/haproxy/settings/toggle_frontend/',
                 options: {
-                    rowCount:[10,25,50,100,500,1000]
                 }
             }
         );
@@ -69,7 +68,6 @@ POSSIBILITY OF SUCH DAMAGE.
                 del:'/api/haproxy/settings/del_backend/',
                 toggle:'/api/haproxy/settings/toggle_backend/',
                 options: {
-                    rowCount:[10,25,50,100,500,1000]
                 }
             }
         );
@@ -82,7 +80,6 @@ POSSIBILITY OF SUCH DAMAGE.
                 del:'/api/haproxy/settings/del_server/',
                 toggle:'/api/haproxy/settings/toggle_server/',
                 options: {
-                    rowCount:[10,25,50,100,500,1000]
                 }
             }
         );
@@ -94,7 +91,6 @@ POSSIBILITY OF SUCH DAMAGE.
                 add:'/api/haproxy/settings/add_healthcheck/',
                 del:'/api/haproxy/settings/del_healthcheck/',
                 options: {
-                    rowCount:[10,25,50,100,500,1000]
                 }
             }
         );
@@ -106,7 +102,6 @@ POSSIBILITY OF SUCH DAMAGE.
                 add:'/api/haproxy/settings/add_action/',
                 del:'/api/haproxy/settings/del_action/',
                 options: {
-                    rowCount:[10,25,50,100,500,1000]
                 }
             }
         );
@@ -118,7 +113,6 @@ POSSIBILITY OF SUCH DAMAGE.
                 add:'/api/haproxy/settings/add_acl/',
                 del:'/api/haproxy/settings/del_acl/',
                 options: {
-                    rowCount:[10,25,50,100,500,1000]
                 }
             }
         );
@@ -131,7 +125,6 @@ POSSIBILITY OF SUCH DAMAGE.
                 del:'/api/haproxy/settings/del_user/',
                 toggle:'/api/haproxy/settings/toggle_user/',
                 options: {
-                    rowCount:[10,25,50,100,500,1000]
                 }
             }
         );
@@ -144,7 +137,6 @@ POSSIBILITY OF SUCH DAMAGE.
                 del:'/api/haproxy/settings/del_group/',
                 toggle:'/api/haproxy/settings/toggle_group/',
                 options: {
-                    rowCount:[10,25,50,100,500,1000]
                 }
             }
         );
@@ -157,7 +149,6 @@ POSSIBILITY OF SUCH DAMAGE.
                 del:'/api/haproxy/settings/del_lua/',
                 toggle:'/api/haproxy/settings/toggle_lua/',
                 options: {
-                    rowCount:[10,25,50,100,500,1000]
                 }
             }
         );
@@ -169,7 +160,6 @@ POSSIBILITY OF SUCH DAMAGE.
                 add:'/api/haproxy/settings/add_fcgi/',
                 del:'/api/haproxy/settings/del_fcgi/',
                 options: {
-                    rowCount:[10,25,50,100,500,1000]
                 }
             }
         );
@@ -181,7 +171,6 @@ POSSIBILITY OF SUCH DAMAGE.
                 add:'/api/haproxy/settings/add_errorfile/',
                 del:'/api/haproxy/settings/del_errorfile/',
                 options: {
-                    rowCount:[10,25,50,100,500,1000]
                 }
             }
         );
@@ -193,7 +182,6 @@ POSSIBILITY OF SUCH DAMAGE.
                 add:'/api/haproxy/settings/add_mapfile/',
                 del:'/api/haproxy/settings/del_mapfile/',
                 options: {
-                    rowCount:[10,25,50,100,500,1000]
                 }
             }
         );
@@ -206,7 +194,6 @@ POSSIBILITY OF SUCH DAMAGE.
                 del:'/api/haproxy/settings/del_cpu/',
                 toggle:'/api/haproxy/settings/toggle_cpu/',
                 options: {
-                    rowCount:[10,25,50,100,500,1000]
                 }
             }
         );
@@ -219,7 +206,6 @@ POSSIBILITY OF SUCH DAMAGE.
                 del:'/api/haproxy/settings/del_resolver/',
                 toggle:'/api/haproxy/settings/toggle_resolver/',
                 options: {
-                    rowCount:[10,25,50,100,500,1000]
                 }
             }
         );
@@ -232,7 +218,6 @@ POSSIBILITY OF SUCH DAMAGE.
                 del:'/api/haproxy/settings/del_mailer/',
                 toggle:'/api/haproxy/settings/toggle_mailer/',
                 options: {
-                    rowCount:[10,25,50,100,500,1000]
                 }
             }
         );

--- a/net/haproxy/src/opnsense/mvc/app/views/OPNsense/HAProxy/maintenance.volt
+++ b/net/haproxy/src/opnsense/mvc/app/views/OPNsense/HAProxy/maintenance.volt
@@ -182,7 +182,6 @@ POSSIBILITY OF SUCH DAMAGE.
                 selection: true,
                 multiSelect: true,
                 keepSelection: true,
-                rowCount:[10,25,50,100,500,1000],
                 searchSettings: {
                     delay: 250,
                     characters: 1
@@ -292,7 +291,6 @@ POSSIBILITY OF SUCH DAMAGE.
                 selection: true,
                 multiSelect: true,
                 keepSelection: true,
-                rowCount:[10,25,50,100,500,1000],
                 searchSettings: {
                     delay: 250,
                     characters: 1

--- a/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/accounts.volt
+++ b/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/accounts.volt
@@ -49,7 +49,6 @@ POSSIBILITY OF SUCH DAMAGE.
             ajax: true,
             selection: true,
             multiSelect: true,
-            rowCount:[10,25,50,100,500,1000],
             url: '/api/acmeclient/accounts/search',
             formatters: {
                 "commands": function (column, row) {

--- a/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/actions.volt
+++ b/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/actions.volt
@@ -43,7 +43,6 @@ POSSIBILITY OF SUCH DAMAGE.
                 del:'/api/acmeclient/actions/del/',
                 toggle:'/api/acmeclient/actions/toggle/',
                 options: {
-                    rowCount:[10,25,50,100,500,1000]
                 }
             }
         );

--- a/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/certificates.volt
+++ b/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/certificates.volt
@@ -56,7 +56,6 @@ POSSIBILITY OF SUCH DAMAGE.
             ajax: true,
             selection: true,
             multiSelect: true,
-            rowCount:[10,25,50,100,500,1000],
             url: '/api/acmeclient/certificates/search',
             formatters: {
                 "commands": function (column, row) {

--- a/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/logs.volt
+++ b/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/logs.volt
@@ -35,7 +35,6 @@
               sorting:false,
               rowSelect: false,
               selection: false,
-              rowCount:[20,50,100,200,500,1000,-1],
               requestHandler: function(request){
                   // Show only log entries that match 'AcmeClient'
                   request['searchPhrase'] = 'acmeclient';
@@ -51,7 +50,6 @@
               sorting:false,
               rowSelect: false,
               selection: false,
-              rowCount:[20,50,100,200,500,1000,-1],
           },
           search:'/api/diagnostics/log/core/acmeclient'
       });

--- a/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/validations.volt
+++ b/security/acme-client/src/opnsense/mvc/app/views/OPNsense/AcmeClient/validations.volt
@@ -43,7 +43,6 @@ POSSIBILITY OF SUCH DAMAGE.
                 del:'/api/acmeclient/validations/del/',
                 toggle:'/api/acmeclient/validations/toggle/',
                 options: {
-                    rowCount:[10,25,50,100,500,1000]
                 }
             }
         );


### PR DESCRIPTION
in https://github.com/opnsense/core/commit/baa1730b1a9f1d8c9f0bb81a0ff1521636824231

rowcounts in os-bind have not been changed as its a master detail grid