### PR TITLE
freeradius: add configurable LDAP group membership mode

### DIFF
--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/ldap.xml
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/ldap.xml
@@ -65,4 +65,10 @@
         <type>text</type>
         <help>Filter for group objects, should match all available group objects a user might be a member of.</help>
     </field>
+    <field>
+        <id>ldap.group_membership_mode</id>
+        <label>Group Membership Mode</label>
+        <type>dropdown</type>
+        <help>How FreeRADIUS checks LDAP group membership. Use "member filter" for Active Directory or Samba 4 with nested groups (uses LDAP_MATCHING_RULE_IN_CHAIN OID for transitive lookup).</help>
+    </field>
 </form>

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Ldap.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Ldap.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/freeradius/ldap</mount>
     <description>LDAP configuration</description>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <items>
         <innertunnel type="BooleanField">
             <Default>0</Default>
@@ -47,5 +47,13 @@
             <Default>(objectClass=posixGroup)</Default>
             <Required>N</Required>
         </group_filter>
+        <group_membership_mode type="OptionField">
+            <Default>attribute</Default>
+            <Required>Y</Required>
+            <OptionValues>
+                <attribute>memberOf attribute (POSIX / flat groups)</attribute>
+                <filter>member filter (Active Directory / Samba 4 nested groups)</filter>
+            </OptionValues>
+        </group_membership_mode>
     </items>
 </model>

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-ldap
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-ldap
@@ -85,7 +85,11 @@ ldap {
 {%     if helpers.exists('OPNsense.freeradius.ldap.group_filter') and OPNsense.freeradius.ldap.group_filter != '' %}
                 filter = "{{ OPNsense.freeradius.ldap.group_filter }}"
 {%     endif %}
+{%     if helpers.exists('OPNsense.freeradius.ldap.group_membership_mode') and OPNsense.freeradius.ldap.group_membership_mode == 'filter' %}
+                membership_filter = "(member:1.2.840.113556.1.4.1941:=%{control:Ldap-UserDn})"
+{%     else %}
                 membership_attribute = 'memberOf'
+{%     endif %}
         }
         profile {
         }


### PR DESCRIPTION
Adds `group_membership_mode` to the LDAP settings (model, form, template):

- `attribute` (default): `membership_attribute = 'memberOf'` — existing behaviour, compatible with POSIX groups and flat LDAP structures.
- `filter`: `membership_filter` with LDAP_MATCHING_RULE_IN_CHAIN OID (1.2.840.113556.1.4.1941) — resolves nested group membership against Active Directory and Samba 4 AD DC in a single LDAP query.

The `memberOf` attribute reflects only direct memberships, breaking `Ldap-Group ==` checks (e.g. VLAN assignment) when groups are nested. The OID-based filter traverses the full membership chain server-side.

Default is `attribute`; existing configurations are unaffected.

Tested with Samba 4.24 AD DC and FreeRADIUS 3.2 (os-freeradius plugin).

**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: Claude Sonnet 4.6 (Anthropic)
- Extent of AI involvement: assisted in designing the solution and writing the implementation (template conditional, model field, form field)

---

**Describe the problem**

FreeRADIUS hardcodes `membership_attribute = 'memberOf'` in the LDAP module configuration. The `memberOf` attribute on a user object reflects only *direct* group memberships. In Active Directory and Samba 4 AD DC deployments that rely on nested security groups, `Ldap-Group ==` checks (used e.g. for VLAN assignment in 802.1X) silently fail for users who are members only through a parent
group.

---

**Describe the proposed solution**

Adds a **Group Membership Mode** option to the FreeRADIUS LDAP settings page:

- **memberOf attribute** (default): existing behaviour, no change for current deployments.
- **member filter**: switches to `membership_filter` using the `LDAP_MATCHING_RULE_IN_CHAIN` OID (`1.2.840.113556.1.4.1941`), which instructs the LDAP server to resolve the full transitive membership chain in a single query — compatible with Active Directory and Samba 4.

---

**Related issue**

None.