### PR TITLE
www/caddy: Fix subdomain http access log

### DIFF
--- a/www/caddy/pkg-descr
+++ b/www/caddy/pkg-descr
@@ -12,6 +12,7 @@ Add: Tabulator groupBy of domain and subdomain (opnsense/plugins/pull/4909)
 Cleanup: Grid HTML and style
 Fix: Tabulator 'Data Load Response Blocked' warning
 Fix: setup.sh interaction with caddy storage and permissions (opnsense/plugins/pull/4911)
+Fix: Emit subdomain http access logs when wildcard parent has logging enabled (opnsense/plugins/issues/4914)
 
 2.0.2
 

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -647,7 +647,7 @@ http://{{ domain }} {
             {% if reverse.DisableTls|default("0") == "1" %}http://{% endif %}{{ subdomain.FromDomain|default("") }}{% if reverse.FromPort %}:{{ reverse.FromPort }}{% endif %} {
                 {% if reverse.AccessLog|default("0") == "1" %}
                     {% if generalSettings.LogAccessPlain|default("0") == "0" %}
-                        log {{ subdomain['@uuid'] }}
+                        log {{ reverse['@uuid'] }}
                     {% else %}
                         log {
                             output file /var/log/caddy/access/{{ subdomain['@uuid'] }}.log {


### PR DESCRIPTION
Fixes: https://github.com/opnsense/plugins/issues/4914