### PR TITLE
os-nextcloud-backup All response codes in range(200,300) are success.

### DIFF
--- a/sysutils/nextcloud-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Nextcloud.php
+++ b/sysutils/nextcloud-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Nextcloud.php
@@ -361,7 +361,7 @@ class Nextcloud extends Base implements IBackupProvider
         $response = curl_exec($curl);
         $err = curl_error($curl);
         $info = curl_getinfo($curl);
-        if (!($info['http_code'] >= 200 && $info['http_code'] < 300)) {
+        if (!($info['http_code'] >= 200 && $info['http_code'] < 300) || $err) {
             if (err) {
                 syslog(LOG_ERR, $err);
             }


### PR DESCRIPTION
Do not throw exceptions just because response is not a 200/201/207 specifically.

204 is used when uploading to an already existing file (making a new version), others might also be used, or might be used in the future.