### PR TITLE
os-nextcloud-backup Skip directories when enumerating local files in /conf/backup/

### DIFF
--- a/sysutils/nextcloud-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Nextcloud.php
+++ b/sysutils/nextcloud-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Nextcloud.php
@@ -84,14 +84,7 @@ class Nextcloud extends Base implements IBackupProvider
                 "type" => "text",
                 "label" => gettext("Directory Name without leading slash, starting from user's root"),
                 "value" => 'OPNsense-Backup'
-            ),
-            array(
-                "name" => "addhostname",
-                "type" => "checkbox",
-                "label" => gettext("Backup to directory named after hostname"),
-                "help" => gettext("Create subdirectory under backupdir for this host"),
-                "value" => null
-            ),
+            )
         );
         $nextcloud = new NextcloudSettings();
         foreach ($fields as &$field) {
@@ -145,11 +138,6 @@ class Nextcloud extends Base implements IBackupProvider
             $password = (string)$nextcloud->password;
             $backupdir = (string)$nextcloud->backupdir;
             $crypto_password = (string)$nextcloud->password_encryption;
-            $add_hostname = (string)$nextcloud->addhostname;
-
-            if ($add_hostname) {
-                $backupdir .= "/".gethostname()."/";
-            }
 
             // Check if destination directory exists, create (full path) if not
             try {

--- a/sysutils/nextcloud-backup/src/opnsense/mvc/app/models/OPNsense/Backup/NextcloudSettings.xml
+++ b/sysutils/nextcloud-backup/src/opnsense/mvc/app/models/OPNsense/Backup/NextcloudSettings.xml
@@ -49,9 +49,5 @@
             <Default>OPNsense-Backup</Default>
             <ValidationMessage>The Backup Directory can only consist of alphanumeric characters, dash, underscores and slash. No leading or trailing slash.</ValidationMessage>
         </backupdir>
-        <addhostname type="BooleanField">
-            <Default>1</Default>
-            <Required>Y</Required>
-        </addhostname>
     </items>
 </model>


### PR DESCRIPTION
Uploading directories as files makes no sense, and some plugins utilize the /conf/backup directory as a place to place their own directories.

Skip directories when enumerating files in /conf/backup should solve that.