### PR TITLE
security/acme-client: add support for DNS challenge Spaceship.com

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -1334,6 +1334,26 @@
         <type>password</type>
     </field>
     <field>
+        <label>Spaceship DNS</label>
+        <type>header</type>
+        <style>table_dns table_dns_spaceship</style>
+    </field>
+    <field>
+        <id>validation.dns_spaceship_api_key</id>
+        <label>API Key</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_spaceship_api_secret</id>
+        <label>API Secret</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_spaceship_root_domain</id>
+        <label>Root Domain (Optional)</label>
+        <type>text</type>
+    </field>
+    <field>
         <label>Timeweb Cloud DNS</label>
         <type>header</type>
         <style>table_dns table_dns_timeweb</style>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsSpaceship.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsSpaceship.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Benno Kutschenreuter
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\AcmeClient\LeValidation;
+
+use OPNsense\AcmeClient\LeValidationInterface;
+use OPNsense\Core\Config;
+
+/**
+ * Spaceship DNS API
+ * @package OPNsense\AcmeClient
+ */
+
+class DnsSpaceship extends Base implements LeValidationInterface
+{
+    public function prepare()
+    {
+        $this->acme_env['SPACESHIP_API_KEY'] = (string)$this->config->dns_spaceship_api_key;
+        $this->acme_env['SPACESHIP_API_SECRET'] = (string)$this->config->dns_spaceship_api_secret;
+
+        // optional root domain
+        if (!empty((string)$this->config->dns_spaceship_root_domain)) {
+            $this->acme_env['SPACESHIP_ROOT_DOMAIN'] = (string)$this->config->dns_spaceship_root_domain;
+        }
+    }
+}

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -522,6 +522,7 @@
                         <dns_selfhost>Selfhost</dns_selfhost>
                         <dns_servercow>Servercow</dns_servercow>
                         <dns_simply>Simply.com</dns_simply>
+                        <dns_spaceship>Spaceship</dns_spaceship>
                         <dns_technitium>Technitium</dns_technitium>
                         <dns_timeweb>Timeweb Cloud</dns_timeweb>
                         <dns_transip>Transip</dns_transip>
@@ -1106,6 +1107,15 @@
                 <dns_simply_account_name type="TextField">
                     <Required>N</Required>
                 </dns_simply_account_name>
+                <dns_spaceship_api_key type="TextField">
+                    <Required>N</Required>
+                </dns_spaceship_api_key>
+                <dns_spaceship_api_secret type="TextField">
+                    <Required>N</Required>
+                </dns_spaceship_api_secret>
+                <dns_spaceship_root_domain type="TextField">
+                    <Required>N</Required>
+                </dns_spaceship_root_domain>
                 <dns_technitium_token type="TextField">
                     <Required>N</Required>
                 </dns_technitium_token>


### PR DESCRIPTION
This PR adds support for Spaceship DNS API.

Implements feature request https://github.com/opnsense/plugins/issues/4959.

No changes to existing providers.