### PR TITLE
nginx: add optional HTTP/3

### DIFF
--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/httpserver.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/httpserver.xml
@@ -174,6 +174,13 @@
     <advanced>true</advanced>
   </field>
   <field>
+    <id>httpserver.enable_http3</id>
+    <label>HTTP/3 (QUIC)</label>
+    <type>checkbox</type>
+    <help>Enable HTTP/3/QUIC for this server (adds QUIC listeners and Alt-Svc header).</help>
+    <advanced>true</advanced>
+  </field>
+  <field>
     <id>httpserver.tls_protocols</id>
     <label>TLS Protocols</label>
     <style>selectpicker</style>

--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
@@ -801,6 +801,10 @@
                 <Default>1</Default>
                 <Required>Y</Required>
             </http2>
+            <enable_http3 type="BooleanField">
+                <Default>0</Default>
+                <Required>Y</Required>
+            </enable_http3>
             <tls_protocols type="OptionField">
                 <Multiple>Y</Multiple>
                 <Sorted>Y</Sorted>

--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/http.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/http.conf
@@ -120,8 +120,19 @@ server {
 {%   endif %}
 
 {%   if server.listen_https_address is defined and server.listen_https_address != '' %}
+{%     set http3_alt_svc_ports = [] %}
 {%     for listen_address in server.listen_https_address.split(',') %}
     listen {{ listen_address }} ssl{% if server.proxy_protocol is defined and server.proxy_protocol == '1' %} proxy_protocol{% endif %}{% if server.default_server is defined and server.default_server == '1' %} default_server{% endif %};
+{%       if server.enable_http3|default("0") == "1" %}
+    listen {{ listen_address }} quic reuseport{% if server.default_server is defined and server.default_server == '1' %} default_server{% endif %};
+{%         set listen_address_clean = listen_address.replace(' ', '') %}
+{%         if listen_address_clean != '' %}
+{%           set listen_port = listen_address_clean.split(':')[-1] %}
+{%           if listen_port not in http3_alt_svc_ports %}
+{%             do http3_alt_svc_ports.append(listen_port) %}
+{%           endif %}
+{%         endif %}
+{%       endif %}
 {%     endfor %}
     http2 {% if server.http2|default("1") == "1" %}on{% else %}off{% endif %};
 {%     if server.tls_reject_handshake is defined and server.tls_reject_handshake == '1'%}
@@ -154,6 +165,9 @@ server {
     ssl_stapling_verify {% if server.ocsp_verify is defined and server.ocsp_verify == '1' %}On{% else %}Off{% endif %};
 {%       else %}
     ssl_stapling off;
+{%       endif %}
+{%       if server.enable_http3|default("0") == "1" and http3_alt_svc_ports|length > 0 %}
+    add_header Alt-Svc '{% for listen_port in http3_alt_svc_ports %}h3=":{{ listen_port }}"; ma=86400{% if not loop.last %}, {% endif %}{% endfor %}' always;
 {%       endif %}
 {%     endif %}
 {%   endif %}


### PR DESCRIPTION
## Summary

This PR adds **optional HTTP/3 (QUIC)** support to the `os-nginx` HTTP/S server.

- Adds an `enable_http3` toggle to the HTTP/S server model and GUI (default **off** for backwards compatibility).
- When HTTP/3 is enabled **and** a certificate is present, the generated `server` block:
  - adds corresponding `listen ... quic reuseport` directives for each configured HTTPS listen address
  - advertises HTTP/3 support using an `Alt-Svc` response header based on the HTTPS port.
- When HTTP/3 is disabled or no certificate is configured, the resulting nginx configuration is unchanged from current behavior.

> **Note:** This feature requires a firewall rule allowing **UDP** on the HTTPS port.


## Implementation

- **Model**
  - Introduced a new boolean field `enable_http3` under the HTTP server model with default `0` (disabled).
- **GUI**
  - Added a *“HTTP/3 (QUIC)”* checkbox to the HTTP server form, next to the existing HTTP/2 toggle.
- **Template**
  - Updated the HTTP server template to:
    - emit `listen ... quic reuseport` only when `enable_http3 == 1` **and** a certificate is configured for the server
    - emit `Alt-Svc 'h3=":$server_port"; ma=86400'` only when HTTP/3 is enabled **and** a certificate is configured.


## Testing

```sh
configctl template reload OPNsense/Nginx
nginx -t
```

Created an HTTPS HTTP server without HTTP/3 enabled:
- Verified that no quic listeners and no Alt-Svc header are present in the generated config.
- Enabled HTTP/3 (QUIC) on the same HTTP server:
- Verified that nginx config now contains listen ... quic reuseport for each HTTPS listen address.
- Verified that nginx advertises HTTP/3 via Alt-Svc:

curl -I --http3 -k https://<TARGET_IP>

Example response (abridged):

HTTP/3 200
server: nginx
...
alt-svc: h3=":443"; ma=86400



## Screenshot

HTTP server configuration with the new HTTP/3 (QUIC) toggled off:

<img width="900" height="777" alt="image" src="https://github.com/user-attachments/assets/f30ae7b4-bbb3-4b5a-bf21-3b65c2430554" />


## Example generated config (HTTP/3 enabled)


```nginx
server {
    listen 80 default_server;
    listen [::]:80 default_server;

    listen 443 ssl default_server;
    listen 443 quic reuseport default_server;
    listen [::]:443 ssl default_server;
    listen [::]:443 quic reuseport default_server;

    ...

    add_header Alt-Svc 'h3=":443"; ma=86400' always;
    ...
```

With HTTP/3 disabled (or no certificate configured), the generated server block matches the current implementation.