### PR TITLE
os-nextcloud-backup Create root backupdir first, then create subdir, if configured

### DIFF
--- a/sysutils/nextcloud-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Nextcloud.php
+++ b/sysutils/nextcloud-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Nextcloud.php
@@ -467,10 +467,6 @@ class Nextcloud extends Base implements IBackupProvider
             $keep_days = $nextcloud->numdays->getValue();
             $keep_num = $nextcloud->numbackups->getValue();
 
-            if ($nextcloud->addhostname->isEqual('1')) {
-                $backupdir .= "/" . gethostname();
-            }
-
             // Check if destination directory exists, create (full path) if not
             try {
                 $internal_username = $this->getInternalUsername($url, $username, $password);
@@ -478,6 +474,18 @@ class Nextcloud extends Base implements IBackupProvider
             } catch (\Exception $e) {
                 return array();
             }
+
+            if ($nextcloud->addhostname->isEqual('1')) {
+                $backupdir .= "/" . gethostname();
+                # Since we have a new backupdir, create this too, if needed
+                try {
+                    $this->create_directory($url, $username, $password, $internal_username, $backupdir);
+                } catch (\Exception $e) {
+                    syslog(LOG_ERR, "nextcloud backup failed: " . $e);
+                    return array();
+                }
+            }
+
 
             if ($strategy) {
                 $list_of_files = $this->backupstrat_one($internal_username, $username, $password, $url, $backupdir, $crypto_password);


### PR DESCRIPTION
**Important notices**
Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guide lines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [] AI tools were used to create at least part of the code submitted herewith.

**Related issue**
If this pull request relates to an issue, link it here:

Fixes #5294


Creates (if missing) the base backup directory, before creating hostname specific subdirectory (if that's missing).


105% my fault. Was so sure I had testet this multiple times, but.. seemingly not.