### PR TITLE
sysutils/node_exporter: add textfile collector directory support

### DIFF
--- a/sysutils/node_exporter/Makefile
+++ b/sysutils/node_exporter/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		node_exporter
-PLUGIN_VERSION=		1.2
+PLUGIN_VERSION=		1.3
 PLUGIN_COMMENT=		Prometheus exporter for machine metrics
 PLUGIN_DEPENDS=		node_exporter
 PLUGIN_MAINTAINER=	jkegh@k123.eu

--- a/sysutils/node_exporter/pkg-descr
+++ b/sysutils/node_exporter/pkg-descr
@@ -9,7 +9,7 @@ Changelog
 
 1.3
 
-* Add textfile collector directory support
+* Add textfile collector support (fixed directory: /var/db/node_exporter/textfile)
 
 1.2
 

--- a/sysutils/node_exporter/pkg-descr
+++ b/sysutils/node_exporter/pkg-descr
@@ -7,6 +7,10 @@ WWW: https://github.com/prometheus/node_exporter
 Changelog
 ---------
 
+1.3
+
+* Add textfile collector directory support
+
 1.2
 
 * Allow setting IPv6 addresses as ListenAddress

--- a/sysutils/node_exporter/src/opnsense/mvc/app/controllers/OPNsense/NodeExporter/forms/general.xml
+++ b/sysutils/node_exporter/src/opnsense/mvc/app/controllers/OPNsense/NodeExporter/forms/general.xml
@@ -84,9 +84,9 @@
     <help>Enable the ZFS collector.</help>
   </field>
   <field>
-    <id>general.textfile_directory</id>
-    <label>Textfile Directory</label>
-    <type>text</type>
-    <help>Path to a directory read by the textfile collector. Files ending in .prom in this directory will be exposed as metrics. Leave empty to disable. Example: /var/db/node_exporter</help>
+    <id>general.textfile</id>
+    <label>Textfile Collector</label>
+    <type>checkbox</type>
+    <help>Enable the textfile collector. When enabled, .prom files placed in /var/db/node_exporter/textfile will be exposed as metrics.</help>
   </field>
 </form>

--- a/sysutils/node_exporter/src/opnsense/mvc/app/controllers/OPNsense/NodeExporter/forms/general.xml
+++ b/sysutils/node_exporter/src/opnsense/mvc/app/controllers/OPNsense/NodeExporter/forms/general.xml
@@ -83,4 +83,10 @@
     <type>checkbox</type>
     <help>Enable the ZFS collector.</help>
   </field>
+  <field>
+    <id>general.textfile_directory</id>
+    <label>Textfile Directory</label>
+    <type>text</type>
+    <help>Path to a directory read by the textfile collector. Files ending in .prom in this directory will be exposed as metrics. Leave empty to disable. Example: /var/db/node_exporter</help>
+  </field>
 </form>

--- a/sysutils/node_exporter/src/opnsense/mvc/app/models/OPNsense/NodeExporter/General.xml
+++ b/sysutils/node_exporter/src/opnsense/mvc/app/models/OPNsense/NodeExporter/General.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/NodeExporter</mount>
     <description>node_exporter configuration</description>
-    <version>0.2.0</version>
+    <version>0.3.0</version>
     <items>
         <enabled type="BooleanField">
             <Default>0</Default>
@@ -29,5 +29,6 @@
         <interrupts type="BooleanField"/>
         <ntp type="BooleanField"/>
         <zfs type="BooleanField"/>
+        <textfile_directory type="TextField"/>
     </items>
 </model>

--- a/sysutils/node_exporter/src/opnsense/mvc/app/models/OPNsense/NodeExporter/General.xml
+++ b/sysutils/node_exporter/src/opnsense/mvc/app/models/OPNsense/NodeExporter/General.xml
@@ -29,6 +29,6 @@
         <interrupts type="BooleanField"/>
         <ntp type="BooleanField"/>
         <zfs type="BooleanField"/>
-        <textfile_directory type="TextField"/>
+        <textfile type="BooleanField"/>
     </items>
 </model>

--- a/sysutils/node_exporter/src/opnsense/mvc/app/models/OPNsense/NodeExporter/General.xml
+++ b/sysutils/node_exporter/src/opnsense/mvc/app/models/OPNsense/NodeExporter/General.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/NodeExporter</mount>
     <description>node_exporter configuration</description>
-    <version>0.3.0</version>
+    <version>0.2.0</version>
     <items>
         <enabled type="BooleanField">
             <Default>0</Default>

--- a/sysutils/node_exporter/src/opnsense/service/templates/OPNsense/NodeExporter/node_exporter
+++ b/sysutils/node_exporter/src/opnsense/service/templates/OPNsense/NodeExporter/node_exporter
@@ -46,8 +46,8 @@
     {%- set zfs = no_collector + "zfs " -%}
 {%- endif -%}
 
-{%- if not helpers.empty('OPNsense.NodeExporter.textfile_directory') -%}
-    {%- set textfile_directory = "--collector.textfile.directory=" + OPNsense.NodeExporter.textfile_directory + " " -%}
+{%- if OPNsense.NodeExporter.textfile == '1' -%}
+    {%- set textfile = "--collector.textfile.directory=/var/db/node_exporter/textfile " -%}
 {%- endif -%}
 
 {%- if ':' in OPNsense.NodeExporter.listenaddress -%}
@@ -56,7 +56,7 @@
   {%- set listenaddress = OPNsense.NodeExporter.listenaddress -%}
 {%- endif -%}
 
-node_exporter_args="{{ cpu }}{{ exec }}{{ filesystem }}{{ loadavg }}{{ meminfo }}{{ netdev }}{{ ntp }}{{ time }}{{ devstat }}{{ zfs }}{{ textfile_directory }}"
+node_exporter_args="{{ cpu }}{{ exec }}{{ filesystem }}{{ loadavg }}{{ meminfo }}{{ netdev }}{{ ntp }}{{ time }}{{ devstat }}{{ zfs }}{{ textfile }}"
 node_exporter_listen_address="{{ listenaddress }}:{{ OPNsense.NodeExporter.listenport }}"
 node_exporter_enable="YES"
 

--- a/sysutils/node_exporter/src/opnsense/service/templates/OPNsense/NodeExporter/node_exporter
+++ b/sysutils/node_exporter/src/opnsense/service/templates/OPNsense/NodeExporter/node_exporter
@@ -46,13 +46,17 @@
     {%- set zfs = no_collector + "zfs " -%}
 {%- endif -%}
 
+{%- if not helpers.empty('OPNsense.NodeExporter.textfile_directory') -%}
+    {%- set textfile_directory = "--collector.textfile.directory=" + OPNsense.NodeExporter.textfile_directory + " " -%}
+{%- endif -%}
+
 {%- if ':' in OPNsense.NodeExporter.listenaddress -%}
   {%- set listenaddress = '[' + OPNsense.NodeExporter.listenaddress + ']' -%}
 {%- else -%}
   {%- set listenaddress = OPNsense.NodeExporter.listenaddress -%}
 {%- endif -%}
 
-node_exporter_args="{{ cpu }}{{ exec }}{{ filesystem }}{{ loadavg }}{{ meminfo }}{{ netdev }}{{ ntp }}{{ time }}{{ devstat }}{{ zfs }}"
+node_exporter_args="{{ cpu }}{{ exec }}{{ filesystem }}{{ loadavg }}{{ meminfo }}{{ netdev }}{{ ntp }}{{ time }}{{ devstat }}{{ zfs }}{{ textfile_directory }}"
 node_exporter_listen_address="{{ listenaddress }}:{{ OPNsense.NodeExporter.listenport }}"
 node_exporter_enable="YES"
 


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

AI disclosure:
- Model used: Claude Sonnet 4.6
- Extent of AI involvement: AI assisted with drafting the implementation and PR; all logic and review by the submitter.

---

**Describe the problem**

The `os-node_exporter` plugin exposes a fixed set of built-in collectors via toggle checkboxes but provides no way to enable node_exporter's `textfile` collector. Without it, users cannot add custom or platform-specific metrics (SSH session counts, SMART data, gateway health, etc.) through the plugin — the only workaround is editing `/etc/rc.conf.d/node_exporter` directly, which is overwritten on every config save or upgrade.

---

**Describe the proposed solution**

Add an optional **Textfile Directory** text field to the node_exporter settings page (Services → Node Exporter). When set, the plugin passes `--collector.textfile.directory=<path>` to the daemon at startup. When left empty, existing behavior is unchanged.

Changes (5 files, +13 / -2):

| File | Change |
|---|---|
| `Makefile` | `PLUGIN_VERSION` 1.2 → 1.3 |
| `pkg-descr` | Changelog entry for 1.3 |
| `General.xml` (model) | `textfile_directory TextField`, model version 0.2.0 → 0.3.0 |
| `node_exporter` (template) | Builds `--collector.textfile.directory=<path>` when field is non-empty |
| `general.xml` (form) | "Textfile Directory" text field in the UI |

The pattern is identical to how ZFS toggle (#2071) and IPv6 listen address (#3707) support were added.

---

**Related issue**

Closes #5454

Also relates to previously auto-closed #4275 and #3906.