### PR TITLE
Fix: Strip whitespace from API token to prevent 401 authentication er…

### DIFF
--- a/security/q-feeds-connector/src/opnsense/scripts/qfeeds/lib/api.py
+++ b/security/q-feeds-connector/src/opnsense/scripts/qfeeds/lib/api.py
@@ -37,7 +37,7 @@ class QFeedsConfig:
             cnf = ConfigParser()
             cnf.read(config_filename)
             if cnf.has_section('api') and cnf.has_option('api', 'key'):
-                self.api_key = cnf.get('api', 'key')
+                self.api_key = cnf.get('api', 'key').strip()
 
 
 class Api:


### PR DESCRIPTION
Strip whitespace from API token to prevent 401 authentication errors