### PR TITLE
Support custom Bind9 Options from Config Files

### DIFF
--- a/dns/bind/src/etc/namedb/named.conf.options.d/00-README.conf
+++ b/dns/bind/src/etc/namedb/named.conf.options.d/00-README.conf
@@ -1,0 +1,7 @@
+# Custom BIND Options Directory
+#
+# Place your custom BIND options in .conf files in this directory
+# Files are included in alphabetical order
+#
+# Examples:
+# response-policy { zone "my.zone"; };

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
@@ -99,6 +99,7 @@ options {
         };
 {%   endif %}
 {% endif %}
+        include "/usr/local/etc/namedb/named.conf.options.d/*.conf";
 };
 
 {% if helpers.exists('OPNsense.bind.general.rndcalgo') and helpers.exists('OPNsense.bind.general.rndcsecret') %}


### PR DESCRIPTION
Support defining custom Bind9 options from configuration files.  This helps the Bind9 plugin be more robust and provides more options for users.

Example:
Defining response-policy zones
File: 50-rpz-zones.conf
~~~
response-policy {
    zone "rpz.my.zone";
};
~~~
