### PR TITLE
Fix the os-redis service page status issue

### DIFF
--- a/databases/redis/src/opnsense/mvc/app/views/OPNsense/Redis/index.volt
+++ b/databases/redis/src/opnsense/mvc/app/views/OPNsense/Redis/index.volt
@@ -72,9 +72,7 @@ $( document ).ready(function() {
                             draggable: true
                         });
                     } else {
-                        ajaxCall(url="/api/redis/service/status", sendData={}, callback=function(data,status) {
-                            updateServiceStatusUI(data['status']);
-                        });
+                        updateServiceControlUI('redis');
                     }
                 });
             });


### PR DESCRIPTION
update index.volt to use new JS function, which was 7 years old and no working in new version.

update to use updateServiceControlUI('redis');  
so Redis service page will honestly showing status.
