### PR TITLE
www/caddy: Fix HTTP access log excluding the process logs accidentally

### DIFF
--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -43,13 +43,6 @@
     #            with the syslog-ng instance running on the OPNsense.
     #}
     log {
-        {% if generalSettings.LogAccessPlain|default("0") == "0" %}
-            {% for reverse in helpers.toList('Pischem.caddy.reverseproxy.reverse') %}
-                {% if reverse.enabled|default("0") == "1" and reverse.AccessLog|default("0") == "1" %}
-                    include http.log.access.{{ reverse['@uuid'] }}
-                {% endif %}
-            {% endfor %}
-        {% endif %}
         output net unixgram//var/run/caddy/log.sock {
         }
         format json {
@@ -614,7 +607,7 @@ http://{{ domain }} {
         {% if reverse.DisableTls|default("0") == "1" %}http://{% endif %}{{ reverse.FromDomain|default("") }}{% if reverse.FromPort %}:{{ reverse.FromPort }}{% endif %} {
             {% if reverse.AccessLog|default("0") == "1" %}
                 {% if generalSettings.LogAccessPlain|default("0") == "0" %}
-                    log {{ reverse['@uuid'] }}
+                    log default
                 {% else %}
                     log {
                         output file /var/log/caddy/access/{{ reverse['@uuid'] }}.log {
@@ -652,7 +645,7 @@ http://{{ domain }} {
             {% if reverse.DisableTls|default("0") == "1" %}http://{% endif %}{{ subdomain.FromDomain|default("") }}{% if reverse.FromPort %}:{{ reverse.FromPort }}{% endif %} {
                 {% if reverse.AccessLog|default("0") == "1" %}
                     {% if generalSettings.LogAccessPlain|default("0") == "0" %}
-                        log {{ reverse['@uuid'] }}
+                        log default
                     {% else %}
                         log {
                             output file /var/log/caddy/access/{{ subdomain['@uuid'] }}.log {


### PR DESCRIPTION
Fixes: https://github.com/opnsense/plugins/issues/4973

When using "include" in the default global logger, all other logs get excluded, except those that get included.

Using a "log default" instead, sends the HTTP access logs to the default logger.

This allows process and HTTP access logs to coexist in the same logger.