### PR TITLE
 dns/dnscrypt-proxy: fix bootstrap_resolvers with multiple comma-separated servers

### DIFF
--- a/dns/dnscrypt-proxy/src/opnsense/service/templates/OPNsense/Dnscryptproxy/dnscrypt-proxy.toml
+++ b/dns/dnscrypt-proxy/src/opnsense/service/templates/OPNsense/Dnscryptproxy/dnscrypt-proxy.toml
@@ -95,7 +95,7 @@ tls_disable_session_tickets = true
 tls_disable_session_tickets = false
 {%   endif %}
 
-bootstrap_resolvers = [{{ "'" + ("','".join(OPNsense.dnscryptproxy.general.fallback_resolver.split(','))) + "'" }}]
+bootstrap_resolvers = ['{{ OPNsense.dnscryptproxy.general.fallback_resolver.split(',') | join("','") }}']
 
 {%   if helpers.exists('OPNsense.dnscryptproxy.general.ignore_system_dns') and OPNsense.dnscryptproxy.general.ignore_system_dns == '1' %}
 ignore_system_dns = true


### PR DESCRIPTION
- [x] I have read the contributing guide lines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [x] I have searched the existing issues, open and closed, and I'm convinced that mine is new.
- [x] The title contains the plugin to which this issue belongs

This PR aims to address #5162 

## Problem

 When multiple bootstrap resolvers are configured in the "Fallback Resolver" field (e.g., `1.1.1.1:53,9.9.9.9:53`), the template generates invalid TOML:

```toml
bootstrap_resolvers = ['1.1.1.1:53,9.9.9.9:53']
```

This causes dnscrypt-proxy to fail to start with:

```bash
[FATAL] Bootstrap resolver [...]: Host does not parse as IP '1.1.1.1:53,9.9.9.9:53'
```

 ## Root Cause

This bug seems to have been introduced introduced in commit 1eec51a65 which renamed `fallback_resolver` (a single string) to `bootstrap_resolvers` (a TOML array) but did not update the template syntax.

## Solution

Applied the same split/join pattern already used for `listen_addresses`, `server_names`, `disabled_server_names`, and `relaylist` in the same template file.

## Testing

Tested on OPNsense 25.7.10 with os-dnscrypt-proxy 1.16 - dnscrypt-proxy starts successfully with multiple bootstrap resolvers.