### PR TITLE
dns/ddclient: Add multiple hostname support for cloudflare

### DIFF
--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/cloudflare.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/cloudflare.py
@@ -117,7 +117,6 @@ class Cloudflare(BaseAccount):
                     },
                     'headers': headers
                 }
-
                 # Get record ID
                 response = requests.get(**req_opts)
                 try:

--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/cloudflare.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/cloudflare.py
@@ -42,7 +42,7 @@ class Cloudflare(BaseAccount):
 
     @staticmethod
     def known_services():
-        return  {'cloudflare': 'Cloudflare'}
+        return {'cloudflare': 'Cloudflare'}
 
     @staticmethod
     def match(account):
@@ -66,25 +66,30 @@ class Cloudflare(BaseAccount):
                 headers["X-Auth-Email"] = self.settings.get('username')
                 headers["X-Auth-Key"] = self.settings.get('password')
 
-            req_opts = {
+            # Check if zone exists
+            request = {
                 'url': url,
                 'params': {
                     'name': self.settings.get('zone')
                 },
                 'headers': headers
             }
-            response = requests.get(**req_opts)
+
+            response = requests.get(**request)
+
             try:
                 payload = response.json()
             except requests.exceptions.JSONDecodeError:
                 payload = {}
+
             if 'success' not in payload:
                 syslog.syslog(
-                        syslog.LOG_ERR,
-                        "Account %s error parsing JSON response [ZoneID] %s" % (self.description, response.text)
-                    )
+                    syslog.LOG_ERR,
+                    "Account %s error parsing JSON response [ZoneID] %s" % (self.description, response.text)
+                )
                 return False
-            if not payload.get('success', False):
+
+            if not payload.get('success', False) or len(payload.get('result', [])) == 0:
                 syslog.syslog(
                     syslog.LOG_ERR,
                     "Account %s error receiving ZoneID [%s]" % (self.description, json.dumps(payload.get('errors', {})))
@@ -98,88 +103,112 @@ class Cloudflare(BaseAccount):
                     "Account %s ZoneID for %s %s" % (self.description, self.settings.get('zone'), zone_id)
                 )
 
-            # Get record ID
-            req_opts = {
-                'url': f"{req_opts['url']}/{zone_id}/dns_records",
-                'params': {
-                    'name': self.settings.get('hostnames'),
-                    'type': recordType
-                },
-                'headers': req_opts['headers']
-            }
-            response = requests.get(**req_opts)
-            try:
-                payload = response.json()
-            except requests.exceptions.JSONDecodeError:
-                payload = {}
-            if 'success' not in payload:
-                syslog.syslog(
+            # Update each hostname
+            failed_hostnames = []
+            for hostname in self.settings.get("hostnames", "").split(","):
+
+                if self.is_verbose:
+                    syslog.syslog(
+                        syslog.LOG_NOTICE,
+                        "Account %s Getting record ID for hostname %s (%s)"
+                        % (self.description, hostname, recordType),
+                    )
+
+                request = {
+                    'url': '%s/%s/dns_records' % (url, zone_id),
+                    'params': {
+                        'name': hostname,
+                        'type': recordType
+                    },
+                    'headers': headers
+                }
+
+                # Get record ID
+                response = requests.get(**request)
+
+                try:
+                    payload = response.json()
+                except requests.exceptions.JSONDecodeError:
+                    syslog.syslog(
                         syslog.LOG_ERR,
                         "Account %s error parsing JSON response [RecordID] %s" % (self.description, response.text)
                     )
-                return
-            if not payload.get('success', False):
-                syslog.syslog(
-                    syslog.LOG_ERR,
-                    "Account %s error receiving RecordID [%s]" % (
-                        self.description, json.dumps(payload.get('errors', {}))
+                    failed_hostnames.append(hostname)
+                    continue
+
+                if not payload.get('success', False):
+                    syslog.syslog(
+                        syslog.LOG_ERR,
+                        "Account %s error receiving RecordID [%s]" % (
+                            self.description, json.dumps(payload.get('errors', {}))
+                        )
                     )
-                )
-                return False
+                    failed_hostnames.append(hostname)
+                    continue
 
-            if len(payload['result']) == 0:
-                syslog.syslog(
-                    syslog.LOG_ERR, "Account %s error locating hostname %s [%s]" % (
-                        self.description, self.settings.get('hostnames'), recordType
+                if len(payload['result']) == 0:
+                    syslog.syslog(
+                        syslog.LOG_ERR, "Account %s error locating hostname %s [%s]" % (
+                            self.description, hostname, recordType
+                        )
                     )
-                )
-                return False
+                    failed_hostnames.append(hostname)
+                    continue
 
-            record_id = payload['result'][0]['id']
-            if self.is_verbose:
-                syslog.syslog(
-                    syslog.LOG_NOTICE,
-                    "Account %s RecordID for %s %s" % (self.description, self.settings.get('hostnames'), record_id)
-                )
+                record_id = payload['result'][0]['id']
+                if self.is_verbose:
+                    syslog.syslog(
+                        syslog.LOG_NOTICE,
+                        "Account %s RecordID for %s %s" % (self.description, hostname, record_id)
+                    )
 
-            # Send IP address update
-            req_opts = {
-                'url': f"{req_opts['url']}/{record_id}",
-                'json': {
-                    'type': recordType,
-                    'name': self.settings.get('hostnames'),
-                    'content': str(self.current_address),
-                },
-                'headers': req_opts['headers']
-            }
-            response = requests.patch(**req_opts)
-            try:
-                payload = response.json()
-            except requests.exceptions.JSONDecodeError:
-                payload = {}
-            if 'success' not in payload:
-                syslog.syslog(
+                # Send IP address update
+                request = {
+                    'url': '%s/%s/dns_records/%s' % (url, zone_id, record_id),
+                    'json': {
+                        'type': recordType,
+                        'name': hostname,
+                        'content': str(self.current_address),
+                    },
+                    'headers': headers
+                }
+
+                # Update record IP
+                response = requests.patch(**request)
+
+                try:
+                    payload = response.json()
+                except requests.exceptions.JSONDecodeError:
+                    payload = {}
+
+                if 'success' not in payload:
+                    syslog.syslog(
                         syslog.LOG_ERR,
                         "Account %s error parsing JSON response [UpdateIP] %s" % (self.description, response.text)
                     )
-                return False
-            if payload.get('success', False):
-                syslog.syslog(
-                    syslog.LOG_NOTICE,
-                    "Account %s set new ip %s [%s]" % (
-                        self.description,
-                        self.current_address,
-                        payload.get('result', {}).get('content', '')
-                    )
-                )
+                    failed_hostnames.append(hostname)
+                    continue
 
+                if payload.get('success', False):
+                    syslog.syslog(
+                        syslog.LOG_NOTICE,
+                        "Account %s set new ip %s [%s]" % (
+                            self.description,
+                            self.current_address,
+                            payload.get('result', {}).get('content', '')
+                        )
+                    )
+                else:
+                    syslog.syslog(
+                        syslog.LOG_ERR,
+                        "Account %s failed to set new ip %s for hostname %s: [%s]" % (self.description,
+                                                                                      self.current_address, hostname,
+                                                                                      response.text)
+                    )
+                    failed_hostnames.append(hostname)
+
+            if not failed_hostnames:
                 self.update_state(address=self.current_address)
                 return True
-            else:
-                syslog.syslog(
-                    syslog.LOG_ERR,
-                    "Account %s failed to set new ip %s [%s]" % (self.description, self.current_address, response.text)
-                )
-
 
         return False

--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/cloudflare.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/cloudflare.py
@@ -109,6 +109,7 @@ class Cloudflare(BaseAccount):
                         % (self.description, hostname, recordType),
                     )
 
+                # Get record ID
                 req_opts = {
                     'url': '%s/%s/dns_records' % (url, zone_id),
                     'params': {
@@ -117,7 +118,6 @@ class Cloudflare(BaseAccount):
                     },
                     'headers': headers
                 }
-                # Get record ID
                 response = requests.get(**req_opts)
                 try:
                     payload = response.json()

--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/cloudflare.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/cloudflare.py
@@ -85,7 +85,6 @@ class Cloudflare(BaseAccount):
                     "Account %s error parsing JSON response [ZoneID] %s" % (self.description, response.text)
                 )
                 return False
-
             if not payload.get('success', False) or len(payload.get('result', [])) == 0:
                 syslog.syslog(
                     syslog.LOG_ERR,
@@ -110,7 +109,7 @@ class Cloudflare(BaseAccount):
                         % (self.description, hostname, recordType),
                     )
 
-                request = {
+                req_opts = {
                     'url': '%s/%s/dns_records' % (url, zone_id),
                     'params': {
                         'name': hostname,
@@ -120,7 +119,7 @@ class Cloudflare(BaseAccount):
                 }
 
                 # Get record ID
-                response = requests.get(**request)
+                response = requests.get(**req_opts)
                 try:
                     payload = response.json()
                 except requests.exceptions.JSONDecodeError:

--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/cloudflare.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/cloudflare.py
@@ -104,7 +104,6 @@ class Cloudflare(BaseAccount):
                 )
 
             # Update each hostname
-            failed_hostnames = []
             for hostname in self.settings.get("hostnames", "").split(","):
 
                 if self.is_verbose:
@@ -133,8 +132,7 @@ class Cloudflare(BaseAccount):
                         syslog.LOG_ERR,
                         "Account %s error parsing JSON response [RecordID] %s" % (self.description, response.text)
                     )
-                    failed_hostnames.append(hostname)
-                    continue
+                    return False
 
                 if not payload.get('success', False):
                     syslog.syslog(
@@ -143,8 +141,7 @@ class Cloudflare(BaseAccount):
                             self.description, json.dumps(payload.get('errors', {}))
                         )
                     )
-                    failed_hostnames.append(hostname)
-                    continue
+                    return False
 
                 if len(payload['result']) == 0:
                     syslog.syslog(
@@ -152,8 +149,7 @@ class Cloudflare(BaseAccount):
                             self.description, hostname, recordType
                         )
                     )
-                    failed_hostnames.append(hostname)
-                    continue
+                    return False
 
                 record_id = payload['result'][0]['id']
                 if self.is_verbose:
@@ -186,8 +182,7 @@ class Cloudflare(BaseAccount):
                         syslog.LOG_ERR,
                         "Account %s error parsing JSON response [UpdateIP] %s" % (self.description, response.text)
                     )
-                    failed_hostnames.append(hostname)
-                    continue
+                    return False
 
                 if payload.get('success', False):
                     syslog.syslog(
@@ -205,10 +200,9 @@ class Cloudflare(BaseAccount):
                                                                                       self.current_address, hostname,
                                                                                       response.text)
                     )
-                    failed_hostnames.append(hostname)
+                    return False
 
-            if not failed_hostnames:
-                self.update_state(address=self.current_address)
-                return True
+            self.update_state(address=self.current_address)
+            return True
 
         return False

--- a/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/cloudflare.py
+++ b/dns/ddclient/src/opnsense/scripts/ddclient/lib/account/cloudflare.py
@@ -67,21 +67,18 @@ class Cloudflare(BaseAccount):
                 headers["X-Auth-Key"] = self.settings.get('password')
 
             # Check if zone exists
-            request = {
+            req_opts = {
                 'url': url,
                 'params': {
                     'name': self.settings.get('zone')
                 },
                 'headers': headers
             }
-
-            response = requests.get(**request)
-
+            response = requests.get(**req_opts)
             try:
                 payload = response.json()
             except requests.exceptions.JSONDecodeError:
                 payload = {}
-
             if 'success' not in payload:
                 syslog.syslog(
                     syslog.LOG_ERR,
@@ -124,7 +121,6 @@ class Cloudflare(BaseAccount):
 
                 # Get record ID
                 response = requests.get(**request)
-
                 try:
                     payload = response.json()
                 except requests.exceptions.JSONDecodeError:
@@ -133,7 +129,6 @@ class Cloudflare(BaseAccount):
                         "Account %s error parsing JSON response [RecordID] %s" % (self.description, response.text)
                     )
                     return False
-
                 if not payload.get('success', False):
                     syslog.syslog(
                         syslog.LOG_ERR,
@@ -159,7 +154,7 @@ class Cloudflare(BaseAccount):
                     )
 
                 # Send IP address update
-                request = {
+                req_opts = {
                     'url': '%s/%s/dns_records/%s' % (url, zone_id, record_id),
                     'json': {
                         'type': recordType,
@@ -168,22 +163,17 @@ class Cloudflare(BaseAccount):
                     },
                     'headers': headers
                 }
-
-                # Update record IP
-                response = requests.patch(**request)
-
+                response = requests.patch(**req_opts)
                 try:
                     payload = response.json()
                 except requests.exceptions.JSONDecodeError:
                     payload = {}
-
                 if 'success' not in payload:
                     syslog.syslog(
                         syslog.LOG_ERR,
                         "Account %s error parsing JSON response [UpdateIP] %s" % (self.description, response.text)
                     )
                     return False
-
                 if payload.get('success', False):
                     syslog.syslog(
                         syslog.LOG_NOTICE,


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

When I provide multiple hostnames for Cloudflare Dynamic DNS service, it fails with error:
```
error locating hostname host1.example.com,host2.example.com [A]
```
See the issue link below for more details.

---

**Describe the proposed solution**

Since "hostname(s)" parameter is a list (according to the documentation: https://docs.opnsense.org/manual/dynamic_dns.html#accounts) I treat its value as comma-separated string. I split it using "," (comma) as a delimiter and then update each hostname in the loop.

---

**Related issue**

#5324 
