### PR TITLE
Fix: Deduplicate rule IDs to prevent multiple log parsing

### DIFF
--- a/security/q-feeds-connector/src/opnsense/scripts/qfeeds/lib/log.py
+++ b/security/q-feeds-connector/src/opnsense/scripts/qfeeds/lib/log.py
@@ -49,7 +49,9 @@ class PFLogCrawler:
         for line in sp.stdout.split("\n"):
             for table in self._table_names:
                 if line.find("<%s>" % table) > 0:
-                    self._rule_ids.append(line.split()[-1].strip('"'))
+                    rule_id = line.split()[-1].strip('"')
+                    if rule_id not in self._rule_ids:
+                        self._rule_ids.append(rule_id)
 
     @staticmethod
     def _parse_log_line(line):


### PR DESCRIPTION
pfctl -sr shows OPNsense reuses the same rule label across multiple interfaces and for inet/inet6. The script was collecting these duplicate IDs, causing the log parser to process a single log line multiple times. This fix deduplicates the rule ID list to ensure each event is logged only once.