### PR TITLE
security/tailscale: Remove requirements for preauth keys

### DIFF
--- a/security/tailscale/src/opnsense/mvc/app/controllers/OPNsense/Tailscale/forms/authentication.xml
+++ b/security/tailscale/src/opnsense/mvc/app/controllers/OPNsense/Tailscale/forms/authentication.xml
@@ -9,6 +9,12 @@
         <id>authentication.preAuthKey</id>
         <label>Pre-authentication Key</label>
         <type>text</type>
-        <help>Use a non-reusable auth key and disable expiration</help>
+        <help>
+            <![CDATA[
+            Pre-authentication Key is required on first launch<br>
+            Use a non-reusable auth key and disable expiration<br>
+            Authkey WILL expire, either delete this after successful authentication, or replace this with "file:/dev/null" (without quotations)
+            ]]>
+        </help>
     </field>
 </form>

--- a/security/tailscale/src/opnsense/mvc/app/models/OPNsense/Tailscale/Authentication.xml
+++ b/security/tailscale/src/opnsense/mvc/app/models/OPNsense/Tailscale/Authentication.xml
@@ -8,7 +8,7 @@
             <ValidationMessage>Please enter a valid URL</ValidationMessage>
         </loginServer>
         <preAuthKey type="TextField">
-            <Required>Y</Required>
+            <Required>N</Required>
         </preAuthKey>
     </items>
 </model>


### PR DESCRIPTION
- Fixes https://github.com/opnsense/plugins/issues/4661

- Remove authkey requirements and allow key deletion (after first auth) for os-tailscale

- Added some notes about usage

