### PR TITLE
Shadowsocks   update web UI ciphers to match shadowsocks rust

### DIFF
--- a/net/shadowsocks/src/opnsense/mvc/app/models/OPNsense/Shadowsocks/General.xml
+++ b/net/shadowsocks/src/opnsense/mvc/app/models/OPNsense/Shadowsocks/General.xml
@@ -31,14 +31,14 @@
             <Default>aes-256-gcm</Default>
             <Required>Y</Required>
             <OptionValues>
-                <blake3-aes-256-gcm value="2022-blake3-aes-256-gcm">2022-BLAKE3-AES-256-GCM</blake3-aes-256-gcm>
+				<blake3-aes-256-gcm value="2022-blake3-aes-256-gcm">2022-BLAKE3-AES-256-GCM</blake3-aes-256-gcm>
                 <aes-256-gcm>AES-256-GCM</aes-256-gcm>
 				<blake3-aes-128-gcm value="2022-blake3-aes-128-gcm">2022-BLAKE3-AES-128-GCM</blake3-aes-128-gcm>
                 <aes-128-gcm>AES-128-GCM</aes-128-gcm>
 				<blake3-chacha20-poly1305 value="2022-blake3-chacha20-poly1305">2022-BLAKE3-ChaCha20-Poly1305</blake3-chacha20-poly1305>
                 <blake3-chacha8-poly1305 value="2022-blake3-chacha8-poly1305">2022-BLAKE3-ChaCha8-Poly1305</blake3-chacha8-poly1305>
                 <chacha20-ietf-poly1305>ChaCha20-IETF-Poly1305</chacha20-ietf-poly1305>
-                <none>NONE</none>
+                <none>NONE (INSECURE)</none>
 				<aes-256-cfb>AES-256-CFB (DEPRECATED)</aes-256-cfb>
 				<aes-256-ctr>AES-256-CTR (DEPRECATED)</aes-256-ctr>
                 <aes-192-cfb>AES-192-CFB (DEPRECATED)</aes-192-cfb>

--- a/net/shadowsocks/src/opnsense/mvc/app/models/OPNsense/Shadowsocks/General.xml
+++ b/net/shadowsocks/src/opnsense/mvc/app/models/OPNsense/Shadowsocks/General.xml
@@ -31,16 +31,14 @@
             <Default>aes-256-cfb</Default>
             <Required>Y</Required>
             <OptionValues>
-                <aes-256-cfb>AES-256-CFB</aes-256-cfb>
+                <2022-blake3-aes-256-gcm>2022-BLAKE3-AES-256-GCM</2022-blake3-aes-256-gcm>
                 <aes-256-gcm>AES-256-GCM</aes-256-gcm>
-                <aes-256-ctr>AES-256-CTR</aes-256-ctr>
-                <aes-192-cfb>AES-192-CFB</aes-192-cfb>
-                <aes-192-gcm>AES-192-GCM</aes-192-gcm>
-                <aes-192-ctr>AES-192-CTR</aes-192-ctr>
-                <aes-128-cfb>AES-128-CFB</aes-128-cfb>
+                <2022-blake3-aes-128-gcm>2022-BLAKE3-AES-128-GCM</2022-blake3-aes-128-gcm>
                 <aes-128-gcm>AES-128-GCM</aes-128-gcm>
-                <aes-128-ctr>AES-128-CTR</aes-128-ctr>
+                <2022-blake3-chacha20-poly1305>2022-BLAKE3-ChaCha20-Poly1305</2022-blake3-chacha20-poly1305>
+                <2022-blake3-chacha8-poly1305>2022-BLAKE3-ChaCha8-Poly1305</2022-blake3-chacha8-poly1305>
                 <chacha20-ietf-poly1305>ChaCha20-IETF-Poly1305</chacha20-ietf-poly1305>
+                <none>NONE</none>
             </OptionValues>
         </cipher>
         <tcpudpmode type="OptionField">

--- a/net/shadowsocks/src/opnsense/mvc/app/models/OPNsense/Shadowsocks/General.xml
+++ b/net/shadowsocks/src/opnsense/mvc/app/models/OPNsense/Shadowsocks/General.xml
@@ -31,21 +31,27 @@
             <Default>aes-256-gcm</Default>
             <Required>Y</Required>
             <OptionValues>
-				<blake3-aes-256-gcm value="2022-blake3-aes-256-gcm">2022-BLAKE3-AES-256-GCM</blake3-aes-256-gcm>
-                <aes-256-gcm>AES-256-GCM</aes-256-gcm>
-				<blake3-aes-128-gcm value="2022-blake3-aes-128-gcm">2022-BLAKE3-AES-128-GCM</blake3-aes-128-gcm>
-                <aes-128-gcm>AES-128-GCM</aes-128-gcm>
-				<blake3-chacha20-poly1305 value="2022-blake3-chacha20-poly1305">2022-BLAKE3-ChaCha20-Poly1305</blake3-chacha20-poly1305>
-                <blake3-chacha8-poly1305 value="2022-blake3-chacha8-poly1305">2022-BLAKE3-ChaCha8-Poly1305</blake3-chacha8-poly1305>
-                <chacha20-ietf-poly1305>ChaCha20-IETF-Poly1305</chacha20-ietf-poly1305>
-				<aes-256-cfb>AES-256-CFB (DEPRECATED)</aes-256-cfb>
-				<aes-256-ctr>AES-256-CTR (DEPRECATED)</aes-256-ctr>
-                <aes-192-cfb>AES-192-CFB (DEPRECATED)</aes-192-cfb>
-                <aes-192-gcm>AES-192-GCM (DEPRECATED)</aes-192-gcm>
-                <aes-192-ctr>AES-192-CTR (DEPRECATED)</aes-192-ctr>
-                <aes-128-cfb>AES-128-CFB (DEPRECATED)</aes-128-cfb>
-				<aes-128-ctr>AES-128-CTR (DEPRECATED)</aes-128-ctr>
-				<none>NONE (INSECURE)</none>
+				<Secure>
+					<blake3-aes-256-gcm value="2022-blake3-aes-256-gcm">2022-BLAKE3-AES-256-GCM</blake3-aes-256-gcm>
+					<aes-256-gcm>AES-256-GCM</aes-256-gcm>
+					<blake3-aes-128-gcm value="2022-blake3-aes-128-gcm">2022-BLAKE3-AES-128-GCM</blake3-aes-128-gcm>
+					<aes-128-gcm>AES-128-GCM</aes-128-gcm>
+					<blake3-chacha20-poly1305 value="2022-blake3-chacha20-poly1305">2022-BLAKE3-ChaCha20-Poly1305</blake3-chacha20-poly1305>
+					<blake3-chacha8-poly1305 value="2022-blake3-chacha8-poly1305">2022-BLAKE3-ChaCha8-Poly1305</blake3-chacha8-poly1305>
+					<chacha20-ietf-poly1305>ChaCha20-IETF-Poly1305</chacha20-ietf-poly1305>
+				</Secure>
+				<Deprecated>
+					<aes-256-cfb>AES-256-CFB</aes-256-cfb>
+					<aes-256-ctr>AES-256-CTR</aes-256-ctr>
+					<aes-192-cfb>AES-192-CFB</aes-192-cfb>
+					<aes-192-gcm>AES-192-GCM</aes-192-gcm>
+					<aes-192-ctr>AES-192-CTR</aes-192-ctr>
+					<aes-128-cfb>AES-128-CFB</aes-128-cfb>
+					<aes-128-ctr>AES-128-CTR</aes-128-ctr>
+				</Deprecated>				
+				<Insecure>				
+					<none>NONE (Plain)</none>
+				</Insecure>
             </OptionValues>
         </cipher>
         <tcpudpmode type="OptionField">

--- a/net/shadowsocks/src/opnsense/mvc/app/models/OPNsense/Shadowsocks/General.xml
+++ b/net/shadowsocks/src/opnsense/mvc/app/models/OPNsense/Shadowsocks/General.xml
@@ -28,7 +28,7 @@
         </localport>
         <password type="TextField"/>
         <cipher type="OptionField">
-            <Default>aes-256-cfb</Default>
+            <Default>aes-256-gcm</Default>
             <Required>Y</Required>
             <OptionValues>
                 <blake3-aes-256-gcm value="2022-blake3-aes-256-gcm">2022-BLAKE3-AES-256-GCM</blake3-aes-256-gcm>

--- a/net/shadowsocks/src/opnsense/mvc/app/models/OPNsense/Shadowsocks/General.xml
+++ b/net/shadowsocks/src/opnsense/mvc/app/models/OPNsense/Shadowsocks/General.xml
@@ -31,12 +31,12 @@
             <Default>aes-256-cfb</Default>
             <Required>Y</Required>
             <OptionValues>
-                <2022-blake3-aes-256-gcm>2022-BLAKE3-AES-256-GCM</2022-blake3-aes-256-gcm>
+                <blake3-aes-256-gcm value="2022-blake3-aes-256-gcm">2022-BLAKE3-AES-256-GCM</blake3-aes-256-gcm>
                 <aes-256-gcm>AES-256-GCM</aes-256-gcm>
-                <2022-blake3-aes-128-gcm>2022-BLAKE3-AES-128-GCM</2022-blake3-aes-128-gcm>
+				<blake3-aes-128-gcm value="2022-blake3-aes-128-gcm">2022-BLAKE3-AES-128-GCM</blake3-aes-128-gcm>
                 <aes-128-gcm>AES-128-GCM</aes-128-gcm>
-                <2022-blake3-chacha20-poly1305>2022-BLAKE3-ChaCha20-Poly1305</2022-blake3-chacha20-poly1305>
-                <2022-blake3-chacha8-poly1305>2022-BLAKE3-ChaCha8-Poly1305</2022-blake3-chacha8-poly1305>
+				<blake3-chacha20-poly1305 value="2022-blake3-chacha20-poly1305">2022-BLAKE3-ChaCha20-Poly1305</blake3-chacha20-poly1305>
+                <blake3-chacha8-poly1305 value="2022-blake3-chacha8-poly1305">2022-BLAKE3-ChaCha8-Poly1305</blake3-chacha8-poly1305>
                 <chacha20-ietf-poly1305>ChaCha20-IETF-Poly1305</chacha20-ietf-poly1305>
                 <none>NONE</none>
             </OptionValues>

--- a/net/shadowsocks/src/opnsense/mvc/app/models/OPNsense/Shadowsocks/General.xml
+++ b/net/shadowsocks/src/opnsense/mvc/app/models/OPNsense/Shadowsocks/General.xml
@@ -38,7 +38,6 @@
 				<blake3-chacha20-poly1305 value="2022-blake3-chacha20-poly1305">2022-BLAKE3-ChaCha20-Poly1305</blake3-chacha20-poly1305>
                 <blake3-chacha8-poly1305 value="2022-blake3-chacha8-poly1305">2022-BLAKE3-ChaCha8-Poly1305</blake3-chacha8-poly1305>
                 <chacha20-ietf-poly1305>ChaCha20-IETF-Poly1305</chacha20-ietf-poly1305>
-                <none>NONE (INSECURE)</none>
 				<aes-256-cfb>AES-256-CFB (DEPRECATED)</aes-256-cfb>
 				<aes-256-ctr>AES-256-CTR (DEPRECATED)</aes-256-ctr>
                 <aes-192-cfb>AES-192-CFB (DEPRECATED)</aes-192-cfb>
@@ -46,6 +45,7 @@
                 <aes-192-ctr>AES-192-CTR (DEPRECATED)</aes-192-ctr>
                 <aes-128-cfb>AES-128-CFB (DEPRECATED)</aes-128-cfb>
 				<aes-128-ctr>AES-128-CTR (DEPRECATED)</aes-128-ctr>
+				<none>NONE (INSECURE)</none>
             </OptionValues>
         </cipher>
         <tcpudpmode type="OptionField">

--- a/net/shadowsocks/src/opnsense/mvc/app/models/OPNsense/Shadowsocks/General.xml
+++ b/net/shadowsocks/src/opnsense/mvc/app/models/OPNsense/Shadowsocks/General.xml
@@ -39,6 +39,13 @@
                 <blake3-chacha8-poly1305 value="2022-blake3-chacha8-poly1305">2022-BLAKE3-ChaCha8-Poly1305</blake3-chacha8-poly1305>
                 <chacha20-ietf-poly1305>ChaCha20-IETF-Poly1305</chacha20-ietf-poly1305>
                 <none>NONE</none>
+				<aes-256-cfb>AES-256-CFB (DEPRECATED)</aes-256-cfb>
+				<aes-256-ctr>AES-256-CTR (DEPRECATED)</aes-256-ctr>
+                <aes-192-cfb>AES-192-CFB (DEPRECATED)</aes-192-cfb>
+                <aes-192-gcm>AES-192-GCM (DEPRECATED)</aes-192-gcm>
+                <aes-192-ctr>AES-192-CTR (DEPRECATED)</aes-192-ctr>
+                <aes-128-cfb>AES-128-CFB (DEPRECATED)</aes-128-cfb>
+				<aes-128-ctr>AES-128-CTR (DEPRECATED)</aes-128-ctr>
             </OptionValues>
         </cipher>
         <tcpudpmode type="OptionField">

--- a/net/shadowsocks/src/opnsense/mvc/app/models/OPNsense/Shadowsocks/Local.xml
+++ b/net/shadowsocks/src/opnsense/mvc/app/models/OPNsense/Shadowsocks/Local.xml
@@ -44,6 +44,13 @@
                 <blake3-chacha8-poly1305 value="2022-blake3-chacha8-poly1305">2022-BLAKE3-ChaCha8-Poly1305</blake3-chacha8-poly1305>
                 <chacha20-ietf-poly1305>ChaCha20-IETF-Poly1305</chacha20-ietf-poly1305>
                 <none>NONE</none>
+				<aes-256-cfb>AES-256-CFB (DEPRECATED)</aes-256-cfb>
+				<aes-256-ctr>AES-256-CTR (DEPRECATED)</aes-256-ctr>
+                <aes-192-cfb>AES-192-CFB (DEPRECATED)</aes-192-cfb>
+                <aes-192-gcm>AES-192-GCM (DEPRECATED)</aes-192-gcm>
+                <aes-192-ctr>AES-192-CTR (DEPRECATED)</aes-192-ctr>
+                <aes-128-cfb>AES-128-CFB (DEPRECATED)</aes-128-cfb>
+				<aes-128-ctr>AES-128-CTR (DEPRECATED)</aes-128-ctr>
             </OptionValues>
         </cipher>
     </items>

--- a/net/shadowsocks/src/opnsense/mvc/app/models/OPNsense/Shadowsocks/Local.xml
+++ b/net/shadowsocks/src/opnsense/mvc/app/models/OPNsense/Shadowsocks/Local.xml
@@ -36,12 +36,12 @@
             <Default>aes-256-gcm</Default>
             <Required>Y</Required>
             <OptionValues>
-                <2022-blake3-aes-256-gcm>2022-BLAKE3-AES-256-GCM</2022-blake3-aes-256-gcm>
+                <blake3-aes-256-gcm value="2022-blake3-aes-256-gcm">2022-BLAKE3-AES-256-GCM</blake3-aes-256-gcm>
                 <aes-256-gcm>AES-256-GCM</aes-256-gcm>
-                <2022-blake3-aes-128-gcm>2022-BLAKE3-AES-128-GCM</2022-blake3-aes-128-gcm>
+				<blake3-aes-128-gcm value="2022-blake3-aes-128-gcm">2022-BLAKE3-AES-128-GCM</blake3-aes-128-gcm>
                 <aes-128-gcm>AES-128-GCM</aes-128-gcm>
-                <2022-blake3-chacha20-poly1305>2022-BLAKE3-ChaCha20-Poly1305</2022-blake3-chacha20-poly1305>
-                <2022-blake3-chacha8-poly1305>2022-BLAKE3-ChaCha8-Poly1305</2022-blake3-chacha8-poly1305>
+				<blake3-chacha20-poly1305 value="2022-blake3-chacha20-poly1305">2022-BLAKE3-ChaCha20-Poly1305</blake3-chacha20-poly1305>
+                <blake3-chacha8-poly1305 value="2022-blake3-chacha8-poly1305">2022-BLAKE3-ChaCha8-Poly1305</blake3-chacha8-poly1305>
                 <chacha20-ietf-poly1305>ChaCha20-IETF-Poly1305</chacha20-ietf-poly1305>
                 <none>NONE</none>
             </OptionValues>

--- a/net/shadowsocks/src/opnsense/mvc/app/models/OPNsense/Shadowsocks/Local.xml
+++ b/net/shadowsocks/src/opnsense/mvc/app/models/OPNsense/Shadowsocks/Local.xml
@@ -33,7 +33,7 @@
         </localport>
         <password type="TextField"/>
         <cipher type="OptionField">
-            <Default>aes-256-cfb</Default>
+            <Default>aes-256-gcm</Default>
             <Required>Y</Required>
             <OptionValues>
                 <2022-blake3-aes-256-gcm>2022-BLAKE3-AES-256-GCM</2022-blake3-aes-256-gcm>

--- a/net/shadowsocks/src/opnsense/mvc/app/models/OPNsense/Shadowsocks/Local.xml
+++ b/net/shadowsocks/src/opnsense/mvc/app/models/OPNsense/Shadowsocks/Local.xml
@@ -36,16 +36,14 @@
             <Default>aes-256-cfb</Default>
             <Required>Y</Required>
             <OptionValues>
-                <aes-256-cfb>AES-256-CFB</aes-256-cfb>
+                <2022-blake3-aes-256-gcm>2022-BLAKE3-AES-256-GCM</2022-blake3-aes-256-gcm>
                 <aes-256-gcm>AES-256-GCM</aes-256-gcm>
-                <aes-256-ctr>AES-256-CTR</aes-256-ctr>
-                <aes-192-cfb>AES-192-CFB</aes-192-cfb>
-                <aes-192-gcm>AES-192-GCM</aes-192-gcm>
-                <aes-192-ctr>AES-192-CTR</aes-192-ctr>
-                <aes-128-cfb>AES-128-CFB</aes-128-cfb>
+                <2022-blake3-aes-128-gcm>2022-BLAKE3-AES-128-GCM</2022-blake3-aes-128-gcm>
                 <aes-128-gcm>AES-128-GCM</aes-128-gcm>
-                <aes-128-ctr>AES-128-CTR</aes-128-ctr>
+                <2022-blake3-chacha20-poly1305>2022-BLAKE3-ChaCha20-Poly1305</2022-blake3-chacha20-poly1305>
+                <2022-blake3-chacha8-poly1305>2022-BLAKE3-ChaCha8-Poly1305</2022-blake3-chacha8-poly1305>
                 <chacha20-ietf-poly1305>ChaCha20-IETF-Poly1305</chacha20-ietf-poly1305>
+                <none>NONE</none>
             </OptionValues>
         </cipher>
     </items>

--- a/net/shadowsocks/src/opnsense/mvc/app/models/OPNsense/Shadowsocks/Local.xml
+++ b/net/shadowsocks/src/opnsense/mvc/app/models/OPNsense/Shadowsocks/Local.xml
@@ -43,7 +43,6 @@
 				<blake3-chacha20-poly1305 value="2022-blake3-chacha20-poly1305">2022-BLAKE3-ChaCha20-Poly1305</blake3-chacha20-poly1305>
                 <blake3-chacha8-poly1305 value="2022-blake3-chacha8-poly1305">2022-BLAKE3-ChaCha8-Poly1305</blake3-chacha8-poly1305>
                 <chacha20-ietf-poly1305>ChaCha20-IETF-Poly1305</chacha20-ietf-poly1305>
-                <none>NONE (INSECURE)</none>
 				<aes-256-cfb>AES-256-CFB (DEPRECATED)</aes-256-cfb>
 				<aes-256-ctr>AES-256-CTR (DEPRECATED)</aes-256-ctr>
                 <aes-192-cfb>AES-192-CFB (DEPRECATED)</aes-192-cfb>
@@ -51,6 +50,7 @@
                 <aes-192-ctr>AES-192-CTR (DEPRECATED)</aes-192-ctr>
                 <aes-128-cfb>AES-128-CFB (DEPRECATED)</aes-128-cfb>
 				<aes-128-ctr>AES-128-CTR (DEPRECATED)</aes-128-ctr>
+				<none>NONE (INSECURE)</none>
             </OptionValues>
         </cipher>
     </items>

--- a/net/shadowsocks/src/opnsense/mvc/app/models/OPNsense/Shadowsocks/Local.xml
+++ b/net/shadowsocks/src/opnsense/mvc/app/models/OPNsense/Shadowsocks/Local.xml
@@ -36,14 +36,14 @@
             <Default>aes-256-gcm</Default>
             <Required>Y</Required>
             <OptionValues>
-                <blake3-aes-256-gcm value="2022-blake3-aes-256-gcm">2022-BLAKE3-AES-256-GCM</blake3-aes-256-gcm>
+				<blake3-aes-256-gcm value="2022-blake3-aes-256-gcm">2022-BLAKE3-AES-256-GCM</blake3-aes-256-gcm>
                 <aes-256-gcm>AES-256-GCM</aes-256-gcm>
 				<blake3-aes-128-gcm value="2022-blake3-aes-128-gcm">2022-BLAKE3-AES-128-GCM</blake3-aes-128-gcm>
                 <aes-128-gcm>AES-128-GCM</aes-128-gcm>
 				<blake3-chacha20-poly1305 value="2022-blake3-chacha20-poly1305">2022-BLAKE3-ChaCha20-Poly1305</blake3-chacha20-poly1305>
                 <blake3-chacha8-poly1305 value="2022-blake3-chacha8-poly1305">2022-BLAKE3-ChaCha8-Poly1305</blake3-chacha8-poly1305>
                 <chacha20-ietf-poly1305>ChaCha20-IETF-Poly1305</chacha20-ietf-poly1305>
-                <none>NONE</none>
+                <none>NONE (INSECURE)</none>
 				<aes-256-cfb>AES-256-CFB (DEPRECATED)</aes-256-cfb>
 				<aes-256-ctr>AES-256-CTR (DEPRECATED)</aes-256-ctr>
                 <aes-192-cfb>AES-192-CFB (DEPRECATED)</aes-192-cfb>

--- a/net/shadowsocks/src/opnsense/mvc/app/models/OPNsense/Shadowsocks/Local.xml
+++ b/net/shadowsocks/src/opnsense/mvc/app/models/OPNsense/Shadowsocks/Local.xml
@@ -36,21 +36,27 @@
             <Default>aes-256-gcm</Default>
             <Required>Y</Required>
             <OptionValues>
-				<blake3-aes-256-gcm value="2022-blake3-aes-256-gcm">2022-BLAKE3-AES-256-GCM</blake3-aes-256-gcm>
-                <aes-256-gcm>AES-256-GCM</aes-256-gcm>
-				<blake3-aes-128-gcm value="2022-blake3-aes-128-gcm">2022-BLAKE3-AES-128-GCM</blake3-aes-128-gcm>
-                <aes-128-gcm>AES-128-GCM</aes-128-gcm>
-				<blake3-chacha20-poly1305 value="2022-blake3-chacha20-poly1305">2022-BLAKE3-ChaCha20-Poly1305</blake3-chacha20-poly1305>
-                <blake3-chacha8-poly1305 value="2022-blake3-chacha8-poly1305">2022-BLAKE3-ChaCha8-Poly1305</blake3-chacha8-poly1305>
-                <chacha20-ietf-poly1305>ChaCha20-IETF-Poly1305</chacha20-ietf-poly1305>
-				<aes-256-cfb>AES-256-CFB (DEPRECATED)</aes-256-cfb>
-				<aes-256-ctr>AES-256-CTR (DEPRECATED)</aes-256-ctr>
-                <aes-192-cfb>AES-192-CFB (DEPRECATED)</aes-192-cfb>
-                <aes-192-gcm>AES-192-GCM (DEPRECATED)</aes-192-gcm>
-                <aes-192-ctr>AES-192-CTR (DEPRECATED)</aes-192-ctr>
-                <aes-128-cfb>AES-128-CFB (DEPRECATED)</aes-128-cfb>
-				<aes-128-ctr>AES-128-CTR (DEPRECATED)</aes-128-ctr>
-				<none>NONE (INSECURE)</none>
+				<Secure>
+					<blake3-aes-256-gcm value="2022-blake3-aes-256-gcm">2022-BLAKE3-AES-256-GCM</blake3-aes-256-gcm>
+					<aes-256-gcm>AES-256-GCM</aes-256-gcm>
+					<blake3-aes-128-gcm value="2022-blake3-aes-128-gcm">2022-BLAKE3-AES-128-GCM</blake3-aes-128-gcm>
+					<aes-128-gcm>AES-128-GCM</aes-128-gcm>
+					<blake3-chacha20-poly1305 value="2022-blake3-chacha20-poly1305">2022-BLAKE3-ChaCha20-Poly1305</blake3-chacha20-poly1305>
+					<blake3-chacha8-poly1305 value="2022-blake3-chacha8-poly1305">2022-BLAKE3-ChaCha8-Poly1305</blake3-chacha8-poly1305>
+					<chacha20-ietf-poly1305>ChaCha20-IETF-Poly1305</chacha20-ietf-poly1305>
+				</Secure>
+				<Deprecated>
+					<aes-256-cfb>AES-256-CFB</aes-256-cfb>
+					<aes-256-ctr>AES-256-CTR</aes-256-ctr>
+					<aes-192-cfb>AES-192-CFB</aes-192-cfb>
+					<aes-192-gcm>AES-192-GCM</aes-192-gcm>
+					<aes-192-ctr>AES-192-CTR</aes-192-ctr>
+					<aes-128-cfb>AES-128-CFB</aes-128-cfb>
+					<aes-128-ctr>AES-128-CTR</aes-128-ctr>
+				</Deprecated>				
+				<Insecure>				
+					<none>NONE (Plain)</none>
+				</Insecure>
             </OptionValues>
         </cipher>
     </items>


### PR DESCRIPTION
**PR objective:**
This PR is to align the OPNSense WEB UI cipher list for ShadowSocks with the cipher list of the plugin.
https://github.com/shadowsocks/shadowsocks-rust?tab=readme-ov-file#supported-ciphers

Some deprecated cipher were removed, new one added.

edit: this PR works now, thanks to @Monviech tip.
