### PR TITLE
security/netbird: Fix typo in firewall settings label

### DIFF
--- a/security/netbird/src/opnsense/mvc/app/controllers/OPNsense/Netbird/forms/settings.xml
+++ b/security/netbird/src/opnsense/mvc/app/controllers/OPNsense/Netbird/forms/settings.xml
@@ -21,7 +21,7 @@
     </field>
     <field>
         <id>settings.firewall.allowConfig</id>
-        <label>Enable firewal</label>
+        <label>Enable Firewall</label>
         <type>checkbox</type>
         <help>Allow the client to filter traffic with its built-in firewall. If disabled, you must assign the NetBird interface and manage firewall rules via OPNsense firewall management.
             Additionally, NetBird routing and DNS may not function as intended.</help>


### PR DESCRIPTION
two small fixes in the header for the firewall toggle. Added the missing second "l" and used a capital F in for Firewall, so that it matches the other headers.