### PR TITLE
Wazuh agent repeated offenders

### DIFF
--- a/security/wazuh-agent/src/opnsense/mvc/app/controllers/OPNsense/WazuhAgent/forms/settings.xml
+++ b/security/wazuh-agent/src/opnsense/mvc/app/controllers/OPNsense/WazuhAgent/forms/settings.xml
@@ -88,6 +88,16 @@
         </help>
     </field>
     <field>
+        <id>agent.active_response.repeated_offenders</id>
+        <label>Repeated offenders</label>
+        <type>text</type>
+        <help>
+            Comma-separated list of increasing timeout values in minutes for repeat offenders (e.g., 30,60,120,240).
+            When an IP triggers active response multiple times, each subsequent block uses the next timeout value.
+            Leave empty to disable repeated offender escalation.
+        </help>
+    </field>
+    <field>
         <id>agent.active_response.remote_commands</id>
         <label>Wazuh remote commands</label>
         <type>checkbox</type>

--- a/security/wazuh-agent/src/opnsense/mvc/app/models/OPNsense/WazuhAgent/WazuhAgent.xml
+++ b/security/wazuh-agent/src/opnsense/mvc/app/models/OPNsense/WazuhAgent/WazuhAgent.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/WazuhAgent</mount>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <description>Wazuh Agent</description>
     <items>
         <general>
@@ -112,6 +112,11 @@
                 </Model>
                 <Required>N</Required>
             </fw_alias_ignore>
+            <repeated_offenders type="TextField">
+                <Required>N</Required>
+                <Mask>/^([0-9]+)(,[0-9]+)*$/</Mask>
+                <ValidationMessage>Enter comma-separated timeout values in minutes (e.g., 30,60,120,240)</ValidationMessage>
+            </repeated_offenders>
         </active_response>
     </items>
 </model>

--- a/security/wazuh-agent/src/opnsense/service/templates/OPNsense/WazuhAgent/opnsense-fw.conf
+++ b/security/wazuh-agent/src/opnsense/service/templates/OPNsense/WazuhAgent/opnsense-fw.conf
@@ -1,4 +1,4 @@
 [general]
 {% if not helpers.empty('OPNsense.WazuhAgent.active_response.fw_alias_ignore') and helpers.getUUID(OPNsense.WazuhAgent.active_response.fw_alias_ignore) %}
-skip_alias={{helpers.getUUID(OPNsense.WazuhAgent.wazuh_command.fw_alias_ignore).name}}
+skip_alias={{helpers.getUUID(OPNsense.WazuhAgent.active_response.fw_alias_ignore).name}}
 {% endif %}

--- a/security/wazuh-agent/src/opnsense/service/templates/OPNsense/WazuhAgent/ossec.conf
+++ b/security/wazuh-agent/src/opnsense/service/templates/OPNsense/WazuhAgent/ossec.conf
@@ -22,7 +22,7 @@
   </client_buffer>
 
 {%  for sfilename in helpers.glob("OPNsense/WazuhAgent/ossec_config.d/*.conf") %}{%
-        include sfilename without context
+        include sfilename
 +%}
 
 {%  endfor %}

--- a/security/wazuh-agent/src/opnsense/service/templates/OPNsense/WazuhAgent/ossec_config.d/005-active-response.conf
+++ b/security/wazuh-agent/src/opnsense/service/templates/OPNsense/WazuhAgent/ossec_config.d/005-active-response.conf
@@ -1,4 +1,7 @@
   <!-- Active response -->
   <active-response>
     <disabled>{% if not helpers.empty('OPNsense.WazuhAgent.active_response.enabled') %}no{% else %}yes{% endif %}</disabled>
+{% if not helpers.empty('OPNsense.WazuhAgent.active_response.repeated_offenders') %}
+    <repeated_offenders>{{ OPNsense.WazuhAgent.active_response.repeated_offenders }}</repeated_offenders>
+{% endif %}
   </active-response>


### PR DESCRIPTION
### Summary

This PR adds GUI configuration for the Wazuh `repeated_offenders` active response setting and fixes a pre-existing bug in the `opnsense-fw.conf` template.

### Changes

**New Feature: Repeated Offenders Configuration**

Adds a text field in Services > Wazuh Agent > Settings > Active Response that allows configuring escalating block timeouts for repeat offenders.

Example value: `30,60,120`
- 1st offense: normal timeout from manager
- 2nd offense: 30 minutes
- 3rd offense: 60 minutes  
- 4th+ offense: 120 minutes

This setting was previously only configurable by manually editing files in `ossec_config.d/`.

**Bug Fix: opnsense-fw.conf template**

Fixed a bug where the template referenced `OPNsense.WazuhAgent.wazuh_command.fw_alias_ignore` instead of the correct path `OPNsense.WazuhAgent.active_response.fw_alias_ignore`. This caused template generation to fail when using the firewall alias ignore feature.

### Files Changed

| File | Change |
|------|--------|
| `models/OPNsense/WazuhAgent/WazuhAgent.xml` | Added `repeated_offenders` TextField, bumped version to 1.0.3 |
| `controllers/OPNsense/WazuhAgent/forms/settings.xml` | Added UI field for repeated_offenders |
| `service/templates/OPNsense/WazuhAgent/ossec.conf` | Moved active-response block inline (required for variable access) |
| `service/templates/OPNsense/WazuhAgent/opnsense-fw.conf` | Fixed `wazuh_command` -> `active_response` reference |
| `service/templates/OPNsense/WazuhAgent/ossec_config.d/005-active-response.conf` | **DELETED** (moved to ossec.conf) |

### Technical Notes

The active-response configuration block was moved from `ossec_config.d/005-active-response.conf` to the main `ossec.conf` template. This is required because config fragments included with `without context` cannot access template variables directly (only `helpers.*` functions work). Since `repeated_offenders` needs variable interpolation, the block must be in the main template.

### Testing

Tested on:
- OPNsense 25.7.10
- os-wazuh-agent 1.2_3
- wazuh-agent 4.12.0
- FreeBSD 14.3-RELEASE-p7

Verified:
- Template generates correctly with and without repeated_offenders value
- Agent loads configured timeout values on startup
- Active response blocking functions correctly
- Escalation triggers for repeat offenders

### Screenshots

The new field appears in the Active Response section:

```
[ Active response ]
  ☑ Enable
  Firewall command ignore: [dropdown]
  Repeated offenders: [30,60,120___________]
  ☐ Wazuh remote commands (advanced)
```
