### PR TITLE
securiry/tinc: don't create symlink as it conflicts with ifconfig symlink creation

### DIFF
--- a/security/tinc/src/opnsense/scripts/OPNsense/Tinc/tincd.py
+++ b/security/tinc/src/opnsense/scripts/OPNsense/Tinc/tincd.py
@@ -116,7 +116,7 @@ def deploy(config_filename):
 
         # configure and rename new tun device, place all in group "tinc" symlink associated tun device
         if interface_name not in interfaces:
-            # remove symlink from previus run if it wasn't cleaned up properly on exit
+            # remove symlink from previus run (created by ifconfig) if it wasn't cleaned up properly on exit
             if os.path.islink('/dev/%s' % interface_name):
                 os.remove('/dev/%s' % interface_name)
             tundev = subprocess.run(['/sbin/ifconfig', interface_type, 'create'],


### PR DESCRIPTION
~~Sometimes it fails to remove the symlink, so unless we retry, tinc won't start~~

Don't create symlink as it conflicts with ifconfig symlink creation

Fixes #5063