### PR TITLE
net/frr: Add capability support for BGP neighbors

### DIFF
--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPNeighbor.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPNeighbor.xml
@@ -248,6 +248,16 @@
     </grid_view>
   </field>
   <field>
+    <id>neighbor.capabilities</id>
+    <label>Enable capabilities</label>
+    <type>select_multiple</type>
+    <advanced>true</advanced>
+    <help>Enable the necessary capabilities. If you don’t know what they are, check the documentation. Note that some are IPv6-only.</help>
+    <grid_view>
+      <visible>false</visible>
+    </grid_view>
+  </field>
+  <field>
     <id>neighbor.linkedPrefixlistIn</id>
     <label>Prefix-List In</label>
     <type>dropdown</type>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
@@ -131,6 +131,17 @@
                         <med>med</med>
                     </OptionValues>
                 </attributeunchanged>
+                <capabilities type="OptionField">
+                    <BlankDesc>Enable capabilities</BlankDesc>
+                    <OptionValues>
+                        <extended-nexthop>extended-nexthop</extended-nexthop>
+                        <dynamic>dynamic</dynamic>
+                        <fqdn>fqdn</fqdn>
+                        <extended-nexthop>extended-nexthop</extended-nexthop>
+                        <link-local>link-local</link-local>
+                    </OptionValues>
+                    <Multiple>Y</Multiple>
+                </capabilities>
                 <linkedPrefixlistIn type="ModelRelationField">
                     <Model>
                         <template>

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -149,6 +149,11 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%         if 'connecttimer' in neighbor and neighbor.connecttimer != '' %}
  neighbor {{ neighbor.address }} timers connect {{ neighbor.connecttimer }}
 {%         endif %}
+{%         if 'capability' in neighbor %}
+{%           for capability in neighbor.capabilities.split(',') %}
+ neighbor {{ neighbor.address }} capability {{ capability }}
+{%           endfor %}
+{%         endif %}
 {%         if 'attributeunchanged' in neighbor and neighbor.attributeunchanged != '' %}
  neighbor {{ neighbor.address }} attribute-unchanged {{ neighbor.attributeunchanged }}
 {%         endif %}


### PR DESCRIPTION
I've recently tried to use OPNsense in an environment where the use of link-local addresses is required.
Since the link-local capability is not available, I was not able to use OPNsense then.

Obviously, there are some other with the same problem:

  * https://github.com/opnsense/plugins/issues/4962
  * https://forum.opnsense.org/index.php?topic=36088.0

So, I'd like to offer support for BGP capabilities.