### PR TITLE
os-postfix: add submission port (587) support

### DIFF
--- a/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
+++ b/mail/postfix/src/opnsense/mvc/app/controllers/OPNsense/Postfix/forms/general.xml
@@ -108,6 +108,18 @@
         <help>If enabled it allows you to use SMTPS.</help>
     </field>
     <field>
+        <id>general.submission_enabled</id>
+        <label>Enable Submission Port (587)</label>
+        <type>checkbox</type>
+        <help>Enable the SMTP submission service on port 587. Clients must authenticate via SASL. Intended for mail user agents and automated senders such as monitoring systems. Port-level access should be restricted at the firewall.</help>
+    </field>
+    <field>
+        <id>general.submission_sasl_local_domain</id>
+        <label>Submission SASL Local Domain</label>
+        <type>text</type>
+        <help>Sets smtpd_sasl_local_domain for the submission service. Required when using Cyrus SASL with realm-based authentication (e.g. smtp.example.com). Leave empty to use the server hostname as the SASL realm.</help>
+    </field>
+    <field>
         <id>general.certificate</id>
         <label>Server Certificate</label>
         <type>dropdown</type>

--- a/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
+++ b/mail/postfix/src/opnsense/mvc/app/models/OPNsense/Postfix/General.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/postfix/general</mount>
     <description>Postfix configuration</description>
-    <version>1.2.7</version>
+    <version>1.2.8</version>
     <items>
         <enabled type="BooleanField">
             <Default>0</Default>
@@ -68,6 +68,11 @@
             <Default>0</Default>
             <Required>Y</Required>
         </tlswrappermode>
+        <submission_enabled type="BooleanField">
+            <Default>0</Default>
+            <Required>Y</Required>
+        </submission_enabled>
+        <submission_sasl_local_domain type="TextField"/>
         <certificate type="CertificateField">
             <Type>cert</Type>
         </certificate>

--- a/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/master.cf
+++ b/mail/postfix/src/opnsense/service/templates/OPNsense/Postfix/master.cf
@@ -15,6 +15,23 @@
 #smtpd     pass  -       -       n       -       -       smtpd
 #dnsblog   unix  -       -       n       -       0       dnsblog
 #tlsproxy  unix  -       -       n       -       0       tlsproxy
+{% if helpers.exists('OPNsense.postfix.general.submission_enabled') and OPNsense.postfix.general.submission_enabled == '1' %}
+submission inet n       -       n       -       -       smtpd
+  -o syslog_name=postfix/submission
+  -o smtpd_tls_security_level=encrypt
+  -o smtpd_sasl_auth_enable=yes
+  -o smtpd_tls_auth_only=yes
+{% if helpers.exists('OPNsense.postfix.general.submission_sasl_local_domain') and OPNsense.postfix.general.submission_sasl_local_domain != '' %}
+  -o smtpd_sasl_local_domain={{ OPNsense.postfix.general.submission_sasl_local_domain }}
+{% endif %}
+  -o smtpd_reject_unlisted_recipient=no
+  -o smtpd_client_restrictions=
+  -o smtpd_helo_restrictions=
+  -o smtpd_sender_restrictions=
+  -o smtpd_recipient_restrictions=
+  -o smtpd_relay_restrictions=permit_sasl_authenticated,reject
+  -o milter_macro_daemon_name=ORIGINATING
+{% else %}
 #submission inet n       -       n       -       -       smtpd
 #  -o syslog_name=postfix/submission
 #  -o smtpd_tls_security_level=encrypt
@@ -27,6 +44,7 @@
 #  -o smtpd_recipient_restrictions=
 #  -o smtpd_relay_restrictions=permit_sasl_authenticated,reject
 #  -o milter_macro_daemon_name=ORIGINATING
+{% endif %}
 #smtps     inet  n       -       n       -       -       smtpd
 #  -o syslog_name=postfix/smtps
 #  -o smtpd_tls_wrappermode=yes


### PR DESCRIPTION
The os-postfix plugin currently has the submission service block in `master.cf` hardcoded as a comment with no way to enable it through the GUI or API. This means anyone who needs port 587 for authenticated relay (monitoring systems, MUAs) must either edit `master.cf` directly or maintain a workaround outside the plugin — both of which get wiped by `postfix/service/reconfigure`.

This PR adds proper support through the model and template:

**Changes**

- `General.xml`: add `submission_enabled` (BooleanField, default off) and `submission_sasl_local_domain` (TextField, optional). Model version bumped to 1.2.8.
- `master.cf`: replace the hardcoded commented submission block with a conditional — when `submission_enabled=1` the service is activated; otherwise the original comment is preserved.
- `forms/general.xml`: add UI fields for both new settings, placed after the TLS Wrapper Mode checkbox.

**Behaviour when enabled**

The submission service enforces STARTTLS (`smtpd_tls_security_level=encrypt`) and requires SASL authentication (`smtpd_sasl_auth_enable=yes`, `smtpd_tls_auth_only=yes`). The client, HELO, and sender restriction lists are explicitly cleared so that the upstream `smtpd_recipient_restrictions` (which may include strict checks appropriate for port 25) do not apply — relay access is controlled solely by `smtpd_relay_restrictions=permit_sasl_authenticated,reject`. Port-level access control is left to the firewall, as is standard practice for submission services.

**`submission_sasl_local_domain`**

This optional field sets `smtpd_sasl_local_domain` in the submission block. It is only emitted when non-empty. It is needed for Cyrus SASL deployments where authentication credentials are scoped to a realm (e.g. `smtp.example.com`), so that clients can authenticate as `user@smtp.example.com` rather than `user@hostname`.

**Testing**

Tested on OPNsense 25.1 with os-postfix installed:

1. Enabled submission port and set SASL local domain via GUI → saved → reconfigure.
2. Verified `master.cf` contained the active submission block with correct `smtpd_sasl_local_domain`.
3. Verified Postfix listening on port 587 (`sockstat`).
4. Successfully relayed mail through port 587 from a remote host using Cyrus SASL credentials.
5. Disabled submission → reconfigure → port 587 gone, commented block restored.
6. Settings persist across reboots and reconfigures (stored in `config.xml`).