### PR TITLE
security/acme-client: allow always renew

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -282,7 +282,7 @@
                 </autoRenewal>
                 <renewInterval type="IntegerField">
                     <Required>Y</Required>
-                    <MinimumValue>1</MinimumValue>
+                    <MinimumValue>0</MinimumValue>
                     <MaximumValue>5000</MaximumValue>
                     <Default>60</Default>
                 </renewInterval>


### PR DESCRIPTION
I run my own CA with very short certificate lifetimes and it is useful to be able to have the automated renewal cron job always renew a certificate when run.