### PR TITLE
security/wazuh-agent: fix syntax error in opnsense-fw active response

### DIFF
--- a/security/wazuh-agent/src/opnsense/scripts/wazuh/opnsense-fw
+++ b/security/wazuh-agent/src/opnsense/scripts/wazuh/opnsense-fw
@@ -101,7 +101,7 @@ def main(params):
     try:
         ipaddress.ip_address(srcip)
     except ValueError:
-        send_log('Unable to process even, invalid srcip (%s)' % srcip)
+        send_log('Unable to process event, invalid srcip (%s)' % srcip)
         return -1
 
     if skip_alias != '' and command == 'add':
@@ -113,16 +113,17 @@ def main(params):
     if command == 'add':
         # return rule id for timeout list
         try:
+            unique_key = "%s-%s" % (event['parameters']['alert']['rule']['id'], srcip)
+            send_log('Sending check_keys for: %s' % unique_key)
             print(json.dumps({
                 "version": 1,
                 "origin": {
                     "name": sys.argv[0],
-                    "module":"active-response"
+                    "module": "active-response"
                 },
                 "command": "check_keys",
-                "parameters":{
-                   unique_key = "%s-%s" % (event['parameters']['alert']['rule']['id'], srcip)
-		   "keys": [unique_key]
+                "parameters": {
+                    "keys": [unique_key]
                 }
             }))
             sys.stdout.flush()
@@ -131,6 +132,7 @@ def main(params):
         # When attached to stdin we're likely running inside the agent, in which case we will read a second event which
         # may abort the first one.
         if params.input == '/dev/stdin':
+            send_log('Waiting for manager response...')
             timeout_event = None
             try:
                 timeout_event=json.loads(read_data(params.input))
@@ -138,6 +140,7 @@ def main(params):
                 pass
             if timeout_event:
                 send_log('Received : %s' % json.dumps(timeout_event))
+                send_log('Manager says: %s' % timeout_event.get('command'))
                 if timeout_event.get('command') == 'abort':
                     send_log('Aborted')
                     return 0


### PR DESCRIPTION
Fix critical syntax error in opnsense-fw active response script that prevents IPs from being added to the __wazuh_agent_drop alias.

## Problem
The script contains invalid Python syntax - a variable assignment inside a dictionary literal:
```python
"parameters":{
   unique_key = "%s-%s" % (...)  # Invalid Python syntax
   "keys": [unique_key]
}
```

This causes the script to fail with a SyntaxError on all 'add' commands, meaning attacking IPs are never blocked.

## Changes
- Move unique_key assignment outside dictionary literal (fixes SyntaxError)
- Fix typo: 'even' -> 'event' in error message
- Add debug logging for easier troubleshooting

## Testing
- Verified syntax with `python3 -m py_compile`
- Tested active response add/delete operations on OPNsense 26.1