### PR TITLE
net/frr: add BFD dependency support for static routes

### DIFF
--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditSTATICRoute.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditSTATICRoute.xml
@@ -27,4 +27,14 @@
     <type>dropdown</type>
     <help>Select an interface where this settings apply to.</help>
   </field>
+  <field>
+    <id>route.bfd</id>
+    <label>BFD</label>
+    <type>checkbox</type>
+    <help>Mark the route as dependent on the BFD neighbor session with the next hop.</help>
+    <advanced>true</advanced>
+    <grid_view>
+      <visible>false</visible>
+    </grid_view>
+  </field>
 </form>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/STATICd.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/STATICd.xml
@@ -28,6 +28,10 @@
                         <type>/^(?!group).*$/</type>
                     </filters>
                 </interfacename>
+                <bfd type="BooleanField">
+                    <Default>0</Default>
+                    <Required>N</Required>
+                </bfd>
             </route>
         </routes>
     </items>

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/staticd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/staticd.conf
@@ -13,6 +13,9 @@ ip
 {%-           endif %}
 {%-           if route.interfacename %}
  {{ helpers.physical_interface(route.interfacename) }}
+{%-           endif %}
+{%-           if 'bfd' in route and route.bfd == '1' %}
+ bfd
 {%-           endif +%}
 {%        endif %}
 {%    endfor %}


### PR DESCRIPTION
**Important notices**
Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Related issue**
If this pull request relates to an issue, link it here:

---

**Describe the problem**
We redistribute static routes from staticd into OSPF via WireGuard tunnels. We want the redistribution to depend on whether the tunnel is actually up.

---

**Describe the proposed solution**
Since WireGuard interfaces remain up even when the tunnel is not functional, BFD appears to be the simplest solution for detecting tunnel failures.

I'm going to provide documentation after peer review.

---
