### PR TITLE
feat(net/frr): run register_sas on restart and reload

### DIFF
--- a/net/frr/src/opnsense/service/conf/actions.d/actions_quagga.conf
+++ b/net/frr/src/opnsense/service/conf/actions.d/actions_quagga.conf
@@ -11,14 +11,14 @@ type:script
 message:stopping frr
 
 [restart]
-command:/usr/local/etc/rc.d/frr restart; /usr/local/opnsense/scripts/frr/carp_event_handler
+command:/usr/local/etc/rc.d/frr restart; /usr/local/opnsense/scripts/frr/register_sas; /usr/local/opnsense/scripts/frr/carp_event_handler
 parameters:
 type:script
 message:restarting frr
 description:Restart FRR
 
 [reload]
-command:service frr reload; /usr/local/opnsense/scripts/frr/carp_event_handler
+command:service frr reload; /usr/local/opnsense/scripts/frr/register_sas; /usr/local/opnsense/scripts/frr/carp_event_handler
 parameters:
 type:script
 message:reloading frr


### PR DESCRIPTION
invoke register_sas during FRR restart and reload to keep SAS state in sync with FRR changes

**Important notices**
Before you submit a pull request, we ask you kindly to acknowledge the following:

- [X] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [X] I opened an issue first for non-trivial changes and linked it below.
- [X] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: xAI/Grok 4.20
- Extent of AI involvement: I asked for validation of the method used.

---

**Related issue**
If this pull request relates to an issue, link it here:
#3372 

---

**Describe the problem**
A clear and concise description of the problem this pull request addresses.
BGP md5-password are not synced to userspace with setkey.
A utility to sync this exists as '/usr/local/opnsense/scripts/frr/register_sas' but that is only ran once in setup.sh 

---

**Describe the proposed solution**

Adding '/usr/local/opnsense/scripts/frr/register_sas' to reload and restart commands in actions_quagga.conf

---
