### PR TITLE
security/acme-client: Add support for Hurricane Electric DDNS API

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -684,6 +684,16 @@
         <type>password</type>
     </field>
     <field>
+        <label>Hurricane Electric DDNS</label>
+        <type>header</type>
+        <style>table_dns table_dns_he_ddns</style>
+    </field>
+    <field>
+        <id>validation.dns_he_ddns_key</id>
+        <label>Key</label>
+        <type>text</type>
+    </field>
+    <field>
         <label>Infoblox</label>
         <type>header</type>
         <style>table_dns table_dns_infoblox</style>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsHeDdns.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsHeDdns.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Thomas Moore
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\AcmeClient\LeValidation;
+
+use OPNsense\AcmeClient\LeValidationInterface;
+use OPNsense\Core\Config;
+
+/**
+ * HE DDNS API
+ * @package OPNsense\AcmeClient
+ */
+class DnsHeDdns extends Base implements LeValidationInterface
+{
+    public function prepare()
+    {
+        $this->acme_env['HE_DDNS_KEY'] = (string)$this->config->dns_he_ddns_key;
+    }
+}

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -473,6 +473,7 @@
                         <dns_hexonet>hexonet.com</dns_hexonet>
                         <dns_hostingde>hosting.de</dns_hostingde>
                         <dns_he>Hurricane Electric</dns_he>
+                        <dns_he_ddns>Hurricane Electric DDNS</dns_he_ddns>
                         <dns_infoblox>Infoblox</dns_infoblox>
                         <dns_infomaniak>Infomaniak</dns_infomaniak>
                         <dns_internetbs>internetbs.net</dns_internetbs>
@@ -746,6 +747,9 @@
                 <dns_he_password type="TextField">
                     <Required>N</Required>
                 </dns_he_password>
+                <dns_he_ddns_key type="TextField">
+                    <Required>N</Required>
+                </dns_he_ddns_key>
                 <dns_infoblox_credentials type="TextField">
                     <Required>N</Required>
                 </dns_infoblox_credentials>


### PR DESCRIPTION
This PR adds support for Hurricane Electric DDNS (dns_he_ddns)
as an ACME DNS-01 provider.

Implements feature request #5073.

Tested with:
- ACME DNS-01 wildcard certificate
- Hurricane Electric DDNS API

No changes to existing providers.
