### PR TITLE
security/tinc: add disablesubnetroutes option

### DIFF
--- a/security/tinc/src/opnsense/mvc/app/controllers/OPNsense/Tinc/forms/dialogNetwork.xml
+++ b/security/tinc/src/opnsense/mvc/app/controllers/OPNsense/Tinc/forms/dialogNetwork.xml
@@ -97,6 +97,12 @@
         <help>This machines part of the network</help>
     </field>
     <field>
+        <id>network.disablesubnetroutes</id>
+        <label>Disable subnet routes</label>
+        <type>checkbox</type>
+        <help>This will prevent installing subnet routes. Usually you only enable this to do own routing decisions via a local gateway and gateway rules.</help>
+    </field>
+    <field>
         <id>network.privkey</id>
         <label>Private key</label>
         <type>textbox</type>

--- a/security/tinc/src/opnsense/mvc/app/models/OPNsense/Tinc/Tinc.xml
+++ b/security/tinc/src/opnsense/mvc/app/models/OPNsense/Tinc/Tinc.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/Tinc</mount>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
     <description>
         OPNsense Tinc VPN
     </description>
@@ -64,6 +64,10 @@
                     <Default>0</Default>
                     <Required>Y</Required>
                 </StrictSubnets>
+                <disablesubnetroutes type="BooleanField">
+                    <Default>0</Default>
+                    <Required>Y</Required>
+                </disablesubnetroutes>
                 <privkey type="TextField">
                     <Required>Y</Required>
                 </privkey>

--- a/security/tinc/src/opnsense/scripts/OPNsense/Tinc/lib/objects.py
+++ b/security/tinc/src/opnsense/scripts/OPNsense/Tinc/lib/objects.py
@@ -70,6 +70,7 @@ class Network(NetwConfObject):
         self._payload['mode'] = 'switch'
         self._payload['PMTUDiscovery'] = 'yes'
         self._payload['StrictSubnets'] = 'no'
+        self._disablesubnetroutes = False
         self._hosts = list()
 
     def get_id(self):
@@ -84,6 +85,9 @@ class Network(NetwConfObject):
     def get_debuglevel(self):
         return self._payload['debuglevel'][1] if len(self._payload['debuglevel']) > 1 else '0'
 
+    def get_disablesubnetroutes(self):
+        return self._disablesubnetroutes
+
     def set_hosts(self, hosts):
         for host in hosts:
             hostObj = Host()
@@ -96,6 +100,9 @@ class Network(NetwConfObject):
 
     def set_StrictSubnets(self, value):
         self._payload['StrictSubnets'] = 'no' if value.text != '1' else 'yes'
+
+    def set_disablesubnetroutes(self, value):
+        self._disablesubnetroutes = value.text == '1'
 
     def config_text(self):
         result = list()

--- a/security/tinc/src/opnsense/scripts/OPNsense/Tinc/tincd.py
+++ b/security/tinc/src/opnsense/scripts/OPNsense/Tinc/tincd.py
@@ -105,14 +105,15 @@ def deploy(config_filename):
         for filename in chroot_needs:
             os.makedirs('%s%s' % (network.get_basepath(), os.path.dirname(filename)), exist_ok=True)
             shutil.copy(filename, '%s/%s' % (network.get_basepath(), filename))
-        write_file("%s/subnet-up" % network.get_basepath(), '\n'.join([
-            "#!/bin/sh",
-            "route add $SUBNET -iface %s\n" % interface_name
-        ]), 0o700)
-        write_file("%s/subnet-down" % network.get_basepath(), '\n'.join([
-            "#!/bin/sh",
-            "route delete $SUBNET -iface %s\n" % interface_name
-        ]), 0o700)
+        if not network.get_disablesubnetroutes():
+            write_file("%s/subnet-up" % network.get_basepath(), '\n'.join([
+                "#!/bin/sh",
+                "route add $SUBNET -iface %s\n" % interface_name
+            ]), 0o700)
+            write_file("%s/subnet-down" % network.get_basepath(), '\n'.join([
+                "#!/bin/sh",
+                "route delete $SUBNET -iface %s\n" % interface_name
+            ]), 0o700)
 
         # configure and rename new tun device, place all in group "tinc" symlink associated tun device
         if interface_name not in interfaces:

--- a/security/tinc/src/opnsense/service/templates/OPNsense/Tinc/tinc_deploy.xml
+++ b/security/tinc/src/opnsense/service/templates/OPNsense/Tinc/tinc_deploy.xml
@@ -15,6 +15,7 @@
         <debuglevel>{{network.debuglevel}}</debuglevel>
         <pingtimeout>{{network.pingtimeout}}</pingtimeout>
         <StrictSubnets>{{network.StrictSubnets}}</StrictSubnets>
+        <disablesubnetroutes>{{network.disablesubnetroutes}}</disablesubnetroutes>
         <hosts>
             <host>
                 <hostname>{{network.hostname}}</hostname>


### PR DESCRIPTION
In order to allow manual routing with tinc VPN.
Stops `subnet-{up,down}` scripts from generating.

Fixes #5135 