### PR TITLE
Fix log parser for rules with tags

### DIFF
--- a/security/q-feeds-connector/src/opnsense/scripts/qfeeds/lib/log.py
+++ b/security/q-feeds-connector/src/opnsense/scripts/qfeeds/lib/log.py
@@ -50,6 +50,11 @@ class PFLogCrawler:
             for table in self._table_names:
                 if line.find("<%s>" % table) > 0:
                     self._rule_ids.add(line.split()[-1].strip('"'))
+                    if 'label "' in line:
+                        quote_start = line.find('"', line.find('label "'))
+                        quote_end = line.find('"', quote_start + 1)
+                        if quote_end > quote_start:
+                            self._rule_ids.add(line[quote_start + 1:quote_end])
 
     @staticmethod
     def _parse_log_line(line):


### PR DESCRIPTION
Example rules:

block drop out log quick on em0_vlan108 inet6 from any to <__qfeeds_malware_ip> label "dc5f8e7ee80be02f12014877d82c96a2" tag qtag block drop out log quick on em0_vlan109 inet from any to <__qfeeds_malware_ip> label "dc5f8e7ee80be02f12014877d82c96a2" tag qtag block drop out log quick on em0_vlan109 inet6 from any to <__qfeeds_malware_ip> label "dc5f8e7ee80be02f12014877d82c96a2" tag qtag block drop in quick on em1 reply-to (em1 x.x.x.22) inet from <__qfeeds_malware_ip> to any label "de057b37c3fe418169db727c1d8a3f79" block drop in quick on em1 reply-to (em1 fe80::1e52) inet6 from <__qfeeds_malware_ip> to any label "de057b37c3fe418169db727c1d8a3f79"