### PR TITLE
net/frr: BGP Allow disabling enforce-first-as, which is a new default in frr10

### DIFF
--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/bgp.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/bgp.xml
@@ -48,6 +48,13 @@
         <help>When enabled (default), BGP only announces networks set at 'Network' if they are present in the routers routing table (alternatively, you can also set a null-route via System -> Routes). If disabled, all configured networks will be announced.</help>
     </field>
     <field>
+        <id>bgp.enforce_first_as</id>
+        <label>Enforce First AS</label>
+        <type>checkbox</type>
+        <advanced>true</advanced>
+        <help>Deny an update received from an external BGP (eBGP) peer that does not list its autonomous system number at the beginning of the AS_PATH in the incoming update.</help>
+    </field>
+    <field>
         <id>bgp.logneighborchanges</id>
         <label>Log Neighbor Changes</label>
         <type>checkbox</type>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
@@ -28,6 +28,10 @@
             <Default>1</Default>
             <Required>Y</Required>
         </networkimportcheck>
+        <enforce_first_as type="BooleanField">
+            <Default>1</Default>
+            <Required>Y</Required>
+        </enforce_first_as>
         <logneighborchanges type="BooleanField">
             <Default>0</Default>
             <Required>Y</Required>

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -32,6 +32,9 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%   if not helpers.empty('OPNsense.quagga.bgp.logneighborchanges') %}
  bgp log-neighbor-changes
 {%   endif %}
+{%   if OPNsense.quagga.bgp.enforce_first_as == '0' %}
+ no bgp enforce-first-as
+{%   endif %}
  no bgp default ipv4-unicast
  no bgp ebgp-requires-policy
 {%   if helpers.exists('OPNsense.quagga.bgp.networkimportcheck') and OPNsense.quagga.bgp.networkimportcheck == '1' %}


### PR DESCRIPTION
Fixes: https://github.com/opnsense/plugins/issues/4936

https://frrouting.org/release/10.0/#enable-enforce-first-as-by-default-for-bgp

https://docs.frrouting.org/en/latest/bgp.html#enforce-first-as