### PR TITLE
net/ntopng: listen address configuration, Redis password support, and other config improvments

### DIFF
--- a/databases/redis/src/opnsense/mvc/app/models/OPNsense/Redis/Redis.php
+++ b/databases/redis/src/opnsense/mvc/app/models/OPNsense/Redis/Redis.php
@@ -29,7 +29,29 @@
 namespace OPNsense\Redis;
 
 use OPNsense\Base\BaseModel;
+use OPNsense\Base\Messages\Message;
 
 class Redis extends BaseModel
 {
+    public function performValidation($validateFullModel = false)
+    {
+        // Call parent validation first
+        $messages = parent::performValidation($validateFullModel);
+
+        // Get the password value
+        $password = (string)$this->security->password;
+
+        // Check if password contains \ or `
+        if (!empty($password) && (strpos($password, '\\') !== false || strpos($password, '`') !== false)) {
+            $message = new Message(
+                gettext(
+                    "Password cannot contain backslash (\\) or backtick (`) characters",
+                ),
+                "security.password"
+            );
+            $messages->appendMessage($message);
+        }
+
+        return $messages;
+    }
 }

--- a/databases/redis/src/opnsense/mvc/app/models/OPNsense/Redis/Redis.php
+++ b/databases/redis/src/opnsense/mvc/app/models/OPNsense/Redis/Redis.php
@@ -35,13 +35,10 @@ class Redis extends BaseModel
 {
     public function performValidation($validateFullModel = false)
     {
-        // Call parent validation first
         $messages = parent::performValidation($validateFullModel);
 
-        // Get the password value
         $password = (string)$this->security->password;
 
-        // Check if password contains \ or `
         if (!empty($password) && (strpos($password, '\\') !== false || strpos($password, '`') !== false)) {
             $message = new Message(
                 gettext(

--- a/net/ntopng/src/opnsense/mvc/app/controllers/OPNsense/Ntopng/forms/general.xml
+++ b/net/ntopng/src/opnsense/mvc/app/controllers/OPNsense/Ntopng/forms/general.xml
@@ -13,6 +13,14 @@
         <help>Select the interface to listen to. Set to none if you want to choose the interface via ntopng UI.</help>
     </field>
     <field>
+        <id>general.address</id>
+        <label>Listen address</label>
+        <style>tokenize</style>
+        <type>select_multiple</type>
+        <allownew>true</allownew>
+        <help>Address this service listens on.</help>
+    </field>
+    <field>
         <id>general.httpport</id>
         <label>HTTP Port</label>
         <type>text</type>
@@ -29,6 +37,12 @@
         <label>Certificate</label>
         <type>dropdown</type>
         <help>Set the certificate to use for HTTPS connections.</help>
+    </field>
+    <field>
+        <id>general.redisconnection</id>
+        <label>redis</label>
+        <type>text</type>
+        <help>HTTPS Port this service listens on. If you enable HTTPS you will be redirected from HTTP to HTTPS. Please select a certificate below</help>
     </field>
     <field>
         <id>general.dnsmode</id>

--- a/net/ntopng/src/opnsense/mvc/app/controllers/OPNsense/Ntopng/forms/general.xml
+++ b/net/ntopng/src/opnsense/mvc/app/controllers/OPNsense/Ntopng/forms/general.xml
@@ -13,24 +13,18 @@
         <help>Select the interface to listen to. Set to none if you want to choose the interface via ntopng UI.</help>
     </field>
     <field>
-        <id>general.addresses</id>
-        <label>Listen addresses</label>
+        <id>general.addresseshttp</id>
+        <label>Listen addresses (HTTP)</label>
         <style>tokenize</style>
         <type>select_multiple</type>
         <allownew>true</allownew>
         <help>Address(es) this service listens on.</help>
     </field>
     <field>
-        <id>general.httpport</id>
-        <label>HTTP Port</label>
+        <id>general.addresseshttps</id>
+        <label>Listen address (HTTPS)</label>
         <type>text</type>
-        <help>HTTP Port this service listens on.</help>
-    </field>
-    <field>
-        <id>general.httpsport</id>
-        <label>HTTPS Port</label>
-        <type>text</type>
-        <help>HTTPS Port this service listens on. If you enable HTTPS you will be redirected from HTTP to HTTPS. Please select a certificate below</help>
+        <help>Address this service listens on. (the limit of 1 address comes from ntopng)</help>
     </field>
     <field>
         <id>general.cert</id>

--- a/net/ntopng/src/opnsense/mvc/app/controllers/OPNsense/Ntopng/forms/general.xml
+++ b/net/ntopng/src/opnsense/mvc/app/controllers/OPNsense/Ntopng/forms/general.xml
@@ -40,9 +40,10 @@
     </field>
     <field>
         <id>general.redisconnection</id>
-        <label>redis</label>
+        <label>Redis connection override</label>
         <type>text</type>
-        <help>HTTPS Port this service listens on. If you enable HTTPS you will be redirected from HTTP to HTTPS. Please select a certificate below</help>
+        <advanced>true</advanced>
+        <help>the defines the redis connections as per --redis in www.ntop.org/guides/ntopng/cli_options/cli_options.html</help>
     </field>
     <field>
         <id>general.dnsmode</id>

--- a/net/ntopng/src/opnsense/mvc/app/controllers/OPNsense/Ntopng/forms/general.xml
+++ b/net/ntopng/src/opnsense/mvc/app/controllers/OPNsense/Ntopng/forms/general.xml
@@ -13,12 +13,12 @@
         <help>Select the interface to listen to. Set to none if you want to choose the interface via ntopng UI.</help>
     </field>
     <field>
-        <id>general.address</id>
-        <label>Listen address</label>
+        <id>general.addresses</id>
+        <label>Listen addresses</label>
         <style>tokenize</style>
         <type>select_multiple</type>
         <allownew>true</allownew>
-        <help>Address this service listens on.</help>
+        <help>Address(es) this service listens on.</help>
     </field>
     <field>
         <id>general.httpport</id>

--- a/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/General.php
+++ b/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/General.php
@@ -76,20 +76,23 @@ class General extends BaseModel
                 ),
                 'redisconnection'
             ));
-        } elseif ($redis_conn !== ltrim($redis_conn)) {
-            $messages->appendMessage(new Message(
-                gettext(
-                    "Can't have leading whitespace"
-                ),
-                'redisconnection'
-            ));
-        } elseif ($redis_conn !== rtrim($redis_conn)) {
-            $messages->appendMessage(new Message(
-                gettext(
-                    "Can't have trailing whitespace"
-                ),
-                'redisconnection'
-            ));
+        } else {
+            if ($redis_conn !== ltrim($redis_conn)) {
+                $messages->appendMessage(new Message(
+                    gettext(
+                        "Can't have leading whitespace"
+                    ),
+                    'redisconnection'
+                ));
+            }
+            if ($redis_conn !== rtrim($redis_conn)) {
+                $messages->appendMessage(new Message(
+                    gettext(
+                        "Can't have trailing whitespace"
+                    ),
+                    'redisconnection'
+                ));
+            }
         }
 
         return $messages;

--- a/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/General.php
+++ b/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/General.php
@@ -42,12 +42,37 @@ class General extends BaseModel
 		$https = (string)$this->httpsport;
 
 		if ($http === '' && $https === '') {
+			$msg = gettext('Please input at least an HTTP or HTTPS port.');
+
 			$messages->appendMessage(new Message(
-				gettext(
-					'Please input at least an HTTP or HTTPS port.'
-				),
+				$msg,
 				'httpport'
 			));
+
+			$messages->appendMessage(new Message(
+				$msg,
+				'httpsport'
+			));
+		}
+
+		$addresses_length = count(explode(',', (string)$this->address));
+		if ($addresses_length > 1 && $https !== '') {
+			$messages->appendMessage(new Message(
+				gettext(
+					"Can't have more then 1 listen address when using HTTPS"
+				),
+				'address'
+			));
+
+		}
+		if ((string)$this->redisconnection === '') {
+			$redisPassword = (string)$this->getNodeByReference('OPNsense.redis.security.password');
+			if (strpos($redisPassword, '\\') !== false || strpos($redisPassword, '`') !== false) {
+				$messages->appendMessage(new Message(
+					gettext('Redis password cannot contain backslash (\) or backtick (`) characters.'),
+					''
+				));
+			}
 		}
 
         return $messages;

--- a/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/General.php
+++ b/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/General.php
@@ -38,32 +38,21 @@ class General extends BaseModel
         $messages = parent::performValidation($validateFullModel);
 
 
-        $http = (string)$this->httpport;
-        $https = (string)$this->httpsport;
+        $http = (string)$this->addresseshttp;
+        $https = (string)$this->addresseshttps;
 
         if ($http === '' && $https === '') {
             $msg = gettext('Please input at least an HTTP or HTTPS port.');
 
             $messages->appendMessage(new Message(
                 $msg,
-                'httpport'
+                'addresseshttp'
             ));
 
             $messages->appendMessage(new Message(
                 $msg,
-                'httpsport'
+                'addresseshttps'
             ));
-        }
-
-        $addresses_length = count(explode(',', (string)$this->addresses));
-        if ($addresses_length > 1 && $https !== '') {
-            $messages->appendMessage(new Message(
-                gettext(
-                    "Can't have more then 1 listen address when using HTTPS"
-                ),
-                'addresses'
-            ));
-
         }
 
 

--- a/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/General.php
+++ b/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/General.php
@@ -38,42 +38,42 @@ class General extends BaseModel
         $messages = parent::performValidation($validateFullModel);
 
 
-		$http = (string)$this->httpport;
-		$https = (string)$this->httpsport;
+        $http = (string)$this->httpport;
+        $https = (string)$this->httpsport;
 
-		if ($http === '' && $https === '') {
-			$msg = gettext('Please input at least an HTTP or HTTPS port.');
+        if ($http === '' && $https === '') {
+            $msg = gettext('Please input at least an HTTP or HTTPS port.');
 
-			$messages->appendMessage(new Message(
-				$msg,
-				'httpport'
-			));
+            $messages->appendMessage(new Message(
+                $msg,
+                'httpport'
+            ));
 
-			$messages->appendMessage(new Message(
-				$msg,
-				'httpsport'
-			));
-		}
+            $messages->appendMessage(new Message(
+                $msg,
+                'httpsport'
+            ));
+        }
 
-		$addresses_length = count(explode(',', (string)$this->address));
-		if ($addresses_length > 1 && $https !== '') {
-			$messages->appendMessage(new Message(
-				gettext(
-					"Can't have more then 1 listen address when using HTTPS"
-				),
-				'address'
-			));
+        $addresses_length = count(explode(',', (string)$this->addresses));
+        if ($addresses_length > 1 && $https !== '') {
+            $messages->appendMessage(new Message(
+                gettext(
+                    "Can't have more then 1 listen address when using HTTPS"
+                ),
+                'addresses'
+            ));
 
-		}
-		if ((string)$this->redisconnection === '') {
-			$redisPassword = (string)$this->getNodeByReference('OPNsense.redis.security.password');
-			if (strpos($redisPassword, '\\') !== false || strpos($redisPassword, '`') !== false) {
-				$messages->appendMessage(new Message(
-					gettext('Redis password cannot contain backslash (\) or backtick (`) characters.'),
-					''
-				));
-			}
-		}
+        }
+        if ((string)$this->redisconnection === '') {
+            $redisPassword = (string)$this->getNodeByReference('OPNsense.redis.security.password');
+            if (strpos($redisPassword, '\\') !== false || strpos($redisPassword, '`') !== false) {
+                $messages->appendMessage(new Message(
+                    gettext('Redis password cannot contain backslash (\) or backtick (`) characters.'),
+                    ''
+                ));
+            }
+        }
 
         return $messages;
     }

--- a/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/General.php
+++ b/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/General.php
@@ -65,14 +65,31 @@ class General extends BaseModel
             ));
 
         }
-        if ((string)$this->redisconnection === '') {
-            $redisPassword = (string)$this->getNodeByReference('OPNsense.redis.security.password');
-            if (strpos($redisPassword, '\\') !== false || strpos($redisPassword, '`') !== false) {
-                $messages->appendMessage(new Message(
-                    gettext('Redis password cannot contain backslash (\) or backtick (`) characters.'),
-                    ''
-                ));
-            }
+
+
+        $redis_conn = (string)$this->redisconnection;
+
+        if (trim($redis_conn) === '' && $redis_conn !== '') {
+            $messages->appendMessage(new Message(
+                gettext(
+                    "Can't be all whitespace"
+                ),
+                'redisconnection'
+            ));
+        } elseif ($redis_conn !== ltrim($redis_conn)) {
+            $messages->appendMessage(new Message(
+                gettext(
+                    "Can't have leading whitespace"
+                ),
+                'redisconnection'
+            ));
+        } elseif ($redis_conn !== rtrim($redis_conn)) {
+            $messages->appendMessage(new Message(
+                gettext(
+                    "Can't have trailing whitespace"
+                ),
+                'redisconnection'
+            ));
         }
 
         return $messages;

--- a/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/General.php
+++ b/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/General.php
@@ -29,7 +29,27 @@
 namespace OPNsense\Ntopng;
 
 use OPNsense\Base\BaseModel;
+use OPNsense\Base\Messages\Message;
 
 class General extends BaseModel
 {
+    public function performValidation($validateFullModel = false)
+    {
+        $messages = parent::performValidation($validateFullModel);
+
+
+		$http = (string)$this->httpport;
+		$https = (string)$this->httpsport;
+
+		if ($http === '' && $https === '') {
+			$messages->appendMessage(new Message(
+				gettext(
+					'Please input at least an HTTP or HTTPS port.'
+				),
+				'httpport'
+			));
+		}
+
+        return $messages;
+    }
 }

--- a/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/General.xml
+++ b/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/General.xml
@@ -45,7 +45,6 @@
         </cert>
         <redisconnection type="TextField">
             <Required>N</Required>
-            <Mask>/^.*\S.*$/</Mask> <!-- forbids only whitespace, still allows if any non-whitespace chars -->
         </redisconnection>
         <dnsmode type="OptionField">
             <Required>N</Required>

--- a/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/General.xml
+++ b/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/General.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/ntopng/general</mount>
     <description>ntopng configuration</description>
-    <version>0.0.2</version>
+    <version>0.1.3</version>
     <items>
         <enabled type="BooleanField">
             <Default>0</Default>
@@ -12,34 +12,31 @@
             <Multiple>Y</Multiple>
             <AllowDynamic>Y</AllowDynamic>
         </interface>
-        <addresses type="NetworkField">
-            <Required>Y</Required>
-            <Default>::,0.0.0.0</Default>
-            <NetMaskAllowed>N</NetMaskAllowed>
+        <addresseshttp type="IPPortField">
+            <Required>N</Required>
+            <Default>[::]:3000,0.0.0.0:3000</Default>
             <AsList>Y</AsList>
-        </addresses>
-        <httpport type="PortField">
+        </addresseshttp>
+        <addresseshttps type="IPPortField">
             <Required>N</Required>
-            <Default>3000</Default>
-        </httpport>
-        <httpsport type="PortField">
-            <Required>N</Required>
+            <Default></Default>
             <Constraints>
                 <check001>
-                    <ValidationMessage>Please select a HTTPS port and a valid certificate</ValidationMessage>
+                    <ValidationMessage>Please select an HTTPS port and a valid certificate</ValidationMessage>
                     <type>AllOrNoneConstraint</type>
                     <addFields>
                         <field1>cert</field1>
                     </addFields>
                 </check001>
             </Constraints>
-        </httpsport>
+            <AsList>N</AsList>
+        </addresseshttps>
         <cert type="CertificateField">
             <Type>cert</Type>
             <Required>N</Required>
             <Constraints>
                 <check001>
-                    <reference>httpsport.check001</reference>
+                    <reference>addresseshttps.check001</reference>
                 </check001>
             </Constraints>
         </cert>

--- a/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/General.xml
+++ b/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/General.xml
@@ -12,8 +12,14 @@
             <Multiple>Y</Multiple>
             <AllowDynamic>Y</AllowDynamic>
         </interface>
-        <httpport type="PortField">
+        <address type="NetworkField">
             <Required>Y</Required>
+            <Default>::,0.0.0.0</Default>
+            <NetMaskAllowed>N</NetMaskAllowed>
+            <AsList>Y</AsList>
+        </address>
+        <httpport type="PortField">
+            <Required>N</Required>
             <Default>3000</Default>
         </httpport>
         <httpsport type="PortField">
@@ -37,6 +43,10 @@
                 </check001>
             </Constraints>
         </cert>
+        <redisconnection type="TextField">
+            <Required>N</Required>
+            <Mask>/^.*\S.*$/</Mask> <!-- forbids only whitespace, still allows if any non-whitespace chars -->
+        </redisconnection>
         <dnsmode type="OptionField">
             <Required>N</Required>
             <OptionValues>

--- a/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/General.xml
+++ b/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/General.xml
@@ -12,12 +12,12 @@
             <Multiple>Y</Multiple>
             <AllowDynamic>Y</AllowDynamic>
         </interface>
-        <address type="NetworkField">
+        <addresses type="NetworkField">
             <Required>Y</Required>
             <Default>::,0.0.0.0</Default>
             <NetMaskAllowed>N</NetMaskAllowed>
             <AsList>Y</AsList>
-        </address>
+        </addresses>
         <httpport type="PortField">
             <Required>N</Required>
             <Default>3000</Default>

--- a/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/Migrations/M0_1_3.php
+++ b/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/Migrations/M0_1_3.php
@@ -6,38 +6,23 @@ use OPNsense\Core\Config;
 
 class M0_1_3 extends BaseModelMigration
 {
-    private function log($msg)
-    {
-        $logMsg = date('Y-m-d H:i:s') . ' ' . $msg . PHP_EOL;
-        @file_put_contents('/tmp/ntopng_migration_debug.log', $logMsg, FILE_APPEND | LOCK_EX);
-    }
-
     public function run($model)
     {
-        $this->log('--- Starting Migration M0_1_3 ---');
-        
         $config = Config::getInstance()->object();
         $ntopngConfig = $config->OPNsense->ntopng->general ?? null;
 
         if ($ntopngConfig) {
             $httpPort = (string)($ntopngConfig->httpport ?? '');
-            $this->log("Raw Config HTTP Port: '$httpPort'");
             if ($httpPort !== '') {
                 $model->addresseshttp = "[::]:{$httpPort},0.0.0.0:{$httpPort}";
-                $this->log("Migrated addresseshttp: '{$model->addresseshttp}'");
             }
 
             $httpsPort = (string)($ntopngConfig->httpsport ?? '');
-            $this->log("Raw Config HTTPS Port: '$httpsPort'");
             if ($httpsPort !== '') {
                 $model->addresseshttps = "[::]:{$httpsPort}";
-                $this->log("Migrated addresseshttps: '{$model->addresseshttps}'");
             }
-        } else {
-            $this->log('No raw ntopng general config found');
         }
 
         parent::run($model);
-        $this->log('--- Finished Migration M0_1_3 ---');
     }
 }

--- a/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/Migrations/M0_1_3.php
+++ b/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/Migrations/M0_1_3.php
@@ -1,0 +1,45 @@
+<?php
+namespace OPNsense\Ntopng\General\Migrations;
+
+use OPNsense\Base\BaseModelMigration;
+use OPNsense\Core\Config;
+
+class M0_1_3 extends BaseModelMigration
+{
+    function ntop_dbg($msg) {
+        // 1) append to a known temp file so we can read it reliably
+        @file_put_contents('/tmp/ntopng_migration.log', date('c') . ' ' . $msg . PHP_EOL, FILE_APPEND|LOCK_EX);
+        // 2) also write to STDERR so it appears when you run the migration interactively
+        if (defined('STDERR')) {
+            @fwrite(STDERR, date('c') . ' ' . $msg . PHP_EOL);
+        }
+    }
+    public function run($model)
+    {
+
+
+        parent::run($model);
+        $general = $model->getNodeByReference('general');
+        $general->addresseshttp  = "[::]:5555,0.0.0.0:5555";
+        $general->addresseshttps = "[::]:5555";
+
+
+        // $config = Config::getInstance()->object();
+        // // $general = $model->getNodeByReference('general');
+        // $general = $model;
+        //
+        // $httpPort = (string)$config->OPNsense->ntopng->general->httpport;
+        // if (true) {
+        //     $general->addresseshttp = "[::]:{$httpPort},0.0.0.0:{$httpPort}";
+        // }
+        //
+        // $httpsPort = (string)$config->OPNsense->ntopng->general->httpsport;
+        // if (true) {
+        //     $general->addresseshttps = "[::]:{$httpsPort}";
+        // }
+        // if ($general !== null) {
+        //
+        // }
+
+    }
+}

--- a/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/Migrations/M0_1_3.php
+++ b/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/Migrations/M0_1_3.php
@@ -19,7 +19,7 @@ class M0_1_3 extends BaseModelMigration
 
             $httpsPort = (string)($ntopngConfig->httpsport ?? '');
             if ($httpsPort !== '') {
-                $model->addresseshttps = "[::]:{$httpsPort}";
+                $model->addresseshttps = "0.0.0.0:{$httpsPort}";
             }
         }
 

--- a/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/Migrations/M0_1_3.php
+++ b/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/Migrations/M0_1_3.php
@@ -2,21 +2,42 @@
 namespace OPNsense\Ntopng\Migrations;
 
 use OPNsense\Base\BaseModelMigration;
+use OPNsense\Core\Config;
 
 class M0_1_3 extends BaseModelMigration
 {
+    private function log($msg)
+    {
+        $logMsg = date('Y-m-d H:i:s') . ' ' . $msg . PHP_EOL;
+        @file_put_contents('/tmp/ntopng_migration_debug.log', $logMsg, FILE_APPEND | LOCK_EX);
+    }
+
     public function run($model)
     {
-        $httpPort = (string)$model->httpport;
-        if ($httpPort !== '') {
-            $model->addresseshttp = "[::]:{$httpPort},0.0.0.0:{$httpPort}";
-        }
+        $this->log('--- Starting Migration M0_1_3 ---');
+        
+        $config = Config::getInstance()->object();
+        $ntopngConfig = $config->OPNsense->ntopng->general ?? null;
 
-        $httpsPort = (string)$model->httpsport;
-        if ($httpsPort !== '') {
-            $model->addresseshttps = "[::]:{$httpsPort}";
+        if ($ntopngConfig) {
+            $httpPort = (string)($ntopngConfig->httpport ?? '');
+            $this->log("Raw Config HTTP Port: '$httpPort'");
+            if ($httpPort !== '') {
+                $model->addresseshttp = "[::]:{$httpPort},0.0.0.0:{$httpPort}";
+                $this->log("Migrated addresseshttp: '{$model->addresseshttp}'");
+            }
+
+            $httpsPort = (string)($ntopngConfig->httpsport ?? '');
+            $this->log("Raw Config HTTPS Port: '$httpsPort'");
+            if ($httpsPort !== '') {
+                $model->addresseshttps = "[::]:{$httpsPort}";
+                $this->log("Migrated addresseshttps: '{$model->addresseshttps}'");
+            }
+        } else {
+            $this->log('No raw ntopng general config found');
         }
 
         parent::run($model);
+        $this->log('--- Finished Migration M0_1_3 ---');
     }
 }

--- a/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/Migrations/M0_1_3.php
+++ b/net/ntopng/src/opnsense/mvc/app/models/OPNsense/Ntopng/Migrations/M0_1_3.php
@@ -1,45 +1,22 @@
 <?php
-namespace OPNsense\Ntopng\General\Migrations;
+namespace OPNsense\Ntopng\Migrations;
 
 use OPNsense\Base\BaseModelMigration;
-use OPNsense\Core\Config;
 
 class M0_1_3 extends BaseModelMigration
 {
-    function ntop_dbg($msg) {
-        // 1) append to a known temp file so we can read it reliably
-        @file_put_contents('/tmp/ntopng_migration.log', date('c') . ' ' . $msg . PHP_EOL, FILE_APPEND|LOCK_EX);
-        // 2) also write to STDERR so it appears when you run the migration interactively
-        if (defined('STDERR')) {
-            @fwrite(STDERR, date('c') . ' ' . $msg . PHP_EOL);
-        }
-    }
     public function run($model)
     {
+        $httpPort = (string)$model->httpport;
+        if ($httpPort !== '') {
+            $model->addresseshttp = "[::]:{$httpPort},0.0.0.0:{$httpPort}";
+        }
 
+        $httpsPort = (string)$model->httpsport;
+        if ($httpsPort !== '') {
+            $model->addresseshttps = "[::]:{$httpsPort}";
+        }
 
         parent::run($model);
-        $general = $model->getNodeByReference('general');
-        $general->addresseshttp  = "[::]:5555,0.0.0.0:5555";
-        $general->addresseshttps = "[::]:5555";
-
-
-        // $config = Config::getInstance()->object();
-        // // $general = $model->getNodeByReference('general');
-        // $general = $model;
-        //
-        // $httpPort = (string)$config->OPNsense->ntopng->general->httpport;
-        // if (true) {
-        //     $general->addresseshttp = "[::]:{$httpPort},0.0.0.0:{$httpPort}";
-        // }
-        //
-        // $httpsPort = (string)$config->OPNsense->ntopng->general->httpsport;
-        // if (true) {
-        //     $general->addresseshttps = "[::]:{$httpsPort}";
-        // }
-        // if ($general !== null) {
-        //
-        // }
-
     }
 }

--- a/net/ntopng/src/opnsense/service/templates/OPNsense/Ntopng/ntopng.conf
+++ b/net/ntopng/src/opnsense/service/templates/OPNsense/Ntopng/ntopng.conf
@@ -6,21 +6,14 @@
 {%     endfor %}
 {%   endif %}
 
-{%   set http_listens = [] %}
-{%   set https_listens = [] %}
-{%   for address in OPNsense.ntopng.general.addresses.split(',') %}
-{%     set _ = http_listens.append(helpers.host_str_for_port(address) ~ ':' ~ OPNsense.ntopng.general.httpport) %}
-{%     set _ = https_listens.append(helpers.host_str_for_port(address) ~ ':' ~ OPNsense.ntopng.general.httpsport) %}
-{%   endfor %}
-
-{%   if helpers.exists('OPNsense.ntopng.general.httpport') and OPNsense.ntopng.general.httpport != '' %}
---http-port="{{ http_listens | join(',') }}"
+{%   if helpers.exists('OPNsense.ntopng.general.addresseshttp') and OPNsense.ntopng.general.addresseshttp != '' %}
+--http-port="{{ OPNsense.ntopng.general.addresseshttp }}"
 {%   else %}
 --http-port=0
 {%   endif %}
 
-{%   if helpers.exists('OPNsense.ntopng.general.httpsport') and OPNsense.ntopng.general.httpsport != '' %}
---https-port="{{ https_listens | join(',') }}"
+{%   if helpers.exists('OPNsense.ntopng.general.addresseshttps') and OPNsense.ntopng.general.addresseshttps != '' %}
+--https-port="{{ OPNsense.ntopng.general.addresseshttps }}"
 {%   endif %}
 
 {%   if helpers.exists('OPNsense.ntopng.general.redisconnection') and OPNsense.ntopng.general.redisconnection != '' %}

--- a/net/ntopng/src/opnsense/service/templates/OPNsense/Ntopng/ntopng.conf
+++ b/net/ntopng/src/opnsense/service/templates/OPNsense/Ntopng/ntopng.conf
@@ -8,7 +8,7 @@
 
 {%   set http_listens = [] %}
 {%   set https_listens = [] %}
-{% for address in OPNsense.ntopng.general.address.split(',') %}
+{% for address in OPNsense.ntopng.general.addresses.split(',') %}
 {%     set _ = http_listens.append(helpers.format_host_str_for_port(address) ~ ':' ~ OPNsense.ntopng.general.httpport) %}
 {%     set _ = https_listens.append(helpers.format_host_str_for_port(address) ~ ':' ~ OPNsense.ntopng.general.httpsport) %}
 {% endfor %}

--- a/net/ntopng/src/opnsense/service/templates/OPNsense/Ntopng/ntopng.conf
+++ b/net/ntopng/src/opnsense/service/templates/OPNsense/Ntopng/ntopng.conf
@@ -9,8 +9,8 @@
 {%   set http_listens = [] %}
 {%   set https_listens = [] %}
 {% for address in OPNsense.ntopng.general.addresses.split(',') %}
-{%     set _ = http_listens.append(helpers.format_host_str_for_port(address) ~ ':' ~ OPNsense.ntopng.general.httpport) %}
-{%     set _ = https_listens.append(helpers.format_host_str_for_port(address) ~ ':' ~ OPNsense.ntopng.general.httpsport) %}
+{%     set _ = http_listens.append(helpers.host_str_for_port(address) ~ ':' ~ OPNsense.ntopng.general.httpport) %}
+{%     set _ = https_listens.append(helpers.host_str_for_port(address) ~ ':' ~ OPNsense.ntopng.general.httpsport) %}
 {% endfor %}
 
 {%   if helpers.exists('OPNsense.ntopng.general.httpport') and OPNsense.ntopng.general.httpport != '' %}

--- a/net/ntopng/src/opnsense/service/templates/OPNsense/Ntopng/ntopng.conf
+++ b/net/ntopng/src/opnsense/service/templates/OPNsense/Ntopng/ntopng.conf
@@ -8,10 +8,10 @@
 
 {%   set http_listens = [] %}
 {%   set https_listens = [] %}
-{% for address in OPNsense.ntopng.general.addresses.split(',') %}
+{%   for address in OPNsense.ntopng.general.addresses.split(',') %}
 {%     set _ = http_listens.append(helpers.host_str_for_port(address) ~ ':' ~ OPNsense.ntopng.general.httpport) %}
 {%     set _ = https_listens.append(helpers.host_str_for_port(address) ~ ':' ~ OPNsense.ntopng.general.httpsport) %}
-{% endfor %}
+{%   endfor %}
 
 {%   if helpers.exists('OPNsense.ntopng.general.httpport') and OPNsense.ntopng.general.httpport != '' %}
 --http-port="{{ http_listens | join(',') }}"

--- a/net/ntopng/src/opnsense/service/templates/OPNsense/Ntopng/ntopng.conf
+++ b/net/ntopng/src/opnsense/service/templates/OPNsense/Ntopng/ntopng.conf
@@ -27,6 +27,8 @@
 --redis={{ OPNsense.ntopng.general.redisconnection }}
 {%   elif helpers.exists('OPNsense.redis.security.password') and OPNsense.redis.security.password != '' %}
 --redis=localhost:{{ OPNsense.redis.general.port | default('6379') }}:{{ OPNsense.redis.security.password }}
+{%   elif helpers.exists('OPNsense.redis.general.port') and OPNsense.redis.general.port != '' %}
+--redis=localhost:{{ OPNsense.redis.general.port }}
 {%   endif %}
 {%   if helpers.exists('OPNsense.ntopng.general.dnsmode') and OPNsense.ntopng.general.dnsmode != '' %}
 --dns-mode={{ OPNsense.ntopng.general.dnsmode }}

--- a/net/ntopng/src/opnsense/service/templates/OPNsense/Ntopng/ntopng.conf
+++ b/net/ntopng/src/opnsense/service/templates/OPNsense/Ntopng/ntopng.conf
@@ -25,6 +25,8 @@
 
 {%   if helpers.exists('OPNsense.ntopng.general.redisconnection') and OPNsense.ntopng.general.redisconnection != '' %}
 --redis={{ OPNsense.ntopng.general.redisconnection }}
+{%   elif helpers.exists('OPNsense.redis.security.password') and OPNsense.redis.security.password != '' %}
+--redis=localhost:{{ OPNsense.redis.general.port | default('6379') }}:{{ OPNsense.redis.security.password }}
 {%   endif %}
 {%   if helpers.exists('OPNsense.ntopng.general.dnsmode') and OPNsense.ntopng.general.dnsmode != '' %}
 --dns-mode={{ OPNsense.ntopng.general.dnsmode }}

--- a/net/ntopng/src/opnsense/service/templates/OPNsense/Ntopng/ntopng.conf
+++ b/net/ntopng/src/opnsense/service/templates/OPNsense/Ntopng/ntopng.conf
@@ -2,17 +2,32 @@
 {% from 'OPNsense/Macros/interface.macro' import physical_interface %}
 {%   if helpers.exists('OPNsense.ntopng.general.interface') and OPNsense.ntopng.general.interface != '' %}
 {%     for iface in OPNsense.ntopng.general.interface.split(',') %}
--i={{ physical_interface(iface) }}
+--interface={{ physical_interface(iface) }}
 {%     endfor %}
 {%   endif %}
+
+{%   set http_listens = [] %}
+{%   set https_listens = [] %}
+{% for address in OPNsense.ntopng.general.address.split(',') %}
+{%     set _ = http_listens.append(helpers.format_host_str_for_port(address) ~ ':' ~ OPNsense.ntopng.general.httpport) %}
+{%     set _ = https_listens.append(helpers.format_host_str_for_port(address) ~ ':' ~ OPNsense.ntopng.general.httpsport) %}
+{% endfor %}
+
 {%   if helpers.exists('OPNsense.ntopng.general.httpport') and OPNsense.ntopng.general.httpport != '' %}
--w={{ OPNsense.ntopng.general.httpport }}
+--http-port="{{ http_listens | join(',') }}"
+{%   else %}
+--http-port=0
 {%   endif %}
+
 {%   if helpers.exists('OPNsense.ntopng.general.httpsport') and OPNsense.ntopng.general.httpsport != '' %}
--W={{ OPNsense.ntopng.general.httpsport }}
+--https-port="{{ https_listens | join(',') }}"
+{%   endif %}
+
+{%   if helpers.exists('OPNsense.ntopng.general.redisconnection') and OPNsense.ntopng.general.redisconnection != '' %}
+--redis={{ OPNsense.ntopng.general.redisconnection }}
 {%   endif %}
 {%   if helpers.exists('OPNsense.ntopng.general.dnsmode') and OPNsense.ntopng.general.dnsmode != '' %}
--n={{ OPNsense.ntopng.general.dnsmode }}
+--dns-mode={{ OPNsense.ntopng.general.dnsmode }}
 {%   endif %}
--d=/var/db/ntopng
+--data-dir=/var/db/ntopng
 {% endif %}

--- a/net/ntopng/src/opnsense/service/templates/OPNsense/Ntopng/ntopng.conf
+++ b/net/ntopng/src/opnsense/service/templates/OPNsense/Ntopng/ntopng.conf
@@ -14,6 +14,8 @@
 
 {%   if helpers.exists('OPNsense.ntopng.general.addresseshttps') and OPNsense.ntopng.general.addresseshttps != '' %}
 --https-port="{{ OPNsense.ntopng.general.addresseshttps }}"
+{%   else %}
+--https-port=0
 {%   endif %}
 
 {%   if helpers.exists('OPNsense.ntopng.general.redisconnection') and OPNsense.ntopng.general.redisconnection != '' %}


### PR DESCRIPTION
- add the option to configure what addresses to listen on
- add automatic configuration from the Redis plugin for Redis password and port
- add an option to override the Redis server to use
- ntopng seems to have a limit of only 1 listen address on HTTPS; that is checked in `performValidation`
- add a limit to Redis not allowing `\` or `` ` `` for ntopng see the `--redis` option [here](https://www.ntop.org/guides/ntopng/cli_options/cli_options.html) (i feel like the simpler option is to disallow a Redis password that is invalid for ntopng but i could remove that check and add a warning to ntopng)
- update ntopng config when Redis settings are applied (in case the user changed the Redis password or port)

requires [opnsense/core#9500](https://github.com/opnsense/core/pull/9500)

P.S. is there any way to change the permissions of files; both redis.conf and ntopng.conf seem to be readable to all users and contain passwords