### PR TITLE
nginx: fix HTTP/3 reuseport duplicates

### DIFF
--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/http.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/http.conf
@@ -97,6 +97,7 @@ if cache_path.use_temp_path is defined and cache_path.use_temp_path == '1'
 include opnsense_http_vhost_plugins/*.conf;
 
 {%   set listen_list = [] %}
+{%   set http3_reuseport_list = [] %}
 {%   if OPNsense.Nginx.general.enabled is defined and OPNsense.Nginx.general.enabled == '1' %}
 {% for server in helpers.toList('OPNsense.Nginx.http_server') %}
 {%   set single_servername = server.servername.split(",")[0] %}
@@ -124,8 +125,14 @@ server {
 {%     for listen_address in server.listen_https_address.split(',') %}
     listen {{ listen_address }} ssl{% if server.proxy_protocol is defined and server.proxy_protocol == '1' %} proxy_protocol{% endif %}{% if server.default_server is defined and server.default_server == '1' %} default_server{% endif %};
 {%       if server.enable_http3|default("0") == "1" %}
-    listen {{ listen_address }} quic reuseport{% if server.default_server is defined and server.default_server == '1' %} default_server{% endif %};
-{%         set listen_address_clean = listen_address.replace(' ', '') %}
+{%         set listen_address_key = listen_address.replace(' ', '') %}
+{%         set http3_reuseport = false %}
+{%         if listen_address_key != '' and listen_address_key not in http3_reuseport_list %}
+{%           set http3_reuseport = true %}
+{%           do http3_reuseport_list.append(listen_address_key) %}
+{%         endif %}
+    listen {{ listen_address }} quic{% if http3_reuseport %} reuseport{% endif %}{% if server.default_server is defined and server.default_server == '1' %} default_server{% endif %};
+{%         set listen_address_clean = listen_address_key %}
 {%         if listen_address_clean != '' %}
 {%           set listen_port = listen_address_clean.split(':')[-1] %}
 {%           if listen_port not in http3_alt_svc_ports %}


### PR DESCRIPTION
## Fix HTTP/3 reuseport duplicates

This PR fixes an Nginx config-generation issue introduced while adding optional HTTP/3 (QUIC) support in **nginx: add optional HTTP/3 #5071**.  
When multiple server blocks ended up emitting `reuseport` for the same `listen` (same `address:port`), Nginx failed to start.

Reference PR: nginx: add optional HTTP/3 (https://github.com/opnsense/plugins/pull/5071)

---

## Problem

With HTTP/3 enabled on more than one server for the same `address:port`, the generated configuration could contain `reuseport` multiple times for the same socket.  
`reuseport` is a socket option and must be applied consistently for a given `address:port`. When duplicated across multiple server blocks for the same listener, Nginx reports an error and refuses to start.

---

## Fix

We now emit `reuseport` **exactly once** per `address:port` for HTTP/3:

- The **first** generated HTTP/3 `listen` for a given `address:port` gets: `quic reuseport`
- Any **additional** HTTP/3 `listen` directives for the same `address:port` get: `quic` (without `reuseport`)

This guarantees that the socket option is not duplicated and prevents Nginx from failing due to conflicting listen parameters.

---

## Testing

Tested on a local OPNsense instance with multiple server blocks sharing the same `address:port` and HTTP/3 enabled on more than one of them.  
If you have a different setup (especially more complex listener/server combinations), please give it a quick try — there may still be edge cases I did not cover.