### PR TITLE
ddclient: fix UI URI validation for powerdns

### DIFF
--- a/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.php
+++ b/dns/ddclient/src/opnsense/mvc/app/models/OPNsense/DynDNS/DynDNS.php
@@ -52,6 +52,7 @@ class DynDNS extends BaseModel
             }
         }
         foreach ($validate_servers as $key => $node) {
+            $srv = (string)$node->server;
             if ((string)$node->service == 'powerdns') {
                 if (empty($srv) || filter_var($srv, FILTER_VALIDATE_URL) === false) {
                     $messages->appendMessage(
@@ -65,7 +66,6 @@ class DynDNS extends BaseModel
             if ((string)$node->service != 'custom') {
                 continue;
             }
-            $srv = (string)$node->server;
             if (in_array((string)$node->protocol, ['get', 'post', 'put'])) {
                 if (empty($srv) || filter_var($srv, FILTER_VALIDATE_URL) === false) {
                     $messages->appendMessage(


### PR DESCRIPTION
**Important notices**
Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guide lines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

---

**Related issue**
If this pull request relates to an issue, link it here: #4772 

---

**Describe the problem**
Adding a PowerDNS API account using the UI is not possible. When attempting to add such an account, no matter what is entered in the 'server' field, an invalid URI error will pop.

---

**Describe the proposed solution**
This is occurring because the `$srv` temporary is not set until after it is validated. Move assignment prior to URI validation and it works properly.

---
