### PR TITLE
os-frr: fixed #5252 - Show OSPFv3-Routes in GUI > Diagnostics > OSPFv3

### DIFF
--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/Api/DiagnosticsController.php
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/Api/DiagnosticsController.php
@@ -254,6 +254,7 @@ class DiagnosticsController extends ApiControllerBase
         $payload = $this->configdJson("ospfv3", "route");
         if (!empty($payload['routes'])) {
             foreach ($payload['routes'] as $net => $route) {
+                $route = $route[0]; // route details are object within array in json. - fixes #5252
                 if (!empty($route['nextHops'])) {
                     foreach ($route['nextHops'] as $nexthop) {
                         $record = array_merge($route, $nexthop);


### PR DESCRIPTION
**Important notices**
Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: %
- Extent of AI involvement: %

---

**Related issue**
If this pull request relates to an issue, link it here: https://github.com/opnsense/plugins/issues/5252

---

**Describe the problem**
A clear and concise description of the problem this pull request addresses:
Fixes issue with displaying OSPFv3-Routes in WebGUI in OpnSense Version 26.1.2, due to restructure of JSON-Routeobject

---

**Describe the proposed solution**
Explain what this pull request changes and why.
Loading Object within the Route Array

---
