### PR TITLE
frr: Extend usage of "localip" option to enforce source-ip of BGP tcp session

### DIFF
--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPNeighbor.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPNeighbor.xml
@@ -70,7 +70,7 @@
     <label>Local Initiater IP</label>
     <type>text</type>
     <advanced>true</advanced>
-    <help>Specify the local IP address used to establish connections with the neighbor. Only relevant for MD5 authentication.</help>
+    <help>Specify the local IP address used to establish connections with the neighbor. Affects BGP session source ip selection and MD5 authentication. Takes precedense before an "updatesource" option.</help>
     <grid_view>
       <visible>false</visible>
     </grid_view>

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -135,7 +135,10 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%         if 'disable_connected_check' in neighbor and neighbor.disable_connected_check == '1' %}
  neighbor {{ neighbor.address }} disable-connected-check
 {%         endif %}
-{%         if ':' not in neighbor.address and 'updatesource' in neighbor and neighbor.updatesource != '' %}
+{%         if 'localip' in neighbor and neighbor.localip != '' %}
+ neighbor {{ neighbor.address }} update-source {{ neighbor.localip }}
+%}
+{%         elif ':' not in neighbor.address and 'updatesource' in neighbor and neighbor.updatesource != '' %}
  neighbor {{ neighbor.address }} update-source {{ physical_interface(neighbor.updatesource) }}
 {%         endif %}
 {%         if ':' in neighbor.address and 'linklocalinterface' in neighbor and neighbor.linklocalinterface != '' %}


### PR DESCRIPTION
**Related issue**
#5362


** solved problem **
Previously "localip" was only used for MD5 Authentication purpose. It was not affecting actuall source-ip used to establish BGP and BFD sessions. Using "updatesource" option was not possible to select specific ip-address. This caused undeterministic address selection for interfaces with multiple ip, it  required settings outside of FRR (lika SNAT) to enforce expected IP.

** change made **
After change "localip" when defined is also used as value of update-source param in frr. It takes precedense over interface specified in "updatesource" option
