### PR TITLE
userprovision: add API-only user provisioning plugin

### DIFF
--- a/security/userprovision/Makefile
+++ b/security/userprovision/Makefile
@@ -1,0 +1,6 @@
+PLUGIN_NAME=		userprovision
+PLUGIN_VERSION=		0.1.0
+PLUGIN_COMMENT=	Headless user/group/RADIUS provisioning API
+PLUGIN_MAINTAINER=	admin@example.com
+
+.include "../../Mk/plugins.mk"

--- a/security/userprovision/Makefile
+++ b/security/userprovision/Makefile
@@ -1,6 +1,6 @@
 PLUGIN_NAME=		userprovision
 PLUGIN_VERSION=		0.1.0
 PLUGIN_COMMENT=	Headless user/group/RADIUS provisioning API
-PLUGIN_MAINTAINER=	admin@example.com
+PLUGIN_MAINTAINER=	omer.rencber.de@gmail.com
 
 .include "../../Mk/plugins.mk"

--- a/security/userprovision/README.md
+++ b/security/userprovision/README.md
@@ -1,0 +1,255 @@
+# OPNsense User Provisioning (userprovision)
+
+Headless API to upsert Users, Groups, external RADIUS servers and query logs (DHCP/access).
+
+
+
+
+## API
+- POST /api/userprovision/group/ensure
+  - name
+- GET  /api/userprovision/group/list
+- POST /api/userprovision/group/delete
+  - name
+- POST /api/userprovision/user/upsert
+  - username, full_name?, password?, groups[]?
+- GET  /api/userprovision/user/list
+- POST /api/userprovision/user/delete
+  - username
+- POST /api/userprovision/user/disable
+  - username
+- POST /api/userprovision/user/enable
+  - username
+- POST /api/userprovision/user/setpassword
+  - username, password
+- POST /api/userprovision/radiusserver/upsert
+  - name, host, secret, services?, auth_port?, acct_port?, timeout?, stationid?, descr?, sync_memberof?, sync_create_local_users?, sync_memberof_groups[]?, sync_default_groups[]?
+- GET  /api/userprovision/radiusserver/list
+- POST /api/userprovision/radiusserver/delete
+  - name
+- POST /api/userprovision/dhcp/upsert
+  - iface, mac, ipaddr, descr?
+- POST /api/userprovision/dhcp/apply
+  - restart dhcpd to apply static-map changes
+- GET  /api/userprovision/logs/dhcp
+  - user?, limit?, q?, since?(RFC822), until?(RFC822), format?=json|csv
+- GET  /api/userprovision/logs/access
+  - user?, limit?, q?, since?(RFC822), until?(RFC822), format?=json|csv
+
+### Captive Portal (CP) endpoints
+- POST /api/userprovision/cp/zone/ensure
+  - name, description?, interfaces[]
+- GET  /api/userprovision/cp/zone/get
+  - zone
+- POST /api/userprovision/cp/zone/auth
+  - zone, method=radius|local, server (required if method=radius)
+- POST /api/userprovision/cp/zone/accounting
+  - zone, enabled=true|false, interval?=300 (numeric)
+- POST /api/userprovision/cp/zone/enable
+  - zone, enabled=true|false
+- POST /api/userprovision/cp/bypass/set
+  - zone, ip? or mac?, enabled=true|false  (duplicate ip/mac entries are not added)
+- POST /api/userprovision/cp/apply
+  - restart captiveportal
+
+Validation (CP):
+- interfaces[]: interface name is validated; duplicates are not added
+- auth: if method=radius, server name must exist and type=radius
+- accounting interval: numeric
+- bypass: ip/mac format is validated; duplicate allowed_ip/allowed_mac entries are not added
+
+### Generic login (optional, alternative UI)
+- POST /api/userprovision/auth/login
+  - server=<authserver name>, username, password
+  - Note: Returns Access‑Accept/Reject information; does not open a CP session.
+
+## Settings
+ The plugin does not maintain a separate runtime database; it relies on config (static-map), CP/RADIUS sessions, and logs.
+  “Dynamic” leases without a static-map can be seen via logs; for full and persistent tracking, create a static-map for the user's device.
+  If your log paths differ, set the settings.dhcpLogPath/accessLogPath values accordingly.
+- GET  /api/userprovision/settings/get
+- POST /api/userprovision/settings/set (JSON body)
+  - settings.dhcpLogPath: default `/var/log/dhcpd.log`
+  - settings.accessLogPath: default `/var/log/system.log`
+  - settings.auditLogPath: default `/var/log/userprovision_audit.log`
+
+## RADIUS Server API Details
+
+### Required Fields (required)
+- **name**: Descriptive name (3-64 chars, letters/digits/._-)
+- **host**: Hostname or IP address (valid IP or RFC compliant hostname)
+- **secret**: Shared Secret (not empty)
+
+### Optional Fields (optional)
+- **services**: "both" (Auth+Accounting) or "auth" (Auth only). Default: "both"
+- **auth_port**: Authentication port. Default: 1812
+- **acct_port**: Accounting port. Default: 1813
+- **timeout**: Authentication timeout in seconds. Default: 5
+- **stationid**: Called Station ID (MAC:SSID format)
+- **descr**: Description text
+- **sync_memberof**: Synchronize groups (boolean)
+- **sync_create_local_users**: Automatic user creation (boolean)
+- **sync_memberof_groups**: Limit groups array (group names)
+- **sync_default_groups**: Default groups array (group names)
+
+### Examples
+
+# Create new RADIUS server (upsert = insert + update)
+curl -u KEY:SECRET -d 'name=TestRADIUS&host=10.0.0.5&secret=mysecret' \
+  http://fw/api/userprovision/radiusserver/upsert
+# Returns: {"status":"ok","created":true}
+
+# Update existing RADIUS server (same endpoint, automatically detects existing)
+curl -u KEY:SECRET -d 'name=TestRADIUS&host=10.0.0.6&timeout=20' \
+  http://fw/api/userprovision/radiusserver/upsert
+# Returns: {"status":"ok","created":false}
+
+# Full RADIUS configuration (you can extend the code to support all fields as needed)
+curl -u KEY:SECRET -d 'name=FullRADIUS&host=radius.company.com&secret=strongsecret&services=both&auth_port=1812&acct_port=1813&timeout=10&stationid=00:11:22:33:44:55:company.com&descr=Company RADIUS&sync_memberof=1&sync_create_local_users=1&sync_default_groups=adminsapi_users' \
+  http://fw/api/userprovision/radiusserver/upsert
+
+# Partial update (only change timeout) - upsert handles edit automatically
+curl -u KEY:SECRET -d 'name=TestRADIUS&timeout=15' \
+  http://fw/api/userprovision/radiusserver/upsert
+
+# List all RADIUS servers
+curl -u KEY:SECRET http://fw/api/userprovision/radiusserver/list
+
+# Delete server
+curl -u KEY:SECRET -d 'name=TestRADIUS' \
+  http://fw/api/userprovision/radiusserver/delete
+
+
+## Validation rules
+- username/group name: 3–64 chars; letters, digits, `._-`
+- password: min 8 chars; upper, lower, digit, special
+- iface: 2–32 chars; letters/digits `._-`
+- mac: `aa:bb:cc:dd:ee:ff`
+- ipaddr: IPv4/IPv6 (filter_var)
+- host: IP or RFC-compliant hostname
+- timeout: numeric and positive
+- services: "both" or "auth"
+
+## RBAC / API key
+1) System → Access → Users → (API user) → Generate API key/secret
+2) Effective Privileges → Add privilege for api/userprovision/*
+3) Call endpoints with -u KEY:SECRET
+
+## Audit log
+This plugin writes a concise audit trail to `/var/log/userprovision_audit.log` (path configurable in settings).
+
+## End-to-end flow (National ID - TCKN)
+
+# 1) Add external RADIUS server to the firewall (one-time)
+curl -u KEY:SECRET -d 'name=ext-rad&host=10.0.0.5&secret=XXXX&auth_port=1812&acct_port=1813' \
+  http://fw/api/userprovision/radiusserver/upsert
+
+# 2) Create Captive Portal zone and assign RADIUS
+curl -u KEY:SECRET -d 'name=ZONE1&interfaces[]=lan' http://fw/api/userprovision/cp/zone/ensure
+curl -u KEY:SECRET -d 'zone=ZONE1&method=radius&server=ext-rad' http://fw/api/userprovision/cp/zone/auth
+curl -u KEY:SECRET -d 'zone=ZONE1&enabled=true' http://fw/api/userprovision/cp/zone/enable
+curl -u KEY:SECRET -X POST http://fw/api/userprovision/cp/apply
+
+# 3) At registration time (National ID)
+curl -u KEY:SECRET -d 'name=GUEST' http://fw/api/userprovision/group/ensure
+curl -u KEY:SECRET -d 'username=12345678901&full_name=John%20Doe&groups[]=GUEST' \
+  http://fw/api/userprovision/user/upsert
+
+# 4) (Optional) CP bypass or DHCP static-map
+curl -u KEY:SECRET -d 'zone=ZONE1&mac=aa:bb:cc:dd:ee:ff&enabled=true' \
+  http://fw/api/userprovision/cp/bypass/set
+curl -u KEY:SECRET -d 'iface=lan&mac=aa:bb:cc:dd:ee:ff&ipaddr=10.0.10.25&descr=12345678901' \
+  http://fw/api/userprovision/dhcp/upsert
+curl -u KEY:SECRET -X POST http://fw/api/userprovision/dhcp/apply
+
+# 5) Logs
+curl -u KEY:SECRET 'http://fw/api/userprovision/logs/dhcp?user=12345678901&limit=200'
+curl -u KEY:SECRET 'http://fw/api/userprovision/logs/access?user=12345678901&limit=200'
+
+
+## Examples
+
+# group ensure
+curl -u KEY:SECRET -d 'name=VIP' http://fw/api/userprovision/group/ensure
+
+# user upsert
+curl -u KEY:SECRET -d 'username=12345678901&full_name=John%20Doe&groups[]=VIP' \
+  http://fw/api/userprovision/user/upsert
+
+# external RADIUS
+curl -u KEY:SECRET -d 'name=ext-rad&host=10.0.0.5&secret=XXXX&descr=External' \
+  http://fw/api/userprovision/radiusserver/upsert
+
+# dhcp static map + apply
+curl -u KEY:SECRET -d 'iface=lan&mac=aa:bb:cc:dd:ee:ff&ipaddr=10.0.10.25&descr=12345678901' \
+  http://fw/api/userprovision/dhcp/upsert
+curl -u KEY:SECRET -X POST http://fw/api/userprovision/dhcp/apply
+
+# logs with filters
+curl -u KEY:SECRET 'http://fw/api/userprovision/logs/dhcp?user=12345678901&q=lease&since=2025-09-25T00:00:00Z&format=csv'
+# read settings
+curl -u KEY:SECRET http://fw/api/userprovision/settings/get
+
+# change dhcp log path
+curl -u KEY:SECRET -H 'Content-Type: application/json' \
+  -d '{"settings":{"dhcpLogPath":"/var/log/dhcpd.log"}}' \
+  http://fw/api/userprovision/settings/set
+
+
+curl -u KEY:SECRET -d 'username=12345678901' http://fw/api/userprovision/user/disable
+curl -u KEY:SECRET -d 'username=12345678901' http://fw/api/userprovision/user/enable
+curl -u KEY:SECRET -d 'username=12345678901&password=StrongPass#1' http://fw/api/userprovision/user/setpassword
+
+curl -u KEY:SECRET http://fw/api/userprovision/radiusserver/list
+curl -u KEY:SECRET -d 'name=ext-rad' http://fw/api/userprovision/radiusserver/delete
+
+
+# list
+curl -u KEY:SECRET http://fw/api/userprovision/user/list
+curl -u KEY:SECRET http://fw/api/userprovision/group/list
+
+# delete
+curl -u KEY:SECRET -d 'username=12345678901' http://fw/api/userprovision/user/delete
+curl -u KEY:SECRET -d 'name=VIP' http://fw/api/userprovision/group/delete
+
+
+ DHCP static map
+curl -u KEY:SECRET -d 'iface=lan&mac=aa:bb:cc:dd:ee:ff&ipaddr=10.0.10.25&descr=12345678901' \
+  http://fw/api/userprovision/dhcp/upsert
+
+# RADIUS server (with descr)
+curl -u KEY:SECRET -d 'name=ext-rad&host=10.0.0.5&secret=XXXX&descr=External Radius' \
+  http://fw/api/userprovision/radiusserver/upsert
+
+# Logs with filters and CSV
+curl -u KEY:SECRET 'http://fw/api/userprovision/logs/dhcp?user=12345678901&q=lease&since=2025-09-25T00:00:00Z&format=csv'
+curl -u KEY:SECRET 'http://fw/api/userprovision/logs/access?user=12345678901&limit=500&format=json'
+
+# DHCP static-map
+curl -u KEY:SECRET -d 'iface=lan&mac=aa:bb:cc:dd:ee:ff&ipaddr=10.0.10.25&descr=12345678901' \
+  http://fw/api/userprovision/dhcp/upsert
+
+# RADIUS server
+curl -u KEY:SECRET -d 'name=ext-rad&host=10.0.0.5&secret=XXXX' \
+  http://fw/api/userprovision/radiusserver/upsert
+
+# Logs
+curl -u KEY:SECRET 'http://fw/api/userprovision/logs/dhcp?user=12345678901&limit=200'
+curl -u KEY:SECRET 'http://fw/api/userprovision/logs/access?user=12345678901&limit=200'
+
+# group
+curl -u KEY:SECRET -d 'name=VIP' http://fw/api/userprovision/group/ensure
+
+# user (National ID or another ID) and group assignment
+curl -u KEY:SECRET -d 'username=12345678901&full_name=John%20Doe&groups[]=VIP' \
+  http://fw/api/userprovision/user/upsert
+
+# external RADIUS record
+curl -u KEY:SECRET -d 'name=ext-rad&host=10.0.0.5&secret=XXXX&auth_port=1812&acct_port=1813&timeout=5' \
+  http://fw/api/userprovision/radiusserver/upsert
+
+# logs
+curl -u KEY:SECRET 'http://fw/api/userprovision/logs/dhcp?user=12345678901&limit=300'
+curl -u KEY:SECRET 'http://fw/api/userprovision/logs/access?user=12345678901&limit=300'
+
+

--- a/security/userprovision/pkg-descr
+++ b/security/userprovision/pkg-descr
@@ -1,0 +1,1 @@
+OPNsense plugin providing headless APIs to provision Users, Groups, external RADIUS servers, DHCP static maps, and retrieve access/DHCP logs with auditing.

--- a/security/userprovision/src/opnsense/mvc/app/controllers/OPNsense/UserProvision/Api/AuditTrait.php
+++ b/security/userprovision/src/opnsense/mvc/app/controllers/OPNsense/UserProvision/Api/AuditTrait.php
@@ -1,0 +1,14 @@
+<?php
+namespace OPNsense\UserProvision\Api;
+
+trait AuditTrait
+{
+    protected function audit(string $action, array $data = []): void
+    {
+        $path = '/var/log/userprovision_audit.log';
+        $line = date('c') . ' userprovision ' . $action . ' ' . json_encode($data);
+        @file_put_contents($path, $line . "\n", FILE_APPEND | LOCK_EX);
+    }
+}
+
+

--- a/security/userprovision/src/opnsense/mvc/app/controllers/OPNsense/UserProvision/Api/AuthController.php
+++ b/security/userprovision/src/opnsense/mvc/app/controllers/OPNsense/UserProvision/Api/AuthController.php
@@ -1,0 +1,61 @@
+<?php
+namespace OPNsense\UserProvision\Api;
+
+use OPNsense\Base\ApiControllerBase;
+use OPNsense\Core\Config;
+
+class AuthController extends ApiControllerBase
+{
+    use AuditTrait;
+    use ValidationTrait;
+
+    /**
+     * Generic RADIUS login proxy for alternative UIs (does not open CP session)
+     * Params: server (authserver name), username, password
+     */
+    public function loginAction(): array
+    {
+        $p = $this->request->getPost() ?: $this->request->get();
+        $serverName = trim((string)($p['server'] ?? ''));
+        $username = trim((string)($p['username'] ?? ''));
+        $password = (string)($p['password'] ?? '');
+        if ($serverName === '' || $username === '' || $password === '') {
+            return ['status'=>'error','message'=>'missing server/username/password'];
+        }
+        $cfg = Config::getInstance()->object();
+        $srvConf = null;
+        foreach ((array)($cfg->system->authserver ?? []) as $srv) {
+            if ((string)($srv->name ?? '') === $serverName && (string)($srv->type ?? '') === 'radius') { $srvConf = $srv; break; }
+        }
+        if ($srvConf === null) { return ['status'=>'error','message'=>'radius server not found']; }
+        $host = (string)($srvConf->host ?? '');
+        $secret = (string)($srvConf->secret ?? '');
+        $authPort = (string)($srvConf->auth_port ?? '1812');
+        if ($host === '' || $secret === '') { return ['status'=>'error','message'=>'invalid radius config']; }
+
+        // Use radclient if available
+        $cmd = '/usr/bin/env radclient';
+        @exec('which radclient 2>/dev/null', $outWhich, $rcWhich);
+        if ($rcWhich !== 0) { $cmd = '/usr/local/bin/radclient'; }
+        @exec('which ' . escapeshellarg($cmd) . ' 2>/dev/null', $dummy, $rcExist);
+        if ($rcExist !== 0) {
+            return ['status'=>'error','message'=>'radclient not available on system'];
+        }
+        $packet = "User-Name=$username\nUser-Password=$password\n";
+        $target = escapeshellarg($host . ':' . $authPort);
+        $secretArg = escapeshellarg($secret);
+        $descriptorspec = [0 => ['pipe','r'], 1 => ['pipe','w'], 2 => ['pipe','w']];
+        $proc = @proc_open($cmd . ' -x ' . $target . ' auth ' . $secretArg, $descriptorspec, $pipes);
+        if (!is_resource($proc)) { return ['status'=>'error','message'=>'failed to run radclient']; }
+        fwrite($pipes[0], $packet);
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]); fclose($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]); fclose($pipes[2]);
+        $rc = proc_close($proc);
+        $ok = (strpos($stdout . $stderr, 'Access-Accept') !== false);
+        $this->audit('auth.login', ['server'=>$serverName,'username'=>$username,'result'=>$ok?'accept':'reject']);
+        return ['status'=>$ok?'ok':'reject','output'=>$stdout];
+    }
+}
+
+

--- a/security/userprovision/src/opnsense/mvc/app/controllers/OPNsense/UserProvision/Api/CpController.php
+++ b/security/userprovision/src/opnsense/mvc/app/controllers/OPNsense/UserProvision/Api/CpController.php
@@ -1,0 +1,369 @@
+<?php
+namespace OPNsense\UserProvision\Api;
+
+use OPNsense\Base\ApiControllerBase;
+use OPNsense\Core\Config;
+
+class CpController extends ApiControllerBase
+{
+    use AuditTrait;
+    use ValidationTrait;
+
+    private function getCpNode()
+    {
+        $cfg = Config::getInstance()->object();
+        if (!isset($cfg->captiveportal)) { $cfg->addChild('captiveportal'); }
+        return $cfg->captiveportal;
+    }
+
+    private function getOpnsenseCpNode()
+    {
+        $cfg = Config::getInstance()->object();
+        if (!isset($cfg->OPNsense)) { $cfg->addChild('OPNsense'); }
+        if (!isset($cfg->OPNsense->captiveportal)) { $cfg->OPNsense->addChild('captiveportal'); }
+        if (!isset($cfg->OPNsense->captiveportal->zones)) { $cfg->OPNsense->captiveportal->addChild('zones'); }
+        return $cfg->OPNsense->captiveportal;
+    }
+
+    private function findZone($cp, string $zone)
+    {
+        if (!isset($cp->zone)) { return null; }
+        foreach ($cp->zone as $z) {
+            if ((string)($z->name ?? '') === $zone) { return $z; }
+        }
+        return null;
+    }
+
+    private function findOpnZone($opn, string $zone)
+    {
+        if (!isset($opn->zones) || !isset($opn->zones->zone)) { return null; }
+        foreach ($opn->zones->zone as $z) {
+            if ((string)($z->name ?? '') === $zone) { return $z; }
+        }
+        return null;
+    }
+
+    private function authServerExists(string $name): bool
+    {
+        $configArray = \OPNsense\Core\Config::getInstance()->toArray();
+        $authServers = $configArray['system']['authserver'] ?? [];
+        
+        // Ensure it's an array (might be single element)
+        if (!is_array($authServers)) {
+            $authServers = [$authServers];
+        }
+        
+        foreach ($authServers as $srv) {
+            if (($srv['name'] ?? '') === $name && ($srv['type'] ?? '') === 'radius') { 
+                return true; 
+            }
+        }
+        return false;
+    }
+
+    public function zoneEnsureAction(): array
+    {
+        $p = $this->request->getPost() ?: $this->request->get();
+        $name = trim((string)($p['name'] ?? ''));
+        $description = trim((string)($p['description'] ?? ''));
+        $ifaces = isset($p['interfaces']) ? (array)$p['interfaces'] : [];
+        if ($name === '') { return ['status'=>'error','message'=>'missing name']; }
+        $cp = $this->getCpNode();
+        $opn = $this->getOpnsenseCpNode();
+        $z = $this->findZone($cp, $name);
+        $zo = $this->findOpnZone($opn, $name);
+        if ($z === null) {
+            $z = $cp->addChild('zone');
+            $z->addChild('name', $name);
+            if ($description !== '') { $z->addChild('descr', $description); }
+            // assign numeric zoneid expected by UI if absent
+            $maxId = 0;
+            if (isset($cp->zone)) {
+                foreach ($cp->zone as $zz) {
+                    $maxId = max($maxId, (int)((string)($zz->zoneid ?? '0')));
+                }
+            }
+            $z->addChild('zoneid', (string)($maxId + 1));
+            if (!empty($ifaces)) {
+                $seen = [];
+                foreach ($ifaces as $ifn) {
+                    $ifn = (string)$ifn;
+                    if ($this->isValidIface($ifn) && !isset($seen[$ifn])) { $z->addChild('interface', $ifn); $seen[$ifn] = true; }
+                }
+            }
+
+            // optional advanced fields on create (legacy)
+            $enabledIn = (string)($p['enabled'] ?? '');
+            if ($enabledIn !== '') { $z->addChild('enable', ((string)$enabledIn ? '1' : '0')); }
+            if (!empty($p['zoneid']) && ctype_digit((string)$p['zoneid'])) { $z->zoneid = (string)$p['zoneid']; }
+            if (!empty($p['hostname'])) { $z->addChild('hostname', (string)$p['hostname']); }
+            if (!empty($p['template'])) { $z->addChild('template', (string)$p['template']); }
+            if (!empty($p['idle_timeout'])) { $z->addChild('idle_timeout', (string)$p['idle_timeout']); }
+            if (!empty($p['hard_timeout'])) { $z->addChild('hard_timeout', (string)$p['hard_timeout']); }
+            if (!empty($p['concurrent_logins'])) { $z->addChild('concurrent_logins', (string)$p['concurrent_logins']); }
+            if (isset($p['enforce_local_group'])) { $z->addChild('enforce_local_group', ((string)$p['enforce_local_group'] ? '1' : '0')); }
+            // allowed lists (legacy)
+            $allowedAddrs = $p['allowed_addresses'] ?? [];
+            if (!is_array($allowedAddrs)) { $allowedAddrs = strlen((string)$allowedAddrs) ? [ (string)$allowedAddrs ] : []; }
+            foreach ($allowedAddrs as $addr) { $addr = trim((string)$addr); if ($addr!=='') { $z->addChild('allowed_ip', $addr); } }
+            $allowedMacs = $p['allowed_macs'] ?? [];
+            if (!is_array($allowedMacs)) { $allowedMacs = strlen((string)$allowedMacs) ? [ (string)$allowedMacs ] : []; }
+            foreach ($allowedMacs as $mac) { $mac = trim((string)$mac); if ($mac!=='') { $z->addChild('allowed_mac', $mac); } }
+
+            // OPNsense tree (use description tag, not descr)
+            if ($zo === null) {
+                $zo = $opn->zones->addChild('zone');
+                $zo->addChild('name', $name);
+                if ($description !== '') { $zo->addChild('description', $description); $zo->addChild('descr', $description); }
+                $zo->addChild('zoneid', (string)$z->zoneid);
+                $zo->addChild('enabled', '0');
+                $zo->addChild('authmethod', 'local');
+                $zo->addChild('accounting', '0');
+                $zo->addChild('accounting_interval', '');
+                $ifsNode = $zo->addChild('interfaces');
+                if (!empty($ifaces)) {
+                    $seen2 = [];
+                    foreach ($ifaces as $ifn) {
+                        $ifn = (string)$ifn;
+                        if ($this->isValidIface($ifn) && !isset($seen2[$ifn])) { $ifsNode->addChild('interface', $ifn); $seen2[$ifn] = true; }
+                    }
+                }
+                if ($enabledIn !== '') { $zo->enabled = ((string)$enabledIn ? '1' : '0'); }
+                if (!empty($p['zoneid']) && ctype_digit((string)$p['zoneid'])) { $zo->zoneid = (string)$p['zoneid']; }
+                if (!empty($p['hostname'])) { $zo->addChild('hostname', (string)$p['hostname']); }
+                if (!empty($p['template'])) { $zo->addChild('template', (string)$p['template']); }
+                if (!empty($p['idle_timeout'])) { $zo->addChild('idle_timeout', (string)$p['idle_timeout']); $zo->addChild('idletimeout', (string)$p['idle_timeout']); }
+                if (!empty($p['hard_timeout'])) { $zo->addChild('hard_timeout', (string)$p['hard_timeout']); $zo->addChild('hardtimeout', (string)$p['hard_timeout']); }
+                if (!empty($p['concurrent_logins'])) { $zo->addChild('concurrent_logins', (string)$p['concurrent_logins']); $zo->addChild('concurrentlogins', (string)$p['concurrent_logins']); }
+                if (isset($p['certificate'])) { $zo->addChild('certificate', (string)$p['certificate']); }
+                if (isset($p['enforce_local_group'])) { $zo->addChild('enforce_local_group', ((string)$p['enforce_local_group'] ? '1' : '0')); }
+                if (!empty($p['local_groups'])) {
+                    $lg = is_array($p['local_groups']) ? $p['local_groups'] : [ (string)$p['local_groups'] ];
+                    $lgNode = $zo->addChild('local_groups');
+                    foreach ($lg as $g) { $g = trim((string)$g); if ($g!=='') { $lgNode->addChild('group', $g); } }
+                }
+                if (!empty($allowedAddrs)) {
+                    $aaNode = $zo->addChild('allowed_addresses');
+                    foreach ($allowedAddrs as $addr) { $addr = trim((string)$addr); if ($addr!=='') { $aaNode->addChild('address', $addr); } }
+                }
+                if (!empty($allowedMacs)) {
+                    $amNode = $zo->addChild('allowed_macs');
+                    foreach ($allowedMacs as $mac) { $mac = trim((string)$mac); if ($mac!=='') { $amNode->addChild('mac', $mac); } }
+                }
+            }
+            Config::getInstance()->save();
+            $this->audit('cp.zone.ensure', ['name'=>$name,'created'=>true]);
+            return ['status'=>'ok','created'=>true];
+        }
+        // update
+        if ($description !== '') { $z->descr = $description; }
+        if (!isset($zo)) { $zo = $this->findOpnZone($opn, $name); }
+        if ($zo && $description !== '') { $zo->description = $description; $zo->descr = $description; }
+        if (!isset($z->zoneid) || (string)$z->zoneid === '') {
+            $maxId = 0;
+            if (isset($cp->zone)) {
+                foreach ($cp->zone as $zz) {
+                    $maxId = max($maxId, (int)((string)($zz->zoneid ?? '0')));
+                }
+            }
+            $z->zoneid = (string)($maxId + 1);
+            if ($zo) { $zo->zoneid = (string)$z->zoneid; }
+        }
+        if (!empty($ifaces)) {
+            unset($z->interface);
+            $seen = [];
+            foreach ($ifaces as $ifn) {
+                $ifn = (string)$ifn;
+                if ($this->isValidIface($ifn) && !isset($seen[$ifn])) { $z->addChild('interface', $ifn); $seen[$ifn] = true; }
+            }
+            if ($zo) {
+                if (isset($zo->interfaces)) { unset($zo->interfaces); }
+                $ifsNode = $zo->addChild('interfaces');
+                $seen2 = [];
+                foreach ($ifaces as $ifn) {
+                    $ifn = (string)$ifn;
+                    if ($this->isValidIface($ifn) && !isset($seen2[$ifn])) { $ifsNode->addChild('interface', $ifn); $seen2[$ifn] = true; }
+                }
+            }
+        }
+        // advanced fields on update
+        if (!isset($zo)) { $zo = $this->findOpnZone($opn, $name); }
+        if (isset($p['enabled'])) { $z->enable = ((string)$p['enabled'] ? '1' : '0'); if ($zo) { $zo->enabled = $z->enable; } }
+        if (!empty($p['hostname'])) { $z->hostname = (string)$p['hostname']; if ($zo) { $zo->hostname = (string)$p['hostname']; } }
+        if (!empty($p['template'])) { $z->template = (string)$p['template']; if ($zo) { $zo->template = (string)$p['template']; } }
+        if (!empty($p['idle_timeout'])) { $z->idle_timeout = (string)$p['idle_timeout']; if ($zo) { $zo->idle_timeout = (string)$p['idle_timeout']; $zo->idletimeout = (string)$p['idle_timeout']; } }
+        if (!empty($p['hard_timeout'])) { $z->hard_timeout = (string)$p['hard_timeout']; if ($zo) { $zo->hard_timeout = (string)$p['hard_timeout']; $zo->hardtimeout = (string)$p['hard_timeout']; } }
+        if (!empty($p['concurrent_logins'])) { $z->concurrent_logins = (string)$p['concurrent_logins']; if ($zo) { $zo->concurrent_logins = (string)$p['concurrent_logins']; $zo->concurrentlogins = (string)$p['concurrent_logins']; } }
+        if (isset($p['enforce_local_group'])) { $z->enforce_local_group = ((string)$p['enforce_local_group'] ? '1' : '0'); if ($zo) { $zo->enforce_local_group = $z->enforce_local_group; } }
+        if (isset($p['certificate'])) { $z->certificate = (string)$p['certificate']; if ($zo) { $zo->certificate = (string)$p['certificate']; } }
+        // allowed lists
+        if (isset($p['allowed_addresses'])) {
+            $allowedAddrs = is_array($p['allowed_addresses']) ? $p['allowed_addresses'] : (strlen((string)$p['allowed_addresses']) ? [ (string)$p['allowed_addresses'] ] : []);
+            if (isset($z->allowed_ip)) { unset($z->allowed_ip); }
+            foreach ($allowedAddrs as $addr) { $addr = trim((string)$addr); if ($addr!=='') { $z->addChild('allowed_ip', $addr); } }
+            if ($zo) {
+                if (isset($zo->allowed_addresses)) { unset($zo->allowed_addresses); }
+                if (!empty($allowedAddrs)) {
+                    $aaNode = $zo->addChild('allowed_addresses');
+                    foreach ($allowedAddrs as $addr) { $addr = trim((string)$addr); if ($addr!==''  ) { $aaNode->addChild('address', $addr); } }
+                }
+            }
+        }
+        if (isset($p['allowed_macs'])) {
+            $allowedMacs = is_array($p['allowed_macs']) ? $p['allowed_macs'] : (strlen((string)$p['allowed_macs']) ? [ (string)$p['allowed_macs'] ] : []);
+            if (isset($z->allowed_mac)) { unset($z->allowed_mac); }
+            foreach ($allowedMacs as $mac) { $mac = trim((string)$mac); if ($mac!=='') { $z->addChild('allowed_mac', $mac); } }
+            if ($zo) {
+                if (isset($zo->allowed_macs)) { unset($zo->allowed_macs); }
+                if (!empty($allowedMacs)) {
+                    $amNode = $zo->addChild('allowed_macs');
+                    foreach ($allowedMacs as $mac) { $mac = trim((string)$mac); if ($mac!=='') { $amNode->addChild('mac', $mac); } }
+                }
+            }
+        }
+        Config::getInstance()->save();
+        $this->audit('cp.zone.ensure', ['name'=>$name,'created'=>false]);
+        return ['status'=>'ok','created'=>false];
+    }
+
+    public function zoneGetAction(): array
+    {
+        $p = $this->request->getPost() ?: $this->request->get();
+        $zone = trim((string)($p['zone'] ?? ''));
+        if ($zone === '') { return ['status'=>'error','message'=>'missing zone']; }
+        $cp = $this->getCpNode();
+        $opn = $this->getOpnsenseCpNode();
+        $z = $this->findZone($cp, $zone);
+        $zo = $this->findOpnZone($opn, $zone);
+        if ($z === null) { return ['status'=>'error','message'=>'zone not found']; }
+        $ifs = [];
+        foreach ((array)($z->interface ?? []) as $i) { $ifs[] = (string)$i; }
+        if ($zo && isset($zo->interfaces)) {
+            foreach ((array)$zo->interfaces->interface as $i) { $ifs[] = (string)$i; }
+            $ifs = array_values(array_unique($ifs));
+        }
+        return [
+            'zone' => [
+                'name' => (string)$z->name,
+                'description' => (string)($zo->description ?? $z->description ?? $z->descr ?? ''),
+                'enabled' => (string)($zo->enabled ?? $z->enable ?? '0'),
+                'interfaces' => $ifs,
+                'auth' => [ 'method' => (string)($z->authmethod ?? ''), 'server' => (string)($z->authserver ?? '') ],
+                'accounting' => [ 'enabled' => (string)($zo->accounting ?? $z->accounting ?? '0'), 'interval' => (string)($zo->accounting_interval ?? $z->accounting_interval ?? '') ],
+                'zoneid' => (string)($zo->zoneid ?? $z->zoneid ?? ''),
+            ]
+        ];
+    }
+
+    public function zoneAuthAction(): array
+    {
+        $p = $this->request->getPost() ?: $this->request->get();
+        $zone = trim((string)($p['zone'] ?? ''));
+        $method = strtolower(trim((string)($p['method'] ?? '')));
+        $server = trim((string)($p['server'] ?? ''));
+        if ($zone==='' || $method==='') { return ['status'=>'error','message'=>'missing zone/method']; }
+        $cp = $this->getCpNode();
+        $opn = $this->getOpnsenseCpNode();
+        $z = $this->findZone($cp, $zone);
+        $zo = $this->findOpnZone($opn, $zone);
+        if ($z === null) { return ['status'=>'error','message'=>'zone not found']; }
+        if (!in_array($method, ['radius','local'], true)) { return ['status'=>'error','message'=>'unsupported auth method']; }
+        if ($method === 'radius') {
+            if ($server === '' || !$this->authServerExists($server)) { return ['status'=>'error','message'=>'radius server not found']; }
+            $z->authserver = $server;
+            if ($zo) { $zo->authserver = $server; }
+        } else {
+            unset($z->authserver);
+            if ($zo && isset($zo->authserver)) { unset($zo->authserver); }
+        }
+        $z->authmethod = $method; // set after validation
+        if ($zo) { $zo->authmethod = $method; }
+        Config::getInstance()->save();
+        $this->audit('cp.zone.auth', ['zone'=>$zone,'method'=>$method,'server'=>$server]);
+        return ['status'=>'ok'];
+    }
+
+    public function zoneAccountingAction(): array
+    {
+        $p = $this->request->getPost() ?: $this->request->get();
+        $zone = trim((string)($p['zone'] ?? ''));
+        $enabled = (string)($p['enabled'] ?? '0');
+        $interval = (string)($p['interval'] ?? '300');
+        if ($zone==='') { return ['status'=>'error','message'=>'missing zone']; }
+        if (!ctype_digit($interval)) { return ['status'=>'error','message'=>'invalid interval']; }
+        $cp = $this->getCpNode();
+        $opn = $this->getOpnsenseCpNode();
+        $z = $this->findZone($cp, $zone);
+        $zo = $this->findOpnZone($opn, $zone);
+        if ($z === null) { return ['status'=>'error','message'=>'zone not found']; }
+        $z->accounting = ($enabled ? '1' : '0');
+        $z->accounting_interval = $interval;
+        if ($zo) { $zo->accounting = ($enabled ? '1' : '0'); $zo->accounting_interval = $interval; }
+        Config::getInstance()->save();
+        $this->audit('cp.zone.accounting', ['zone'=>$zone,'enabled'=>$enabled,'interval'=>$interval]);
+        return ['status'=>'ok'];
+    }
+
+    public function zoneEnableAction(): array
+    {
+        $zone = trim((string)($this->request->getPost('zone') ?? $this->request->get('zone') ?? ''));
+        $enabled = (string)($this->request->getPost('enabled') ?? $this->request->get('enabled') ?? '1');
+        if ($zone==='') { return ['status'=>'error','message'=>'missing zone']; }
+        $cp = $this->getCpNode();
+        $opn = $this->getOpnsenseCpNode();
+        $z = $this->findZone($cp, $zone);
+        $zo = $this->findOpnZone($opn, $zone);
+        if ($z === null) { return ['status'=>'error','message'=>'zone not found']; }
+        $z->enable = ($enabled ? '1' : '0');
+        if ($zo) { $zo->enabled = ($enabled ? '1' : '0'); }
+        Config::getInstance()->save();
+        $this->audit('cp.zone.enable', ['zone'=>$zone,'enabled'=>$enabled]);
+        return ['status'=>'ok'];
+    }
+
+    public function bypassSetAction(): array
+    {
+        $p = $this->request->getPost() ?: $this->request->get();
+        $zone = trim((string)($p['zone'] ?? ''));
+        $ip = trim((string)($p['ip'] ?? ''));
+        $mac = trim((string)($p['mac'] ?? ''));
+        $enabled = (string)($p['enabled'] ?? '1');
+        if ($zone==='') { return ['status'=>'error','message'=>'missing zone']; }
+        if ($ip==='' && $mac==='') { return ['status'=>'error','message'=>'ip or mac required']; }
+        if ($ip!=='' && !$this->isValidIp($ip)) { return ['status'=>'error','message'=>'invalid ip']; }
+        if ($mac!=='' and !$this->isValidMac($mac)) { return ['status'=>'error','message'=>'invalid mac']; }
+        $cp = $this->getCpNode();
+        $z = $this->findZone($cp, $zone);
+        if ($z === null) { return ['status'=>'error','message'=>'zone not found']; }
+        if ($enabled) {
+            if ($ip!=='') {
+                $exists = false; foreach ((array)($z->allowed_ip ?? []) as $n) { if ((string)$n === $ip) { $exists = true; break; } }
+                if (!$exists) { $z->addChild('allowed_ip', $ip); }
+            }
+            if ($mac!=='') {
+                $exists = false; foreach ((array)($z->allowed_mac ?? []) as $n) { if (strtolower((string)$n) === strtolower($mac)) { $exists = true; break; } }
+                if (!$exists) { $z->addChild('allowed_mac', $mac); }
+            }
+        } else {
+            if ($ip!=='' && isset($z->allowed_ip)) {
+                $idx=0; foreach ($z->allowed_ip as $n) { if ((string)$n === $ip) { unset($z->allowed_ip[$idx]); break; } $idx++; }
+            }
+            if ($mac!=='' and isset($z->allowed_mac)) {
+                $idx=0; foreach ($z->allowed_mac as $n) { if (strtolower((string)$n) === strtolower($mac)) { unset($z->allowed_mac[$idx]); break; } $idx++; }
+            }
+        }
+        Config::getInstance()->save();
+        $this->audit('cp.bypass.set', ['zone'=>$zone,'ip'=>$ip,'mac'=>$mac,'enabled'=>$enabled]);
+        return ['status'=>'ok'];
+    }
+
+    public function applyAction(): array
+    {
+        @exec('/usr/local/sbin/configctl captiveportal restart 2>/dev/null', $out, $rc);
+        if ($rc !== 0) { return ['status'=>'error','message'=>'captiveportal restart failed']; }
+        $this->audit('cp.apply', []);
+        return ['status'=>'ok'];
+    }
+}
+
+

--- a/security/userprovision/src/opnsense/mvc/app/controllers/OPNsense/UserProvision/Api/DhcpController.php
+++ b/security/userprovision/src/opnsense/mvc/app/controllers/OPNsense/UserProvision/Api/DhcpController.php
@@ -1,0 +1,58 @@
+<?php
+namespace OPNsense\UserProvision\Api;
+
+use OPNsense\Base\ApiControllerBase;
+use OPNsense\Core\Config;
+
+class DhcpController extends ApiControllerBase
+{
+    use AuditTrait;
+    use ValidationTrait;
+    /**
+     * Upsert static mapping into dhcpd config (interface section)
+     * Params: iface, mac, ipaddr, descr
+     */
+    public function upsertAction(): array
+    {
+        $p = $this->request->getPost() ?: $this->request->get();
+        $iface = trim((string)($p['iface'] ?? ''));
+        $mac = strtolower(trim((string)($p['mac'] ?? '')));
+        $ip = trim((string)($p['ipaddr'] ?? ''));
+        $descr = trim((string)($p['descr'] ?? ''));
+        if ($iface==='' || $mac==='' || $ip==='') {
+            return ['status'=>'error','message'=>'missing iface/mac/ipaddr'];
+        }
+        if (!$this->isValidIface($iface)) { return ['status'=>'error','message'=>'invalid iface']; }
+        if (!$this->isValidMac($mac)) { return ['status'=>'error','message'=>'invalid mac']; }
+        if (!$this->isValidIp($ip)) { return ['status'=>'error','message'=>'invalid ipaddr']; }
+        $cfg = Config::getInstance()->object();
+        if (!isset($cfg->dhcpd)) { $cfg->addChild('dhcpd'); }
+        if (!isset($cfg->dhcpd->{$iface})) { $cfg->dhcpd->addChild($iface); }
+        if (!isset($cfg->dhcpd->{$iface}->staticmap)) { $cfg->dhcpd->{$iface}->addChild('staticmap'); }
+
+        $target = null;
+        foreach ($cfg->dhcpd->{$iface}->staticmap as $sm) {
+            if (strtolower((string)$sm->mac) === $mac) { $target = $sm; break; }
+        }
+        if ($target === null) {
+            $target = $cfg->dhcpd->{$iface}->addChild('staticmap');
+        }
+        $target->mac = $mac;
+        $target->ipaddr = $ip;
+        if ($descr !== '') { $target->descr = $descr; }
+        Config::getInstance()->save();
+        $this->audit('dhcp.upsert', ['iface'=>$iface,'mac'=>$mac,'ipaddr'=>$ip]);
+        return ['status'=>'ok'];
+    }
+
+    public function applyAction(): array
+    {
+        // restart dhcpd using configd action defined in actions_userprovision.conf
+        @exec('/usr/local/sbin/configctl dhcpd restart 2>/dev/null', $out, $rc);
+        if ($rc !== 0) { return ['status'=>'error','message'=>'dhcpd restart failed']; }
+        $this->audit('dhcp.apply', []);
+        return ['status'=>'ok'];
+    }
+}
+
+

--- a/security/userprovision/src/opnsense/mvc/app/controllers/OPNsense/UserProvision/Api/GroupController.php
+++ b/security/userprovision/src/opnsense/mvc/app/controllers/OPNsense/UserProvision/Api/GroupController.php
@@ -1,0 +1,89 @@
+<?php
+namespace OPNsense\UserProvision\Api;
+
+use OPNsense\Base\ApiControllerBase;
+use OPNsense\Core\Config;
+
+class GroupController extends ApiControllerBase
+{
+    use AuditTrait;
+    use ValidationTrait;
+    public function listAction(): array
+    {
+        $p = $this->request->getPost() ?: $this->request->get();
+        $current = (int)($p['current'] ?? 1);
+        $rowCount = (int)($p['rowCount'] ?? 25);
+        $searchPhrase = strtolower(trim((string)($p['searchPhrase'] ?? '')));
+        $cfg = \OPNsense\Core\Config::getInstance()->object();
+        $rows = [];
+        // Safe SimpleXML iteration
+        if (isset($cfg->system) && isset($cfg->system->group) && $cfg->system->group instanceof \SimpleXMLElement) {
+            foreach ($cfg->system->group as $grp) {
+                $name = (string)($grp->name ?? '');
+                $descr = (string)($grp->description ?? $grp->descr ?? '');
+                $rows[] = [ 'name' => $name, 'descr' => $descr ];
+            }
+        }
+        // Fallback via toArray() if no rows
+        if (count($rows) === 0) {
+            $arr = \OPNsense\Core\Config::getInstance()->toArray();
+            $groups = $arr['system']['group'] ?? [];
+            if (!empty($groups)) {
+                if (!is_array($groups) || isset($groups['name'])) { $groups = [$groups]; }
+                foreach ($groups as $g) {
+                    $name = (string)($g['name'] ?? '');
+                    $descr = (string)($g['description'] ?? $g['descr'] ?? '');
+                    $rows[] = [ 'name' => $name, 'descr' => $descr ];
+                }
+            }
+        }
+        if ($searchPhrase !== '') {
+            $rows = array_values(array_filter($rows, function($r) use ($searchPhrase){
+                return (strpos(strtolower($r['name']), $searchPhrase) !== false) || (strpos(strtolower($r['descr']), $searchPhrase) !== false);
+            }));
+        }
+        $total = count($rows);
+        if ($rowCount == -1) { $rowCount = $total; }
+        elseif ($rowCount <= 0) { $rowCount = 25; }
+        $current = max(1, $current);
+        $offset = ($current - 1) * $rowCount;
+        $pageRows = array_slice($rows, $offset, $rowCount);
+        return ['current'=>$current,'rowCount'=>count($pageRows),'rows'=>$pageRows,'total'=>$total];
+    }
+
+    public function deleteAction(): array
+    {
+        $name = trim((string)($this->request->getPost('name') ?? $this->request->get('name') ?? ''));
+        if ($name === '' || !$this->isValidGroupName($name)) { return ['status'=>'error','message'=>'invalid name']; }
+        $cfg = \OPNsense\Core\Config::getInstance()->object();
+        if (!isset($cfg->system) || !isset($cfg->system->group)) { return ['status'=>'ok','deleted'=>false]; }
+        $idx = 0; $deleted = false;
+        foreach ($cfg->system->group as $grp) {
+            if ((string)$grp->name === $name) { unset($cfg->system->group[$idx]); $deleted = true; break; }
+            $idx++;
+        }
+        if ($deleted) { \OPNsense\Core\Config::getInstance()->save(); $this->audit('group.delete', ['name'=>$name]); }
+        return ['status'=>'ok','deleted'=>$deleted];
+    }
+    public function ensureAction(): array
+    {
+        $name = trim((string)($this->request->getPost('name') ?? $this->request->get('name') ?? ''));
+        if ($name === '' || !$this->isValidGroupName($name)) { return ['status'=>'error','message'=>'invalid name']; }
+        $cfg = Config::getInstance()->object();
+        if (!isset($cfg->system)) { $cfg->addChild('system'); }
+        if (!isset($cfg->system->group)) { $cfg->system->addChild('group'); }
+        // search group
+        foreach ($cfg->system->group as $grp) {
+            if ((string)$grp->name === $name) { return ['status'=>'ok','created'=>false]; }
+        }
+        // create
+        $grp = $cfg->system->addChild('group');
+        $grp->addChild('name', $name);
+        $grp->addChild('description', $name);
+        Config::getInstance()->save();
+        $this->audit('group.ensure', ['name'=>$name, 'created'=>true]);
+        return ['status'=>'ok','created'=>true];
+    }
+}
+
+

--- a/security/userprovision/src/opnsense/mvc/app/controllers/OPNsense/UserProvision/Api/LogsController.php
+++ b/security/userprovision/src/opnsense/mvc/app/controllers/OPNsense/UserProvision/Api/LogsController.php
@@ -1,0 +1,65 @@
+<?php
+namespace OPNsense\UserProvision\Api;
+
+use OPNsense\Base\ApiControllerBase;
+
+class LogsController extends ApiControllerBase
+{
+    public function dhcpAction(): array
+    {
+        $user = trim((string)($this->request->get('user') ?? ''));
+        $limit = (int)($this->request->get('limit') ?? 200);
+        $q = trim((string)($this->request->get('q') ?? ''));
+        $since = (string)($this->request->get('since') ?? '');
+        $until = (string)($this->request->get('until') ?? '');
+        $format = strtolower(trim((string)($this->request->get('format') ?? 'json')));
+        // naive grep of dhcp logs mapping descr/host to user; adapt as needed
+        $out = [];
+        $dhcpPath = '/var/log/dhcpd.log';
+        if (class_exists('OPNsense\\UserProvision\\Settings')) {
+            $mdl = new \OPNsense\UserProvision\Settings();
+            $dhcpPath = (string)$mdl->settings->dhcpLogPath ?? $dhcpPath;
+        }
+        @exec("/usr/bin/tail -n ".(int)$limit." " . escapeshellarg($dhcpPath) . " 2>/dev/null", $out);
+        $rows = [];
+        foreach ($out as $line) {
+            if ($user!=='' && stripos($line, $user) === false) { continue; }
+            if ($q!=='' && stripos($line, $q) === false) { continue; }
+            if ($since!=='' && strtotime($line) && strtotime($line) < strtotime($since)) { continue; }
+            if ($until!=='' && strtotime($line) && strtotime($line) > strtotime($until)) { continue; }
+            $rows[] = $line;
+        }
+        if ($format === 'csv') { return ['rows'=>array_map(function($l){ return [$l]; }, $rows)]; }
+        return ['rows'=>$rows];
+    }
+
+    public function accessAction(): array
+    {
+        $user = trim((string)($this->request->get('user') ?? ''));
+        $limit = (int)($this->request->get('limit') ?? 200);
+        $q = trim((string)($this->request->get('q') ?? ''));
+        $since = (string)($this->request->get('since') ?? '');
+        $until = (string)($this->request->get('until') ?? '');
+        $format = strtolower(trim((string)($this->request->get('format') ?? 'json')));
+        // if using captive portal or radius accounting logs locally; fallback to system.log
+        $out = [];
+        $accessPath = '/var/log/system.log';
+        if (class_exists('OPNsense\\UserProvision\\Settings')) {
+            $mdl = new \OPNsense\UserProvision\Settings();
+            $accessPath = (string)$mdl->settings->accessLogPath ?? $accessPath;
+        }
+        @exec("/usr/bin/tail -n ".(int)$limit." " . escapeshellarg($accessPath) . " 2>/dev/null", $out);
+        $rows = [];
+        foreach ($out as $line) {
+            if ($user!=='' && stripos($line, $user) === false) { continue; }
+            if ($q!=='' && stripos($line, $q) === false) { continue; }
+            if ($since!=='' && strtotime($line) && strtotime($line) < strtotime($since)) { continue; }
+            if ($until!=='' && strtotime($line) && strtotime($line) > strtotime($until)) { continue; }
+            $rows[] = $line;
+        }
+        if ($format === 'csv') { return ['rows'=>array_map(function($l){ return [$l]; }, $rows)]; }
+        return ['rows'=>$rows];
+    }
+}
+
+

--- a/security/userprovision/src/opnsense/mvc/app/controllers/OPNsense/UserProvision/Api/RadiusServerController.php
+++ b/security/userprovision/src/opnsense/mvc/app/controllers/OPNsense/UserProvision/Api/RadiusServerController.php
@@ -1,0 +1,395 @@
+<?php
+namespace OPNsense\UserProvision\Api;
+
+use OPNsense\Base\ApiControllerBase;
+use OPNsense\Core\Config;
+
+class RadiusServerController extends ApiControllerBase
+{
+    use AuditTrait;
+    use ValidationTrait;
+    
+    public function listAction(): array
+    {
+        $p = $this->request->getPost() ?: $this->request->get();
+        $current = (int)($p['current'] ?? 0);
+        $rowCount = (int)($p['rowCount'] ?? 12);
+        $searchPhrase = strtolower(trim((string)($p['searchPhrase'] ?? '')));
+        
+        $rows = [];
+        
+        // Try multiple config reading methods
+        $methods = [];
+        
+        // Method 1: Direct XML file reading
+        $configPaths = ['/conf/config.xml', '/usr/local/etc/config.xml', '/etc/config.xml'];
+        foreach ($configPaths as $path) {
+            if (is_readable($path)) {
+                $xml = @simplexml_load_file($path);
+                if ($xml && isset($xml->system->authserver)) {
+                    $methods['direct_xml'] = $path;
+                    foreach ($xml->system->authserver as $srv) {
+                        if ((string)($srv->type ?? '') !== 'radius') continue;
+                        
+                        $name = (string)($srv->name ?? '');
+                        $host = (string)($srv->host ?? '');
+                        $auth_port = (string)($srv->auth_port ?? $srv->radius_auth_port ?? '1812');
+                        $acct_port = (string)($srv->acct_port ?? $srv->radius_acct_port ?? '');
+                        $timeout = (string)($srv->timeout ?? $srv->radius_timeout ?? '5');
+                        $stationid = (string)($srv->radius_stationid ?? '');
+                        $descr = (string)($srv->descr ?? '');
+                        $services = (!empty($auth_port) && !empty($acct_port)) ? 'both' : 'auth';
+                        
+                        $rows[] = [
+                            'name' => $name,
+                            'host' => $host,
+                            'secret' => '***',
+                            'services' => $services,
+                            'auth_port' => $auth_port,
+                            'acct_port' => $acct_port === '' ? null : $acct_port,
+                            'timeout' => $timeout,
+                            'stationid' => $stationid,
+                            'descr' => $descr,
+                            'sync_memberof' => !empty((string)($srv->sync_memberof ?? '')),
+                            'sync_create_local_users' => !empty((string)($srv->sync_create_local_users ?? '')),
+                            'sync_memberof_groups' => !empty((string)($srv->sync_memberof_groups ?? '')) ? explode(',', (string)$srv->sync_memberof_groups) : [],
+                            'sync_default_groups' => !empty((string)($srv->sync_default_groups ?? '')) ? explode(',', (string)$srv->sync_default_groups) : [],
+                            'refid' => (string)($srv->refid ?? ''),
+                        ];
+                    }
+                    break;
+                }
+            }
+        }
+        
+        // Method 2: Config::getInstance() if direct reading failed
+        if (count($rows) === 0) {
+            try {
+                Config::getInstance()->forceReload();
+                $cfg = Config::getInstance()->object();
+                $methods['config_instance'] = 'used';
+                
+                if (isset($cfg->system->authserver)) {
+                    foreach ($cfg->system->authserver as $srv) {
+                        if ((string)($srv->type ?? '') !== 'radius') continue;
+                        
+                        $name = (string)($srv->name ?? '');
+                        $host = (string)($srv->host ?? '');
+                        $auth_port = (string)($srv->auth_port ?? $srv->radius_auth_port ?? '1812');
+                        $acct_port = (string)($srv->acct_port ?? $srv->radius_acct_port ?? '');
+                        $timeout = (string)($srv->timeout ?? $srv->radius_timeout ?? '5');
+                        $stationid = (string)($srv->radius_stationid ?? '');
+                        $descr = (string)($srv->descr ?? '');
+                        $services = (!empty($auth_port) && !empty($acct_port)) ? 'both' : 'auth';
+                        
+                        $rows[] = [
+                            'name' => $name,
+                            'host' => $host,
+                            'secret' => '***',
+                            'services' => $services,
+                            'auth_port' => $auth_port,
+                            'acct_port' => $acct_port === '' ? null : $acct_port,
+                            'timeout' => $timeout,
+                            'stationid' => $stationid,
+                            'descr' => $descr,
+                            'sync_memberof' => !empty((string)($srv->sync_memberof ?? '')),
+                            'sync_create_local_users' => !empty((string)($srv->sync_create_local_users ?? '')),
+                            'sync_memberof_groups' => !empty((string)($srv->sync_memberof_groups ?? '')) ? explode(',', (string)$srv->sync_memberof_groups) : [],
+                            'sync_default_groups' => !empty((string)($srv->sync_default_groups ?? '')) ? explode(',', (string)$srv->sync_default_groups) : [],
+                            'refid' => (string)($srv->refid ?? ''),
+                        ];
+                    }
+                }
+            } catch (\Exception $e) {
+                $methods['config_instance_error'] = $e->getMessage();
+            }
+        }
+        
+        if ($searchPhrase !== '') {
+            $rows = array_values(array_filter($rows, function($r) use ($searchPhrase){
+                return (strpos(strtolower($r['name']), $searchPhrase) !== false)
+                       || (strpos(strtolower($r['host']), $searchPhrase) !== false)
+                       || (strpos(strtolower($r['descr']), $searchPhrase) !== false);
+            }));
+        }
+        
+        $total = count($rows);
+        if ($rowCount == -1) { $rowCount = $total; }
+        elseif ($rowCount <= 0) { $rowCount = 25; }
+        $current = max(1, $current);
+        $offset = ($current - 1) * $rowCount;
+        $pageRows = array_slice($rows, $offset, $rowCount);
+        
+        return [
+            'current' => $current,
+            'rowCount' => count($pageRows),
+            'rows' => $pageRows,
+            'total' => $total
+        ];
+    }
+
+    public function deleteAction(): array
+    {
+        $name = trim((string)($this->request->getPost('name') ?? $this->request->get('name') ?? ''));
+        if ($name === '') { 
+            return ['status'=>'error','message'=>'missing name']; 
+        }
+        
+        $cfg = Config::getInstance()->object();
+        if (!isset($cfg->system) || !isset($cfg->system->authserver)) { 
+            return ['status'=>'ok','deleted'=>false]; 
+        }
+        
+        $deleted = false;
+        $idx = 0;
+            foreach ($cfg->system->authserver as $srv) {
+            if ((string)($srv->type ?? '') === 'radius' && (string)$srv->name === $name) { 
+                    unset($cfg->system->authserver[$idx]); 
+                    $deleted = true; 
+                    break; 
+                }
+                $idx++;
+        }
+        
+        if ($deleted) { 
+            Config::getInstance()->save(); 
+            $this->audit('radius.delete', ['name'=>$name]); 
+        }
+        return ['status'=>'ok','deleted'=>$deleted];
+    }
+
+    public function upsertAction(): array
+    {
+            $p = $this->request->getPost();
+            
+            // Extract and validate required fields
+            $name = trim((string)($p['name'] ?? ''));
+            $host = trim((string)($p['host'] ?? ''));
+            $secret = (string)($p['secret'] ?? '');
+        $services = (string)($p['services'] ?? $p['radius_srvcs'] ?? 'both');
+            
+            if ($name === '') {
+                return ['status'=>'error','message'=>'missing descriptive name'];
+            }
+            if ($host === '') {
+                return ['status'=>'error','message'=>'missing hostname or IP address'];
+            }
+            if ($secret === '') {
+                return ['status'=>'error','message'=>'missing shared secret'];
+            }
+            if (!$this->isValidHostname($host)) {
+                return ['status'=>'error','message'=>'invalid hostname or IP address'];
+            }
+            
+            // Extract optional fields with defaults
+            $auth_port = (int)($p['auth_port'] ?? $p['radius_auth_port'] ?? 1812);
+            $acct_port = (int)($p['acct_port'] ?? $p['radius_acct_port'] ?? 1813);
+            $timeout = (int)($p['timeout'] ?? $p['radius_timeout'] ?? 5);
+            $stationid = trim((string)($p['stationid'] ?? $p['radius_stationid'] ?? ''));
+            $descr = trim((string)($p['descr'] ?? ''));
+            
+            if ($timeout <= 0) {
+                return ['status'=>'error','message'=>'timeout must be numeric and positive'];
+            }
+            
+            $cfg = Config::getInstance()->object();
+            
+        // Find existing server by name
+        $existing = null;
+        if (isset($cfg->system->authserver)) {
+            foreach ($cfg->system->authserver as $srv) {
+                if ((string)$srv->name === $name) { 
+                    $existing = $srv; 
+                    break; 
+                }
+            }
+        }
+            
+            if ($existing === null) {
+                // Create new authserver entry
+            if (!isset($cfg->system)) { $cfg->addChild('system'); }
+                $srv = $cfg->system->addChild('authserver');
+                $srv->addChild('refid', uniqid());
+                $srv->addChild('name', htmlspecialchars($name));
+                $srv->addChild('type', 'radius');
+                $srv->addChild('host', htmlspecialchars($host));
+            $srv->addChild('secret', htmlspecialchars($secret));
+            $srv->addChild('timeout', (string)$timeout);
+                
+            // Set service-dependent ports (using legacy field names)
+                if ($services === 'both') {
+                $srv->addChild('auth_port', (string)$auth_port);
+                $srv->addChild('acct_port', (string)$acct_port);
+                } elseif ($services === 'auth') {
+                $srv->addChild('auth_port', (string)$auth_port);
+                }
+                
+                // Optional fields
+                if ($stationid !== '') {
+                    $srv->addChild('radius_stationid', htmlspecialchars($stationid));
+                }
+                if ($descr !== '') {
+                    $srv->addChild('descr', htmlspecialchars($descr));
+                }
+                
+                Config::getInstance()->save();
+                $this->audit('radius.create', ['name'=>$name]);
+                
+                return ['status'=>'ok','created'=>true,'message'=>'RADIUS server created successfully'];
+                
+            } else {
+                // Update existing server
+                $existing->type = 'radius';
+                $existing->host = htmlspecialchars($host);
+            $existing->secret = htmlspecialchars($secret);
+            $existing->timeout = (string)$timeout;
+                
+            // Update service-dependent ports (using legacy field names)
+                if ($services === 'both') {
+                $existing->auth_port = (string)$auth_port;
+                $existing->acct_port = (string)$acct_port;
+                } elseif ($services === 'auth') {
+                $existing->auth_port = (string)$auth_port;
+                if (isset($existing->acct_port)) {
+                    unset($existing->acct_port);
+                }
+                }
+                
+                // Remove legacy radius_* fields to prevent duplicate keys in config
+                if (isset($existing->radius_auth_port)) {
+                    unset($existing->radius_auth_port);
+                }
+                if (isset($existing->radius_acct_port)) {
+                    unset($existing->radius_acct_port);
+                }
+                if (isset($existing->radius_timeout)) {
+                    unset($existing->radius_timeout);
+                }
+                if (isset($existing->radius_secret)) {
+                    unset($existing->radius_secret);
+                }
+                
+                // Update optional fields
+                if ($stationid !== '') {
+                    $existing->radius_stationid = htmlspecialchars($stationid);
+                } elseif (isset($existing->radius_stationid)) {
+                    unset($existing->radius_stationid);
+                }
+                
+                if ($descr !== '') {
+                    $existing->descr = htmlspecialchars($descr);
+                } elseif (isset($existing->descr)) {
+                    unset($existing->descr);
+                }
+                
+                Config::getInstance()->save();
+                $this->audit('radius.update', ['name'=>$name]);
+                
+                return ['status'=>'ok','created'=>false,'message'=>'RADIUS server updated successfully'];
+        }
+    }
+
+    public function getAction(): array
+    {
+        $name = trim((string)($this->request->get('name') ?? ''));
+        if ($name === '') {
+            return ['status'=>'error','message'=>'missing server name parameter'];
+        }
+        
+        $cfg = Config::getInstance()->object();
+        if (!isset($cfg->system->authserver)) {
+            return ['status'=>'error','message'=>'no servers configured'];
+        }
+        
+            foreach ($cfg->system->authserver as $srv) {
+                if ((string)$srv->name === $name && (string)$srv->type === 'radius') {
+                // Parse group arrays
+                $sync_memberof_groups = [];
+                $sync_default_groups = [];
+                
+                if (!empty($srv->sync_memberof_groups)) {
+                    $sync_memberof_groups = explode(',', (string)$srv->sync_memberof_groups);
+                }
+                if (!empty($srv->sync_default_groups)) {
+                    $sync_default_groups = explode(',', (string)$srv->sync_default_groups);
+                }
+                
+                // Determine service type
+                $services = 'auth';
+                $auth_port_val = (string)($srv->auth_port ?? $srv->radius_auth_port ?? '');
+                $acct_port_val = (string)($srv->acct_port ?? $srv->radius_acct_port ?? '');
+                if (!empty($auth_port_val) && !empty($acct_port_val)) {
+                    $services = 'both';
+                }
+                
+                return [
+                    'status' => 'ok',
+                    'server' => [
+                        'name' => (string)($srv->name ?? ''),
+                        'host' => (string)($srv->host ?? ''),
+                        'secret' => (string)($srv->secret ?? $srv->radius_secret ?? ''),
+                        'services' => $services,
+                        'auth_port' => (string)($srv->auth_port ?? $srv->radius_auth_port ?? '1812'),
+                        'acct_port' => (string)($srv->acct_port ?? $srv->radius_acct_port ?? '1813'),
+                        'timeout' => (string)($srv->timeout ?? $srv->radius_timeout ?? '5'),
+                        'stationid' => (string)($srv->radius_stationid ?? ''),
+                        'descr' => (string)($srv->descr ?? ''),
+                        'sync_memberof' => !empty($srv->sync_memberof),
+                        'sync_create_local_users' => !empty($srv->sync_create_local_users),
+                        'sync_memberof_groups' => $sync_memberof_groups,
+                        'sync_default_groups' => $sync_default_groups,
+                        'refid' => (string)($srv->refid ?? ''),
+                    ]
+                ];
+            }
+        }
+        
+        return ['status'=>'error','message'=>'server not found'];
+    }
+
+    public function testAction(): array
+    {
+        return ['status'=>'ok','message'=>'RadiusServerController is working','timestamp'=>date('H:i:s')];
+    }
+    
+    public function listallAction(): array
+    {
+        $rows = [];
+        
+        // Try direct XML reading from production paths
+        $configPaths = ['/conf/config.xml', '/usr/local/etc/config.xml', '/etc/config.xml'];
+        foreach ($configPaths as $path) {
+            if (is_readable($path)) {
+                $xml = @simplexml_load_file($path);
+                if ($xml && isset($xml->system->authserver)) {
+                    foreach ($xml->system->authserver as $srv) {
+                        if ((string)($srv->type ?? '') !== 'radius') continue;
+                        
+                        $rows[] = [
+                            'name' => (string)($srv->name ?? ''),
+                            'host' => (string)($srv->host ?? ''),
+                            'secret' => '***',
+                            'services' => (!empty((string)($srv->auth_port ?? '')) && !empty((string)($srv->acct_port ?? ''))) ? 'both' : 'auth',
+                            'auth_port' => (string)($srv->auth_port ?? $srv->radius_auth_port ?? '1812'),
+                            'acct_port' => (string)($srv->acct_port ?? $srv->radius_acct_port ?? ''),
+                            'timeout' => (string)($srv->timeout ?? $srv->radius_timeout ?? '5'),
+                            'stationid' => (string)($srv->radius_stationid ?? ''),
+                            'descr' => (string)($srv->descr ?? ''),
+                            'refid' => (string)($srv->refid ?? ''),
+                        ];
+                    }
+                    break;
+                }
+            }
+        }
+        
+        return [
+            'current' => 1,
+            'rowCount' => count($rows),
+            'rows' => $rows,
+            'total' => count($rows),
+            'config_found' => count($rows) > 0
+        ];
+    }
+}
+

--- a/security/userprovision/src/opnsense/mvc/app/controllers/OPNsense/UserProvision/Api/SettingsController.php
+++ b/security/userprovision/src/opnsense/mvc/app/controllers/OPNsense/UserProvision/Api/SettingsController.php
@@ -1,0 +1,21 @@
+<?php
+namespace OPNsense\UserProvision\Api;
+
+use OPNsense\Base\ApiMutableModelControllerBase;
+
+class SettingsController extends ApiMutableModelControllerBase
+{
+    protected static $internalModelName = 'Settings';
+    protected static $internalModelClass = 'OPNsense\\UserProvision\\Settings';
+    // expose standard get/set endpoints under /api/userprovision/settings/get and /set
+    public function getAction(): array
+    {
+        return $this->getBase('settings');
+    }
+    public function setAction(): array
+    {
+        return $this->setBase('settings');
+    }
+}
+
+

--- a/security/userprovision/src/opnsense/mvc/app/controllers/OPNsense/UserProvision/Api/UserController.php
+++ b/security/userprovision/src/opnsense/mvc/app/controllers/OPNsense/UserProvision/Api/UserController.php
@@ -1,0 +1,233 @@
+<?php
+namespace OPNsense\UserProvision\Api;
+
+use OPNsense\Base\ApiControllerBase;
+use OPNsense\Core\Config;
+
+class UserController extends ApiControllerBase
+{
+    use AuditTrait;
+    use ValidationTrait;
+    public function listAction(): array
+    {
+        $p = $this->request->getPost() ?: $this->request->get();
+        if (empty($p) && stripos((string)$this->request->getHeader('Content-Type'), 'application/json') !== false) {
+            $json = json_decode((string)$this->request->getRawBody(), true);
+            if (is_array($json)) { $p = $json; }
+        }
+        $current = (int)($p['current'] ?? 1);
+        $rowCount = (int)($p['rowCount'] ?? 25);
+        $searchPhrase = strtolower(trim((string)($p['searchPhrase'] ?? '')));
+        $cfg = Config::getInstance()->object();
+        $rows = [];
+        if (isset($cfg->system) && isset($cfg->system->user)) {
+            foreach ($cfg->system->user as $usr) {
+                $rows[] = [
+                    'name' => (string)$usr->name,
+                    'descr' => (string)$usr->descr
+                ];
+            }
+        }
+        if ($searchPhrase !== '') {
+            $rows = array_values(array_filter($rows, function($r) use ($searchPhrase){
+                return (strpos(strtolower($r['name']), $searchPhrase) !== false) || (strpos(strtolower($r['descr']), $searchPhrase) !== false);
+            }));
+        }
+        $total = count($rows);
+        if ($rowCount == -1) { $rowCount = $total; }
+        elseif ($rowCount <= 0) { $rowCount = 25; }
+        $current = max(1, $current);
+        $offset = ($current - 1) * $rowCount;
+        $pageRows = array_slice($rows, $offset, $rowCount);
+        return ['current'=>$current,'rowCount'=>$rowCount,'rows'=>$pageRows,'total'=>$total];
+    }
+
+    public function deleteAction(): array
+    {
+        $username = trim((string)($this->request->getPost('username') ?? $this->request->get('username') ?? ''));
+        if ($username === '' || !$this->isValidUsername($username)) { return ['status'=>'error','message'=>'invalid username']; }
+        $cfg = Config::getInstance()->object();
+        if (!isset($cfg->system) || !isset($cfg->system->user)) { return ['status'=>'ok','deleted'=>false]; }
+        $idx = 0; $deleted = false;
+        foreach ($cfg->system->user as $usr) {
+            if ((string)$usr->name === $username) {
+                unset($cfg->system->user[$idx]);
+                $deleted = true; break;
+            }
+            $idx++;
+        }
+        if ($deleted) { Config::getInstance()->save(); $this->audit('user.delete', ['username'=>$username]); }
+        return ['status'=>'ok','deleted'=>$deleted];
+    }
+    public function upsertAction(): array
+    {
+        $u = $this->request->getPost() ?: $this->request->get();
+        $username = trim((string)($u['username'] ?? ''));
+        if ($username === '') { return ['status'=>'error','message'=>'missing username']; }
+        $full_name = trim((string)($u['full_name'] ?? ''));
+        $password = (string)($u['password'] ?? '');
+        // groups parameters
+        $mode = strtolower(trim((string)($u['mode'] ?? 'merge'))); // merge | replace
+        $groupsParam = $u['groups'] ?? [];
+        $groupsAddParam = $u['groups_add'] ?? [];
+        $groupsRemoveParam = $u['groups_remove'] ?? [];
+        $groups = is_array($groupsParam) ? $groupsParam : ( ($groupsParam==='') ? [] : [(string)$groupsParam] );
+        $groups_add = is_array($groupsAddParam) ? $groupsAddParam : ( ($groupsAddParam==='') ? [] : [(string)$groupsAddParam] );
+        $groups_remove = is_array($groupsRemoveParam) ? $groupsRemoveParam : ( ($groupsRemoveParam==='') ? [] : [(string)$groupsRemoveParam] );
+
+        $cfg = Config::getInstance()->object();
+        if (!isset($cfg->system)) { $cfg->addChild('system'); }
+        if (!isset($cfg->system->user)) { $cfg->system->addChild('user'); }
+
+        $existing = null; $idx = 0; $foundIdx = null;
+        foreach ($cfg->system->user as $usr) {
+            if ((string)$usr->name === $username) { $existing = $usr; $foundIdx = $idx; break; }
+            $idx++;
+        }
+        if ($existing === null) {
+            $usr = $cfg->system->addChild('user');
+            $usr->addChild('name', $username);
+            if ($full_name !== '') { $usr->addChild('descr', $full_name); }
+            if ($password !== '') {
+                if (!$this->isValidPassword($password)) { return ['status'=>'error','message'=>'weak password']; }
+                $usr->addChild('password', password_hash($password, PASSWORD_DEFAULT));
+            }
+        } else {
+            $usr = $existing;
+            if ($full_name !== '') { $usr->descr = $full_name; }
+            if ($password !== '') {
+                if (!$this->isValidPassword($password)) { return ['status'=>'error','message'=>'weak password']; }
+                $usr->password = password_hash($password, PASSWORD_DEFAULT);
+            }
+        }
+
+        // ensure uid exists (required for group membership linking)
+        $uid = (string)($usr->uid ?? '');
+        if ($uid === '') {
+            $maxUid = 0;
+            if (isset($cfg->system->user)) {
+                foreach ($cfg->system->user as $u2) {
+                    $u2uid = (int)((string)($u2->uid ?? '0'));
+                    if ($u2uid > $maxUid) { $maxUid = $u2uid; }
+                }
+            }
+            $newUid = max(2000, $maxUid + 1);
+            if (isset($usr->uid)) { unset($usr->uid); }
+            $usr->addChild('uid', (string)$newUid);
+            $uid = (string)$usr->uid;
+        }
+        // ensure groups for all potentially referenced names
+        $allReferencedGroups = array_unique(array_filter(array_map('strval', array_merge($groups, $groups_add))));
+        if (!isset($cfg->system->group)) { $cfg->system->addChild('group'); }
+        foreach ($allReferencedGroups as $gname) {
+            $has = false;
+            foreach ($cfg->system->group as $grp) {
+                if ((string)$grp->name === (string)$gname) { $has = true; break; }
+            }
+            if (!$has) {
+                if (!$this->isValidGroupName((string)$gname)) { return ['status'=>'error','message'=>'invalid group']; }
+                $grp = $cfg->system->addChild('group');
+                $grp->addChild('name', (string)$gname);
+                $grp->addChild('description', (string)$gname);
+            }
+        }
+        // determine final user group set based on mode
+        $existingUserGroups = [];
+        if (isset($usr->groupname)) {
+            foreach ($usr->groupname as $gn) { $existingUserGroups[] = (string)$gn; }
+        }
+        $existingUserGroups = array_values(array_unique($existingUserGroups));
+
+        $finalGroups = $existingUserGroups;
+        if ($mode === 'replace') {
+            $finalGroups = array_values(array_unique(array_map('strval', $groups)));
+        } else { // merge (default)
+            // if 'groups' provided, treat as additions in merge mode
+            $finalGroups = array_values(array_unique(array_merge($finalGroups, array_map('strval', $groups))));
+            // also merge explicit groups_add
+            $finalGroups = array_values(array_unique(array_merge($finalGroups, array_map('strval', $groups_add))));
+            // remove explicit groups_remove
+            if (!empty($groups_remove)) {
+                $toRemove = array_map('strval', $groups_remove);
+                $finalGroups = array_values(array_diff($finalGroups, $toRemove));
+            }
+        }
+
+        // rewrite user groupname entries to reflect finalGroups
+        unset($usr->groupname);
+        foreach ($finalGroups as $gname) { $usr->addChild('groupname', (string)$gname); }
+
+        // sync group memberships bi-directionally using uid in each group
+        if (isset($cfg->system->group)) {
+            foreach ($cfg->system->group as $grp) {
+                $gname = (string)$grp->name;
+                $isDesired = in_array($gname, $finalGroups, true);
+
+                // collect current members
+                $members = [];
+                if (isset($grp->member)) {
+                    foreach ($grp->member as $mem) { $members[] = (string)$mem; }
+                }
+                $has = in_array((string)$uid, $members, true);
+
+                if ($isDesired && !$has) {
+                    $grp->addChild('member', (string)$uid);
+                } elseif (!$isDesired && $has) {
+                    // remove only in replace mode or when explicitly requested
+                    $shouldRemove = ($mode === 'replace') || in_array($gname, array_map('strval', $groups_remove), true);
+                    if ($shouldRemove) {
+                        $idx = 0;
+                        foreach ($grp->member as $mem) {
+                            if ((string)$mem === (string)$uid) { unset($grp->member[$idx]); }
+                            $idx++;
+                        }
+                    }
+                }
+            }
+        }
+
+        Config::getInstance()->save();
+        $this->audit('user.upsert', ['username'=>$username,'created'=>($existing===null),'groups'=>$groups]);
+        return ['status'=>'ok','username'=>$username,'created'=>($existing===null)];
+    }
+
+    public function disableAction(): array
+    {
+        $username = trim((string)($this->request->getPost('username') ?? $this->request->get('username') ?? ''));
+        if ($username === '' || !$this->isValidUsername($username)) { return ['status'=>'error','message'=>'invalid username']; }
+        $cfg = Config::getInstance()->object();
+        if (!isset($cfg->system) || !isset($cfg->system->user)) { return ['status'=>'ok','updated'=>false]; }
+        foreach ($cfg->system->user as $usr) {
+            if ((string)$usr->name === $username) { $usr->disabled = '1'; Config::getInstance()->save(); $this->audit('user.disable', ['username'=>$username]); return ['status'=>'ok','updated'=>true]; }
+        }
+        return ['status'=>'ok','updated'=>false];
+    }
+
+    public function enableAction(): array
+    {
+        $username = trim((string)($this->request->getPost('username') ?? $this->request->get('username') ?? ''));
+        if ($username === '' || !$this->isValidUsername($username)) { return ['status'=>'error','message'=>'invalid username']; }
+        $cfg = Config::getInstance()->object();
+        if (!isset($cfg->system) || !isset($cfg->system->user)) { return ['status'=>'ok','updated'=>false]; }
+        foreach ($cfg->system->user as $usr) {
+            if ((string)$usr->name === $username) { unset($usr->disabled); Config::getInstance()->save(); $this->audit('user.enable', ['username'=>$username]); return ['status'=>'ok','updated'=>true]; }
+        }
+        return ['status'=>'ok','updated'=>false];
+    }
+
+    public function setpasswordAction(): array
+    {
+        $username = trim((string)($this->request->getPost('username') ?? $this->request->get('username') ?? ''));
+        $password = (string)($this->request->getPost('password') ?? $this->request->get('password') ?? '');
+        if ($username === '' || !$this->isValidUsername($username)) { return ['status'=>'error','message'=>'invalid username']; }
+        if ($password === '' || !$this->isValidPassword($password)) { return ['status'=>'error','message'=>'weak password']; }
+        $cfg = Config::getInstance()->object();
+        if (!isset($cfg->system) || !isset($cfg->system->user)) { return ['status'=>'ok','updated'=>false]; }
+        foreach ($cfg->system->user as $usr) {
+            if ((string)$usr->name === $username) { $usr->password = password_hash($password, PASSWORD_DEFAULT); Config::getInstance()->save(); $this->audit('user.setpassword', ['username'=>$username]); return ['status'=>'ok','updated'=>true]; }
+        }
+        return ['status'=>'ok','updated'=>false];
+    }
+}
+
+

--- a/security/userprovision/src/opnsense/mvc/app/controllers/OPNsense/UserProvision/Api/ValidationTrait.php
+++ b/security/userprovision/src/opnsense/mvc/app/controllers/OPNsense/UserProvision/Api/ValidationTrait.php
@@ -1,0 +1,53 @@
+<?php
+namespace OPNsense\UserProvision\Api;
+
+trait ValidationTrait
+{
+    protected function isValidUsername(string $username): bool
+    {
+        // allow digits/letters/_/-/., 3-64 chars
+        return (bool)preg_match('/^[A-Za-z0-9._-]{3,64}$/', $username);
+    }
+
+
+    
+
+    protected function isValidGroupName(string $name): bool
+    {
+        return (bool)preg_match('/^[A-Za-z0-9._-]{3,64}$/', $name);
+    }
+
+    protected function isValidPassword(string $password): bool
+    {
+        if (strlen($password) < 8) { return false; }
+        $hasUpper = preg_match('/[A-Z]/', $password);
+        $hasLower = preg_match('/[a-z]/', $password);
+        $hasDigit = preg_match('/[0-9]/', $password);
+        $hasSpec  = preg_match('/[^A-Za-z0-9]/', $password);
+        return $hasUpper && $hasLower && $hasDigit && $hasSpec;
+    }
+
+    protected function isValidMac(string $mac): bool
+    {
+        return (bool)preg_match('/^[0-9a-f]{2}(:[0-9a-f]{2}){5}$/i', $mac);
+    }
+
+    protected function isValidIp(string $ip): bool
+    {
+        return (bool)filter_var($ip, FILTER_VALIDATE_IP);
+    }
+
+    protected function isValidIface(string $iface): bool
+    {
+        // common interface naming patterns
+        return (bool)preg_match('/^[A-Za-z0-9._-]{2,32}$/', $iface);
+    }
+
+    protected function isValidHostname(string $host): bool
+    {
+        if (filter_var($host, FILTER_VALIDATE_IP)) { return true; }
+        return (bool)preg_match('/^([a-zA-Z0-9-]{1,63}\.)*[a-zA-Z0-9-]{1,63}$/', $host);
+    }
+}
+
+

--- a/security/userprovision/src/opnsense/mvc/app/models/OPNsense/UserProvision/ACL/ACL.xml
+++ b/security/userprovision/src/opnsense/mvc/app/models/OPNsense/UserProvision/ACL/ACL.xml
@@ -1,0 +1,9 @@
+<acl>
+ 
+  <page-userprovision-api>
+    <name>User Provisioning API</name>
+    <patterns>
+      <pattern>api/userprovision/*</pattern>
+    </patterns>
+  </page-userprovision-api>
+</acl>

--- a/security/userprovision/src/opnsense/mvc/app/models/OPNsense/UserProvision/Settings.php
+++ b/security/userprovision/src/opnsense/mvc/app/models/OPNsense/UserProvision/Settings.php
@@ -1,0 +1,8 @@
+<?php
+namespace OPNsense\UserProvision;
+
+use OPNsense\Base\BaseModel;
+
+class Settings extends BaseModel
+{
+}

--- a/security/userprovision/src/opnsense/mvc/app/models/OPNsense/UserProvision/Settings.xml
+++ b/security/userprovision/src/opnsense/mvc/app/models/OPNsense/UserProvision/Settings.xml
@@ -1,0 +1,19 @@
+<model>
+  <mount>OPNsense/UserProvision</mount>
+  <version>0.0.1</version>
+  <description>User Provisioning settings</description>
+  <settings>
+    <dhcpLogPath type="TextField">
+      <default>/var/log/dhcpd.log</default>
+      <ValidationMessage>Path to DHCP log file</ValidationMessage>
+    </dhcpLogPath>
+    <accessLogPath type="TextField">
+      <default>/var/log/system.log</default>
+      <ValidationMessage>Path to access/auth log file</ValidationMessage>
+    </accessLogPath>
+    <auditLogPath type="TextField">
+      <default>/var/log/userprovision_audit.log</default>
+      <ValidationMessage>Path to audit log file</ValidationMessage>
+    </auditLogPath>
+  </settings>
+</model>

--- a/security/userprovision/src/opnsense/scripts/userprovision_list_radius.php
+++ b/security/userprovision/src/opnsense/scripts/userprovision_list_radius.php
@@ -1,0 +1,41 @@
+#!/usr/local/bin/php
+<?php
+error_reporting(0);
+header('Content-Type: application/json');
+
+$paths = ['/conf/config.xml','/usr/local/etc/config.xml','/etc/config.xml','/var/etc/config.xml','./config.xml','../config.xml','../../config.xml'];
+$xml = null; $used = null;
+foreach ($paths as $p) {
+    if (is_readable($p)) { $xml = @simplexml_load_file($p); $used = $p; if ($xml) break; }
+}
+$rows = [];
+if ($xml && isset($xml->system) && isset($xml->system->authserver)) {
+    foreach ($xml->system->authserver as $srv) {
+        if ((string)($srv->type ?? '') !== 'radius') { continue; }
+        $name = (string)($srv->name ?? '');
+        $host = (string)($srv->host ?? '');
+        $auth_port = (string)($srv->auth_port ?? $srv->radius_auth_port ?? '1812');
+        $acct_port = (string)($srv->acct_port ?? $srv->radius_acct_port ?? '');
+        $timeout = (string)($srv->timeout ?? $srv->radius_timeout ?? '5');
+        $stationid = (string)($srv->radius_stationid ?? '');
+        $descr = (string)($srv->descr ?? '');
+        $services = (!empty($auth_port) && !empty($acct_port)) ? 'both' : 'auth';
+        $rows[] = [
+            'name' => $name,
+            'host' => $host,
+            'secret' => '***',
+            'services' => $services,
+            'auth_port' => $auth_port,
+            'acct_port' => $acct_port === '' ? null : $acct_port,
+            'timeout' => $timeout,
+            'stationid' => $stationid,
+            'descr' => $descr,
+            'refid' => (string)($srv->refid ?? ''),
+        ];
+    }
+}
+echo json_encode(['rows'=>$rows,'total'=>count($rows),'config_path'=>$used]);
+exit(0);
+?>
+
+

--- a/security/userprovision/src/opnsense/service/conf/actions.d/actions_userprovision.conf
+++ b/security/userprovision/src/opnsense/service/conf/actions.d/actions_userprovision.conf
@@ -1,0 +1,15 @@
+[dhcp/apply]
+command:/usr/local/sbin/configctl dhcpd restart
+parameters:
+type:script
+
+[cp/apply]
+command:/usr/local/sbin/configctl captiveportal restart
+parameters:
+type:script
+
+[radius/list]
+command:/usr/local/opnsense/scripts/userprovision_list_radius.php
+parameters:
+type:script
+


### PR DESCRIPTION
**# OPNsense User Provisioning (userprovision)

Headless API to upsert Users, Groups, external RADIUS servers and query logs (DHCP/access).**




**## API**
- POST /api/userprovision/group/ensure
  - name
- GET  /api/userprovision/group/list
- POST /api/userprovision/group/delete
  - name
- POST /api/userprovision/user/upsert
  - username, full_name?, password?, groups[]?
- GET  /api/userprovision/user/list
- POST /api/userprovision/user/delete
  - username
- POST /api/userprovision/user/disable
  - username
- POST /api/userprovision/user/enable
  - username
- POST /api/userprovision/user/setpassword
  - username, password
- POST /api/userprovision/radiusserver/upsert
  - name, host, secret, services?, auth_port?, acct_port?, timeout?, stationid?, descr?, sync_memberof?, sync_create_local_users?, sync_memberof_groups[]?, sync_default_groups[]?
- GET  /api/userprovision/radiusserver/list
- POST /api/userprovision/radiusserver/delete
  - name
- POST /api/userprovision/dhcp/upsert
  - iface, mac, ipaddr, descr?
- POST /api/userprovision/dhcp/apply
  - restart dhcpd to apply static-map changes
- GET  /api/userprovision/logs/dhcp
  - user?, limit?, q?, since?(RFC822), until?(RFC822), format?=json|csv
- GET  /api/userprovision/logs/access
  - user?, limit?, q?, since?(RFC822), until?(RFC822), format?=json|csv

### Captive Portal (CP) endpoints
- POST /api/userprovision/cp/zone/ensure
  - name, description?, interfaces[]
- GET  /api/userprovision/cp/zone/get
  - zone
- POST /api/userprovision/cp/zone/auth
  - zone, method=radius|local, server (required if method=radius)
- POST /api/userprovision/cp/zone/accounting
  - zone, enabled=true|false, interval?=300 (numeric)
- POST /api/userprovision/cp/zone/enable
  - zone, enabled=true|false
- POST /api/userprovision/cp/bypass/set
  - zone, ip? or mac?, enabled=true|false  (duplicate ip/mac entries are not added)
- POST /api/userprovision/cp/apply
  - restart captiveportal

Validation (CP):
- interfaces[]: interface name is validated; duplicates are not added
- auth: if method=radius, server name must exist and type=radius
- accounting interval: numeric
- bypass: ip/mac format is validated; duplicate allowed_ip/allowed_mac entries are not added

### Generic login (optional, alternative UI)
- POST /api/userprovision/auth/login
  - server=<authserver name>, username, password
  - Note: Returns Access‑Accept/Reject information; does not open a CP session.

## Settings
 The plugin does not maintain a separate runtime database; it relies on config (static-map), CP/RADIUS sessions, and logs.
  “Dynamic” leases without a static-map can be seen via logs; for full and persistent tracking, create a static-map for the user's device.
  If your log paths differ, set the settings.dhcpLogPath/accessLogPath values accordingly.
- GET  /api/userprovision/settings/get
- POST /api/userprovision/settings/set (JSON body)
  - settings.dhcpLogPath: default `/var/log/dhcpd.log`
  - settings.accessLogPath: default `/var/log/system.log`
  - settings.auditLogPath: default `/var/log/userprovision_audit.log`

## RADIUS Server API Details

### Required Fields (required)
- **name**: Descriptive name (3-64 chars, letters/digits/._-)
- **host**: Hostname or IP address (valid IP or RFC compliant hostname)
- **secret**: Shared Secret (not empty)

### Optional Fields (optional)
- **services**: "both" (Auth+Accounting) or "auth" (Auth only). Default: "both"
- **auth_port**: Authentication port. Default: 1812
- **acct_port**: Accounting port. Default: 1813
- **timeout**: Authentication timeout in seconds. Default: 5
- **stationid**: Called Station ID (MAC:SSID format)
- **descr**: Description text
- **sync_memberof**: Synchronize groups (boolean)
- **sync_create_local_users**: Automatic user creation (boolean)
- **sync_memberof_groups**: Limit groups array (group names)
- **sync_default_groups**: Default groups array (group names)

### Examples

# Create new RADIUS server (upsert = insert + update)
curl -u KEY:SECRET -d 'name=TestRADIUS&host=10.0.0.5&secret=mysecret' \
  http://fw/api/userprovision/radiusserver/upsert
# Returns: {"status":"ok","created":true}

# Update existing RADIUS server (same endpoint, automatically detects existing)
curl -u KEY:SECRET -d 'name=TestRADIUS&host=10.0.0.6&timeout=20' \
  http://fw/api/userprovision/radiusserver/upsert
# Returns: {"status":"ok","created":false}

# Full RADIUS configuration (you can extend the code to support all fields as needed)
curl -u KEY:SECRET -d 'name=FullRADIUS&host=radius.company.com&secret=strongsecret&services=both&auth_port=1812&acct_port=1813&timeout=10&stationid=00:11:22:33:44:55:company.com&descr=Company RADIUS&sync_memberof=1&sync_create_local_users=1&sync_default_groups=adminsapi_users' \
  http://fw/api/userprovision/radiusserver/upsert

# Partial update (only change timeout) - upsert handles edit automatically
curl -u KEY:SECRET -d 'name=TestRADIUS&timeout=15' \
  http://fw/api/userprovision/radiusserver/upsert

# List all RADIUS servers
curl -u KEY:SECRET http://fw/api/userprovision/radiusserver/list

# Delete server
curl -u KEY:SECRET -d 'name=TestRADIUS' \
  http://fw/api/userprovision/radiusserver/delete


## Validation rules
- username/group name: 3–64 chars; letters, digits, `._-`
- password: min 8 chars; upper, lower, digit, special
- iface: 2–32 chars; letters/digits `._-`
- mac: `aa:bb:cc:dd:ee:ff`
- ipaddr: IPv4/IPv6 (filter_var)
- host: IP or RFC-compliant hostname
- timeout: numeric and positive
- services: "both" or "auth"

## RBAC / API key
1) System → Access → Users → (API user) → Generate API key/secret
2) Effective Privileges → Add privilege for api/userprovision/*
3) Call endpoints with -u KEY:SECRET

## Audit log
This plugin writes a concise audit trail to `/var/log/userprovision_audit.log` (path configurable in settings).

## End-to-end flow (National ID - TCKN)

# 1) Add external RADIUS server to the firewall (one-time)
curl -u KEY:SECRET -d 'name=ext-rad&host=10.0.0.5&secret=XXXX&auth_port=1812&acct_port=1813' \
  http://fw/api/userprovision/radiusserver/upsert

# 2) Create Captive Portal zone and assign RADIUS
curl -u KEY:SECRET -d 'name=ZONE1&interfaces[]=lan' http://fw/api/userprovision/cp/zone/ensure
curl -u KEY:SECRET -d 'zone=ZONE1&method=radius&server=ext-rad' http://fw/api/userprovision/cp/zone/auth
curl -u KEY:SECRET -d 'zone=ZONE1&enabled=true' http://fw/api/userprovision/cp/zone/enable
curl -u KEY:SECRET -X POST http://fw/api/userprovision/cp/apply

# 3) At registration time (National ID)
curl -u KEY:SECRET -d 'name=GUEST' http://fw/api/userprovision/group/ensure
curl -u KEY:SECRET -d 'username=12345678901&full_name=John%20Doe&groups[]=GUEST' \
  http://fw/api/userprovision/user/upsert

# 4) (Optional) CP bypass or DHCP static-map
curl -u KEY:SECRET -d 'zone=ZONE1&mac=aa:bb:cc:dd:ee:ff&enabled=true' \
  http://fw/api/userprovision/cp/bypass/set
curl -u KEY:SECRET -d 'iface=lan&mac=aa:bb:cc:dd:ee:ff&ipaddr=10.0.10.25&descr=12345678901' \
  http://fw/api/userprovision/dhcp/upsert
curl -u KEY:SECRET -X POST http://fw/api/userprovision/dhcp/apply

# 5) Logs
curl -u KEY:SECRET 'http://fw/api/userprovision/logs/dhcp?user=12345678901&limit=200'
curl -u KEY:SECRET 'http://fw/api/userprovision/logs/access?user=12345678901&limit=200'


## Examples

# group ensure
curl -u KEY:SECRET -d 'name=VIP' http://fw/api/userprovision/group/ensure

# user upsert
curl -u KEY:SECRET -d 'username=12345678901&full_name=John%20Doe&groups[]=VIP' \
  http://fw/api/userprovision/user/upsert

# external RADIUS
curl -u KEY:SECRET -d 'name=ext-rad&host=10.0.0.5&secret=XXXX&descr=External' \
  http://fw/api/userprovision/radiusserver/upsert

# dhcp static map + apply
curl -u KEY:SECRET -d 'iface=lan&mac=aa:bb:cc:dd:ee:ff&ipaddr=10.0.10.25&descr=12345678901' \
  http://fw/api/userprovision/dhcp/upsert
curl -u KEY:SECRET -X POST http://fw/api/userprovision/dhcp/apply

# logs with filters
curl -u KEY:SECRET 'http://fw/api/userprovision/logs/dhcp?user=12345678901&q=lease&since=2025-09-25T00:00:00Z&format=csv'
# read settings
curl -u KEY:SECRET http://fw/api/userprovision/settings/get

# change dhcp log path
curl -u KEY:SECRET -H 'Content-Type: application/json' \
  -d '{"settings":{"dhcpLogPath":"/var/log/dhcpd.log"}}' \
  http://fw/api/userprovision/settings/set


curl -u KEY:SECRET -d 'username=12345678901' http://fw/api/userprovision/user/disable
curl -u KEY:SECRET -d 'username=12345678901' http://fw/api/userprovision/user/enable
curl -u KEY:SECRET -d 'username=12345678901&password=StrongPass#1' http://fw/api/userprovision/user/setpassword

curl -u KEY:SECRET http://fw/api/userprovision/radiusserver/list
curl -u KEY:SECRET -d 'name=ext-rad' http://fw/api/userprovision/radiusserver/delete


# list
curl -u KEY:SECRET http://fw/api/userprovision/user/list
curl -u KEY:SECRET http://fw/api/userprovision/group/list

# delete
curl -u KEY:SECRET -d 'username=12345678901' http://fw/api/userprovision/user/delete
curl -u KEY:SECRET -d 'name=VIP' http://fw/api/userprovision/group/delete


 DHCP static map
curl -u KEY:SECRET -d 'iface=lan&mac=aa:bb:cc:dd:ee:ff&ipaddr=10.0.10.25&descr=12345678901' \
  http://fw/api/userprovision/dhcp/upsert

# RADIUS server (with descr)
curl -u KEY:SECRET -d 'name=ext-rad&host=10.0.0.5&secret=XXXX&descr=External Radius' \
  http://fw/api/userprovision/radiusserver/upsert

# Logs with filters and CSV
curl -u KEY:SECRET 'http://fw/api/userprovision/logs/dhcp?user=12345678901&q=lease&since=2025-09-25T00:00:00Z&format=csv'
curl -u KEY:SECRET 'http://fw/api/userprovision/logs/access?user=12345678901&limit=500&format=json'

# DHCP static-map
curl -u KEY:SECRET -d 'iface=lan&mac=aa:bb:cc:dd:ee:ff&ipaddr=10.0.10.25&descr=12345678901' \
  http://fw/api/userprovision/dhcp/upsert

# RADIUS server
curl -u KEY:SECRET -d 'name=ext-rad&host=10.0.0.5&secret=XXXX' \
  http://fw/api/userprovision/radiusserver/upsert

# Logs
curl -u KEY:SECRET 'http://fw/api/userprovision/logs/dhcp?user=12345678901&limit=200'
curl -u KEY:SECRET 'http://fw/api/userprovision/logs/access?user=12345678901&limit=200'

# group
curl -u KEY:SECRET -d 'name=VIP' http://fw/api/userprovision/group/ensure

# user (National ID or another ID) and group assignment
curl -u KEY:SECRET -d 'username=12345678901&full_name=John%20Doe&groups[]=VIP' \
  http://fw/api/userprovision/user/upsert

# external RADIUS record
curl -u KEY:SECRET -d 'name=ext-rad&host=10.0.0.5&secret=XXXX&auth_port=1812&acct_port=1813&timeout=5' \
  http://fw/api/userprovision/radiusserver/upsert

# logs
curl -u KEY:SECRET 'http://fw/api/userprovision/logs/dhcp?user=12345678901&limit=300'
curl -u KEY:SECRET 'http://fw/api/userprovision/logs/access?user=12345678901&limit=300'


