### PR TITLE
mail/postfix: Add Transport to the Domain model

### DIFF
--- a/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/Api/DomainController.php
+++ b/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/Api/DomainController.php
@@ -38,7 +38,7 @@ class DomainController extends ApiMutableModelControllerBase
 
     public function searchDomainAction()
     {
-        return $this->searchBase('domains.domain', array("enabled", "domainname", "destination"));
+        return $this->searchBase('domains.domain', array("enabled", "domainname", "transport", "destination"));
     }
 
     public function getDomainAction($uuid = null)

--- a/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/dialogEditPostfixDomain.xml
+++ b/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/dialogEditPostfixDomain.xml
@@ -12,6 +12,12 @@
         <help>Set the unique domain name to relay for.</help>
     </field>
     <field>
+        <id>domain.transport</id>
+        <label>Transport</label>
+        <type>text</type>
+        <help>Set the transport method. If empty, smtp will be used. https://www.postfix.org/transport.5.html</help>
+    </field>
+    <field>
         <id>domain.destination</id>
         <label>Destination</label>
         <type>text</type>

--- a/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Domain.xml
+++ b/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/Domain.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/postfix/domain</mount>
     <description>Postfix domain configuration</description>
-    <version>1.0.1</version>
+    <version>1.1.0</version>
     <items>
         <domains>
                 <domain type="ArrayField">
@@ -13,6 +13,12 @@
                                 <Default></Default>
                                 <Required>Y</Required>
                         </domainname>
+                        <transport type="TextField">
+                                <Default></Default>
+                                <Required>N</Required>
+                                <Mask>/^([0-9a-zA-Z.:\-\[\]]{0,63}[0-9a-zA-Z.\-\[\]])$/u</Mask>
+                                <ValidationMessage>Only 64 of the following characters are allowed: 0-9a-zA-Z.:-[] and must not end with :</ValidationMessage>
+                        </transport>
                         <destination type="TextField">
                                 <Default></Default>
                                 <Required>N</Required>

--- a/mail/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/domain.volt
+++ b/mail/postfix/src/opnsense/mvc/app/views/OPNsense/Postfix/domain.volt
@@ -58,6 +58,7 @@ POSSIBILITY OF SUCH DAMAGE.
             <tr>
                 <th data-column-id="enabled" data-type="string" data-formatter="rowtoggle">{{ lang._('Enabled') }}</th>
                 <th data-column-id="domainname" data-type="string" data-visible="true">{{ lang._('Domain') }}</th>
+                <th data-column-id="transport" data-type="string" data-visible="true">{{ lang._('Transport') }}</th>
                 <th data-column-id="destination" data-type="string" data-visible="true">{{ lang._('Destination') }}</th>
                 <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
                 <th data-column-id="commands" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>            </tr>

--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/transport
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/transport
@@ -2,7 +2,11 @@
 {%   if helpers.exists('OPNsense.postfix.domain.domains.domain') %}
 {%     for domain in helpers.toList('OPNsense.postfix.domain.domains.domain') %}
 {%       if domain.enabled == '1' %}
+{%         if domain.transport|length > 0 %}
+{{ domain.domainname }} {{domain.transport}}:{{domain.destination}}
+{%         else %}
 {{ domain.domainname }} smtp:{{ domain.destination }}
+{%         endif %}
 {%       endif %}
 {%     endfor %}
 {%   endif %}


### PR DESCRIPTION
I wanted postfix to relay to my dovecot instance via lmtp, but smtp transport was hard-coded in. This commit adds the transport field to the domain model and integrates it with the views and controllers, and then conditionally uses it in the transport template. The transport field will default to empty and in that case smtp is used as the transport, as before, so current users should be unaffected by the addition.

Solves https://github.com/opnsense/plugins/issues/1739