### PR TITLE
os-tailscale peer relay option

### DIFF
--- a/security/tailscale/src/opnsense/mvc/app/controllers/OPNsense/Tailscale/forms/settings.xml
+++ b/security/tailscale/src/opnsense/mvc/app/controllers/OPNsense/Tailscale/forms/settings.xml
@@ -56,4 +56,10 @@
         <type>checkbox</type>
         <help>Disable source NAT to disable subnet routing (experimental).</help>
     </field>
+    <field>
+        <id>settings.peerRelayPort</id>
+        <label>Peer Relay Port</label>
+        <type>text</type>
+        <help>Keep empty to disable peer relay.</help>
+    </field>
 </form>

--- a/security/tailscale/src/opnsense/mvc/app/models/OPNsense/Tailscale/Settings.xml
+++ b/security/tailscale/src/opnsense/mvc/app/models/OPNsense/Tailscale/Settings.xml
@@ -36,6 +36,10 @@
             <Default>0</Default>
             <Required>Y</Required>
         </disableSNAT>
+        <peerRelayPort type="IntegerField">
+            <Default>0</Default>
+            <Required>Y</Required>
+        </peerRelayPort>
         <subnets>
             <subnet4 type="ArrayField">
                 <subnet type="NetworkField">

--- a/security/tailscale/src/opnsense/service/templates/OPNsense/Tailscale/rc.conf.d
+++ b/security/tailscale/src/opnsense/service/templates/OPNsense/Tailscale/rc.conf.d
@@ -39,6 +39,11 @@ tailscaled_port="{{ OPNsense.tailscale.settings.listenPort }}"
 {%    if helpers.exists('OPNsense.tailscale.authentication.loginServer') %}
 {%      do up_args.append("--login-server=" + OPNsense.tailscale.authentication.loginServer) %}
 {%    endif %}
+{% if helpers.exists('OPNsense.tailscale.settings.peerRelayPort') and OPNsense.tailscale.settings.peerRelayPort|default("0") != "0" %}
+    {% do up_args.append("--relay-server-port=" + OPNsense.tailscale.settings.peerRelayPort) %}
+{% else %}
+    {% do up_args.append("--relay-server-port=") %}
+{% endif %}
 {#    loop through subnets to build list #}
 {%      if helpers.exists('OPNsense.tailscale.settings.subnets.subnet4') %}
 {%        set subnets = [] %}


### PR DESCRIPTION
This PR adds peer relay option to os-tailscale.

Creates a field for peer relay port, if 0 peer relay is disabled.

Related: #5122