### PR TITLE
bind: add DNS-over-TLS forwarding and fix missing NS record in zones

### DIFF
--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/general.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/general.xml
@@ -70,6 +70,12 @@
         <help>Set one or more hosts to send your DNS queries if the request is unknown.</help>
     </field>
     <field>
+        <id>general.forwardertls</id>
+        <label>DNS over TLS</label>
+        <type>checkbox</type>
+        <help>Use DNS-over-TLS (port 853) when forwarding queries. Requires BIND 9.18+.</help>
+    </field>
+    <field>
         <id>general.filteraaaav4</id>
         <label>Enable filter-aaaa on IPv4 Clients</label>
         <type>checkbox</type>

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/General.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/General.xml
@@ -48,6 +48,10 @@
         <forwarders type="NetworkField">
             <AsList>Y</AsList>
         </forwarders>
+        <forwardertls type="BooleanField">
+            <Default>0</Default>
+            <Required>Y</Required>
+        </forwardertls>
         <filteraaaav4 type="BooleanField">
             <Default>0</Default>
             <Required>Y</Required>

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
@@ -39,7 +39,11 @@ options {
 {% endif -%}
 
 {% if helpers.exists('OPNsense.bind.general.forwarders') and OPNsense.bind.general.forwarders != '' %}
+{% if helpers.exists('OPNsense.bind.general.forwardertls') and OPNsense.bind.general.forwardertls == '1' %}
+        forwarders port 853 tls ephemeral { {{ OPNsense.bind.general.forwarders.replace(',', '; ') }}; };
+{% else %}
         forwarders    { {{ OPNsense.bind.general.forwarders.replace(',', '; ') }}; };
+{% endif %}
 {% endif -%}
 
 {% if helpers.exists('OPNsense.bind.dnsbl.enabled') and OPNsense.bind.dnsbl.enabled == '1' %}


### PR DESCRIPTION
## Summary

- Add DNS-over-TLS (DoT) forwarding support via a new checkbox in BIND general settings
- Fix zone template to include mandatory NS record after SOA

## Problem

**DoT forwarding:** BIND 9.18+ supports forwarding queries via DNS-over-TLS (`forwarders port 853 tls ephemeral`), but the os-bind plugin has no way to enable this. Users who want encrypted upstream forwarding must manually edit named.conf after every restart.

**Missing NS record:** The `domain.db` zone template generates a SOA record but no NS record. BIND requires at least one NS record per zone — without it, the zone fails to load with `has no NS records` and all queries return SERVFAIL.

## Changes

| File | Change |
|------|--------|
| `General.xml` | Add `forwardertls` BooleanField |
| `forms/general.xml` | Add "DNS over TLS" checkbox after DNS Forwarders |
| `named.conf` template | Use `forwarders port 853 tls ephemeral` when enabled |
| `domain.db` template | Add `NS {{ domaindb.dnsserver }}.` after SOA |

## Test plan

- [ ] Enable BIND with DNS Forwarders configured (e.g. 1.1.1.1, 9.9.9.9)
- [ ] Check "DNS over TLS" checkbox, save and apply
- [ ] Verify `named.conf` contains `forwarders port 853 tls ephemeral`
- [ ] Verify `dig @localhost google.com` resolves (DoT working)
- [ ] Uncheck "DNS over TLS", verify plain `forwarders` line is generated
- [ ] Create a primary zone, verify zone file contains NS record
- [ ] Verify zone loads without errors (`named-checkzone`)

Tested on OPNsense 26.1.6 with BIND 9.20.20.