### PR TITLE
GDrive: fix 0-byte backup upload when password is empty

### DIFF
--- a/sysutils/gdrive-backup/src/opnsense/mvc/app/library/OPNsense/Backup/GDrive.php
+++ b/sysutils/gdrive-backup/src/opnsense/mvc/app/library/OPNsense/Backup/GDrive.php
@@ -203,7 +203,9 @@ class GDrive extends Base implements IBackupProvider
                 // backup source data to local strings (plain/encrypted)
                 $confdata = file_get_contents('/conf/config.xml');
                 $confdata_enc = $this->encrypt($confdata, (string)$config->system->remotebackup->GDrivePassword);
-
+                if (empty($confdata_enc)) {
+                    $confdata_enc = $confdata;
+                }
                 // read filelist ({prefix}*.xml)
                 try {
                     $files = $client->listFiles((string)$config->system->remotebackup->GDriveFolderID);


### PR DESCRIPTION
**Important notices**
Before you submit a pull request, we ask you kindly to acknowledge the following:
- [x] I have read the contributing guide lines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.
If AI was used, please disclose:
- Model used: Claude (Anthropic)
- Extent of AI involvement: Used to assist in debugging and drafting the PR description. The fix itself was identified and tested manually on a real OPNsense 26.1.4 installation.

---
**Related issue**
No issue opened. The fix is minimal and self-explanatory, but happy to open one if required.

---
**Describe the problem**
When the Password field is left empty in the Google Drive backup settings, `encrypt()` fails silently because OpenSSL receives an empty password file and returns exit code 1. As a result, `encrypt()` returns `null`, which is passed directly to `$client->upload()`. The file is created on Google Drive with 0 bytes, and the UI still reports "Backup successful" with no indication of failure.

---
**Describe the proposed solution**
Added a null-check after `$this->encrypt()`. If encryption fails due to an empty password, the plaintext config is uploaded instead of `null`, ensuring the backup always contains valid data.

Note: an alternative approach would be to enforce a mandatory password via UI validation, or abort the backup with an explicit error when encryption fails. If the maintainer prefers either of those approaches, this PR can be adjusted accordingly.