### PR TITLE
net-mgmt/zabbix-proxy: Add StartAgentPollers and MaxConcurrentChecksPerPoller options to Zabix Proxy plugin

### DIFF
--- a/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/controllers/OPNsense/Zabbixproxy/forms/general.xml
+++ b/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/controllers/OPNsense/Zabbixproxy/forms/general.xml
@@ -76,6 +76,12 @@
         <help>Number of pre-forked instances of pollers for unreachable hosts (including IPMI and Java).</help>
     </field>
     <field>
+        <id>general.startagentpollers</id>
+        <label>Start Agent Pollers</label>
+        <type>text</type>
+        <help>The number of pre-forked instances of Zabbix agent pollers.</help>
+    </field>
+    <field>
         <id>general.starttrappers</id>
         <label>Start Trappers</label>
         <type>text</type>
@@ -98,6 +104,12 @@
         <label>Start VMware Collectors</label>
         <type>text</type>
         <help>Number of pre-forked instances of VMware Collectors.</help>
+    </field>
+    <field>
+        <id>general.maxconcurrentchecksperpoller</id>
+        <label>Max Concurrent Checks per Poller</label>
+        <type>text</type>
+        <help>The maximum number of asynchronous checks that can be executed at once.</help>
     </field>
     <field>
         <id>general.starthttppollers</id>

--- a/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/models/OPNsense/Zabbixproxy/General.xml
+++ b/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/models/OPNsense/Zabbixproxy/General.xml
@@ -29,6 +29,16 @@
         <startpollers type="TextField"/>
         <startipmipollers type="IntegerField"/>
         <startpollersunreachable type="IntegerField"/>
+        <startagentpollers type="IntegerField">
+            <MinimumValue>0</MinimumValue>
+            <MaximumValue>1000</MaximumValue>
+            <Required>N</Required>
+        </startagentpollers>
+        <maxconcurrentchecksperpoller type="IntegerField">
+            <MinimumValue>1</MinimumValue>
+            <MaximumValue>1000</MaximumValue>
+            <Required>N</Required>
+        </maxconcurrentchecksperpoller>
         <starttrappers type="IntegerField"/>
         <startpingers type="IntegerField"/>
         <startdiscoverers type="IntegerField"/>

--- a/net-mgmt/zabbix-proxy/src/opnsense/service/templates/OPNsense/Zabbixproxy/zabbix_proxy.conf.in
+++ b/net-mgmt/zabbix-proxy/src/opnsense/service/templates/OPNsense/Zabbixproxy/zabbix_proxy.conf.in
@@ -57,6 +57,12 @@ StartIPMIPollers={{ OPNsense.zabbixproxy.general.startipmipollers }}
 {% if helpers.exists('OPNsense.zabbixproxy.general.startpollersunreachable') and OPNsense.zabbixproxy.general.startpollersunreachable != '' %}
 StartPollersUnreachable={{ OPNsense.zabbixproxy.general.startpollersunreachable }}
 {% endif %}
+{% if helpers.exists('OPNsense.zabbixproxy.general.startagentpollers') and OPNsense.zabbixproxy.general.startagentpollers != '' %}
+StartAgentPollers={{ OPNsense.zabbixproxy.general.startagentpollers }}
+{% endif %}
+{% if helpers.exists('OPNsense.zabbixproxy.general.maxconcurrentchecksperpoller') and OPNsense.zabbixproxy.general.maxconcurrentchecksperpoller != '' %}
+MaxConcurrentChecksPerPoller={{ OPNsense.zabbixproxy.general.maxconcurrentchecksperpoller }}
+{% endif %}
 {% if helpers.exists('OPNsense.zabbixproxy.general.starttrappers') and OPNsense.zabbixproxy.general.starttrappers != '' %}
 StartTrappers={{ OPNsense.zabbixproxy.general.starttrappers }}
 {% endif %}


### PR DESCRIPTION
This PR adds two new configuration options to the Zabbix Proxy plugin:

    StartAgentPollers – number of pre-forked Zabbix agent pollers.

    MaxConcurrentChecksPerPoller – maximum concurrent checks per poller.

The model, GUI form, and template have been updated so these settings can be configured in the web interface and appear in the generated Zabbix Proxy config.