### PR TITLE
Add some scripts to automatically handle JNL file pollution

### DIFF
--- a/dns/bind/src/etc/rc.syshook.d/early/99-named
+++ b/dns/bind/src/etc/rc.syshook.d/early/99-named
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+#
+# It's OK to delete these files on bootup because we clean them out
+# during a clean shutdown. Therefore if these files still exist on
+# bootup, it means that the system wasn't shut down cleanly and as
+# a result these files are suspect and likely broken, so they need
+# to be removed to avoid any BIND9 bootup issues.
+#
+echo "Clearing out vestigial BIND9 journal files ..."
+find /usr/local/etc/namedb/primary -type f -name '*.jnl' -delete -print

--- a/dns/bind/src/etc/rc.syshook.d/stop/99-named
+++ b/dns/bind/src/etc/rc.syshook.d/stop/99-named
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+BINDHOME="/usr/local/etc/namedb"
+
+log()
+{
+	[ ${#} -gt 0 ] || return 0
+	logger -is -t "bind-cleanup" "${@}"
+}
+
+#
+# First, do things the easy way (only possible if BIND9 is running!)
+#
+if service named status 1>/dev/null 2>&1 ; then
+	log "Clearing out pending BIND9 journal files..."
+	OUT="$(rndc sync -clean 2>&1)" || log "RNDC SYNC failed (rc=${?}): ${OUT}"
+
+	log "Stopping BIND ..."
+	OUT="$(service named stop 2>&1)" || log "Could not stop BIND (rc=${?}): ${OUT}"
+fi
+
+#
+# If the easy way didn't work, we do things the hard way because these
+# journal files can cause a LOT of issues when BIND9 next tries to start
+#
+if OUT="$(cd "${BINDHOME}/primary" && find * -type f -name '*.jnl' | fgrep '.jnl')" ; then
+	log "WARNING: BIND9 journal files still exist - [${OUT}]"
+	find "${BINDHOME}/primary" -type f -name '*.jnl' -delete -print
+fi
+
+exit 0

--- a/dns/bind/src/opnsense/scripts/OPNsense/Bind/setup.sh
+++ b/dns/bind/src/opnsense/scripts/OPNsense/Bind/setup.sh
@@ -5,3 +5,13 @@ for DIR in /var/run/named /var/dump /var/stats /var/log/named /usr/local/etc/nam
 	chown -R bind:bind ${DIR}
 	chmod 755 ${DIR}
 done
+
+# This should help clean out orphaned journal files
+if ! rndc sync -clean ; then
+	# If the RNDC command didn't work, we should probably clean
+	# the files out manually because on a clean shutdown they
+	# would be cleared out by "service named stop" ... so if
+	# they're still around it means something went down HARD and
+	# thus the files are suspect and could derail BIND9 startup
+	find /usr/local/etc/namedb/primary -type f -name '*.jnl' -print -delete
+fi


### PR DESCRIPTION
In some cases, when running primary zones using BIND as the DNS, the journal files may not get properly synchronized into their primary zone databases - possibly because bind isn't shut down cleanly using the O/S's service scripts. As a result, on the next bootup, BIND9 may refuse to boot because those journal files are corrupted.

These scripts try to maximize the instances under which those journal files are cleaned out properly. The right way to do the cleanout is by either running `service named stop` or `rndc sync -clean`. Either of these commands will instruct BIND to sync the journal files to their DBs and clean them out properly.

However, if that fails, then there are contingencies in place to forcibly remove those files - if they didn't get synchronized cleanly, then they're garbage and should be removed. If they did, then they disappear and there will be nothing to forcibly delete.

Either way, the intent is to ensure that BIND has no issues starting up when runnin a master zone.

This is related to issue #5068, also reported by me (via a different account ... sorry :) ).