### PR TITLE
security/acme-client: always use configured cert name in cert description

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeCertificate.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeCertificate.php
@@ -203,7 +203,6 @@ class LeCertificate extends LeCommon
             $cert_details = CertStore::parseX509($cert_content);
             $cert_subject = $cert_details['name'];
             $cert_serial  = $cert_details['serialNumber'];
-            $cert_cn      = $cert_details['commonname'];
             $cert_issuer  = implode(",", $cert_details['issuer']);
         } else {
             LeUtils::log_error('unable to read certificate content from file');
@@ -226,12 +225,7 @@ class LeCertificate extends LeCommon
         $cert = array();
         $cert['refid'] = uniqid();
         $cert['caref'] = (string)$ca['refid'];
-        if (empty($cert_cn)) {
-            // Fallback to configured name if Common Name is empty (e.g. for IP certificates)
-            $cert['descr'] = (string)$this->config->name . ' (ACME Client)';
-        } else {
-            $cert['descr'] = (string)$cert_cn . ' (ACME Client)';
-        }
+        $cert['descr'] = (string)$this->config->name . ' (ACME Client)';
         $import_log_message = 'imported';
         $cert_found = false;
 
@@ -273,7 +267,7 @@ class LeCertificate extends LeCommon
             $newcert->crt = base64_encode($cert_content);
             $newcert->prv = base64_encode($key_content);
         }
-        LeUtils::log("{$import_log_message} ACME X.509 certificate: {$cert_cn} ({$cert['refid']})");
+        LeUtils::log("{$import_log_message} ACME X.509 certificate: {$this->config->name} ({$cert['refid']})");
 
         // Serialize to config and save
         // Skip validation because the current in-memory model may not


### PR DESCRIPTION
**Important notices**
Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guide lines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

n/a

---

**Related issue**
n/a

---

**Describe the problem**
A PHP warning is triggered.

---

**Describe the proposed solution**

See commit message.

---
