### PR TITLE
security/acme-client: fix IPv6 support

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/HttpOpnsense.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/HttpOpnsense.php
@@ -86,6 +86,33 @@ class HttpOpnsense extends Base implements LeValidationInterface
 	    }
         }
 
+        // Find redirect target for IPv6
+        //
+        // Needed because redirecting to ::1 isn't allowed [1].
+        //
+        // [1]: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=193568
+        $ipv6_redirect_addr = null;
+        if (is_ipv6_allowed()) {
+            $backend = new \OPNsense\Core\Backend();
+            $interface = "wan";
+            $response = json_decode($backend->configdpRun('interface address', [$interface]));
+
+            if (isset($response->$interface)) {
+                foreach ($response->$interface as $if) {
+                    if (!empty($if->address) && $if->family == "inet6") {
+                        $ipv6_redirect_addr = $if->address;
+                        break;
+                    }
+                }
+            }
+
+            if ($ipv6_redirect_addr != null) {
+                LeUtils::log("found IPv6 on WAN interface, will redirect traffic there ({$ipv6_redirect_addr})");
+            } else {
+                LeUtils::log("failed to find IPv6 on WAN interface ($interface), will not rewrite target address");
+            }
+        }
+
         // Generate rules for all IP addresses
         $anchor_rules = "";
         if (!empty($iplist)) {
@@ -99,7 +126,7 @@ class HttpOpnsense extends Base implements LeValidationInterface
                     LeUtils::log("using IPv4 address: {$ip}");
                 } elseif (is_ipv6_allowed() && (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6))) {
                     // IPv6
-                    $_dst = '::1';
+                    $_dst = $ipv6_redirect_addr != null ? $ipv6_redirect_addr : $ip;
                     $_family = 'inet6';
                     LeUtils::log("using IPv6 address: {$ip}");
                 } else {

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/TlsalpnAcme.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/TlsalpnAcme.php
@@ -87,6 +87,33 @@ class TlsalpnAcme extends Base implements LeValidationInterface
 	    }
         }
 
+        // Find redirect target for IPv6
+        //
+        // Needed because redirecting to ::1 isn't allowed [1].
+        //
+        // [1]: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=193568
+        $ipv6_redirect_addr = null;
+        if (is_ipv6_allowed()) {
+            $backend = new \OPNsense\Core\Backend();
+            $interface = "wan";
+            $response = json_decode($backend->configdpRun('interface address', [$interface]));
+
+            if (isset($response->$interface)) {
+                foreach ($response->$interface as $if) {
+                    if (!empty($if->address) && $if->family == "inet6") {
+                        $ipv6_redirect_addr = $if->address;
+                        break;
+                    }
+                }
+            }
+
+            if ($ipv6_redirect_addr != null) {
+                LeUtils::log("found IPv6 on WAN interface, will redirect traffic there ({$ipv6_redirect_addr})");
+            } else {
+                LeUtils::log("failed to find IPv6 on WAN interface ($interface), will not rewrite target address");
+            }
+        }
+
         // Generate rules for all IP addresses
         $anchor_rules = "";
         if (!empty($iplist)) {
@@ -100,7 +127,7 @@ class TlsalpnAcme extends Base implements LeValidationInterface
                     LeUtils::log("using IPv4 address: {$ip}");
                 } elseif (is_ipv6_allowed() && (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6))) {
                     // IPv6
-                    $_dst = '::1';
+                    $_dst = $ipv6_redirect_addr != null ? $ipv6_redirect_addr : $ip;
                     $_family = 'inet6';
                     LeUtils::log("using IPv6 address: {$ip}");
                 } else {

--- a/security/acme-client/src/opnsense/service/templates/OPNsense/AcmeClient/lighttpd-acme-challenge.conf
+++ b/security/acme-client/src/opnsense/service/templates/OPNsense/AcmeClient/lighttpd-acme-challenge.conf
@@ -7,7 +7,7 @@
 # FreeBSD!
 server.event-handler = "freebsd-kqueue"
 server.network-backend = "writev"
-#server.use-ipv6 = "enable"
+server.use-ipv6 = "{{ 'enable' if OPNsense.Interfaces.settings.disableipv6 == "0" else 'disable' }}"
 
 # modules to load
 server.modules = ( "mod_access", "mod_expire", "mod_deflate", "mod_redirect",
@@ -60,13 +60,10 @@ mimetype.assign             = (
 url.access-deny = ( "~", ".inc" )
 
 # bind to port
-server.bind = "127.0.0.1"
 server.port = {{OPNsense.AcmeClient.settings.challengePort}}
-$SERVER["socket"]  == "127.0.0.1:{{OPNsense.AcmeClient.settings.challengePort}}" { }
-
-{% if OPNsense.Interfaces.settings.disableipv6 == "0" %}
-# IPv6
-$SERVER["socket"]  == "[::1]:{{OPNsense.AcmeClient.settings.challengePort}}" { }
+$SERVER["socket"] == "0.0.0.0:{{OPNsense.AcmeClient.settings.challengePort}}" { }
+{% if OPNsense.Interfaces.settings.disableipv6 == "1" %}
+$SERVER["socket"] == "[::]:{{OPNsense.AcmeClient.settings.challengePort}}" { }
 {% endif %}
 
 # to help the rc.scripts


### PR DESCRIPTION
**Important notices**
Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guide lines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

n/a

---

**Related issue**
Fixes #5228

---

**Describe the problem**

Issuing certificates for IPv6-only hosts failed.

---

**Describe the proposed solution**

See commit messages.

---
