### PR TITLE
dns/bind: add dedicated DDNS TSIG key support

### DIFF
--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindPrimaryDomain.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindPrimaryDomain.xml
@@ -36,6 +36,12 @@
         <help>Allow updates via the RDNC key named "rndc-key". The key is shown in the general tab.</help>
     </field>
     <field>
+        <id>domain.allowddnsupdate</id>
+        <label>Allow DDNS update (TSIG)</label>
+        <type>checkbox</type>
+        <help>Generates an update-policy grant for the configured DDNS TSIG key (e.g. Kea). If all update options are disabled, no update-policy will be generated (use named.conf.d drop-ins).</help>
+    </field>
+    <field>
         <id>domain.ttl</id>
         <label>TTL</label>
         <type>text</type>

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/general.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/general.xml
@@ -195,4 +195,32 @@
         <advanced>true</advanced>
         <help>The base64-encoded RNDC key. This requires a restart of the Bind Service.</help>
     </field>
+    <field>
+        <type>header</type>
+        <label>DDNS TSIG Key</label>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>general.ddnskeyname</id>
+        <label>Name</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>TSIG key name used for dynamic DNS updates (e.g. from Kea).</help>
+    </field>
+
+    <field>
+        <id>general.ddnskeyalgo</id>
+        <label>Algorithm</label>
+        <type>dropdown</type>
+        <advanced>true</advanced>
+        <help>TSIG algorithm for the DDNS key.</help>
+    </field>
+
+    <field>
+        <id>general.ddnskeysecret</id>
+        <label>Secret</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>Base64-encoded TSIG secret for the DDNS key. This requires a restart of the Bind Service.</help>
+    </field>
 </form>

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Domain.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Domain.xml
@@ -67,6 +67,10 @@
                     <Default>1</Default>
                     <Required>Y</Required>
                 </allowrndcupdate>
+                <allowddnsupdate type="BooleanField">
+                    <DefaultValue>0</DefaultValue>
+                </allowddnsupdate>
+
                 <serial type="TextField"/>
                 <ttl type="IntegerField">
                     <Default>86400</Default>

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/General.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/General.xml
@@ -167,5 +167,21 @@
             <Required>Y</Required>
             <Default>VxtIzJevSQXqnr7h2qerrcwjnZlMWSGGFBndKeNIDfw=</Default>
         </rndcsecret>
+        <ddnskeyname type="TextField"/>
+        <ddnskeyalgo type="OptionField">
+            <Default>hmac-sha256</Default>
+            <OptionValues>
+                <hmac-sha512>HMAC-SHA512</hmac-sha512>
+                <hmac-sha384>HMAC-SHA384</hmac-sha384>
+                <hmac-sha256>HMAC-SHA256</hmac-sha256>
+                <hmac-sha224>HMAC-SHA224</hmac-sha224>
+                <hmac-sha1>HMAC-SHA1</hmac-sha1>
+                <hmac-md5>HMAC-MD5</hmac-md5>
+            </OptionValues>
+        </ddnskeyalgo>
+        <ddnskeysecret type="Base64Field">
+            <Required>false</Required>
+        </ddnskeysecret>
+
     </items>
 </model>

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
@@ -111,6 +111,13 @@ controls {
                 allow { 127.0.0.1; } keys { "rndc-key"; };
 };
 {% endif %}
+{% if helpers.exists('OPNsense.bind.general.ddnskeyname') and OPNsense.bind.general.ddnskeyname != ''
+      and helpers.exists('OPNsense.bind.general.ddnskeysecret') and OPNsense.bind.general.ddnskeysecret != '' %}
+key "{{ OPNsense.bind.general.ddnskeyname }}" {
+        algorithm "{{ OPNsense.bind.general.ddnskeyalgo }}";
+        secret "{{ OPNsense.bind.general.ddnskeysecret }}";
+};
+{% endif %}
 
 include "/usr/local/etc/namedb/named.conf.d/*.conf";
 
@@ -189,11 +196,29 @@ zone "{{ domain.domainname }}" {
 {%              endfor %}
         };
 {%      endif %}
-{%      if domain.allowrndcupdate is defined and domain.allowrndcupdate == "1" and domain.type == 'primary' %}
+{%      set ddns_key_ok = (helpers.exists('OPNsense.bind.general.ddnskeyname')
+                           and OPNsense.bind.general.ddnskeyname != ''
+                           and helpers.exists('OPNsense.bind.general.ddnskeysecret')
+                           and OPNsense.bind.general.ddnskeysecret != '') %}
+
+{%      set ddns_ok = (domain.type == 'primary'
+                       and domain.allowddnsupdate is defined and domain.allowddnsupdate == "1"
+                       and ddns_key_ok) %}
+
+{%      set rndc_ok = (domain.type == 'primary'
+                       and domain.allowrndcupdate is defined and domain.allowrndcupdate == "1") %}
+
+{%      if ddns_ok or rndc_ok %}
         update-policy {
-		grant rndc-key zonesub ANY;
+{%          if ddns_ok %}
+                grant {{ OPNsense.bind.general.ddnskeyname }} zonesub ANY;
+{%          endif %}
+{%          if rndc_ok %}
+                grant rndc-key zonesub ANY;
+{%          endif %}
         };
 {%      endif %}
+
 };
 {%       if domain.type == 'secondary' and domain.transferkey is defined and not(domain.transferkeyname in usedkeys) %}
 {%         do usedkeys.append(domain.transferkeyname) %}


### PR DESCRIPTION
This change adds support for a dedicated TSIG key for DNS dynamic updates,
allowing DHCP-DDNS clients (e.g. Kea) to update primary zones without relying
on the RNDC key.

The implementation:
- introduces a configurable DDNS TSIG key (name / algorithm / secret)
- allows enabling DDNS updates per primary zone
- supports multiple grants in update-policy (RNDC + DDNS)
- does not overwrite update-policy when DDNS is disabled
- keeps BIND and DDNS clients fully decoupled

This enables secure DDNS setups where the DHCP server and BIND may run on
separate hosts.
