### PR TITLE
caddy: fix Dynamic DNS zone detection for subdomain domain entries

### DIFF
--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -152,7 +152,14 @@
             {% if reverse.FromDomain.startswith("*.") %}
                 {% do dynDnsDomains.append(cleanedDomain + " *") %}
             {% else %}
-                {% do dynDnsDomains.append(cleanedDomain + " @") %}
+                {% set domainParts = cleanedDomain.split('.') %}
+                {% if domainParts | length > 2 %}
+                    {% set baseDomain = domainParts[1:] | join('.') %}
+                    {% set subDomainPart = domainParts[0] %}
+                    {% do dynDnsDomains.append(baseDomain + " " + subDomainPart) %}
+                {% else %}
+                    {% do dynDnsDomains.append(cleanedDomain + " @") %}
+                {% endif %}
             {% endif %}
         {% endif %}
 


### PR DESCRIPTION
**Important notices**
Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guide lines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

---

**Related issue**
https://github.com/opnsense/plugins/issues/5303

---

**Describe the problem**

When a non-wildcard domain entry like `blog.example.com` has Dynamic DNS enabled, the Caddyfile template generates `blog.example.com @` in the `dynamic_dns` domains block. The `caddy-dynamicdns` module treats the first field as the DNS zone name, but `blog.example.com` is not a DNS zone - `example.com` is. The DNS provider lookup fails silently and the record never gets updated.

This only works correctly for:
- Wildcard entries (`*.example.com` -> `example.com *`)
- Subdomains nested under a wildcard parent (lines 161-164 already have the correct split logic)

The current workaround is to create a wildcard parent domain and nest subdomains under it, which is unintuitive and unnecessary.

---

**Describe the proposed solution**

When a non-wildcard domain entry has more than two parts (e.g. `blog.example.com`), split it into zone + record name using the same logic already present for subdomain entries:

- `blog.example.com` -> `example.com blog`
- `example.com` -> `example.com @` (unchanged)
- `*.example.com` -> `example.com *` (unchanged)

---