### PR TITLE
dns/ddclient hetzner existing record update patch

### DIFF
--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/hetzner.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/hetzner.py
@@ -59,7 +59,7 @@ class Hetzner(HetznerAccount):
     _priority = 65535
 
     _services = ['hetzner']
-    
+
     _api_base = "https://api.hetzner.cloud/v1"
 
     def __init__(self, account: dict):


### PR DESCRIPTION
**Fix ddclient update Hetzner for new API**
**Reference**
[pull#5082](https://github.com/opnsense/plugins/pull/5082#issuecomment-3828630666)
[issue#5187](https://github.com/opnsense/plugins/issues/5187])

**Problem**
The actual update method returns code 200 for an update, because it doesnt use the right entrypoint.

**Fix**
Changed the API entrypoint "actions" and removed code duplication.

**Testing**
Tested on a local OPNsense instance with multiple records.

