### PR TITLE
os-frr: Add description of bgp neighbor to frr.conf

### DIFF
--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/bgpd.conf
@@ -123,6 +123,9 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%         if 'localas' in neighbor and neighbor.localas != '' %}
  neighbor {{ neighbor.address }} local-as {{ neighbor.localas }}
 {%         endif %}
+{%         if 'description' in neighbor and neighbor.description != '' %}
+ neighbor {{ neighbor.address }} description {{ neighbor.description }}
+{%         endif %}
 {%         if neighbor.bfd|default('') == '1' %}
  neighbor {{ neighbor.address }} bfd
 {%         endif %}


### PR DESCRIPTION
Description is useful when using tools like frr-exporter. If set for-exporter exports description as one of metric labels which improves further monitoring and visibility.

**Describe the problem**
Description of bgp peer was not added to frr.conf


**Describe the proposed solution**
Add description of peer to frr.conf

