### PR TITLE
www/caddy: Prevent sudo on startup for unprivileged users

### DIFF
--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -228,7 +228,6 @@
     # Default of Caddy is to wait for all connections to close before allowing reload, meaning the higher the value, the longer applies take.
     #}
     grace_period {{ generalSettings.GracePeriod }}s
-    {# Important: Prevent sudo appearing on startup for unprivileged users. https://github.com/smallstep/truststore/blob/master/truststore_freebsd.go #}
     skip_install_trust
     import /usr/local/etc/caddy/caddy.d/*.global
 }


### PR DESCRIPTION
Fixes: https://github.com/opnsense/plugins/issues/5011

This can happen when an internal domain has been added, e.g. example.internal. Caddy will then generate a self signed certificate via smallstep CA, and on startup it tries to install a root certificate for it into the FreeBSD trust store.

If running as www user, this causes sudo to appear at boot, because that is baked into smallstep CA.

Via skip_install_trust, we prevent caddy from trying this.