### PR TITLE
net/frr: add local-address and interface options to BFD neighbors

### DIFF
--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBFDNeighbor.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBFDNeighbor.xml
@@ -32,6 +32,24 @@
     </grid_view>
   </field>
   <field>
+    <id>neighbor.localaddress</id>
+    <label>Local Address</label>
+    <type>text</type>
+    <help>Local IP address to bind and send packets from. Mandatory for IPv6 peers.</help>
+    <grid_view>
+      <visible>false</visible>
+    </grid_view>
+  </field>
+  <field>
+    <id>neighbor.interfacename</id>
+    <label>Interface</label>
+    <type>dropdown</type>
+    <help>Select interface to use for this BFD peer.</help>
+    <grid_view>
+      <visible>false</visible>
+    </grid_view>
+  </field>
+  <field>
     <id>neighbor.detect_multiplier</id>
     <label>Detect multiplier</label>
     <type>text</type>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BFD.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BFD.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/quagga/bfd</mount>
     <description>BFD configuration</description>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <items>
         <enabled type="BooleanField">
             <Default>0</Default>
@@ -21,6 +21,17 @@
                     <Default>0</Default>
                     <Required>Y</Required>
                 </multihop>
+                <localaddress type="NetworkField">
+                    <Required>N</Required>
+                    <NetMaskAllowed>N</NetMaskAllowed>
+                </localaddress>
+                <interfacename type="InterfaceField">
+                    <Required>N</Required>
+                    <AllowDynamic>Y</AllowDynamic>
+                    <filters>
+                        <enable>/^(?!0).*$/</enable>
+                    </filters>
+                </interfacename>
                 <detect_multiplier type="IntegerField">
                     <Default>3</Default>
                     <Required>Y</Required>

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bfdd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bfdd.conf
@@ -4,7 +4,7 @@ bfd
 {%   if helpers.exists('OPNsense.quagga.bfd.neighbors.neighbor') %}
 {%     for neighbor in helpers.toList('OPNsense.quagga.bfd.neighbors.neighbor') %}
 {%       if neighbor.enabled == '1' %}
- peer {{ neighbor.address }}{% if neighbor.multihop|default('0') == '1' %} multihop{% endif %}{% if neighbor.localaddress|default('') != '' %} local-address {{ neighbor.localaddress }}{% endif %}{% if neighbor.interfacename|default('') != '' %} interface {{ neighbor.interfacename }}{% endif %}
+ peer {{ neighbor.address }}{% if neighbor.multihop|default('0') == '1' %} multihop{% endif %}{% if neighbor.localaddress %} local-address {{ neighbor.localaddress }}{% endif %}{% if neighbor.interfacename %} interface {{ neighbor.interfacename }}{% endif %}
   detect-multiplier {{ neighbor.detect_multiplier }}
   receive-interval {{ neighbor.receive_interval }}
   transmit-interval {{ neighbor.transmit_interval }}

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bfdd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bfdd.conf
@@ -4,7 +4,7 @@ bfd
 {%   if helpers.exists('OPNsense.quagga.bfd.neighbors.neighbor') %}
 {%     for neighbor in helpers.toList('OPNsense.quagga.bfd.neighbors.neighbor') %}
 {%       if neighbor.enabled == '1' %}
- peer {{ neighbor.address }} {% if neighbor.multihop|default('0') == '1' %}multihop{% endif +%}
+ peer {{ neighbor.address }}{% if neighbor.multihop|default('0') == '1' %} multihop{% endif %}{% if neighbor.localaddress|default('') != '' %} local-address {{ neighbor.localaddress }}{% endif %}{% if neighbor.interfacename|default('') != '' %} interface {{ neighbor.interfacename }}{% endif %}
   detect-multiplier {{ neighbor.detect_multiplier }}
   receive-interval {{ neighbor.receive_interval }}
   transmit-interval {{ neighbor.transmit_interval }}


### PR DESCRIPTION
**Important notices**
Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guide lines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] ~~AI tools were used to create at least part of the code submitted herewith.~~

---

**Related issue**

#5316 

---

**Describe the problem**

The OPNsense FRR plugin currently lacks support for BFD `local-address` and `interface` peer options to BFD neighbors configuration. This FRR feature ensures BFD sessions can bind to specific source addresses and interfaces, sometimes necessary for properly linking BFD sessions to BGP neighbors that require explicit interface binding.

---

**Describe the proposed solution**

This PR adds two optional fields to BFD neighbor configuration :
- Local Address (`localaddress`): `NetworkField` allowing IPv4 or IPv6 input without netmask. Provides the local IP address to bind the BFD peer listener to and use for sending packets.
- Interface (`interfacename`): `InterfaceField` with dropdown selection, filtered to exclude disabled interfaces. Specifies which interface the BFD session should use.

[docs.frrouting.org/en/latest/bfd.html](https://docs.frrouting.org/en/latest/bfd.html#clicmd-peer-A.B.C.D-X-X-X-X-multihop-local-address-A.B.C.D-X-X-X-X-interface-IFNAME-vrf-NAME)

```
peer <address> [multihop] [local-address <ip>] [interface <ifname>]
```