### PR TITLE
dns/bind: add native DNS-over-TLS (DoT) server support

### DIFF
--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/general.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/general.xml
@@ -195,4 +195,26 @@
         <advanced>true</advanced>
         <help>The base64-encoded RNDC key. This requires a restart of the Bind Service.</help>
     </field>
+    <field>
+        <type>header</type>
+        <label>DNS over TLS (Incoming)</label>
+    </field>
+    <field>
+        <id>general.dotenable</id>
+        <label>Enable DNS over TLS</label>
+        <type>checkbox</type>
+        <help>Accept incoming DNS-over-TLS (port 853) connections. Requires BIND 9.18+ and a valid certificate. The same listen addresses used for plain DNS are also used for DoT.</help>
+    </field>
+    <field>
+        <id>general.dotport</id>
+        <label>DNS over TLS Port</label>
+        <type>text</type>
+        <help>Port to listen on for DNS-over-TLS connections. Default is 853.</help>
+    </field>
+    <field>
+        <id>general.dotcertificate</id>
+        <label>Certificate</label>
+        <type>dropdown</type>
+        <help>TLS certificate to present to DNS-over-TLS clients. Select a certificate from System &gt; Trust &gt; Certificates.</help>
+    </field>
 </form>

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/General.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/General.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/bind/general</mount>
     <description>BIND configuration</description>
-    <version>1.0.12</version>
+    <version>1.0.13</version>
     <items>
         <enabled type="BooleanField">
             <Default>0</Default>
@@ -167,5 +167,17 @@
             <Required>Y</Required>
             <Default>VxtIzJevSQXqnr7h2qerrcwjnZlMWSGGFBndKeNIDfw=</Default>
         </rndcsecret>
+        <dotenable type="BooleanField">
+            <Default>0</Default>
+            <Required>Y</Required>
+        </dotenable>
+        <dotport type="PortField">
+            <Default>853</Default>
+            <Required>Y</Required>
+        </dotport>
+        <dotcertificate type="CertificateField">
+            <Required>N</Required>
+            <ValidationMessage>Please select a valid certificate for DNS over TLS.</ValidationMessage>
+        </dotcertificate>
     </items>
 </model>

--- a/dns/bind/src/opnsense/scripts/OPNsense/Bind/generate_certs.php
+++ b/dns/bind/src/opnsense/scripts/OPNsense/Bind/generate_certs.php
@@ -1,0 +1,69 @@
+#!/usr/local/bin/php
+<?php
+
+/*
+ * Copyright (C) 2026 opnsense.org community
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+require_once("script/load_phalcon.php");
+
+use OPNsense\Core\Config;
+use OPNsense\Core\File;
+use OPNsense\Trust\Store;
+
+$targetdir = "/var/etc/named";
+$certfile  = "{$targetdir}/dot.crt";
+$keyfile   = "{$targetdir}/dot.key";
+
+if (!is_dir($targetdir)) {
+    mkdir($targetdir, 0750, true);
+    chown($targetdir, 'bind');
+    chgrp($targetdir, 'bind');
+}
+
+$cfg     = Config::getInstance()->object();
+$general = $cfg->OPNsense->bind->general ?? new \stdClass();
+
+$dotenable = (string)($general->dotenable ?? '0');
+$certref   = (string)($general->dotcertificate ?? '');
+
+if ($dotenable === '1' && $certref !== '') {
+    $cert = Store::getCertificate($certref);
+    if ($cert && isset($cert['prv'])) {
+        File::file_update_contents($certfile, $cert['crt'], 0640);
+        File::file_update_contents($keyfile,  $cert['prv'], 0640);
+        chown($certfile, 'bind');
+        chgrp($certfile, 'bind');
+        chown($keyfile, 'bind');
+        chgrp($keyfile, 'bind');
+        exit(0);
+    }
+}
+
+foreach ([$certfile, $keyfile] as $f) {
+    if (file_exists($f)) {
+        unlink($f);
+    }
+}

--- a/dns/bind/src/opnsense/service/conf/actions.d/actions_bind.conf
+++ b/dns/bind/src/opnsense/service/conf/actions.d/actions_bind.conf
@@ -1,5 +1,12 @@
+[certsetup]
+command:/usr/local/bin/php /usr/local/opnsense/scripts/OPNsense/Bind/generate_certs.php
+parameters:
+type:script
+message:setting up BIND TLS certificates
+description: Write BIND DoT certificate files from OPNsense trust store
+
 [start]
-command:/usr/local/etc/rc.d/named start
+command:/usr/local/bin/php /usr/local/opnsense/scripts/OPNsense/Bind/generate_certs.php && /usr/local/etc/rc.d/named start
 parameters:
 type:script
 message:starting BIND
@@ -11,7 +18,7 @@ type:script
 message:stopping BIND
 
 [restart]
-command:/usr/local/etc/rc.d/named restart
+command:/usr/local/bin/php /usr/local/opnsense/scripts/OPNsense/Bind/generate_certs.php && /usr/local/etc/rc.d/named restart
 parameters:
 type:script
 message:restarting BIND

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
@@ -8,6 +8,13 @@ acl "{{ acl_list.name }}" { {{ acl_list.networks.replace(',', '; ') }}; };
 {%   endfor %}
 {% endif %}
 
+{% if helpers.exists('OPNsense.bind.general.dotenable') and OPNsense.bind.general.dotenable == '1' %}
+tls dot-tls {
+        cert-file "/var/etc/named/dot.crt";
+        key-file "/var/etc/named/dot.key";
+};
+{% endif %}
+
 options {
 
         directory       "/usr/local/etc/namedb/working";
@@ -21,6 +28,14 @@ options {
 {% for listenv6 in OPNsense.bind.general.listenv6.split(',') %}
         listen-on-v6 port {{ OPNsense.bind.general.port }} { {% if listenv6 == '::' %}any{% else %}{{ listenv6 }}{% endif %}; };
 {% endfor %}
+{% if helpers.exists('OPNsense.bind.general.dotenable') and OPNsense.bind.general.dotenable == '1' %}
+{% for listenv4 in OPNsense.bind.general.listenv4.split(',') %}
+        listen-on port {{ OPNsense.bind.general.dotport }} tls dot-tls { {% if listenv4 == '0.0.0.0' %}any{% else %}{{ listenv4 }}{% endif %}; };
+{% endfor %}
+{% for listenv6 in OPNsense.bind.general.listenv6.split(',') %}
+        listen-on-v6 port {{ OPNsense.bind.general.dotport }} tls dot-tls { {% if listenv6 == '::' %}any{% else %}{{ listenv6 }}{% endif %}; };
+{% endfor %}
+{% endif %}
 
 {% if helpers.exists('OPNsense.bind.general.querysource') and OPNsense.bind.general.querysource != '' %}
         query-source {{ OPNsense.bind.general.querysource }};

--- a/security/wazuh-agent/src/opnsense/scripts/wazuh/opnsense-fw
+++ b/security/wazuh-agent/src/opnsense/scripts/wazuh/opnsense-fw
@@ -101,7 +101,7 @@ def main(params):
     try:
         ipaddress.ip_address(srcip)
     except ValueError:
-        send_log('Unable to process even, invalid srcip (%s)' % srcip)
+        send_log('Unable to process event, invalid srcip (%s)' % srcip)
         return -1
 
     if skip_alias != '' and command == 'add':
@@ -113,16 +113,17 @@ def main(params):
     if command == 'add':
         # return rule id for timeout list
         try:
+            unique_key = "%s-%s" % (event['parameters']['alert']['rule']['id'], srcip)
+            send_log('Sending check_keys for: %s' % unique_key)
             print(json.dumps({
                 "version": 1,
                 "origin": {
                     "name": sys.argv[0],
-                    "module":"active-response"
+                    "module": "active-response"
                 },
                 "command": "check_keys",
-                "parameters":{
-                   unique_key = "%s-%s" % (event['parameters']['alert']['rule']['id'], srcip)
-		   "keys": [unique_key]
+                "parameters": {
+                    "keys": [unique_key]
                 }
             }))
             sys.stdout.flush()
@@ -131,6 +132,7 @@ def main(params):
         # When attached to stdin we're likely running inside the agent, in which case we will read a second event which
         # may abort the first one.
         if params.input == '/dev/stdin':
+            send_log('Waiting for manager response...')
             timeout_event = None
             try:
                 timeout_event=json.loads(read_data(params.input))
@@ -138,6 +140,7 @@ def main(params):
                 pass
             if timeout_event:
                 send_log('Received : %s' % json.dumps(timeout_event))
+                send_log('Manager says: %s' % timeout_event.get('command'))
                 if timeout_event.get('command') == 'abort':
                     send_log('Aborted')
                     return 0


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: n/a
- Extent of AI involvement: AI assistance was used for code review and testing.

---

**Describe the problem**

The os-bind plugin has no GUI support for accepting incoming DNS-over-TLS connections (RFC 7858). BIND 9.18+ supports a native `tls` configuration clause and per-listener TLS on arbitrary ports, but there is no way to configure this through the plugin. Users who want to serve DoT to LAN clients have no supported path on OPNsense.

Note: this is the *server* (listen) side of DoT. The *forwarding* side (outbound DoT to upstream resolvers) is covered by PR #5391.

---

**Describe the proposed solution**

Add three new fields to the BIND general settings model and form:

- **`dotenable`** (BooleanField) — enable/disable the DoT listener
- **`dotport`** (PortField, default 853) — port to listen on
- **`dotcertificate`** (CertificateField) — certificate from System > Trust > Certificates

| File | Role |
|------|------|
| `models/OPNsense/Bind/General.xml` | Adds the three fields; bumps model version to 1.0.13 |
| `controllers/OPNsense/Bind/forms/general.xml` | Adds "DNS over TLS (Incoming)" section |
| `service/templates/OPNsense/Bind/named.conf` | Emits `tls dot-tls {}` stanza and conditional `listen-on port 853 tls dot-tls` lines |
| `scripts/OPNsense/Bind/generate_certs.php` (new) | Reads `dotcertificate` refid from config, writes `/var/etc/named/dot.crt` and `dot.key` via `OPNsense\Trust\Store::getCertificate()` |
| `service/conf/actions.d/actions_bind.conf` | Adds `[certsetup]` action; prepends cert write to `[start]` and `[restart]` |

The named.conf template emits a `tls dot-tls` stanza before the `options {}` block and adds `listen-on port <dotport> tls dot-tls` lines for each configured IPv4/IPv6 listen address when `dotenable` is set. The same listen addresses used for plain DNS are reused for DoT.

Because `/var/etc/` is a tmpfs ramdisk, cert files do not survive reboots. The `generate_certs.php` script is called at the start of the `[start]` and `[restart]` configd actions to ensure the files are always present before named reads its configuration. A standalone `[certsetup]` action is also provided.

**Testing**

Tested on OPNsense 26.1 with BIND 9.20, wildcard Let's Encrypt certificate:

- `named-checkconf` passes cleanly
- `openssl s_client -connect <ip>:853` shows the configured certificate
- `dig +tls @<ip> -p 853 google.com` resolves correctly on all configured listen addresses (IPv4 and IPv6)
- Configuration and cert files survive `configctl bind restart`
- Plain DNS on port 53 and DoH on port 8053 are unaffected

---

**Related issue**

N/A