### PR TITLE
net/frr: add BGP maximum-paths support for ECMP multipath

### DIFF
--- a/net/frr/Makefile
+++ b/net/frr/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		frr
-PLUGIN_VERSION=		1.51
+PLUGIN_VERSION=		1.52
 PLUGIN_COMMENT=		The FRRouting Protocol Suite
 PLUGIN_DEPENDS=		frr10-pythontools
 PLUGIN_MAINTAINER=	ad@opnsense.org

--- a/net/frr/pkg-descr
+++ b/net/frr/pkg-descr
@@ -12,6 +12,10 @@ WWW: https://frrouting.org/
 Plugin Changelog
 ================
 
+1.52
+
+* Add BGP maximum-paths support for ECMP multipath (contributed by maxfield-allison) (opnsense/plugins#4878)
+
 1.51
 
 * Add per-neighbor local-as option for BGP (contributed by danohn) (opnsense/plugins/pull/5308)

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/bgp.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/bgp.xml
@@ -67,4 +67,18 @@
         <type>checkbox</type>
         <help>Enable extended logging of BGP neighbor changes.</help>
     </field>
+    <field>
+        <id>bgp.maximumpaths</id>
+        <label>Maximum Paths</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>Maximum number of equal-cost paths for EBGP multipath (ECMP). Leave empty to use FRR default (1).</help>
+    </field>
+    <field>
+        <id>bgp.maximumpathsibgp</id>
+        <label>Maximum Paths (IBGP)</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>Maximum number of equal-cost paths for IBGP multipath (ECMP). Leave empty to use FRR default (1).</help>
+    </field>
 </form>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
@@ -48,6 +48,16 @@
             </OptionValues>
             <Multiple>Y</Multiple>
         </bestpath>
+        <maximumpaths type="IntegerField">
+            <MinimumValue>1</MinimumValue>
+            <MaximumValue>128</MaximumValue>
+            <ValidationMessage>The value shall be between 1 and 128 or left empty to use the default.</ValidationMessage>
+        </maximumpaths>
+        <maximumpathsibgp type="IntegerField">
+            <MinimumValue>1</MinimumValue>
+            <MaximumValue>128</MaximumValue>
+            <ValidationMessage>The value shall be between 1 and 128 or left empty to use the default.</ValidationMessage>
+        </maximumpathsibgp>
         <neighbors>
             <neighbor type="ArrayField">
                 <enabled type="BooleanField">

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -170,6 +170,12 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 
 {%  for addressFamily in addressFamilies %}
  address-family {{ addressFamily }} unicast
+{%   if helpers.exists('OPNsense.quagga.bgp.maximumpaths') and OPNsense.quagga.bgp.maximumpaths != '' %}
+  maximum-paths {{ OPNsense.quagga.bgp.maximumpaths }}
+{%   endif %}
+{%   if helpers.exists('OPNsense.quagga.bgp.maximumpathsibgp') and OPNsense.quagga.bgp.maximumpathsibgp != '' %}
+  maximum-paths ibgp {{ OPNsense.quagga.bgp.maximumpathsibgp }}
+{%   endif %}
 {%   for redistribution in helpers.toList('OPNsense.quagga.bgp.redistributions.redistribution') %}
 {%     if redistribution.enabled == '1' %}
  redistribute {{ redistribution.redistribute }}{% if redistribution.linkedRoutemap %} route-map {{ helpers.getUUID(redistribution.linkedRoutemap).name }}{% endif +%}


### PR DESCRIPTION
**Important notices**
Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guide lines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: N/A
- Extent of AI involvement: N/A

---

**Related issue**
Resolves #4878

---

**Describe the problem**
BGP `maximum-paths` and `maximum-paths ibgp` cannot be configured through the OPNsense GUI. Users must apply these settings via `vtysh` directly, which are then lost whenever the GUI "Apply" button is clicked and FRR regenerates its configuration.

---

**Describe the proposed solution**
Adds `maximum-paths` and `maximum-paths ibgp` support to the BGP address-family configuration, enabling ECMP multipath for both EBGP and IBGP peers.

**Changes:**
- **Model** (`BGP.xml`): two optional `IntegerField`s (range 1–128) after `bestpath`
- **Form** (`bgp.xml`): two advanced-mode fields on the BGP General tab
- **Template** (`bgpd.conf`): renders `maximum-paths [ibgp] N` inside the address-family loop
- **Makefile/pkg-descr**: version bump to 1.52

Follows the same pattern as the `local-as` addition in #5308.

---