### PR TITLE
sysutils/git-backup: fix force push

### DIFF
--- a/sysutils/git-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Git.php
+++ b/sysutils/git-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Git.php
@@ -168,7 +168,7 @@ class Git extends Base implements IBackupProvider
         }
         exec("cd {$targetdir} && {$git} remote remove origin");
         exec("cd {$targetdir} && {$git} remote add origin " . escapeshellarg($url));
-        $force_flag = (string)$mdl->force_push === "1" ? "--force-with-lease " : "";
+        $force_flag = (string)$mdl->force_push === "1" ? "--force " : "";
         $pushtxt = shell_exec(
             "(cd {$targetdir} && {$git} push {$force_flag}origin " . escapeshellarg("master:{$mdl->branch}") .
             " && echo '__exit_ok__') 2>&1"


### PR DESCRIPTION
Fixes an oversight in https://github.com/opnsense/plugins/pull/4981.

I have just tested the latest OPNsense version on my machine after it was released and the force push always fails for me.
```
git-backup unknown error, check log for details (To ssh://github.com/shgew/opnsense-backup.git ! [rejected] master -> master (stale info) error: failed to push some refs to 'ssh://github.com/shgew/opnsense-backup.git' )
```

I forgot to account for the fact that the remote is removed and added again right before the push is done, so there are no remote refs available to compare to `origin`'s state, hence `--force-with-lease` always fails, unless a new branch is being created.

Keeping `--force-with-lease` is redundant, since it would require us to fetch origin right before pushing, but I doubt the remote history can change between two back-to-back network requests, so using a regular `--force` should do fine here.
The existing documentation still applies and asks users to be cautious while doing this, listing the risks. So I think the change is safe.

Sorry for this oversight.