### PR TITLE
sysutils/nextcloud-backup: add option to disable SSL verification

### DIFF
--- a/sysutils/nextcloud-backup/Makefile
+++ b/sysutils/nextcloud-backup/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		nextcloud-backup
-PLUGIN_VERSION=		1.2
+PLUGIN_VERSION=		1.3
 PLUGIN_COMMENT=		Track config changes using NextCloud
 
 .include "../../Mk/plugins.mk"

--- a/sysutils/nextcloud-backup/pkg-descr
+++ b/sysutils/nextcloud-backup/pkg-descr
@@ -6,6 +6,10 @@ strongly advise to not use a public service to send backups to.
 Plugin Changelog
 ================
 
+1.3
+
+* Add option to disable SSL certificate verification
+
 1.2
 
 * Add option to upload to one file each day instead of syncing the contents of /conf/backup

--- a/sysutils/nextcloud-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Nextcloud.php
+++ b/sysutils/nextcloud-backup/src/opnsense/mvc/app/library/OPNsense/Backup/Nextcloud.php
@@ -80,6 +80,14 @@ class Nextcloud extends Base implements IBackupProvider
                 "value" => null
             ),
             array(
+                "name" => "verify_ssl",
+                "type" => "checkbox",
+                "label" => gettext("Verify SSL certificate"),
+                "help" => gettext("Uncheck to allow self-signed or otherwise untrusted certificates. " .
+                    "Only disable this if you trust the network path to the Nextcloud server."),
+                "value" => null
+            ),
+            array(
                 "name" => "backupdir",
                 "type" => "text",
                 "label" => gettext("Directory Name without leading slash, starting from user's root"),
@@ -691,6 +699,9 @@ class Nextcloud extends Base implements IBackupProvider
         $postdata = null,
         $headers = array("User-Agent: OPNsense Firewall")
     ) {
+        // verify_ssl defaults to '1' via the model definition (NextcloudSettings.xml),
+        // so unset/upgraded configs verify by default; only an explicit '0' disables it
+        $verify_ssl = (string)(new NextcloudSettings())->verify_ssl !== '0';
         $curl = curl_init();
         curl_setopt_array($curl, array(
             CURLOPT_URL => $url,
@@ -701,6 +712,8 @@ class Nextcloud extends Base implements IBackupProvider
             CURLOPT_TIMEOUT => 60,          // maximum time: 1 min
             CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
             CURLOPT_USERPWD => $username . ":" . $password,
+            CURLOPT_SSL_VERIFYPEER => $verify_ssl,
+            CURLOPT_SSL_VERIFYHOST => $verify_ssl ? 2 : 0,
             CURLOPT_HTTPHEADER => $headers
         ));
         if ($postdata != null) {

--- a/sysutils/nextcloud-backup/src/opnsense/mvc/app/models/OPNsense/Backup/NextcloudSettings.xml
+++ b/sysutils/nextcloud-backup/src/opnsense/mvc/app/models/OPNsense/Backup/NextcloudSettings.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//system/backup/nextcloud</mount>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <description>OPNsense Nextcloud Backup Settings</description>
     <items>
         <enabled type="BooleanField">
@@ -43,6 +43,9 @@
             </Constraints>
         </password>
         <password_encryption type="UpdateOnlyTextField"/>
+        <verify_ssl type="BooleanField">
+            <Default>1</Default>
+        </verify_ssl>
         <backupdir type="TextField">
             <Required>Y</Required>
             <Mask>/^([\w%+\-]+\/)*[\w+%\-]+$/</Mask>


### PR DESCRIPTION
Adds an optional "Verify SSL certificate" checkbox to the Nextcloud backup settings.

- Defaults to enabled; existing behavior is unchanged on upgrade.
- When unchecked, `CURLOPT_SSL_VERIFYPEER` and `CURLOPT_SSL_VERIFYHOST` are disabled in
  `curl_request_nothrow()`, so backups work against Nextcloud instances behind self-signed
  or otherwise untrusted certificates.
- Without this, users have to hand-edit `Nextcloud.php` after every plugin update.

Relates to #3405 (accept self-signed certificates) and #4422 (custom CA roots).

Changes:
- `NextcloudSettings.xml`: new `verify_ssl` BooleanField, default 1; model version 1.0.2 -> 1.0.3
- `Nextcloud.php`: UI field in `getConfigurationFields()`, curl options in `curl_request_nothrow()`
- `Makefile`: plugin version 1.2 -> 1.3
- `pkg-descr`: changelog entry
