### PR TITLE
Fix/qfeeds unbound blocklist priority conflict

### DIFF
--- a/security/q-feeds-connector/src/opnsense/scripts/unbound/blocklists/qfeeds_bl.py
+++ b/security/q-feeds-connector/src/opnsense/scripts/unbound/blocklists/qfeeds_bl.py
@@ -59,7 +59,7 @@ class DefaultBlocklistHandler(BaseBlocklistHandler):
         return []
     
     def _is_enabled(self):
-        """Check if unbound blocklist integration is enabled"""
+        # Check if unbound blocklist integration is enabled
         try:
             import subprocess
             result = subprocess.run(['/usr/local/sbin/configctl', 'config', 'get', 


### PR DESCRIPTION
The Q-Feeds plugin's unbound blocklist handler was interfering with existing blocklists (AdGuard, Abuse.ch, etc.) when `enable_unbound_bl` was enabled, causing only Q-Feeds domains to be blocked.

Root Cause
Q-Feeds handler used priority 100, same as most predefined handlers
Handler always returned domains regardless of `enable_unbound_bl` setting
Same priority caused conflicts where Q-Feeds would override other handlers

Solution
Changed from 100 to 50 so does not interfere with other handlers
Added `_is_enabled()` method to check `enable_unbound_bl` setting
Returns `{}` when integration is disabled
