### PR TITLE
net-mgmt/telegraf: Add header config to OpenTelemetry output and fix service_address string

### DIFF
--- a/net-mgmt/telegraf/Makefile
+++ b/net-mgmt/telegraf/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		telegraf
-PLUGIN_VERSION=		1.12.14
+PLUGIN_VERSION=		1.12.15
 PLUGIN_COMMENT=		Agent for collecting metrics and data
 PLUGIN_DEPENDS=		telegraf
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net-mgmt/telegraf/pkg-descr
+++ b/net-mgmt/telegraf/pkg-descr
@@ -12,6 +12,11 @@ WWW: https://www.influxdata.com/time-series-platform/telegraf/
 Plugin Changelog
 ================
 
+1.12.15
+
+* Add custom header support for OpenTelemetry output
+* Quote OpenTelemetry service_address in config
+
 1.12.14
 
 * Add name_prefix in influxdb config

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/output.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/controllers/OPNsense/Telegraf/forms/output.xml
@@ -347,7 +347,7 @@
         <id>output.opentelemetry_server</id>
         <label>OpenTelemetry Server</label>
         <type>text</type>
-        <help>Set the IP and port where metrics shoud be sent to, e.g. 192.168.0.1:4317.</help>
+        <help>For gRPC, set the address and port, e.g. 192.168.0.1:4317. For HTTP, use a full URL, e.g. https://collector.example.com/v1/metrics.</help>
     </field>
     <field>
         <id>output.opentelemetry_compression</id>
@@ -366,5 +366,17 @@
         <label>Disable TLS verification</label>
         <type>checkbox</type>
         <help>This will skip chain and host verification.</help>
+    </field>
+    <field>
+        <id>output.opentelemetry_header_name</id>
+        <label>Custom Header Name</label>
+        <type>text</type>
+        <help>Name of an additional HTTP header to send with requests, e.g. Authorization.</help>
+    </field>
+    <field>
+        <id>output.opentelemetry_header_value</id>
+        <label>Custom Header Value</label>
+        <type>text</type>
+        <help>Value for the custom header, e.g. Bearer your-token-here.</help>
     </field>
 </form>

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Output.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Output.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/telegraf/output</mount>
     <description>Telegraf outputs configuration</description>
-    <version>1.4.7</version>
+    <version>1.4.6</version>
     <items>
         <influx_enable type="BooleanField">
             <Default>0</Default>

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Output.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Output.xml
@@ -205,8 +205,6 @@
             </OptionValues>
         </opentelemetry_compression>
         <opentelemetry_header_name type="TextField"/>
-        <opentelemetry_header_value type="TextField">
-            <Required>N</Required>
-        </opentelemetry_header_value>
+        <opentelemetry_header_value type="TextField"/>
     </items>
 </model>

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Output.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Output.xml
@@ -204,9 +204,7 @@
                 <none>none</none>
             </OptionValues>
         </opentelemetry_compression>
-        <opentelemetry_header_name type="TextField">
-            <Required>N</Required>
-        </opentelemetry_header_name>
+        <opentelemetry_header_name type="TextField"/>
         <opentelemetry_header_value type="TextField">
             <Required>N</Required>
         </opentelemetry_header_value>

--- a/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Output.xml
+++ b/net-mgmt/telegraf/src/opnsense/mvc/app/models/OPNsense/Telegraf/Output.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/telegraf/output</mount>
     <description>Telegraf outputs configuration</description>
-    <version>1.4.6</version>
+    <version>1.4.7</version>
     <items>
         <influx_enable type="BooleanField">
             <Default>0</Default>
@@ -204,5 +204,11 @@
                 <none>none</none>
             </OptionValues>
         </opentelemetry_compression>
+        <opentelemetry_header_name type="TextField">
+            <Required>N</Required>
+        </opentelemetry_header_name>
+        <opentelemetry_header_value type="TextField">
+            <Required>N</Required>
+        </opentelemetry_header_value>
     </items>
 </model>

--- a/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
+++ b/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
@@ -159,7 +159,7 @@
 {%   if helpers.exists('OPNsense.telegraf.output.opentelemetry_header_name') and OPNsense.telegraf.output.opentelemetry_header_name != '' %}
 [outputs.opentelemetry.headers]
   "{{ OPNsense.telegraf.output.opentelemetry_header_name }}" = "{{ OPNsense.telegraf.output.opentelemetry_header_value }}"
-{% endif %}
+{%   endif %}
 {% endif %}
 
 {% if helpers.exists('OPNsense.telegraf.output.graphite_enable') and OPNsense.telegraf.output.graphite_enable == '1' %}

--- a/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
+++ b/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
@@ -155,7 +155,7 @@
 {%   endif %}
 {%   if helpers.exists('OPNsense.telegraf.output.opentelemetry_compression') and OPNsense.telegraf.output.opentelemetry_compression != '' %}
   compression = "{{ OPNsense.telegraf.output.opentelemetry_compression }}"
-{% endif %}
+{%   endif %}
 {%   if helpers.exists('OPNsense.telegraf.output.opentelemetry_header_name') and OPNsense.telegraf.output.opentelemetry_header_name != '' %}
 [outputs.opentelemetry.headers]
   "{{ OPNsense.telegraf.output.opentelemetry_header_name }}" = "{{ OPNsense.telegraf.output.opentelemetry_header_value }}"

--- a/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
+++ b/net-mgmt/telegraf/src/opnsense/service/templates/OPNsense/Telegraf/telegraf.conf
@@ -143,7 +143,7 @@
 {% if helpers.exists('OPNsense.telegraf.output.opentelemetry_enable') and OPNsense.telegraf.output.opentelemetry_enable == '1' %}
 [[outputs.opentelemetry]]
 {%   if helpers.exists('OPNsense.telegraf.output.opentelemetry_server') and OPNsense.telegraf.output.opentelemetry_server != '' %}
-  service_address = {{ OPNsense.telegraf.output.opentelemetry_server }}
+  service_address = "{{ OPNsense.telegraf.output.opentelemetry_server }}"
 {%   endif %}
 {%   if helpers.exists('OPNsense.telegraf.output.opentelemetry_timeout') and OPNsense.telegraf.output.opentelemetry_timeout != '' %}
   timeout = "{{ OPNsense.telegraf.output.opentelemetry_timeout }}s"
@@ -155,7 +155,11 @@
 {%   endif %}
 {%   if helpers.exists('OPNsense.telegraf.output.opentelemetry_compression') and OPNsense.telegraf.output.opentelemetry_compression != '' %}
   compression = "{{ OPNsense.telegraf.output.opentelemetry_compression }}"
-{%   endif %}
+{% endif %}
+{%   if helpers.exists('OPNsense.telegraf.output.opentelemetry_header_name') and OPNsense.telegraf.output.opentelemetry_header_name != '' %}
+[outputs.opentelemetry.headers]
+  "{{ OPNsense.telegraf.output.opentelemetry_header_name }}" = "{{ OPNsense.telegraf.output.opentelemetry_header_value }}"
+{% endif %}
 {% endif %}
 
 {% if helpers.exists('OPNsense.telegraf.output.graphite_enable') and OPNsense.telegraf.output.graphite_enable == '1' %}


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: Qwen3.6-27B
- Extent of AI involvement: Had it analyse the plugin code, propose, draft, discuss the changes. Make the changes.

---

**Describe the problem**

My OpenTelemetry collector is running on a https endpoint and requires a bearer token to be passed with each ingestion request. With 1.12.14 it is impossible to set this header in the config even though telegraf itself provides for it. see https://github.com/influxdata/telegraf/tree/master/plugins/outputs/opentelemetry

---

**Describe the proposed solution**

This PR adds two fields to the OpenTelemetry output config: One for the header name and one for the header value. I considered other formats, maybe even a possibility to add multiple headers but this all seemed overkill and would make the UI and input processing way more complex. This should solve the problem for the vast majority of users.
The other change is an even more trivial fix, adding quotes on the service_address field value as otherwise it does not work with https urls like https://hostname.tld/path/to/collector . The help text now also reflects the correct usage.

---

**Related issue**

None, consider it a trivial change. 