### PR TITLE
sysutils/git-backup: add force push option

### DIFF
--- a/sysutils/git-backup/Makefile
+++ b/sysutils/git-backup/Makefile
@@ -1,6 +1,6 @@
 PLUGIN_NAME=		git-backup
 PLUGIN_VERSION=		1.0
-PLUGIN_REVISION=	3
+PLUGIN_REVISION=	4
 PLUGIN_COMMENT=		Track config changes using git
 PLUGIN_DEPENDS=		git
 PLUGIN_MAINTAINER=	ad@opnsense.org

--- a/sysutils/git-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Git.php
+++ b/sysutils/git-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Git.php
@@ -67,6 +67,13 @@ class Git extends Base implements IBackupProvider
              "value" => null
            ],
            [
+             "name" => "force_push",
+             "type" => "checkbox",
+             "label" => gettext("Force Push"),
+             "help" => gettext("When enabled, force push to origin if diverged (e.g., after restoring from an earlier backup). Use with caution as this overwrites remote history."),
+             "value" => null
+           ],
+           [
              "name" => "privkey",
              "type" => "passwordarea",
              "label" => gettext("SSH private key"),
@@ -161,8 +168,9 @@ class Git extends Base implements IBackupProvider
         }
         exec("cd {$targetdir} && {$git} remote remove origin");
         exec("cd {$targetdir} && {$git} remote add origin " . escapeshellarg($url));
+        $force_flag = (string)$mdl->force_push === "1" ? "--force-with-lease " : "";
         $pushtxt = shell_exec(
-            "(cd {$targetdir} && {$git} push origin " . escapeshellarg("master:{$mdl->branch}") .
+            "(cd {$targetdir} && {$git} push {$force_flag}origin " . escapeshellarg("master:{$mdl->branch}") .
             " && echo '__exit_ok__') 2>&1"
         );
         if (strpos($pushtxt, '__exit_ok__')) {

--- a/sysutils/git-backup/src/opnsense/mvc/app/models/OPNsense/Backup/GitSettings.xml
+++ b/sysutils/git-backup/src/opnsense/mvc/app/models/OPNsense/Backup/GitSettings.xml
@@ -33,6 +33,10 @@
           <Default>master</Default>
           <Required>Y</Required>
         </branch>
+        <force_push type="BooleanField">
+          <Default>0</Default>
+          <Required>Y</Required>
+        </force_push>
         <privkey type="TextField">
             <Required>N</Required>
         </privkey>


### PR DESCRIPTION
The `git-backup` plugin failed for me because I restored a previous configuration revision via GUI. I haven't noticed it for a while, and the only solution I could see was to force push the current state of the repository, as indicated [here](https://forum.opnsense.org/index.php?topic=48294.0).

I found it excessive to have to ssh into the router to resolve such a conflict. So in this PR I added an option to toggle force push on or off for the repository. I would keep it on all the time, since I always want my remote to be a mirror of the local repo. However users can also just:
1. Enable it
2. Do a single push via a Setup/Test Git button in the GUI
3. Disable it

And that would resolve the present divergence.

Let me know if you see any concerns in this solution, please :)