### PR TITLE
www/nginx: 1.35.1 change ban_ttl default

### DIFF
--- a/www/nginx/Makefile
+++ b/www/nginx/Makefile
@@ -1,5 +1,6 @@
 PLUGIN_NAME=		nginx
 PLUGIN_VERSION=		1.35
+PLUGIN_REVISION=	1
 PLUGIN_COMMENT=		Nginx HTTP server and reverse proxy
 PLUGIN_DEPENDS=		nginx
 PLUGIN_MAINTAINER=	franz.fabian.94@gmail.com

--- a/www/nginx/pkg-descr
+++ b/www/nginx/pkg-descr
@@ -10,6 +10,10 @@ WWW: https://nginx.org/
 Plugin Changelog
 ================
 
+1.35.1
+
+* Change ban_ttl default value to avoid unintentional system slowdown
+
 1.35
 
 * Global options sendfile directive typo fix

--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/settings.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/settings.xml
@@ -11,7 +11,7 @@
                 <id>nginx.general.ban_ttl</id>
                 <label>Autoblock TTL (minutes)</label>
                 <type>text</type>
-                <help>Set autoblock lifetime in minutes. Set to 0 for infinite.</help>
+                <help>Set autoblock lifetime in minutes. 72 hours by default. Set to 0 for infinite. Please note that setting this to 0 may result in gradual system slowdown and the need to manually clear the entries.</help>
                 <advanced>true</advanced>
             </field>
         </subtab>

--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Migrations/M1_35_1.php
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Migrations/M1_35_1.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * Copyright (C) 2025 kulikov.a@gmail.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Nginx\Migrations;
+
+use OPNsense\Base\BaseModelMigration;
+
+class M1_35_1 extends BaseModelMigration
+{
+    // Rewrite default ban_ttl value
+    public function run($model)
+    {
+        $general_node = $model->getNodeByReference('general');
+
+        if ((string)$general_node->ban_ttl == '0') {
+            $general_node->ban_ttl = '4320';
+        }
+        // run default migration actions
+        parent::run($model);
+    }
+}

--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/Nginx</mount>
-    <version>1.35</version>
+    <version>1.35.1</version>
     <description>nginx web server, reverse proxy and waf</description>
     <items>
         <general>
@@ -9,7 +9,7 @@
                 <Required>Y</Required>
             </enabled>
             <ban_ttl type="IntegerField">
-                <Default>0</Default>
+                <Default>4320</Default>
                 <MinimumValue>0</MinimumValue>
                 <Required>Y</Required>
             </ban_ttl>


### PR DESCRIPTION
Hi!
related to
https://github.com/opnsense/plugins/pull/4903
https://github.com/opnsense/plugins/issues/4577
migate to the new ban_ttl value to avoid unintentional gradual system slowdown
Thanks!
ps. the ability to return to a zero value has been left for those cases when the administrator knows what he is doing)