### PR TITLE
os-nextcloud-backup Add some note about UTC time, in case people get confused:)

### DIFF
--- a/sysutils/nextcloud-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Nextcloud.php
+++ b/sysutils/nextcloud-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Nextcloud.php
@@ -88,8 +88,8 @@ class Nextcloud extends Base implements IBackupProvider
             array(
                 "name" => "strategy",
                 "type" => "checkbox",
-                "help" => gettext("Select this one to back up to a file named config-YYYYMMDD instead of syncing contents of /conf/backup"),
-                "label" => gettext("Daily file instead of sync all"),
+                "help" => gettext("Select this one to back up to a file named config-YYYYMMDD (based on UTC time) instead of syncing contents of /conf/backup"),
+                "label" => gettext("Daily file (UTC time) instead of sync all"),
             ),
             array(
                 "name" => "addhostname",


### PR DESCRIPTION
**Important notices**
Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guide lines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Related issue**
https://github.com/opnsense/plugins/issues/5327

---

**Describe the problem**
Files named YYYYMMDD is timezone agnostic, but the code isn't.. UTC is the truth here. Users might get confused about this, when noone say it is so.

---

**Describe the proposed solution**
Add text describing that UTC is the timezone utilized for naming.

---
