### PR TITLE
security/acme-client: add support for acme.sh deploy hook "Ruckus"

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogAction.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogAction.xml
@@ -378,6 +378,28 @@
         <style>method_table method_table_acme_truenas</style>
     </field>
     <field>
+        <label>Required Parameters</label>
+        <type>header</type>
+        <style>method_table method_table_acme_ruckus</style>
+    </field>
+    <field>
+        <id>action.acme_ruckus_host</id>
+        <label>Ruckus Host</label>
+        <type>text</type>
+    </field>
+
+    <field>
+        <id>action.acme_ruckus_user</id>
+        <label>Ruckus User</label>
+        <type>text</type>
+    </field>
+
+    <field>
+        <id>action.acme_ruckus_pass</id>
+        <label>Ruckus Password</label>
+        <type>password</type>
+    </field>
+    <field>
         <id>action.acme_truenas_apikey</id>
         <label>TrueNAS API key</label>
         <type>text</type>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeAutomation/AcmeRuckus.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeAutomation/AcmeRuckus.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Jeremy Gutierrez
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\AcmeClient\LeAutomation;
+
+use OPNsense\AcmeClient\LeAutomationInterface;
+
+/**
+ * Run acme.sh deploy hook ruckus
+ * @package OPNsense\AcmeClient
+ */
+class AcmeRuckus extends Base implements LeAutomationInterface
+{
+    public function prepare()
+    {
+        $this->acme_env['RUCKUS_HOST'] = (string)$this->config->acme_ruckus_host;
+        $this->acme_env['RUCKUS_USER'] = (string)$this->config->acme_ruckus_user;
+        $this->acme_env['RUCKUS_PASS'] = (string)$this->config->acme_ruckus_pass;
+        $this->acme_args[] = '--deploy-hook ruckus';
+        return true;
+    }
+}

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -1408,6 +1408,7 @@
                         <acme_panos>Upload certificate to Palo Alto Networks Firewall</acme_panos>
                         <acme_proxmoxbs>Upload certificate to Proxmox Backup Server</acme_proxmoxbs>
                         <acme_proxmoxve>Upload certificate to Proxmox VE</acme_proxmoxve>
+                        <acme_ruckus>Upload certificate to Ruckus controller</acme_ruckus>
                         <acme_vault>Upload certificate to HashiCorp Vault</acme_vault>
                         <acme_synology_dsm>Upload certificate to Synology DSM</acme_synology_dsm>
                         <acme_truenas>Upload certificate to TrueNAS Core Server</acme_truenas>
@@ -1694,6 +1695,17 @@
                     <Mask>/^.{1,1024}$/u</Mask>
                     <ValidationMessage>Should be a string between 1 and 1024 characters.</ValidationMessage>
                 </acme_proxmoxbs_tokenkey>
+                <acme_ruckus_host type="HostnameField">
+                    <Mask>/^.{1,1024}$/u</Mask>
+                    <ValidationMessage>Should be a string between 1 and 1024 characters.</ValidationMessage>
+                    <Required>N</Required>
+                </acme_ruckus_host>
+                <acme_ruckus_user type="TextField">
+                    <Required>N</Required>
+                </acme_ruckus_user>
+                <acme_ruckus_pass type="TextField">
+                    <Required>N</Required>
+                </acme_ruckus_pass>
                 <acme_truenas_apikey type="TextField">
                     <Required>N</Required>
                     <Mask>/^.{1,1024}$/u</Mask>


### PR DESCRIPTION
This PR adds a new ACME deploy automation for uploading certificates to a Ruckus controller using the existing `acme.sh` ruckus deploy hook.

Fixes https://github.com/opnsense/plugins/issues/3536