### PR TITLE
www/squid: SNI based blocking and exclude list

### DIFF
--- a/www/squid/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
+++ b/www/squid/src/opnsense/mvc/app/controllers/OPNsense/Proxy/forms/main.xml
@@ -347,6 +347,22 @@
                 <help>Create a list of sites which may not be inspected, for example bank sites. Prefix the domain with a . to accept all subdomains (e.g. .google.com).</help>
             </field>
             <field>
+                <id>proxy.forward.ssl_sni_block_sites</id>
+                <label>Block connections by SSL SNI</label>
+                <type>select_multiple</type>
+                <style>tokenize</style>
+                <allownew>true</allownew>
+                <help>Create a list of sites which must be blocked by SSL SNI domain. Prefix the domain with a . to accept all subdomains (e.g. .google.com).</help>
+            </field>
+            <field>
+                <id>proxy.forward.ssl_sni_block_excludeip</id>
+                <label>Exclude IP from SSL inspection and SNI based blocking</label>
+                <type>select_multiple</type>
+                <style>tokenize</style>
+                <allownew>true</allownew>
+                <help>Create a list of IP addresses.</help>
+            </field>
+            <field>
                 <id>proxy.forward.workers</id>
                 <label>Number of squid workers</label>
                 <type>text</type>

--- a/www/squid/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
+++ b/www/squid/src/opnsense/mvc/app/models/OPNsense/Proxy/Proxy.xml
@@ -263,6 +263,20 @@
                             <field1>sslurlonly</field1>
                         </addFields>
                     </check001>
+                    <check002>
+                        <ValidationMessage>When enabling "Block connections by SSL SNI", SSL inspection must also be enabled.</ValidationMessage>
+                        <type>DependConstraint</type>
+                        <addFields>
+                            <field1>ssl_sni_block_sites</field1>
+                        </addFields>
+                    </check002>
+                    <check003>
+                        <ValidationMessage>When enabling "Exclude IP from SSL inspection and SNI based blocking", SSL inspection must also be enabled.</ValidationMessage>
+                        <type>DependConstraint</type>
+                        <addFields>
+                            <field1>ssl_sni_block_excludeip</field1>
+                        </addFields>
+                    </check003>
                 </Constraints>
             </sslbump>
             <sslurlonly type="BooleanField">
@@ -282,6 +296,25 @@
               <Mask>/^([a-zA-Z0-9\.:\[\]\s\-]*?,)*([a-zA-Z0-9\.:\[\]\s\-]*)$/</Mask>
               <ValidationMessage>Please enter ip addresses or domain names here.</ValidationMessage>
             </sslnobumpsites>
+            <ssl_sni_block_sites type="CSVListField">
+                <Mask>/^([a-zA-Z0-9\.:\[\]\s\-]*?,)*([a-zA-Z0-9\.:\[\]\s\-]*)$/</Mask>
+                <ValidationMessage>Please enter ip addresses or domain names here.</ValidationMessage>
+                <AsList>Y</AsList>
+                <Constraints>
+                    <check001>
+                        <reference>sslbump.check002</reference>
+                    </check001>
+                </Constraints>
+            </ssl_sni_block_sites>
+            <ssl_sni_block_excludeip type="NetworkField">
+                <NetMaskAllowed>N</NetMaskAllowed>
+                <AsList>Y</AsList>
+                <Constraints>
+                    <check001>
+                        <reference>sslbump.check003</reference>
+                    </check001>
+                </Constraints>
+            </ssl_sni_block_excludeip>
             <workers type="IntegerField">
               <MinimumValue>1</MinimumValue>
               <MaximumValue>100</MaximumValue>

--- a/www/squid/src/opnsense/service/templates/OPNsense/Proxy/+TARGETS
+++ b/www/squid/src/opnsense/service/templates/OPNsense/Proxy/+TARGETS
@@ -5,6 +5,8 @@ error_directory_in:/usr/local/etc/squid/error_directory.in
 externalACLs.conf:/usr/local/etc/squid/externalACLs.conf
 newsyslog.conf:/etc/newsyslog.conf.d/squid
 nobumpsites.acl:/usr/local/etc/squid/nobumpsites.acl
+ssl_sni_block_sites.acl:/usr/local/etc/squid/ssl_sni_block_sites.acl
+ssl_sni_block_excludeip.acl:/usr/local/etc/squid/ssl_sni_block_excludeip.acl
 parentproxy.conf:/usr/local/etc/squid/pre-auth/parentproxy.conf
 post-auth.conf:/usr/local/etc/squid/post-auth/dummy.conf
 pre-auth.conf:/usr/local/etc/squid/pre-auth/dummy.conf

--- a/www/squid/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
+++ b/www/squid/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
@@ -69,17 +69,46 @@ acl bump_step1 at_step SslBump1
 acl bump_step2 at_step SslBump2
 acl bump_step3 at_step SslBump3
 acl bump_nobumpsites ssl::server_name "/usr/local/etc/squid/nobumpsites.acl"
+{% if helpers.exists('OPNsense.proxy.forward.ssl_sni_block_sites') and OPNsense.proxy.forward.ssl_sni_block_sites != '' %}
+acl bump_ssl_sni_block_sites ssl::server_name --consensus "/usr/local/etc/squid/ssl_sni_block_sites.acl"
+{% if helpers.exists('OPNsense.proxy.forward.ssl_sni_block_excludeip') and OPNsense.proxy.forward.ssl_sni_block_excludeip != '' %}
+acl bump_ssl_sni_block_excludeip src "/usr/local/etc/squid/ssl_sni_block_excludeip.acl"
+{% endif %}
+{% endif %}
 
-# configure bump
 {% if helpers.exists('OPNsense.proxy.forward.sslurlonly') and OPNsense.proxy.forward.sslurlonly == '1' %}
-ssl_bump peek bump_step1 all
-ssl_bump splice all
-ssl_bump peek bump_step2 all
-ssl_bump splice bump_step3 all
-ssl_bump bump
+# configure bump - logging only config
+
+ssl_bump peek bump_step1
+
+{% if helpers.exists('OPNsense.proxy.forward.ssl_sni_block_sites') and OPNsense.proxy.forward.ssl_sni_block_sites %}
+{% if helpers.exists('OPNsense.proxy.forward.ssl_sni_block_excludeip') and OPNsense.proxy.forward.ssl_sni_block_excludeip != '' %}
+ssl_bump splice bump_step2 bump_ssl_sni_block_excludeip
+{% endif %}
+# terminate by SNI, splice anyway
+ssl_bump terminate bump_step2 bump_ssl_sni_block_sites
+{% else %}
+# no SNI blocking
+ssl_bump peek bump_step2
+{% endif %}
+
+ssl_bump splice bump_step3
 
 {% else %}
-ssl_bump peek bump_step1 all
+
+# configure bump - transparent proxy config
+ssl_bump peek bump_step1
+{% if helpers.exists('OPNsense.proxy.forward.ssl_sni_block_sites') and OPNsense.proxy.forward.ssl_sni_block_sites != '' %}
+{% if helpers.exists('OPNsense.proxy.forward.ssl_sni_block_excludeip') and OPNsense.proxy.forward.ssl_sni_block_excludeip != '' %}
+# no SNI based blocking and bump on exluded IPs
+ssl_bump peek bump_step2 bump_ssl_sni_block_excludeip
+ssl_bump splice bump_step2 bump_ssl_sni_block_excludeip
+{% endif %}
+# SNI blocking
+ssl_bump terminate bump_step3 bump_ssl_sni_block_sites
+{% endif %}
+
+# no bump on sites
 ssl_bump peek bump_step2 bump_nobumpsites
 ssl_bump splice bump_step3 bump_nobumpsites
 ssl_bump stare bump_step2


### PR DESCRIPTION
Hi,

This change allows SNI-based blocking of https requests. An IP exclusion list allows you to override the blocking.
It's most useful when both transparent mode and SNI logging settings are enabled. E.g. you want to block sites on devices that do not have the proxy CA installed.

I tested these configurations:

transparent: enabled, bump: enabled, log only: disabled
- no bump: filled, block sni: filled, exclude ip: filled
  - exlude ip: ok (not blocked by SNI, original cert in browser)
  - block sni: ok (ip logged only)
  - nobump : ok (original cert in browser)
  - bump: ok
- no bump: filled, block sni: filled, exclude ip: empty
  - block sni: ok (ip logged only)
  - nobump : ok (original cert in browser)
  - bump: ok
- no bump: filled, block sni: empty, exclude ip: empty
  - nobump : ok (original cert in browser)
  - bump: ok
- no bump: empty, block sni: filled, exclude ip: empty
  - block sni : ok (ip logged only)
  - bump: ok
- no bump: empty, block sni: empty, exclude ip: empty
  - bump: ok

transparent: enabled, bump: enabled, log only: enabled
(nobump not tested, traffic is not decrypted)
- block sni: filled, exclude ip: filled
  - exlude ip: ok (not blocked by SNI, original cert in browser)
  - block sni: ok (ip logged only)
  - TCP_TUNNEL or CONNECT in log : ok (original cert in browser)
- block sni: filled, exclude ip: empty
  - block sni: ok (ip logged only)
  - TCP_TUNNEL or CONNECT in log : ok (original cert in browser)
- block sni: empty, exclude ip: empty
  - TCP_TUNNEL or CONNECT in log : ok (original cert in browser)


transparent: disabled, bump: enabled, log only: disabled
- no bump: filled, block sni: filled, exclude ip: filled
  - exlude ip: ok (not blocked by SNI, original cert)
  - block sni: ok
  - nobump : ok (original cert in browser)
  - bump: ok
- no bump: filled, block sni: filled, exclude ip: empty
  - block sni: ok
  - nobump : ok (original cert in browser)
  - bump: ok
- no bump: filled, block sni: empty, exclude ip: empty
  - nobump : ok (original cert in browser)
  - bump: ok
- no bump: empty, block sni: filled, exclude ip: empty
  - block sni : ok
  - bump: ok
- no bump: empty, block sni: empty, exclude ip: empty
  - bump: ok

transparent: disabled, bump: enabled, log only: enabled
(nobump not tested, traffic is not decrypted)
- block sni: filled, exclude ip: filled
  - exlude ip: ok (not blocked by SNI, original cert in browser)
  - block sni: ok
  - TCP_TUNNEL or CONNECT in log : ok (original cert in browser)
- block sni: filled, exclude ip: empty
  - block sni: ok (ip logged only)
  - TCP_TUNNEL or CONNECT in log : ok (original cert in browser)
- block sni: empty, exclude ip: empty
  - TCP_TUNNEL or CONNECT in log : ok (original cert in browser)
