### PR TITLE
net/upnp: fix ACL entry validation and error messages

### DIFF
--- a/net/upnp/src/www/services_upnp.php
+++ b/net/upnp/src/www/services_upnp.php
@@ -154,22 +154,22 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     /* user permissions validation */
     foreach (miniupnpd_permuser_list() as $i => $permuser) {
         if (!empty($pconfig[$permuser])) {
-            $perm = explode(' ', $pconfig[$permuser]);
+            $perm = explode(' ', trim($pconfig[$permuser]));
             /* should explode to 4 args */
             if (count($perm) != 4) {
-                $input_errors[] = sprintf(gettext("You must follow the specified format in the 'User specified permissions %s' field"), $i);
+                $input_errors[] = sprintf(gettext("You must follow the specified format in the 'ACL entry %s' field"), $i);
             } else {
               /* must with allow or deny */
               if (!($perm[0] == 'allow' || $perm[0] == 'deny')) {
-                $input_errors[] = sprintf(gettext("You must begin with allow or deny in the 'User specified permissions %s' field"), $i);
+                $input_errors[] = sprintf(gettext("You must begin with allow or deny in the 'ACL entry %s' field"), $i);
               }
               /* verify port or port range */
               if (!miniupnpd_validate_port($perm[1]) || !miniupnpd_validate_port($perm[3])) {
-                  $input_errors[] = sprintf(gettext("You must specify a port or port range between 0 and 65535 in the 'User specified permissions %s' field"), $i);
+                  $input_errors[] = sprintf(gettext("You must specify a port or port range between 0 and 65535 in the 'ACL entry %s' field"), $i);
               }
               /* verify ip address */
               if (!miniupnpd_validate_ip($perm[2])) {
-                  $input_errors[] = sprintf(gettext("You must specify a valid ip address in the 'User specified permissions %s' field"), $i);
+                  $input_errors[] = sprintf(gettext("You must specify a valid ip address in the 'ACL entry %s' field"), $i);
               }
             }
         }
@@ -191,7 +191,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
             $upnp[$fieldname] = $pconfig[$fieldname];
         }
         foreach (miniupnpd_permuser_list() as $fieldname) {
-            $upnp[$fieldname] = $pconfig[$fieldname];
+            $upnp[$fieldname] = trim($pconfig[$fieldname] ?? '');
         }
         // array types
         $upnp['iface_array'] = implode(',', $pconfig['iface_array']);


### PR DESCRIPTION
**Important notices**
Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

---

**Describe the problem**
Two issues with ACL entry validation on the UPnP settings page (`/services_upnp.php`):

1. **Trailing whitespace causes false validation failure**: `explode(' ', ...)` on an ACL entry with trailing whitespace (e.g. `allow 1024-65535 192.168.1.0/24 1024-65535 `) produces 5 tokens instead of 4.
2. **Error messages reference wrong field name**: Validation errors say "User specified permissions N" but the UI labels the fields as "ACL entry N".

---

**Describe the proposed solution**
- `trim()` ACL input before validation and before saving to config
- Replace "User specified permissions" with "ACL entry" in validation error messages to match the UI label

---

This is my first contribution to this project, happy to address any feedback!