### PR TITLE
os-nextcloud-backup Skip non-files when enumerating local entries to backup

### DIFF
--- a/sysutils/nextcloud-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Nextcloud.php
+++ b/sysutils/nextcloud-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Nextcloud.php
@@ -155,7 +155,7 @@ class Nextcloud extends Base implements IBackupProvider
                 if ($tmp_local_file === '.' || $tmp_local_file === '..') {
                     continue;
                 }
-                if (is_dir("/conf/backup/".$tmp_local_file)) {
+                if (!is_file("/conf/backup/".$tmp_local_file)) {
                     continue;
                 }
                 $local_files[] = $tmp_local_file;


### PR DESCRIPTION
As some other plugins also use /conf/backup to save their backups (inside subdirectories), we skip anything not a file when enumerating what to backup.

Should satisfy one of the requests in #5181 