### PR TITLE
ddclient: add Hostinger DNS provider

### DIFF
--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/hostinger.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/hostinger.py
@@ -1,4 +1,6 @@
 """
+    Copyright (c) 2024 Thomas Cekal <thomas@cekal.org>
+    Copyright (c) 2024 Ad Schellevis <ad@opnsense.org>
     Copyright (c) 2026 Leandro Scardua
     All rights reserved.
 


### PR DESCRIPTION
## Adds Hostinger DNS as a new provider

### Overview
This pull request introduces support for **Hostinger DNS** using their native API, as documented in the [official Hostinger API reference](https://developers.hostinger.com/#tag/dns-zone/PUT/api/dns/v1/zones/{domain}).

---

### Configuration Guide

To configure the Hostinger DNS provider, use the following settings:

| Field     | Value/Instruction                                                                 |
|-----------|-----------------------------------------------------------------------------------|
| Service   | `Hostinger`                                                                       |
| Zone      | Your domain (e.g., `example.com`)                                                |
| Username  | Leave empty                                                                       |
| Password  | Your Hostinger API token              |
| Hostname  | The record name (e.g., `test`)                                                   |

> **Note:** Generate your API token via [Hostinger’s API token page](https://hpanel.hostinger.com/profile/api)  -> API token -> click in New Token.

---

### References
- [Hostinger API Documentation](https://developers.hostinger.com/)