### PR TITLE
security/acme-client: add support for Hetzner Cloud DNS API

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -1591,6 +1591,16 @@
         <type>password</type>
     </field>
     <field>
+        <label>Hetzner Cloud DNS API</label>
+        <type>header</type>
+        <style>table_dns table_dns_hetznercloud</style>
+    </field>
+    <field>
+        <id>validation.dns_hetznercloud_token</id>
+        <label>API Token</label>
+        <type>password</type>
+    </field>
+    <field>
         <label>1984Hosting API</label>
         <type>header</type>
         <style>table_dns table_dns_1984hosting</style>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsHetznercloud.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsHetznercloud.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Copyright (C) 2025 Florian Latifi
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\AcmeClient\LeValidation;
+
+use OPNsense\AcmeClient\LeValidationInterface;
+use OPNsense\Core\Config;
+
+/**
+ * Hetzner Cloud DNS API
+ * @package OPNsense\AcmeClient
+ */
+class DnsHetznercloud extends Base implements LeValidationInterface
+{
+    public function prepare()
+    {
+        $this->acme_env['HETZNER_TOKEN'] = (string)$this->config->dns_hetznercloud_token;
+    }
+}

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -469,6 +469,7 @@
                         <dns_googledomains>Google Domains</dns_googledomains>
                         <dns_gdnsdk>GratisDNS.dk</dns_gdnsdk>
                         <dns_hetzner>Hetzner</dns_hetzner>
+                        <dns_hetznercloud>Hetzner Cloud</dns_hetznercloud>
                         <dns_hexonet>hexonet.com</dns_hexonet>
                         <dns_hostingde>hosting.de</dns_hostingde>
                         <dns_he>Hurricane Electric</dns_he>
@@ -1177,6 +1178,9 @@
                 <dns_hetzner_token type="TextField">
                     <Required>N</Required>
                 </dns_hetzner_token>
+                <dns_hetznercloud_token type="TextField">
+                    <Required>N</Required>
+                </dns_hetznercloud_token>
                 <dns_hexonet_login type="TextField">
                     <Required>N</Required>
                 </dns_hexonet_login>


### PR DESCRIPTION
This PR adds support for the new Hetzner Cloud DNS API to the OPNSense Acme Client plugin.

Related issues/prs in acme.sh:
* https://github.com/acmesh-official/acme.sh/issues/6554
* https://github.com/acmesh-official/acme.sh/pull/6563