### PR TITLE
Feature/dnscrypt proxy blocklist support

### DIFF
--- a/dns/dnscrypt-proxy/src/opnsense/mvc/app/models/OPNsense/Dnscryptproxy/Dnsbl.xml
+++ b/dns/dnscrypt-proxy/src/opnsense/mvc/app/models/OPNsense/Dnscryptproxy/Dnsbl.xml
@@ -19,6 +19,7 @@
                 <ep>Easyprivacy List</ep>
                 <nc>NoCoin List</nc>
                 <pt>PornTop1M List</pt>
+                <qf>Q-Feeds (when installed)</qf>
                 <sa>Simple Ad List</sa>
                 <st>Simple Tracker List</st>
                 <sb>Steven Black List</sb>

--- a/dns/dnscrypt-proxy/src/opnsense/scripts/OPNsense/Dnscryptproxy/dnsbl.sh
+++ b/dns/dnscrypt-proxy/src/opnsense/scripts/OPNsense/Dnscryptproxy/dnsbl.sh
@@ -154,6 +154,13 @@ simpletrack() {
 	rm ${WORKDIR}/simpletrack-raw
 }
 
+qfeeds() {
+	# Q-Feeds List
+	if [ -f "/usr/local/etc/dnscrypt-proxy/blacklist-qfeeds.txt" ] && [ -s "/usr/local/etc/dnscrypt-proxy/blacklist-qfeeds.txt" ]; then
+		sed "/\.$/d" /usr/local/etc/dnscrypt-proxy/blacklist-qfeeds.txt | sed "/^#/d" | sed "/\_/d" | sed "/^[[:space:]]*$/d" | sed "/\.\./d" | sed "s/^\.//g" > ${WORKDIR}/qfeeds
+	fi
+}
+
 install() {
 	# Put all files in correct format
 	for FILE in $(find ${WORKDIR} -type f); do
@@ -161,11 +168,6 @@ install() {
 	done
 	# Merge resulting files (/dev/null in case there are none)
 	cat $(find ${WORKDIR} -type f -name "*.inc") /dev/null | sort -u > ${DESTDIR}/blacklist.txt
-	# Merge additional blacklist-*.txt files (e.g., from q-feeds-connector)
-	if [ -n "$(find ${DESTDIR} -maxdepth 1 -name 'blacklist-*.txt' -type f 2>/dev/null)" ]; then
-		cat ${DESTDIR}/blacklist.txt $(find ${DESTDIR} -maxdepth 1 -name 'blacklist-*.txt' -type f 2>/dev/null) | sort -u > ${DESTDIR}/blacklist.txt.tmp
-		mv ${DESTDIR}/blacklist.txt.tmp ${DESTDIR}/blacklist.txt
-	fi
 	chown _dnscrypt-proxy:_dnscrypt-proxy ${DESTDIR}/blacklist.txt
 	rm -rf ${WORKDIR}
 }
@@ -226,6 +228,9 @@ for CAT in $(echo ${DNSBL} | tr ',' ' '); do
 		;;
 	yy)
 		yoyo
+		;;
+	qf)
+		qfeeds
 		;;
 	esac
 done

--- a/security/q-feeds-connector/src/opnsense/mvc/app/controllers/OPNsense/QFeeds/forms/settings.xml
+++ b/security/q-feeds-connector/src/opnsense/mvc/app/controllers/OPNsense/QFeeds/forms/settings.xml
@@ -15,10 +15,4 @@
         <type>checkbox</type>
         <help>Use domain feeds in Unbound DNS blocklist, requires blocklists to be enabled in order to have effect</help>
     </field>
-    <field>
-        <id>connect.general.enable_dnscryptproxy_bl</id>
-        <label>Register domain feeds for DNSCrypt-Proxy</label>
-        <type>checkbox</type>
-        <help>Use domain feeds in DNSCrypt-Proxy DNSBL blacklist, requires DNSBL to be enabled in DNSCrypt-Proxy settings</help>
-    </field>
 </form>

--- a/security/q-feeds-connector/src/opnsense/mvc/app/models/OPNsense/QFeeds/Connector.xml
+++ b/security/q-feeds-connector/src/opnsense/mvc/app/models/OPNsense/QFeeds/Connector.xml
@@ -6,7 +6,6 @@
         <general>
             <apikey type="TextField"/>
             <enable_unbound_bl type="BooleanField"/>
-            <enable_dnscryptproxy_bl type="BooleanField"/>
         </general>
     </items>
 </model>

--- a/security/q-feeds-connector/src/opnsense/service/templates/OPNsense/QFeeds/+TARGETS
+++ b/security/q-feeds-connector/src/opnsense/service/templates/OPNsense/QFeeds/+TARGETS
@@ -1,3 +1,2 @@
 qfeeds.conf:/usr/local/etc/qfeeds.conf
 qfeeds-blocklists.conf:/usr/local/etc/unbound/qfeeds-blocklists.conf
-qfeeds-dnscryptproxy-bl.conf:/usr/local/etc/qfeeds-dnscryptproxy-bl.conf

--- a/security/q-feeds-connector/src/opnsense/service/templates/OPNsense/QFeeds/qfeeds-dnscryptproxy-bl.conf
+++ b/security/q-feeds-connector/src/opnsense/service/templates/OPNsense/QFeeds/qfeeds-dnscryptproxy-bl.conf
@@ -1,6 +1,0 @@
-{% if not helpers.empty('OPNsense.QFeedsConnector.general.apikey') and
-      not helpers.empty('OPNsense.QFeedsConnector.general.enable_dnscryptproxy_bl') %}
-[settings]
-filenames=/var/db/qfeeds-tables/malware_domains.txt
-{% endif %}
-


### PR DESCRIPTION
Adds support for integrating Q-Feeds domain feeds with DNSCrypt-Proxy DNSBL, similar to the existing Unbound blocklist integration.

**Changes**:
New enable_dnscryptproxy_bl setting and UI checkbox
Script to add/remove q-feeds domains from DNSCrypt-Proxy blacklist

**Requirements**:
DNSCrypt-Proxy plugin installed
DNSBL enabled in DNSCrypt-Proxy settings

**Tested**: 

Verified blocking works correctly on development box.