### PR TITLE
fix mijnhost/scaleway DNS API settings

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -2013,6 +2013,8 @@
         <label>API Key</label>
         <type>text</type>
         <help><![CDATA[Please refer to the <a href="https://mijn.host/api/doc/">API documentation</a> for further information.]]></help>
+    </field>
+    <field>
         <label>scaleway</label>
         <type>header</type>
         <style>table_dns table_dns_scaleway</style>


### PR DESCRIPTION
See comment https://github.com/opnsense/plugins/pull/4446#issuecomment-3637663519. Missing close and open field tags between mijn.host and scaleway entries.