### PR TITLE
os-nginx: fix setup command paths for nginx and php_fpm

### DIFF
--- a/www/nginx/src/opnsense/scripts/nginx/setup.php
+++ b/www/nginx/src/opnsense/scripts/nginx/setup.php
@@ -354,7 +354,7 @@ file_put_contents(
 chmod('/usr/local/etc/nginx/tls_fingerprints.json', 0644);
 
 // test config and exit early if it not good
-$conf_test_errors = shell_safe('nginx -t -q 2>&1');
+$conf_test_errors = shell_safe('/usr/local/sbin/nginx -t -q 2>&1');
 if (!empty($conf_test_errors)) {
     syslog(LOG_EMERG, $conf_test_errors);
     closelog();
@@ -364,4 +364,4 @@ if (!empty($conf_test_errors)) {
 syslog(LOG_DEBUG, "NGINX setup routine completed.");
 closelog();
 
-pass_safe('/usr/local/etc/rc.d/php-fpm start');
+pass_safe('/usr/local/etc/rc.d/php_fpm start');


### PR DESCRIPTION
## Problem

The os-nginx setup routine uses two incorrect command invocations in the nginx setup script:

- `nginx -t -q 2>&1` is executed without an absolute path
- `/usr/local/etc/rc.d/php-fpm start` uses `php-fpm`, while the correct rc script name on FreeBSD/OPNsense is `php_fpm`

This can trigger runtime errors such as:

- `sh: nginx: not found`
- `sh: /usr/local/etc/rc.d/php-fpm: not found`

## Solution

This PR applies the smallest possible fix by updating the command strings to:

- `/usr/local/sbin/nginx -t -q 2>&1`
- `/usr/local/etc/rc.d/php_fpm start`

## Scope

This change is intentionally limited to the two affected command invocations only.

## Validation

The fix was validated by restarting nginx and confirming that:

- the setup routine completed cleanly
- the previous shell errors disappeared
- nginx continued to start and run normally

## AI disclosure

This change and PR text were prepared with assistance from OpenAI ChatGPT (GPT-5.4 Thinking). The result was manually reviewed and the final responsibility for the submission remains with the author.