### PR TITLE
q-feeds-connector: Update help text to mention DNScrypt-proxy blocklists

### DIFF
--- a/security/q-feeds-connector/src/opnsense/mvc/app/controllers/OPNsense/QFeeds/forms/settings.xml
+++ b/security/q-feeds-connector/src/opnsense/mvc/app/controllers/OPNsense/QFeeds/forms/settings.xml
@@ -13,7 +13,7 @@
         <id>connect.general.enable_unbound_bl</id>
         <label>Register domain feeds</label>
         <type>checkbox</type>
-        <help>Use domain feeds in Unbound DNS blocklist, requires blocklists to be enabled in order to have effect</help>
+        <help>Use domain feeds in Unbound DNS and DNScrypt-proxy blocklists, requires blocklists to be enabled in order to have effect</help>
     </field>
     <field>
         <type>header</type>


### PR DESCRIPTION
Small fix in help text. 