### PR TITLE
www/caddy: Add IP address support for reverse proxy domains

### DIFF
--- a/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
+++ b/www/caddy/src/opnsense/mvc/app/controllers/OPNsense/Caddy/forms/dialogReverseProxy.xml
@@ -27,7 +27,7 @@
         <id>reverse.FromDomain</id>
         <label>Domain</label>
         <type>text</type>
-        <help>Enter a domain name. For a base domain, use "example.com" or "opn.example.com". For a wildcard domain, use "*.example.com". Using a wildcard domain with subdomains requires a "DNS Provider" and the "DNS-01 Challenge" or a custom certificate.</help>
+        <help>Enter a domain name or IP address. For a base domain, use "example.com" or "opn.example.com". For a wildcard domain, use "*.example.com". Using a wildcard domain with subdomains requires a "DNS Provider" and the "DNS-01 Challenge" or a custom certificate. For an IP address, use "203.0.113.1" (IPv4) or "2001:db8::1" (IPv6) - a short-lived Let's Encrypt certificate will be requested automatically.</help>
         <grid_view>
             <formatter>from_domain</formatter>
         </grid_view>

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.php
@@ -308,6 +308,37 @@ class Caddy extends BaseModel
         }
     }
 
+    // Prevent the usage of DNS-01 Challenge and Dynamic DNS with IP address domains
+    private function checkIpAddressConflicts($messages)
+    {
+        foreach ($this->reverseproxy->reverse->iterateItems() as $item) {
+            if ($item->isFieldChanged()) {
+                $fromDomain = $item->FromDomain->getValue();
+
+                if (filter_var($fromDomain, FILTER_VALIDATE_IP) !== false) {
+                    if ($item->DnsChallenge->isEqual('1')) {
+                        $messages->appendMessage(new Message(
+                            gettext(
+                                'DNS-01 Challenge is not supported for IP addresses. ' .
+                                'Use HTTP-01 or TLS-ALPN-01 challenge instead.'
+                            ),
+                            $item->__reference . ".DnsChallenge"
+                        ));
+                    }
+
+                    if ($item->DynDns->isEqual('1')) {
+                        $messages->appendMessage(new Message(
+                            gettext(
+                                'Dynamic DNS is not supported for IP addresses.'
+                            ),
+                            $item->__reference . ".DynDns"
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
     // Perform the actual validation
     public function performValidation($validateFullModel = false)
     {
@@ -317,6 +348,7 @@ class Caddy extends BaseModel
         $this->checkDisableTlsConflicts($messages);
         $this->checkSuperuserPorts($messages);
         $this->checkLayer4Matchers($messages);
+        $this->checkIpAddressConflicts($messages);
 
         return $messages;
     }

--- a/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
+++ b/www/caddy/src/opnsense/mvc/app/models/OPNsense/Caddy/Caddy.xml
@@ -184,9 +184,9 @@
                 </enabled>
                 <FromDomain type="HostnameField">
                     <Required>Y</Required>
-                    <IpAllowed>N</IpAllowed>
+                    <IpAllowed>Y</IpAllowed>
                     <FqdnWildcardAllowed>Y</FqdnWildcardAllowed>
-                    <ValidationMessage>Please enter a valid domain name.</ValidationMessage>
+                    <ValidationMessage>Please enter a valid domain name or IP address.</ValidationMessage>
                 </FromDomain>
                 <FromPort type="PortField"/>
                 <accesslist type="ModelRelationField">

--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -304,9 +304,10 @@ http://{{ domain }} {
     tlsDnsPropagationTimeout="",
     tlsDnsPropagationTimeoutPeriod="",
     tlsDnsPropagationDelay="",
-    tlsDnsPropagationResolvers=""
+    tlsDnsPropagationResolvers="",
+    isIpDomain="0"
 ) %}
-    {% if customCert or (dnsChallenge == "1" and dnsProvider) or clientAuthTrustPool %}
+    {% if customCert or (dnsChallenge == "1" and dnsProvider) or clientAuthTrustPool or isIpDomain == "1" %}
         tls {% if customCert %}/usr/local/etc/caddy/certificates/{{ customCert }}.pem /usr/local/etc/caddy/certificates/{{ customCert }}.key{% endif %} {
             {% if not customCert and (dnsChallenge == "1" and dnsProvider) %}
             issuer acme {
@@ -326,6 +327,12 @@ http://{{ domain }} {
                 {% if tlsDnsPropagationDelay %}
                 propagation_delay {{ tlsDnsPropagationDelay }}s
                 {% endif %}
+            }
+            {% endif %}
+
+            {% if not customCert and isIpDomain == "1" and dnsChallenge != "1" %}
+            issuer acme {
+                profile shortlived
             }
             {% endif %}
 
@@ -601,7 +608,12 @@ http://{{ domain }} {
 
 {% for reverse in helpers.toList('Pischem.caddy.reverseproxy.reverse') %}
     {% if reverse.enabled|default("0") == "1" %}
-        {% if reverse.DisableTls|default("0") == "1" %}http://{% endif %}{{ reverse.FromDomain|default("") }}{% if reverse.FromPort %}:{{ reverse.FromPort }}{% endif %} {
+        {% set is_ipv6_from = (':' in reverse.FromDomain|default("") and (reverse.FromDomain|default("")).count(':') >= 2) %}
+        {% set is_ipv4_from = (reverse.FromDomain|default("") | regex_replace('[0-9.]', '') == '' and '.' in reverse.FromDomain|default("")) %}
+        {% set is_ip_from_domain = is_ipv6_from or is_ipv4_from %}
+        {% set from_domain_display = '[' ~ reverse.FromDomain ~ ']' if is_ipv6_from else reverse.FromDomain|default("") %}
+        {% set from_port_display = reverse.FromPort if reverse.FromPort else (httpsPort if httpsPort and is_ipv6_from and reverse.DisableTls|default("0") != "1" else ('443' if is_ipv6_from and reverse.DisableTls|default("0") != "1" else '')) %}
+        {% if reverse.DisableTls|default("0") == "1" %}http://{% endif %}{{ from_domain_display }}{% if from_port_display %}:{{ from_port_display }}{% endif %} {
             {% if reverse.AccessLog|default("0") == "1" %}
                 {% if generalSettings.LogAccessPlain|default("0") == "0" %}
                     log default
@@ -624,7 +636,8 @@ http://{{ domain }} {
                 tlsDnsPropagationTimeout=generalSettings.TlsDnsPropagationTimeout,
                 tlsDnsPropagationTimeoutPeriod=generalSettings.TlsDnsPropagationTimeoutPeriod,
                 tlsDnsPropagationDelay=generalSettings.TlsDnsPropagationDelay,
-                tlsDnsPropagationResolvers=generalSettings.TlsDnsPropagationResolvers
+                tlsDnsPropagationResolvers=generalSettings.TlsDnsPropagationResolvers,
+                isIpDomain='1' if is_ip_from_domain else '0'
             ) }}
             {% set domain_handles = helpers.toList('Pischem.caddy.reverseproxy.handle') | selectattr('reverse', 'equalto', reverse['@uuid']) | selectattr('subdomain', 'undefined') | list %}
             {{ handle_accesslist(reverse.accesslist, reverse.FromDomain) }}


### PR DESCRIPTION
Allow IP addresses (IPv4 and IPv6) as reverse proxy domains with automatic short-lived Let's Encrypt certificate provisioning.

- Relax IpAllowed on FromDomain field and update help text
- Add checkIpAddressConflicts validation to block DNS-01 and DynDNS for IPs
- Bracket-wrap IPv6 addresses in Caddyfile site address lines
- Inject issuer acme { profile shortlived } for IP-based domains

**Important notices**
Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guide lines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: Claude Opus 4.6
- Extent of AI involvement: Code generation and testing assistance. All changes were reviewed, validated on a live OPNsense 26.1 instance, and caddy validate passes on all configurations.

---

**Related issue**
If this pull request relates to an issue, link it here:
https://github.com/opnsense/plugins/issues/5322

---

**Describe the problem**
Caddy natively supports serving HTTPS on IP addresses using Let's Encrypt's short-lived certificate profile (profile shortlived, 6-day validity, auto-renewed). However, the plugin currently rejects IP addresses in the Domain field (IpAllowed=N), so users cannot take advantage of this capability.

---

**Describe the proposed solution**
  Allow IPv4 and IPv6 addresses as reverse proxy domains with automatic short-lived certificate provisioning.
- Model: Set IpAllowed=Y on FromDomain and update the validation message
- Validation: Add checkIpAddressConflicts() to block DNS-01 Challenge and Dynamic DNS when an IP address is used, since these features are incompatible with IP-based domains
- Caddyfile template: Detect IP domains, bracket-wrap IPv6 addresses in site address lines (e.g. [2001:db8::1]:443), and inject issuer acme { profile shortlived } for IP-based domains without custom certificate or DNS challenge

---
