### PR TITLE
GDrive: add optional encryption checkbox for backup files

### DIFF
--- a/sysutils/gdrive-backup/src/opnsense/mvc/app/library/OPNsense/Backup/GDrive.php
+++ b/sysutils/gdrive-backup/src/opnsense/mvc/app/library/OPNsense/Backup/GDrive.php
@@ -90,6 +90,13 @@ class GDrive extends Base implements IBackupProvider
             "value" => 60
         );
         $fields[] = array(
+            "name" => "GDriveEncrypt",
+            "type" => "checkbox",
+            "label" => gettext("Encrypt backup files"),
+            "help" => gettext("Encrypt the configuration file before uploading to Google Drive. A password is required when enabled."),
+            "value" => null
+        );
+        $fields[] = array(
             "name" => "GDrivePassword",
             "type" => "password",
             "label" => gettext("Password"),
@@ -202,7 +209,14 @@ class GDrive extends Base implements IBackupProvider
 
                 // backup source data to local strings (plain/encrypted)
                 $confdata = file_get_contents('/conf/config.xml');
-                $confdata_enc = $this->encrypt($confdata, (string)$config->system->remotebackup->GDrivePassword);
+                $confdata_enc = $confdata;
+                if (!empty($config->system->remotebackup->GDriveEncrypt)) {
+                    $confdata_enc = $this->encrypt($confdata, (string)$config->system->remotebackup->GDrivePassword);
+                    if (empty($confdata_enc)) {
+                        syslog(LOG_ERR, "GDrive: encryption failed, aborting backup.");
+                        return array();
+                    }
+                }
 
                 // read filelist ({prefix}*.xml)
                 try {
@@ -220,7 +234,6 @@ class GDrive extends Base implements IBackupProvider
                 }
                 krsort($configfiles);
 
-
                 // backup new file if changed (or if first in backup)
                 $target_filename = $fileprefix . time() . ".xml";
                 if (count($configfiles) > 1) {
@@ -233,10 +246,14 @@ class GDrive extends Base implements IBackupProvider
                             $end_at = strpos($bck_data_enc, "\n---");
                             $bck_data_enc = substr($bck_data_enc, $start_at, ($end_at - $start_at));
                         }
-                        $bck_data = $this->decrypt(
-                            $bck_data_enc,
-                            (string)$config->system->remotebackup->GDrivePassword
-                        );
+                        if (!empty($config->system->remotebackup->GDriveEncrypt)) {
+                            $bck_data = $this->decrypt(
+                                $bck_data_enc,
+                                (string)$config->system->remotebackup->GDrivePassword
+                            );
+                        } else {
+                            $bck_data = $bck_data_enc;
+                        }
                         if ($bck_data == $confdata) {
                             $target_filename = null;
                         }


### PR DESCRIPTION
**Important notices**
Before you submit a pull request, we ask you kindly to acknowledge the following:
- [x] I have read the contributing guide lines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.
If AI was used, please disclose:
- Model used: Claude (Anthropic)
- Extent of AI involvement: Used to assist in debugging and drafting the PR description. The fix was identified and tested manually on a real OPNsense 26.1.4 (amd64) installation.

---
**Related issue**
No issue opened. The change is self-contained and the problem is described below.

---
**Describe the problem**
When the Password field is left empty in the Google Drive backup settings, `encrypt()` fails silently because OpenSSL receives an empty password file. As a result, `encrypt()` returns `null`, which is passed directly to `$client->upload()`. The file is created on Google Drive with 0 bytes, and the UI still reports "Backup successful" with no indication of failure.

Additionally, encryption should be opt-in. There are valid use cases where a user may not want to encrypt backups (e.g. private Shared Drives with restricted access), and forcing encryption without a clear UI option is inconsistent with the rest of the backup UI (Download and Restore sections already use an explicit encrypt/decrypt checkbox).

---
**Describe the proposed solution**
Added an optional **"Encrypt backup files"** checkbox to the Google Drive backup configuration, consistent with the existing Download and Restore UI patterns.

- If the checkbox is **unchecked**: the configuration is uploaded in plaintext. No password required.
- If the checkbox is **checked** and a password is provided: the configuration is encrypted before upload.
- If the checkbox is **checked** but no password is provided: encryption fails, the backup is aborted, and an error is logged. No 0-byte file is uploaded.

The comparison logic when checking for duplicate backups also respects the encryption setting, decrypting the previous backup only when encryption is enabled.