### PR TITLE
www/squid: remove allowed default IPv6 networks

### DIFF
--- a/www/squid/src/opnsense/service/templates/OPNsense/Proxy/squid.acl.conf
+++ b/www/squid/src/opnsense/service/templates/OPNsense/Proxy/squid.acl.conf
@@ -222,15 +222,18 @@ http_access allow local_auth
 
 #
 # ACL - localnet - default these include ranges from selected interfaces (Allow local subnets)
-{% if helpers.exists('OPNsense.proxy.forward.icap.enable') and OPNsense.proxy.forward.icap.enable == '1' %}
-{%   if helpers.exists('OPNsense.proxy.forward.icap.ResponseURL') %}
+{% if helpers.exists('OPNsense.proxy.forward.addACLforInterfaceSubnets') and OPNsense.proxy.forward.addACLforInterfaceSubnets == '1'
+      and helpers.exists('OPNsense.proxy.forward.interfaces') and OPNsense.proxy.forward.interfaces != '' %}
+{%   if helpers.exists('OPNsense.proxy.forward.icap.enable') and OPNsense.proxy.forward.icap.enable == '1' %}
+{%     if helpers.exists('OPNsense.proxy.forward.icap.ResponseURL') %}
 adaptation_access response_mod allow localnet
-{%   endif %}
-{%   if helpers.exists('OPNsense.proxy.forward.icap.RequestURL') %}
+{%     endif %}
+{%     if helpers.exists('OPNsense.proxy.forward.icap.RequestURL') %}
 adaptation_access request_mod allow localnet
+{%     endif %}
 {%   endif %}
-{% endif %}
 http_access allow localnet
+{% endif %}
 
 # ACL - localhost
 {% if helpers.exists('OPNsense.proxy.forward.icap.enable') and OPNsense.proxy.forward.icap.enable == '1' %}

--- a/www/squid/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
+++ b/www/squid/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
@@ -144,9 +144,6 @@ acl localnet src {{intf_item.subnet}}/{{intf_item.subnet_bits}} # Possible inter
 {%      endif %}
 {%  endif %}
 {% endif %}
-# Default allow for local-link and private networks
-acl localnet src fc00::/7       # RFC 4193 local private network range
-acl localnet src fe80::/10      # RFC 4291 link-local (directly plugged) machines
 
 # ACL - Allow localhost for PURGE cache if enabled
 {% if helpers.exists('OPNsense.proxy.general.cache.local') and OPNsense.proxy.general.cache.local.enabled == '1' %}


### PR DESCRIPTION
**Important notices**
Before you add a new report, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guide lines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [x] I have searched the existing issues, open and closed, and I'm convinced that mine is new.
- [x] When the request is meant for an existing plugin, I've added its name to the title.

**Is your feature request related to a problem? Please describe.**
Currently, fc00::/7 and fe80::/10 networks are silently enabled and this feature is undocumented. There is no option to disable these networks.

As I understand the RFC, the purpose of the fc00::/7 network (RFC 4193) is the same as that of IPv4 private networks (RFC 1918) and routed on local networks.
It's confusing to me that IPv6 private networks are always allowed, but IPv4 ones are not.
fc00::/7 is configurable on interfaces, so I think networks from fc00::/7 should be enabled by selecting the interface in the Proxy interfaces selection box (/ui/proxy#subtab_proxy-forward-general). Unconfigured IP addresses or networks can be allowed in the list of allowed subnets (/ui/proxy#subtab_proxy-forward-acl).

The same problems exists with fe80::/10 network (RFC 4291), except that it's only used on local links and not routed.

**Describe the solution you'd like**
I think both networks should be removed from localnet acls.  An fc00::/7 subnet can be allowed by configuring an address from it on an interface and adding that interface to the Proxy Interfaces list. Or you can add any network to the Allowed Subnets list.