### PR TITLE
[netbird] Fix netbird service not starting on boot

### DIFF
--- a/security/netbird/src/opnsense/service/conf/actions.d/actions_netbird.conf
+++ b/security/netbird/src/opnsense/service/conf/actions.d/actions_netbird.conf
@@ -1,17 +1,17 @@
 [start]
-command:/usr/local/etc/rc.d/netbird start
+command:/usr/local/etc/rc.d/netbird service start
 parameters:
 type:script
 message:starting netbird
 
 [stop]
-command:/usr/local/etc/rc.d/netbird stop
+command:/usr/local/etc/rc.d/netbird service stop
 parameters:
 type:script
 message:stopping netbird
 
 [restart]
-command:/usr/local/etc/rc.d/netbird restart
+command:/usr/local/etc/rc.d/netbird service restart
 parameters:
 type:script
 message:restarting netbird


### PR DESCRIPTION
Hi there,

netbird is not starting on boot. I think the problem is fixed with this pull request. There is no ```netbird start```, it should be ```netbird service start```.

Am I right, that ```security/netbird/src/etc/inc/plugins.inc.d/netbird.inc``` is referencing the sections (e.g. ```[start]```) of ```security/netbird/src/opnsense/service/conf/actions.d/actions_netbird.conf``` ? Or should these also be corrected?