### PR TITLE
net/frr: add BFD strict mode for BGP neighbors

### DIFF
--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPNeighbor.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPNeighbor.xml
@@ -173,6 +173,18 @@
     </grid_view>
   </field>
   <field>
+    <id>neighbor.bfd_strict</id>
+    <label>BFD Strict Mode</label>
+    <type>checkbox</type>
+    <help>Strict mode requires the BFD session to be established before allowing BGP to connect. If BFD goes down, BGP immediately closes the session. This prevents BGP sessions from remaining up when the underlying link is down. Requires BFD to be enabled.</help>
+    <style>bfd_strict_mode</style>
+    <grid_view>
+      <type>boolean</type>
+      <formatter>boolean</formatter>
+      <visible>false</visible>
+    </grid_view>
+  </field>
+  <field>
     <id>neighbor.keepalive</id>
     <label>Keepalive</label>
     <type>text</type>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/quagga/bgp</mount>
     <description>BGP Routing configuration</description>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <items>
         <enabled type="BooleanField">
             <Default>0</Default>
@@ -98,6 +98,7 @@
                 <rrclient type="BooleanField"/>
                 <soft_reconfiguration_inbound type="BooleanField"/>
                 <bfd type="BooleanField"/>
+                <bfd_strict type="BooleanField"/>
                 <keepalive type="IntegerField">
                     <MinimumValue>1</MinimumValue>
                     <MaximumValue>1000</MaximumValue>

--- a/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/bgp.volt
+++ b/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/bgp.volt
@@ -34,6 +34,14 @@ POSSIBILITY OF SUCH DAMAGE.
             formatTokenizersUI();
             $('.selectpicker').selectpicker('refresh');
             updateServiceControlUI('quagga');
+
+        $(document).on('change', '#neighbor\\.bfd', function(){
+            if ($(this).is(':checked')) {
+                $(".bfd_strict_mode").closest('tr').show();
+            } else {
+                $(".bfd_strict_mode").closest('tr').hide();
+            }
+        });
         });
 
         $("#reconfigureAct").SimpleActionButton({

--- a/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/bgp.volt
+++ b/net/frr/src/opnsense/mvc/app/views/OPNsense/Quagga/bgp.volt
@@ -30,11 +30,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 <script>
     $(document).ready(function() {
-        mapDataToFormUI({'frm_bgp_settings':"/api/quagga/bgp/get"}).done(function(data){
-            formatTokenizersUI();
-            $('.selectpicker').selectpicker('refresh');
-            updateServiceControlUI('quagga');
-
         $(document).on('change', '#neighbor\\.bfd', function(){
             if ($(this).is(':checked')) {
                 $(".bfd_strict_mode").closest('tr').show();
@@ -42,6 +37,11 @@ POSSIBILITY OF SUCH DAMAGE.
                 $(".bfd_strict_mode").closest('tr').hide();
             }
         });
+
+        mapDataToFormUI({'frm_bgp_settings':"/api/quagga/bgp/get"}).done(function(data){
+            formatTokenizersUI();
+            $('.selectpicker').selectpicker('refresh');
+            updateServiceControlUI('quagga');
         });
 
         $("#reconfigureAct").SimpleActionButton({

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -124,10 +124,7 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
  neighbor {{ neighbor.address }} local-as {{ neighbor.localas }}
 {%         endif %}
 {%         if neighbor.bfd|default('') == '1' %}
- neighbor {{ neighbor.address }} bfd
-{%         endif %}
-{%         if neighbor.bfd_strict|default('') == '1' %}
- neighbor {{ neighbor.address }} bfd strict
+ neighbor {{ neighbor.address }} bfd {% if neighbor.bfd_strict|default('') == '1' %}strict{% endif %}
 {%         endif %}
 {%         if 'password' in neighbor and neighbor.password != '' %}
  neighbor {{ neighbor.address }} password {{ neighbor.password }}

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -126,6 +126,9 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%         if neighbor.bfd|default('') == '1' %}
  neighbor {{ neighbor.address }} bfd
 {%         endif %}
+{%         if neighbor.bfd_strict|default('') == '1' %}
+ neighbor {{ neighbor.address }} bfd strict
+{%         endif %}
 {%         if 'password' in neighbor and neighbor.password != '' %}
  neighbor {{ neighbor.address }} password {{ neighbor.password }}
 {%         endif %}


### PR DESCRIPTION
**Important notices**
Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guide lines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] ~~AI tools were used to create at least part of the code submitted herewith.~~

---

**Related issue**

#5314 

---

**Describe the problem**

The OPNsense FRR plugin currently lacks support for BFD Strict Mode in BGP neighbor configuration. This FRR feature ensures BGP sessions are only established when the underlying BFD session is up, preventing routing issues when physical connectivity is lost but BGP sessions remain artificially active.

---

**Describe the proposed solution**

This PR adds a "BFD Strict Mode" checkbox to the BGP neighbor configuration. The checkbox is hidden when BFD is disabled and appears when BFD is enabled, following the same pattern as OSPFv3's "Advertise Default Gateway" feature (I'm not sure this is the best way to do it, please let me know if not).

[docs.frrouting.org/en/latest/bfd.html](https://docs.frrouting.org/en/latest/bfd.html#clicmd-neighbor-A.B.C.D-X-X-X-X-WORD-bfd-strict-hold-time-seconds)

```
router bgp ASN
 neighbor <address> bfd strict
```