### PR TITLE
net-mgmt/zabbix-proxy and zabbix-agent: add ListenBacklog option

### DIFF
--- a/net-mgmt/zabbix-agent/src/opnsense/mvc/app/controllers/OPNsense/ZabbixAgent/forms/settings.xml
+++ b/net-mgmt/zabbix-agent/src/opnsense/mvc/app/controllers/OPNsense/ZabbixAgent/forms/settings.xml
@@ -35,6 +35,14 @@
             <help><![CDATA[An optional source IP address for outgoing connections.]]></help>
         </field>
         <field>
+            <id>zabbixagent.settings.main.listenBacklog</id>
+            <label>Listen Backlog</label>
+            <type>text</type>
+            <minimum>0</minimum>
+            <maximum>2147483647</maximum>
+            <help><![CDATA[The maximum number of pending connections in the TCP queue.]]></help>
+        </field>
+        <field>
             <id>zabbixagent.settings.main.serverList</id>
             <label>Zabbix Servers</label>
             <type>select_multiple</type>

--- a/net-mgmt/zabbix-agent/src/opnsense/mvc/app/models/OPNsense/ZabbixAgent/ZabbixAgent.xml
+++ b/net-mgmt/zabbix-agent/src/opnsense/mvc/app/models/OPNsense/ZabbixAgent/ZabbixAgent.xml
@@ -46,6 +46,11 @@
                     <NetMaskAllowed>N</NetMaskAllowed>
                     <ValidationMessage>Please provide a valid IP address, i.e. 10.0.0.1.</ValidationMessage>
                 </sourceIP>
+                <listenBacklog type="IntegerField">
+                    <MinimumValue>0</MinimumValue>
+                    <MaximumValue>2147483647</MaximumValue>
+                    <Required>N</Required>
+                </listenBacklog>
                 <syslogEnable type="BooleanField"/>
                 <logFileSize type="IntegerField">
                     <Default>100</Default>

--- a/net-mgmt/zabbix-agent/src/opnsense/service/templates/OPNsense/ZabbixAgent/zabbix_agentd.conf
+++ b/net-mgmt/zabbix-agent/src/opnsense/service/templates/OPNsense/ZabbixAgent/zabbix_agentd.conf
@@ -33,6 +33,10 @@ Server={{OPNsense.ZabbixAgent.settings.main.serverList}}
 ListenPort={{OPNsense.ZabbixAgent.settings.main.listenPort}}
 ListenIP={{OPNsense.ZabbixAgent.settings.main.listenIP}}
 
+{% if helpers.exists('OPNsense.ZabbixAgent.settings.main.listenBacklog') and OPNsense.ZabbixAgent.settings.main.listenBacklog != '' %}
+ListenBacklog={{ OPNsense.ZabbixAgent.settings.main.listenBacklog }}
+{% endif %}
+
 {% if OPNsense.ZabbixAgent.settings.features.enableActiveChecks == '1' and OPNsense.ZabbixAgent.settings.features.activeCheckServers|default("") != "" %}
 ServerActive={{OPNsense.ZabbixAgent.settings.features.activeCheckServers}}
 {% endif %}

--- a/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/controllers/OPNsense/Zabbixproxy/forms/general.xml
+++ b/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/controllers/OPNsense/Zabbixproxy/forms/general.xml
@@ -58,6 +58,12 @@
         <help>Source IP address for outgoing connections.</help>
     </field>
     <field>
+        <id>general.listenbacklog</id>
+        <label>Listen Backlog</label>
+        <type>text</type>
+        <help>The maximum number of pending connections in the TCP queue.</help>
+    </field>
+    <field>
         <id>general.startpollers</id>
         <label>Start Pollers</label>
         <type>text</type>

--- a/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/models/OPNsense/Zabbixproxy/General.xml
+++ b/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/models/OPNsense/Zabbixproxy/General.xml
@@ -26,6 +26,11 @@
             <AsList>Y</AsList>
         </listenip>
         <sourceip type="NetworkField"/>
+        <listenbacklog type="IntegerField">
+            <MinimumValue>0</MinimumValue>
+            <MaximumValue>2147483647</MaximumValue>
+            <Required>N</Required>
+        </listenbacklog>
         <startpollers type="TextField"/>
         <startipmipollers type="IntegerField"/>
         <startpollersunreachable type="IntegerField"/>

--- a/net-mgmt/zabbix-proxy/src/opnsense/service/templates/OPNsense/Zabbixproxy/zabbix_proxy.conf.in
+++ b/net-mgmt/zabbix-proxy/src/opnsense/service/templates/OPNsense/Zabbixproxy/zabbix_proxy.conf.in
@@ -25,6 +25,9 @@ ListenPort={{ OPNsense.zabbixproxy.general.listenport }}
 {% if helpers.exists('OPNsense.zabbixproxy.general.sourceip') and OPNsense.zabbixproxy.general.sourceip != '' %}
 SourceIP={{ OPNsense.zabbixproxy.general.sourceip }}
 {% endif %}
+{% if helpers.exists('OPNsense.zabbixproxy.general.listenbacklog') and OPNsense.zabbixproxy.general.listenbacklog != '' %}
+ListenBacklog={{ OPNsense.zabbixproxy.general.listenbacklog }}
+{% endif %}
 {% if helpers.exists('OPNsense.zabbixproxy.general.syslogEnable') and OPNsense.zabbixproxy.general.syslogEnable == '1' %}
 LogType=system
 {% else %}


### PR DESCRIPTION
This PR adds a new configuration option to the Zabbix Agent and Proxy plugins:

ListenBacklog – the maximum number of pending connections in the TCP queue.

The model, GUI form, and template have been updated so this setting can be configured in the web interface and appears in the generated Zabbix Agent and Proxy configuration files.