### PR TITLE
net/chrony: Improve configuration options

### DIFF
--- a/net/chrony/Makefile
+++ b/net/chrony/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		chrony
-PLUGIN_VERSION=		1.5
+PLUGIN_VERSION=		1.6
 PLUGIN_REVISION=	3
 PLUGIN_COMMENT=		Chrony time synchronisation
 PLUGIN_DEPENDS=		chrony

--- a/net/chrony/pkg-descr
+++ b/net/chrony/pkg-descr
@@ -6,7 +6,14 @@ Plugin Changelog
 
 1.6
 
-* Add NTP data tab
+* Update config UI to expose the following features:
+    - local/orphan mode
+    - pools
+    - prefer
+    - iburst
+    - min/max poll
+    - interleaving
+* Add NTP data diagnostics
 
 1.5
 

--- a/net/chrony/pkg-descr
+++ b/net/chrony/pkg-descr
@@ -4,6 +4,10 @@ better in virtual environments.
 Plugin Changelog
 ----------------
 
+1.6
+
+* Add NTP data tab
+
 1.5
 
 * Allow adding a fallback NTP when using NTS

--- a/net/chrony/pkg-descr
+++ b/net/chrony/pkg-descr
@@ -13,6 +13,7 @@ Plugin Changelog
     - iburst
     - min/max poll
     - interleaving
+* Add per-source NTS option
 * Add NTP data diagnostics
 
 1.5

--- a/net/chrony/src/opnsense/mvc/app/controllers/OPNsense/Chrony/Api/GeneralController.php
+++ b/net/chrony/src/opnsense/mvc/app/controllers/OPNsense/Chrony/Api/GeneralController.php
@@ -32,6 +32,36 @@ use OPNsense\Base\ApiMutableModelControllerBase;
 
 class GeneralController extends ApiMutableModelControllerBase
 {
-    protected static $internalModelClass = '\OPNsense\Chrony\General';
     protected static $internalModelName = 'general';
+    protected static $internalModelClass = '\OPNsense\Chrony\General';
+
+    public function searchItemAction()
+    {
+        return $this->searchBase("peers.peer", null, "address");
+    }
+
+    public function setItemAction($uuid)
+    {
+        return $this->setBase("peer", "peers.peer", $uuid);
+    }
+
+    public function addItemAction()
+    {
+        return $this->addBase("peer", "peers.peer");
+    }
+
+    public function getItemAction($uuid = null)
+    {
+        return $this->getBase("peer", "peers.peer", $uuid);
+    }
+
+    public function delItemAction($uuid)
+    {
+        return $this->delBase("peers.peer", $uuid);
+    }
+
+    public function toggleItemAction($uuid, $enabled = null)
+    {
+        return $this->toggleBase("peers.peer", $uuid, $enabled);
+    }
 }

--- a/net/chrony/src/opnsense/mvc/app/controllers/OPNsense/Chrony/Api/ServiceController.php
+++ b/net/chrony/src/opnsense/mvc/app/controllers/OPNsense/Chrony/Api/ServiceController.php
@@ -82,4 +82,15 @@ class ServiceController extends ApiMutableServiceControllerBase
         $response = $backend->configdRun("chrony chronyauthdata");
         return array("response" => $response);
     }
+
+    /**
+     * show chrony ntpdata
+     * @return array
+     */
+    public function chronyntpdataAction()
+    {
+        $backend = new Backend();
+        $response = $backend->configdRun("chrony chronyntpdata");
+        return array("response" => $response);
+    }
 }

--- a/net/chrony/src/opnsense/mvc/app/controllers/OPNsense/Chrony/IndexController.php
+++ b/net/chrony/src/opnsense/mvc/app/controllers/OPNsense/Chrony/IndexController.php
@@ -28,11 +28,13 @@
 
 namespace OPNsense\Chrony;
 
-class GeneralController extends \OPNsense\Base\IndexController
+class IndexController extends \OPNsense\Base\IndexController
 {
     public function indexAction()
     {
+        $this->view->pick('OPNsense/Chrony/index');
         $this->view->generalForm = $this->getForm('general');
-        $this->view->pick('OPNsense/Chrony/general');
+        $this->view->formDialogPeer = $this->getForm("dialogPeer");
+        $this->view->formGridPeer = $this->getFormGrid("dialogPeer");
     }
 }

--- a/net/chrony/src/opnsense/mvc/app/controllers/OPNsense/Chrony/forms/dialogPeer.xml
+++ b/net/chrony/src/opnsense/mvc/app/controllers/OPNsense/Chrony/forms/dialogPeer.xml
@@ -17,10 +17,10 @@
         <help>The address/hostname of the NTP server or pool.</help>
     </field>
     <field>
-        <id>peer.iburst</id>
-        <label>iburst</label>
+        <id>peer.prefer</id>
+        <label>prefer</label>
         <type>checkbox</type>
-        <help>Enable iburst for this source.</help>
+        <help>Prefer this source over sources without the prefer option.</help>
         <grid_view>
             <width>6em</width>
             <type>boolean</type>
@@ -28,10 +28,10 @@
         </grid_view>
     </field>
     <field>
-        <id>peer.prefer</id>
-        <label>prefer</label>
+        <id>peer.iburst</id>
+        <label>iburst</label>
         <type>checkbox</type>
-        <help>Prefer this source over sources without the prefer option.</help>
+        <help>Enable iburst for this source.</help>
         <grid_view>
             <width>6em</width>
             <type>boolean</type>
@@ -50,13 +50,13 @@
         </grid_view>
     </field>
     <field>
-        <id>general.minpoll</id>
+        <id>peer.minpoll</id>
         <label>minpoll</label>
         <type>text</type>
         <help>The minimum interval between requests sent to the server as a power of 2 in seconds.</help>
     </field>
     <field>
-        <id>general.maxpoll</id>
+        <id>peer.maxpoll</id>
         <label>maxpoll</label>
         <type>text</type>
         <help>The maximum interval between requests sent to the server as a power of 2 in seconds.</help>

--- a/net/chrony/src/opnsense/mvc/app/controllers/OPNsense/Chrony/forms/dialogPeer.xml
+++ b/net/chrony/src/opnsense/mvc/app/controllers/OPNsense/Chrony/forms/dialogPeer.xml
@@ -1,0 +1,64 @@
+<form>
+    <field>
+        <id>peer.pool</id>
+        <label>pool</label>
+        <type>checkbox</type>
+        <help>Address refers to a pool of NTP servers</help>
+        <grid_view>
+            <width>6em</width>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+        </grid_view>
+    </field>
+    <field>
+        <id>peer.address</id>
+        <label>Address</label>
+        <type>text</type>
+        <help>The address/hostname of the NTP server or pool.</help>
+    </field>
+    <field>
+        <id>peer.iburst</id>
+        <label>iburst</label>
+        <type>checkbox</type>
+        <help>Enable iburst for this source.</help>
+        <grid_view>
+            <width>6em</width>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+        </grid_view>
+    </field>
+    <field>
+        <id>peer.prefer</id>
+        <label>prefer</label>
+        <type>checkbox</type>
+        <help>Prefer this source over sources without the prefer option.</help>
+        <grid_view>
+            <width>6em</width>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+        </grid_view>
+    </field>
+    <field>
+        <id>peer.xleave</id>
+        <label>xleave</label>
+        <type>checkbox</type>
+        <help>Enable interleaved mode for this source.</help>
+        <grid_view>
+            <width>6em</width>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+        </grid_view>
+    </field>
+    <field>
+        <id>general.minpoll</id>
+        <label>minpoll</label>
+        <type>text</type>
+        <help>The minimum interval between requests sent to the server as a power of 2 in seconds.</help>
+    </field>
+    <field>
+        <id>general.maxpoll</id>
+        <label>maxpoll</label>
+        <type>text</type>
+        <help>The maximum interval between requests sent to the server as a power of 2 in seconds.</help>
+    </field>
+</form>

--- a/net/chrony/src/opnsense/mvc/app/controllers/OPNsense/Chrony/forms/dialogPeer.xml
+++ b/net/chrony/src/opnsense/mvc/app/controllers/OPNsense/Chrony/forms/dialogPeer.xml
@@ -61,4 +61,15 @@
         <type>text</type>
         <help>The maximum interval between requests sent to the server as a power of 2 in seconds.</help>
     </field>
+    <field>
+        <id>peer.nts</id>
+        <label>NTS</label>
+        <type>checkbox</type>
+        <help>Enable NTS authentication.</help>
+        <grid_view>
+            <width>6em</width>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+        </grid_view>
+    </field>
 </form>

--- a/net/chrony/src/opnsense/mvc/app/controllers/OPNsense/Chrony/forms/general.xml
+++ b/net/chrony/src/opnsense/mvc/app/controllers/OPNsense/Chrony/forms/general.xml
@@ -6,14 +6,6 @@
         <help>Enable Chrony time daemon.</help>
     </field>
     <field>
-        <id>general.peers</id>
-        <label>NTP Peers</label>
-        <style>tokenize</style>
-        <type>select_multiple</type>
-        <allownew>true</allownew>
-        <help>Set as many NTP peers you need.</help>
-    </field>
-    <field>
         <id>general.localstratum</id>
         <label>Local Stratum</label>
         <type>text</type>

--- a/net/chrony/src/opnsense/mvc/app/controllers/OPNsense/Chrony/forms/general.xml
+++ b/net/chrony/src/opnsense/mvc/app/controllers/OPNsense/Chrony/forms/general.xml
@@ -32,21 +32,9 @@
         <help>Set the networks allowed to synchronize time with this server. If this value is not set it will also not listen to the port and just synchronize the time for itself.</help>
     </field>
     <field>
-        <id>general.ntsclient</id>
-        <label>NTS Client Support</label>
-        <type>checkbox</type>
-        <help>Enable NTS in client mode. This will add another layer of security for peers when OPNsense is the client. Every server in Peers has to support NTS.</help>
-    </field>
-    <field>
         <id>general.ntsnocert</id>
         <label>NTS Disable Certcheck</label>
         <type>checkbox</type>
         <help>If you run NTS mode you can enable this option in order to ignore wrong time in certificates for the first check. This helps if your system starts with wrong time.</help>
-    </field>
-    <field>
-        <id>general.fallbackpeers</id>
-        <label>Fallback Peer</label>
-        <type>text</type>
-        <help>Set fallback peer if you use NTS and your system starts with wrong time. Best to only use this for internal trusted peers.</help>
     </field>
 </form>

--- a/net/chrony/src/opnsense/mvc/app/controllers/OPNsense/Chrony/forms/general.xml
+++ b/net/chrony/src/opnsense/mvc/app/controllers/OPNsense/Chrony/forms/general.xml
@@ -6,10 +6,38 @@
         <help>Enable Chrony time daemon.</help>
     </field>
     <field>
+        <id>general.peers</id>
+        <label>NTP Peers</label>
+        <style>tokenize</style>
+        <type>select_multiple</type>
+        <allownew>true</allownew>
+        <help>Set as many NTP peers you need.</help>
+    </field>
+    <field>
+        <id>general.localstratum</id>
+        <label>Local Stratum</label>
+        <type>text</type>
+        <help>(1-15) Local mode allows the system clock to be used when no other clocks are available. The number here specifies the stratum reported by the local clock and should normally be set to a number high enough to ensure that any other servers available to clients are preferred over this server.</help>
+    </field>
+    <field>
+        <id>general.orphanmode</id>
+        <label>Orphan Mode</label>
+        <type>checkbox</type>
+        <help></help>
+    </field>
+    <field>
         <id>general.port</id>
         <label>Listen Port</label>
         <type>text</type>
         <help>Set the port chrony listen to.</help>
+    </field>
+    <field>
+        <id>general.allowednetworks</id>
+        <label>Allowed Networks</label>
+        <style>tokenize</style>
+        <type>select_multiple</type>
+        <allownew>true</allownew>
+        <help>Set the networks allowed to synchronize time with this server. If this value is not set it will also not listen to the port and just synchronize the time for itself.</help>
     </field>
     <field>
         <id>general.ntsclient</id>
@@ -24,25 +52,9 @@
         <help>If you run NTS mode you can enable this option in order to ignore wrong time in certificates for the first check. This helps if your system starts with wrong time.</help>
     </field>
     <field>
-        <id>general.peers</id>
-        <label>NTP Peers</label>
-        <style>tokenize</style>
-        <type>select_multiple</type>
-        <allownew>true</allownew>
-        <help>Set as many NTP peers you need.</help>
-    </field>
-    <field>
         <id>general.fallbackpeers</id>
         <label>Fallback Peer</label>
         <type>text</type>
         <help>Set fallback peer if you use NTS and your system starts with wrong time. Best to only use this for internal trusted peers.</help>
-    </field>
-    <field>
-        <id>general.allowednetworks</id>
-        <label>Allowed Networks</label>
-        <style>tokenize</style>
-        <type>select_multiple</type>
-        <allownew>true</allownew>
-        <help>Set the networks allowed to synchronize time with this server. If this value is not set it will also not listen to the port and just synchronize the time for itself.</help>
     </field>
 </form>

--- a/net/chrony/src/opnsense/mvc/app/models/OPNsense/Chrony/General.xml
+++ b/net/chrony/src/opnsense/mvc/app/models/OPNsense/Chrony/General.xml
@@ -10,21 +10,21 @@
         <peers>
             <peer type="ArrayField">
                 <pool type="BooleanField">
-                    <Default>1</Default>
+                    <Default>0</Default>
                     <Required>Y</Required>
                 </pool>
                 <address type="HostnameField">
                     <Default>opnsense.pool.ntp.org</Default>
                     <Required>Y</Required>
                 </address>
-                <iburst type="BooleanField">
-                    <Default>0</Default>
-                    <Required>Y</Required>
-                </iburst>
                 <prefer type="BooleanField">
                     <Default>0</Default>
                     <Required>Y</Required>
                 </prefer>
+                <iburst type="BooleanField">
+                    <Default>0</Default>
+                    <Required>Y</Required>
+                </iburst>
                 <xleave type="BooleanField">
                     <Default>0</Default>
                     <Required>Y</Required>

--- a/net/chrony/src/opnsense/mvc/app/models/OPNsense/Chrony/General.xml
+++ b/net/chrony/src/opnsense/mvc/app/models/OPNsense/Chrony/General.xml
@@ -7,6 +7,29 @@
             <Default>0</Default>
             <Required>Y</Required>
         </enabled>
+        <localstratum type="IntegerField">
+            <MinimumValue>1</MinimumValue>
+            <MaximumValue>15</MaximumValue>
+            <Required>N</Required>
+            <ValidationMessage>Local stratum must be within 1-15.</ValidationMessage>
+        </localstratum>
+        <orphanmode type="BooleanField">
+            <Default>0</Default>
+            <Required>Y</Required>
+        </orphanmode>
+        <port type="PortField">
+            <Default>123</Default>
+            <Required>Y</Required>
+        </port>
+        <allowednetworks type="NetworkField">
+            <Required>N</Required>
+            <FieldSeparator>,</FieldSeparator>
+            <AsList>Y</AsList>
+        </allowednetworks>
+        <ntsnocert type="BooleanField">
+            <Default>0</Default>
+            <Required>Y</Required>
+        </ntsnocert>
         <peers>
             <peer type="ArrayField">
                 <pool type="BooleanField">
@@ -41,37 +64,11 @@
                     <Required>N</Required>
                     <ValidationMessage>maxpoll value must be between -6 and 24.</ValidationMessage>
                 </maxpoll>
+                <nts type="BooleanField">
+                    <Default>0</Default>
+                    <Required>Y</Required>
+                </nts>
             </peer>
         </peers>
-        <localstratum type="IntegerField">
-            <MinimumValue>1</MinimumValue>
-            <MaximumValue>15</MaximumValue>
-            <Required>N</Required>
-            <ValidationMessage>Local stratum must be within 1-15.</ValidationMessage>
-        </localstratum>
-        <orphanmode type="BooleanField">
-            <Default>0</Default>
-            <Required>Y</Required>
-        </orphanmode>
-        <port type="PortField">
-            <Default>123</Default>
-            <Required>Y</Required>
-        </port>
-        <allowednetworks type="NetworkField">
-            <Required>N</Required>
-            <FieldSeparator>,</FieldSeparator>
-            <AsList>Y</AsList>
-        </allowednetworks>
-        <ntsclient type="BooleanField">
-            <Default>0</Default>
-            <Required>Y</Required>
-        </ntsclient>
-        <ntsnocert type="BooleanField">
-            <Default>0</Default>
-            <Required>Y</Required>
-        </ntsnocert>
-        <fallbackpeers type="HostnameField">
-            <Required>N</Required>
-        </fallbackpeers>
     </items>
 </model>

--- a/net/chrony/src/opnsense/mvc/app/models/OPNsense/Chrony/General.xml
+++ b/net/chrony/src/opnsense/mvc/app/models/OPNsense/Chrony/General.xml
@@ -7,11 +7,41 @@
             <Default>0</Default>
             <Required>Y</Required>
         </enabled>
-        <peers type="HostnameField">
-            <Default>0.opnsense.pool.ntp.org</Default>
-            <Required>Y</Required>
-            <FieldSeparator>,</FieldSeparator>
-            <AsList>Y</AsList>
+        <peers>
+            <peer type="ArrayField">
+                <pool type="BooleanField">
+                    <Default>1</Default>
+                    <Required>Y</Required>
+                </pool>
+                <address type="HostnameField">
+                    <Default>opnsense.pool.ntp.org</Default>
+                    <Required>Y</Required>
+                </address>
+                <iburst type="BooleanField">
+                    <Default>0</Default>
+                    <Required>Y</Required>
+                </iburst>
+                <prefer type="BooleanField">
+                    <Default>0</Default>
+                    <Required>Y</Required>
+                </prefer>
+                <xleave type="BooleanField">
+                    <Default>0</Default>
+                    <Required>Y</Required>
+                </xleave>
+                <minpoll type="IntegerField">
+                    <MinimumValue>-6</MinimumValue>
+                    <MaximumValue>24</MaximumValue>
+                    <Required>N</Required>
+                    <ValidationMessage>minpoll value must be between -6 and 24.</ValidationMessage>
+                </minpoll>
+                <maxpoll type="IntegerField">
+                    <MinimumValue>-6</MinimumValue>
+                    <MaximumValue>24</MaximumValue>
+                    <Required>N</Required>
+                    <ValidationMessage>maxpoll value must be between -6 and 24.</ValidationMessage>
+                </maxpoll>
+            </peer>
         </peers>
         <localstratum type="IntegerField">
             <MinimumValue>1</MinimumValue>

--- a/net/chrony/src/opnsense/mvc/app/models/OPNsense/Chrony/General.xml
+++ b/net/chrony/src/opnsense/mvc/app/models/OPNsense/Chrony/General.xml
@@ -7,10 +7,31 @@
             <Default>0</Default>
             <Required>Y</Required>
         </enabled>
+        <peers type="HostnameField">
+            <Default>0.opnsense.pool.ntp.org</Default>
+            <Required>Y</Required>
+            <FieldSeparator>,</FieldSeparator>
+            <AsList>Y</AsList>
+        </peers>
+        <localstratum type="IntegerField">
+            <MinimumValue>1</MinimumValue>
+            <MaximumValue>15</MaximumValue>
+            <Required>N</Required>
+            <ValidationMessage>Local stratum must be within 1-15.</ValidationMessage>
+        </localstratum>
+        <orphanmode type="BooleanField">
+            <Default>0</Default>
+            <Required>Y</Required>
+        </orphanmode>
         <port type="PortField">
             <Default>323</Default>
             <Required>Y</Required>
         </port>
+        <allowednetworks type="NetworkField">
+            <Required>N</Required>
+            <FieldSeparator>,</FieldSeparator>
+            <AsList>Y</AsList>
+        </allowednetworks>
         <ntsclient type="BooleanField">
             <Default>0</Default>
             <Required>Y</Required>
@@ -19,19 +40,8 @@
             <Default>0</Default>
             <Required>Y</Required>
         </ntsnocert>
-        <peers type="HostnameField">
-            <Default>0.opnsense.pool.ntp.org</Default>
-            <Required>Y</Required>
-            <FieldSeparator>,</FieldSeparator>
-            <AsList>Y</AsList>
-        </peers>
         <fallbackpeers type="HostnameField">
             <Required>N</Required>
         </fallbackpeers>
-        <allowednetworks type="NetworkField">
-            <Required>N</Required>
-            <FieldSeparator>,</FieldSeparator>
-            <AsList>Y</AsList>
-        </allowednetworks>
     </items>
 </model>

--- a/net/chrony/src/opnsense/mvc/app/models/OPNsense/Chrony/General.xml
+++ b/net/chrony/src/opnsense/mvc/app/models/OPNsense/Chrony/General.xml
@@ -54,7 +54,7 @@
             <Required>Y</Required>
         </orphanmode>
         <port type="PortField">
-            <Default>323</Default>
+            <Default>123</Default>
             <Required>Y</Required>
         </port>
         <allowednetworks type="NetworkField">

--- a/net/chrony/src/opnsense/mvc/app/models/OPNsense/Chrony/Menu/Menu.xml
+++ b/net/chrony/src/opnsense/mvc/app/models/OPNsense/Chrony/Menu/Menu.xml
@@ -1,7 +1,7 @@
 <menu>
   <Services>
     <Chrony cssClass="fa fa-clock-o">
-      <General url="/ui/chrony/general/index"/>
+      <General url="/ui/chrony/index/index"/>
     </Chrony>
   </Services>
 </menu>

--- a/net/chrony/src/opnsense/mvc/app/views/OPNsense/Chrony/general.volt
+++ b/net/chrony/src/opnsense/mvc/app/views/OPNsense/Chrony/general.volt
@@ -31,6 +31,7 @@
     <li><a data-toggle="tab" href="#chronysourcestats">{{ lang._('Source Stats') }}</a></li>
     <li><a data-toggle="tab" href="#chronytracking">{{ lang._('Tracking') }}</a></li>
     <li><a data-toggle="tab" href="#chronyauthdata">{{ lang._('Auth Data') }}</a></li>
+    <li><a data-toggle="tab" href="#chronyntpdata">{{ lang._('NTP Data') }}</a></li>
 </ul>
 
 <div class="tab-content content-box tab-content">
@@ -54,6 +55,9 @@
     </div>
     <div id="chronyauthdata" class="tab-pane fade in">
         <pre id="listchronyauthdata"></pre>
+    </div>
+    <div id="chronyntpdata" class="tab-pane fade in">
+        <pre id="listchronyntpdata"></pre>
     </div>
 </div>
 
@@ -85,6 +89,12 @@ function update_chronyauthdata() {
     });
 }
 
+function update_chronyntpdata() {
+    ajaxCall(url="/api/chrony/service/chronyntpdata", sendData={}, callback=function(data,status) {
+        $("#listchronyntpdata").text(data['response']);
+    });
+}
+
     $(function() {
         var data_get_map = {'frm_general_settings':"/api/chrony/general/get"};
         mapDataToFormUI(data_get_map).done(function(data){
@@ -99,6 +109,7 @@ function update_chronyauthdata() {
     setInterval(update_chronysourcestats, 5000);
     setInterval(update_chronytracking, 5000);
     setInterval(update_chronyauthdata, 5000);
+    setInterval(update_chronyntpdata, 5000);
 
         // link save button to API set action
         $("#saveAct").click(function(){

--- a/net/chrony/src/opnsense/mvc/app/views/OPNsense/Chrony/general.volt
+++ b/net/chrony/src/opnsense/mvc/app/views/OPNsense/Chrony/general.volt
@@ -72,7 +72,7 @@ function update_chronysources() {
 
 function update_chronysourcestats() {
     ajaxCall(url="/api/chrony/service/chronysourcestats", sendData={}, callback=function(data,status) {
-        $("#listchronysourcestats").text(data['response']);
+        $("#listchronysourcestats").text($('<div>').html(data['response']).text());
     });
 }
 

--- a/net/chrony/src/opnsense/mvc/app/views/OPNsense/Chrony/index.volt
+++ b/net/chrony/src/opnsense/mvc/app/views/OPNsense/Chrony/index.volt
@@ -38,10 +38,14 @@
     <div id="general" class="tab-pane fade in active">
         <div class="content-box" style="padding-bottom: 1.5em;">
             {{ partial("layout_partials/base_form",['fields':generalForm,'id':'frm_general_settings'])}}
-            <div class="col-md-12">
-                <hr />
-                <button class="btn btn-primary" id="saveAct" type="button"><b>{{ lang._('Save') }}</b> <i id="saveAct_progress"></i></button>
-            </div>
+
+            <h1>{{ lang._('Sources') }}</h1>
+
+            {{ partial('layout_partials/base_bootgrid_table', formGridPeer) }}
+            
+            {{ partial('layout_partials/base_apply_button', {'data_endpoint': '/api/chrony/service/reconfigure'}) }}
+
+            {{ partial("layout_partials/base_dialog",['fields':formDialogPeer,'id':formGridPeer['edit_dialog_id'],'label':lang._('Edit source')])}}
         </div>
     </div>
     <div id="chronysources" class="tab-pane fade in">
@@ -62,7 +66,21 @@
 </div>
 
 <script>
-    
+
+$(document).ready(function() {
+    $("#{{formGridPeer['table_id']}}").UIBootgrid(
+        {
+            search:'/api/chrony/general/search_item/',
+            get:'/api/chrony/general/get_item/',
+            set:'/api/chrony/general/set_item/',
+            add:'/api/chrony/general/add_item/',
+            del:'/api/chrony/general/del_item/',
+            toggle:'/api/chrony/general/toggle_item/'
+        }
+    );
+
+    $("#reconfigureAct").SimpleActionButton();
+});
 
 var chronyActiveInterval = null;
 
@@ -132,17 +150,6 @@ $(function() {
     $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
         var targetTab = $(e.target).attr("href");
         autoRefresh(targetTab);
-    });
-
-    // link save button to API set action
-    $("#saveAct").click(function(){
-        saveFormToEndpoint(url="/api/chrony/general/set", formid='frm_general_settings',callback_ok=function(){
-            $("#saveAct_progress").addClass("fa fa-spinner fa-pulse");
-            ajaxCall(url="/api/chrony/service/reconfigure", sendData={}, callback=function(data,status) {
-                updateServiceControlUI('chrony');
-                $("#saveAct_progress").removeClass("fa fa-spinner fa-pulse");
-            });
-        });
     });
 });
 </script>

--- a/net/chrony/src/opnsense/mvc/app/views/OPNsense/Chrony/index.volt
+++ b/net/chrony/src/opnsense/mvc/app/views/OPNsense/Chrony/index.volt
@@ -43,9 +43,12 @@
 
             {{ partial('layout_partials/base_bootgrid_table', formGridPeer) }}
             
-            {{ partial('layout_partials/base_apply_button', {'data_endpoint': '/api/chrony/service/reconfigure'}) }}
-
             {{ partial("layout_partials/base_dialog",['fields':formDialogPeer,'id':formGridPeer['edit_dialog_id'],'label':lang._('Edit source')])}}
+        
+            <div class="col-md-12">
+                <hr />
+                <button class="btn btn-primary" id="saveAct" type="button"><b>{{ lang._('Save') }}</b> <i id="saveAct_progress"></i></button>
+            </div>
         </div>
     </div>
     <div id="chronysources" class="tab-pane fade in">
@@ -150,6 +153,17 @@ $(function() {
     $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
         var targetTab = $(e.target).attr("href");
         autoRefresh(targetTab);
+    });
+
+    // link save button to API set action
+    $("#saveAct").click(function(){
+        saveFormToEndpoint(url="/api/chrony/general/set", formid='frm_general_settings',callback_ok=function(){
+            $("#saveAct_progress").addClass("fa fa-spinner fa-pulse");
+            ajaxCall(url="/api/chrony/service/reconfigure", sendData={}, callback=function(data,status) {
+                updateServiceControlUI('chrony');
+                $("#saveAct_progress").removeClass("fa fa-spinner fa-pulse");
+            });
+        });
     });
 });
 </script>

--- a/net/chrony/src/opnsense/service/conf/actions.d/actions_chrony.conf
+++ b/net/chrony/src/opnsense/service/conf/actions.d/actions_chrony.conf
@@ -23,13 +23,13 @@ type:script_output
 message:request chrony status
 
 [chronysources]
-command:/usr/local/bin/chronyc -m 'timeout 100' 'retries 0' sources
+command:/usr/local/bin/chronyc -m 'timeout 100' 'retries 0' 'sources -v'
 parameters:
 type:script_output
 message:show chrony sources
 
 [chronysourcestats]
-command:/usr/local/bin/chronyc -m 'timeout 100' 'retries 0' sourcestats
+command:/usr/local/bin/chronyc -m 'timeout 100' 'retries 0' 'sourcestats -v'
 parameters:
 type:script_output
 message:show chrony sourcestats
@@ -41,7 +41,7 @@ type:script_output
 message:show chrony tracking
 
 [chronyauthdata]
-command:/usr/local/bin/chronyc -N -m 'timeout 100' 'retries 0' authdata
+command:/usr/local/bin/chronyc -N -m 'timeout 100' 'retries 0' 'authdata -v'
 parameters:
 type:script_output
 message:show chrony authdata

--- a/net/chrony/src/opnsense/service/conf/actions.d/actions_chrony.conf
+++ b/net/chrony/src/opnsense/service/conf/actions.d/actions_chrony.conf
@@ -45,3 +45,9 @@ command:/usr/local/bin/chronyc -N -m 'timeout 100' 'retries 0' authdata
 parameters:
 type:script_output
 message:show chrony authdata
+
+[chronyntpdata]
+command:/usr/local/bin/chronyc -N -m 'timeout 100' 'retries 0' ntpdata
+parameters:
+type:script_output
+message:show chrony ntpdata

--- a/net/chrony/src/opnsense/service/templates/OPNsense/Chrony/chrony.conf
+++ b/net/chrony/src/opnsense/service/templates/OPNsense/Chrony/chrony.conf
@@ -5,32 +5,35 @@ driftfile /var/db/chrony/drift
 pidfile /var/run/chrony/chronyd.pid
 makestep 1 3
 
-{%   if helpers.exists('OPNsense.chrony.general.ntsclient') and OPNsense.chrony.general.ntsclient == '1' %}
+{%  if not helpers.empty('OPNsense.chrony.general.peers') %}
+{%      for peer in OPNsense.chrony.general.peers.split(',') %}
+server {{ peer }} iburst {% if helpers.exists('OPNsense.chrony.general.ntsclient') and OPNsense.chrony.general.ntsclient == '1' %}nts{% endif %}
+{%      endfor %}
+{%  endif %}
+
+{%  if helpers.exists('OPNsense.chrony.general.fallbackpeers') and OPNsense.chrony.general.fallbackpeers != '' %}
+authselectmode mix
+server {{ OPNsense.chrony.general.fallbackpeers }}
+{%  endif %}
+
+{%  if not helpers.empty('OPNsense.chrony.general.localstratum') %}
+local stratum {{ OPNsense.chrony.general.localstratum }} {% if helpers.exists('OPNsense.chrony.general.orphanmode') and OPNsense.chrony.general.orphanmode == '1' %}orphan{% endif %}
+{%  endif %}
+
+{%  if not helpers.empty('OPNsense.chrony.general.allowednetworks') %}
+{%      for network in OPNsense.chrony.general.allowednetworks.split(',') %}
+allow {{ network }}
+{%      endfor %}
+{%  endif %}
+
+{%  if helpers.exists('OPNsense.chrony.general.ntsclient') and OPNsense.chrony.general.ntsclient == '1' %}
 ntsdumpdir /var/lib/chrony
 ntstrustedcerts /usr/local/etc/ssl/cert.pem
 nosystemcert
-{%   endif %}
+{%  endif %}
 
-{%   if helpers.exists('OPNsense.chrony.general.ntsnocert') and OPNsense.chrony.general.ntsnocert == '1' %}
+{%  if helpers.exists('OPNsense.chrony.general.ntsnocert') and OPNsense.chrony.general.ntsnocert == '1' %}
 nocerttimecheck 1
-{%   endif %}
-
-{%   if not helpers.empty('OPNsense.chrony.general.peers') %}
-{%     for peer in OPNsense.chrony.general.peers.split(',') %}
-server {{ peer }} iburst {% if helpers.exists('OPNsense.chrony.general.ntsclient') and OPNsense.chrony.general.ntsclient == '1' %}nts{% endif %}
-
-{%     endfor %}
-{%   endif %}
-
-{%   if helpers.exists('OPNsense.chrony.general.fallbackpeers') and OPNsense.chrony.general.fallbackpeers != '' %}
-authselectmode mix
-server {{ OPNsense.chrony.general.fallbackpeers }}
-{%   endif %}
-
-{%   if not helpers.empty('OPNsense.chrony.general.allowednetworks') %}
-{%     for network in OPNsense.chrony.general.allowednetworks.split(',') %}
-allow {{ network }}
-{%     endfor %}
-{%   endif %}
+{%  endif %}
 
 {% endif %}

--- a/net/chrony/src/opnsense/service/templates/OPNsense/Chrony/chrony.conf
+++ b/net/chrony/src/opnsense/service/templates/OPNsense/Chrony/chrony.conf
@@ -7,7 +7,8 @@ makestep 1 3
 
 {%  if not helpers.empty('OPNsense.chrony.general.peers') %}
 {%      for peer in OPNsense.chrony.general.peers.peer %}
-{% if peer.pool == '1' %}pool   {% else %}server {% endif %}{{ peer.address }}{% if peer.prefer == '1' %} prefer{% endif %}{% if peer.iburst == '1' %} iburst{% endif %}{% if peer.xleave == '1' %} xleave{% endif %} 
+{% if peer.pool == '1' %}pool   {% else %}server {% endif %}{{peer.address}}{% if peer.prefer == '1' %} prefer{% endif %}{% if peer.iburst == '1' %} iburst{% endif %}{% if peer.xleave == '1' %} xleave{% endif %}{% if peer.minpoll is defined and peer.minpoll != '' %} minpoll{{ peer.minpoll }}{% endif %}{% if peer.maxpoll is defined and peer.maxpoll != '' %} maxpoll {{ peer.maxpoll }}{% endif %}
+
 {%      endfor %}
 {%  endif %}
 

--- a/net/chrony/src/opnsense/service/templates/OPNsense/Chrony/chrony.conf
+++ b/net/chrony/src/opnsense/service/templates/OPNsense/Chrony/chrony.conf
@@ -6,8 +6,8 @@ pidfile /var/run/chrony/chronyd.pid
 makestep 1 3
 
 {%  if not helpers.empty('OPNsense.chrony.general.peers') %}
-{%      for peer in OPNsense.chrony.general.peers.split(',') %}
-server {{ peer }} iburst {% if helpers.exists('OPNsense.chrony.general.ntsclient') and OPNsense.chrony.general.ntsclient == '1' %}nts{% endif %}
+{%      for peer in OPNsense.chrony.general.peers.peer %}
+{% if peer.pool == '1' %}pool   {% else %}server {% endif %}{{ peer.address }}{% if peer.prefer == '1' %} prefer{% endif %}{% if peer.iburst == '1' %} iburst{% endif %}{% if peer.xleave == '1' %} xleave{% endif %} 
 {%      endfor %}
 {%  endif %}
 

--- a/net/chrony/src/opnsense/service/templates/OPNsense/Chrony/chrony.conf
+++ b/net/chrony/src/opnsense/service/templates/OPNsense/Chrony/chrony.conf
@@ -1,12 +1,18 @@
 {% if helpers.exists('OPNsense.chrony.general.enabled') and OPNsense.chrony.general.enabled == '1' %}
 
 port {{ OPNsense.chrony.general.port }}
-driftfile /var/db/chrony/drift
-pidfile /var/run/chrony/chronyd.pid
-makestep 1 3
+{%  if not helpers.empty('OPNsense.chrony.general.allowednetworks') %}
+{%      for network in OPNsense.chrony.general.allowednetworks.split(',') %}
+allow {{ network }}
+{%      endfor %}
+{%  endif %}
 
 {%  if not helpers.empty('OPNsense.chrony.general.peers') %}
-{%      for peer in OPNsense.chrony.general.peers.peer %}
+{%      set peers = OPNsense.chrony.general.peers.peer %}
+{%      if peers is mapping %}
+{%          set peers = [peers] %}
+{%      endif %}
+{%      for peer in peers %}
 {% if peer.pool == '1' %}pool   {% else %}server {% endif %}{{peer.address}}{% if peer.prefer == '1' %} prefer{% endif %}{% if peer.iburst == '1' %} iburst{% endif %}{% if peer.xleave == '1' %} xleave{% endif %}{% if peer.minpoll is defined and peer.minpoll != '' %} minpoll {{ peer.minpoll }}{% endif %}{% if peer.maxpoll is defined and peer.maxpoll != '' %} maxpoll {{ peer.maxpoll }}{% endif %}
 
 {%      endfor %}
@@ -19,13 +25,11 @@ server {{ OPNsense.chrony.general.fallbackpeers }}
 
 {%  if not helpers.empty('OPNsense.chrony.general.localstratum') %}
 local stratum {{ OPNsense.chrony.general.localstratum }} {% if helpers.exists('OPNsense.chrony.general.orphanmode') and OPNsense.chrony.general.orphanmode == '1' %}orphan{% endif %}
-{%  endif %}
 
-{%  if not helpers.empty('OPNsense.chrony.general.allowednetworks') %}
-{%      for network in OPNsense.chrony.general.allowednetworks.split(',') %}
-allow {{ network }}
-{%      endfor %}
 {%  endif %}
+driftfile /var/db/chrony/drift
+pidfile /var/run/chrony/chronyd.pid
+makestep 1 3
 
 {%  if helpers.exists('OPNsense.chrony.general.ntsclient') and OPNsense.chrony.general.ntsclient == '1' %}
 ntsdumpdir /var/lib/chrony

--- a/net/chrony/src/opnsense/service/templates/OPNsense/Chrony/chrony.conf
+++ b/net/chrony/src/opnsense/service/templates/OPNsense/Chrony/chrony.conf
@@ -7,7 +7,7 @@ makestep 1 3
 
 {%  if not helpers.empty('OPNsense.chrony.general.peers') %}
 {%      for peer in OPNsense.chrony.general.peers.peer %}
-{% if peer.pool == '1' %}pool   {% else %}server {% endif %}{{peer.address}}{% if peer.prefer == '1' %} prefer{% endif %}{% if peer.iburst == '1' %} iburst{% endif %}{% if peer.xleave == '1' %} xleave{% endif %}{% if peer.minpoll is defined and peer.minpoll != '' %} minpoll{{ peer.minpoll }}{% endif %}{% if peer.maxpoll is defined and peer.maxpoll != '' %} maxpoll {{ peer.maxpoll }}{% endif %}
+{% if peer.pool == '1' %}pool   {% else %}server {% endif %}{{peer.address}}{% if peer.prefer == '1' %} prefer{% endif %}{% if peer.iburst == '1' %} iburst{% endif %}{% if peer.xleave == '1' %} xleave{% endif %}{% if peer.minpoll is defined and peer.minpoll != '' %} minpoll {{ peer.minpoll }}{% endif %}{% if peer.maxpoll is defined and peer.maxpoll != '' %} maxpoll {{ peer.maxpoll }}{% endif %}
 
 {%      endfor %}
 {%  endif %}

--- a/net/chrony/src/opnsense/service/templates/OPNsense/Chrony/chrony.conf
+++ b/net/chrony/src/opnsense/service/templates/OPNsense/Chrony/chrony.conf
@@ -13,14 +13,9 @@ allow {{ network }}
 {%          set peers = [peers] %}
 {%      endif %}
 {%      for peer in peers %}
-{% if peer.pool == '1' %}pool   {% else %}server {% endif %}{{peer.address}}{% if peer.prefer == '1' %} prefer{% endif %}{% if peer.iburst == '1' %} iburst{% endif %}{% if peer.xleave == '1' %} xleave{% endif %}{% if peer.minpoll is defined and peer.minpoll != '' %} minpoll {{ peer.minpoll }}{% endif %}{% if peer.maxpoll is defined and peer.maxpoll != '' %} maxpoll {{ peer.maxpoll }}{% endif %}
+{% if peer.pool == '1' %}pool   {% else %}server {% endif %}{{peer.address}}{% if peer.prefer == '1' %} prefer{% endif %}{% if peer.iburst == '1' %} iburst{% endif %}{% if peer.xleave == '1' %} xleave{% endif %}{% if peer.minpoll is defined and peer.minpoll != '' %} minpoll {{ peer.minpoll }}{% endif %}{% if peer.maxpoll is defined and peer.maxpoll != '' %} maxpoll {{ peer.maxpoll }}{% endif %}{% if peer.nts == '1' %} nts{% endif %}
 
 {%      endfor %}
-{%  endif %}
-
-{%  if helpers.exists('OPNsense.chrony.general.fallbackpeers') and OPNsense.chrony.general.fallbackpeers != '' %}
-authselectmode mix
-server {{ OPNsense.chrony.general.fallbackpeers }}
 {%  endif %}
 
 {%  if not helpers.empty('OPNsense.chrony.general.localstratum') %}
@@ -31,11 +26,7 @@ driftfile /var/db/chrony/drift
 pidfile /var/run/chrony/chronyd.pid
 makestep 1 3
 
-{%  if helpers.exists('OPNsense.chrony.general.ntsclient') and OPNsense.chrony.general.ntsclient == '1' %}
 ntsdumpdir /var/lib/chrony
-ntstrustedcerts /usr/local/etc/ssl/cert.pem
-nosystemcert
-{%  endif %}
 
 {%  if helpers.exists('OPNsense.chrony.general.ntsnocert') and OPNsense.chrony.general.ntsnocert == '1' %}
 nocerttimecheck 1


### PR DESCRIPTION
The current chrony plugin provides insufficient options for configuration.

This PR adds support for the following source options on a per-source basis:
* NTS
* prefer
* iburst
* min/max poll
* interleaving

It additionally adds support for pool-type sources, an NTP data diagnostics tab,  and the local stratum feature as requested in #5115 