### PR TITLE
net/frr: Add hint about service reload (frr-reload) vs full restart requirement

### DIFF
--- a/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/bfd.volt
+++ b/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/bfd.volt
@@ -79,9 +79,7 @@ POSSIBILITY OF SUCH DAMAGE.
     {
         'data_endpoint': '/api/quagga/service/reconfigure',
         'data_service_widget': 'quagga',
-        'data_change_message_content':
-            'Apply will reload the service without causing interruptions. ' ~
-            'Some changes will need a full restart with the available service buttons.'
+        'data_change_message_content': lang._('Apply will reload the service without causing interruptions. Some changes will need a full restart with the available service control buttons.')
     }
 ) }}
 {{ partial("layout_partials/base_dialog",['fields':formDialogEditBFDNeighbor,'id':formGridEditBFDNeighbor['edit_dialog_id'],'label':lang._('Edit Neighbor')])}}

--- a/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/bgp.volt
+++ b/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/bgp.volt
@@ -177,9 +177,7 @@ POSSIBILITY OF SUCH DAMAGE.
     {
         'data_endpoint': '/api/quagga/service/reconfigure',
         'data_service_widget': 'quagga',
-        'data_change_message_content':
-            'Apply will reload the service without causing interruptions. ' ~
-            'Some changes will need a full restart with the available service buttons.'
+        'data_change_message_content': lang._('Apply will reload the service without causing interruptions. Some changes will need a full restart with the available service control buttons.')
     }
 ) }}
 {{ partial("layout_partials/base_dialog",['fields':formDialogEditBGPNeighbor,'id':formGridEditBGPNeighbor['edit_dialog_id'],'label':lang._('Edit Neighbor')])}}

--- a/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/general.volt
+++ b/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/general.volt
@@ -56,8 +56,6 @@ POSSIBILITY OF SUCH DAMAGE.
     {
         'data_endpoint': '/api/quagga/service/reconfigure',
         'data_service_widget': 'quagga',
-        'data_change_message_content':
-            'Apply will reload the service without causing interruptions. ' ~
-            'Some changes will need a full restart with the available service buttons.'
+        'data_change_message_content': lang._('Apply will reload the service without causing interruptions. Some changes will need a full restart with the available service control buttons.')
     }
 ) }}

--- a/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/ospf.volt
+++ b/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/ospf.volt
@@ -204,9 +204,7 @@ POSSIBILITY OF SUCH DAMAGE.
     {
         'data_endpoint': '/api/quagga/service/reconfigure',
         'data_service_widget': 'quagga',
-        'data_change_message_content':
-            'Apply will reload the service without causing interruptions. ' ~
-            'Some changes will need a full restart with the available service buttons.'
+        'data_change_message_content': lang._('Apply will reload the service without causing interruptions. Some changes will need a full restart with the available service control buttons.')
     }
 ) }}
 {{ partial("layout_partials/base_dialog",['fields':formDialogEditOSPFArea,'id':formGridEditOSPFArea['edit_dialog_id'],'label':lang._('Edit Area')])}}

--- a/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/ospf6.volt
+++ b/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/ospf6.volt
@@ -159,9 +159,7 @@
     {
         'data_endpoint': '/api/quagga/service/reconfigure',
         'data_service_widget': 'quagga',
-        'data_change_message_content':
-            'Apply will reload the service without causing interruptions. ' ~
-            'Some changes will need a full restart with the available service buttons.'
+        'data_change_message_content': lang._('Apply will reload the service without causing interruptions. Some changes will need a full restart with the available service control buttons.')
     }
 ) }}
 {{ partial("layout_partials/base_dialog",['fields':formDialogEditNetwork,'id':formGridEditNetwork['edit_dialog_id'],'label':lang._('Edit Network')])}}

--- a/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/rip.volt
+++ b/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/rip.volt
@@ -56,8 +56,6 @@ POSSIBILITY OF SUCH DAMAGE.
     {
         'data_endpoint': '/api/quagga/service/reconfigure',
         'data_service_widget': 'quagga',
-        'data_change_message_content':
-            'Apply will reload the service without causing interruptions. ' ~
-            'Some changes will need a full restart with the available service buttons.'
+        'data_change_message_content': lang._('Apply will reload the service without causing interruptions. Some changes will need a full restart with the available service control buttons.')
     }
 ) }}

--- a/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/static.volt
+++ b/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/static.volt
@@ -76,9 +76,7 @@
     {
         'data_endpoint': '/api/quagga/service/reconfigure',
         'data_service_widget': 'quagga',
-        'data_change_message_content':
-            'Apply will reload the service without causing interruptions. ' ~
-            'Some changes will need a full restart with the available service buttons.'
+        'data_change_message_content': lang._('Apply will reload the service without causing interruptions. Some changes will need a full restart with the available service control buttons.')
     }
 ) }}
 {{ partial("layout_partials/base_dialog",['fields':formDialogEditSTATICRoute,'id':formGridEditSTATICRoute['edit_dialog_id'],'label':lang._('Edit Routes')])}}


### PR DESCRIPTION
Fixes: https://github.com/opnsense/plugins/issues/5021

Some actions like loading modules or destructive actions like removing configuration will need a full restart.

frr-reload tries to maintain all current connectivity, incremental changes that add to the configuration or do not load or unload modules are covered by only apply.

This PR aims to make it clearer for the user that they might have to decide for a full restart if something is not as expected.