### PR TITLE
net/frr: OSPF/OSPF6 More visibility and safety for ModelRelationField references

### DIFF
--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/Api/Ospf6settingsController.php
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/Api/Ospf6settingsController.php
@@ -37,6 +37,7 @@ class Ospf6settingsController extends ApiMutableModelControllerBase
 {
     protected static $internalModelName = 'ospf6';
     protected static $internalModelClass = '\OPNsense\Quagga\OSPF6';
+    protected static $internalModelUseSafeDelete = true;
 
     public function searchNetworkAction()
     {

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/Api/OspfsettingsController.php
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/Api/OspfsettingsController.php
@@ -36,6 +36,7 @@ class OspfsettingsController extends ApiMutableModelControllerBase
 {
     protected static $internalModelName = 'ospf';
     protected static $internalModelClass = '\OPNsense\Quagga\OSPF';
+    protected static $internalModelUseSafeDelete = true;
 
     public function searchNeighborAction()
     {

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditOSPF6Network.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditOSPF6Network.xml
@@ -40,7 +40,7 @@
     <id>network.linkedPrefixlistIn</id>
     <label>Prefix-List In</label>
     <type>dropdown</type>
-    <help>Filters inbound route advertisements using a prefix list.</help>
+    <help>Filters inbound route advertisements using a prefix list. If multiple items with the same name exist, choosing one of them will apply all items with the same name.</help>
     <grid_view>
       <visible>false</visible>
     </grid_view>
@@ -49,7 +49,7 @@
     <id>network.linkedPrefixlistOut</id>
     <label>Prefix-List Out</label>
     <type>dropdown</type>
-    <help>Filters outbound route advertisements using a prefix list.</help>
+    <help>Filters outbound route advertisements using a prefix list. If multiple items with the same name exist, choosing one of them will apply all items with the same name.</help>
     <grid_view>
       <visible>false</visible>
     </grid_view>

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditOSPF6RouteMaps.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditOSPF6RouteMaps.xml
@@ -32,7 +32,7 @@
     <label>Prefix List</label>
     <type>select_multiple</type>
     <allownew>true</allownew>
-    <help>Allows for matching based on prefix lists, multiple selections enabled.</help>
+    <help>Allows for matching based on prefix lists, multiple selections enabled. If multiple items with the same name exist, choosing one of them will apply all items with the same name.</help>
   </field>
     <field>
     <id>routemap.set</id>

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditOSPF6RouteMaps.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditOSPF6RouteMaps.xml
@@ -31,7 +31,6 @@
     <id>routemap.match2</id>
     <label>Prefix List</label>
     <type>select_multiple</type>
-    <style>tokenize</style>
     <allownew>true</allownew>
     <help>Allows for matching based on prefix lists, multiple selections enabled.</help>
   </field>

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditOSPFNetwork.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditOSPFNetwork.xml
@@ -40,7 +40,7 @@
     <id>network.linkedPrefixlistIn</id>
     <label>Prefix-List In</label>
     <type>dropdown</type>
-    <help>Filters inbound route advertisements using a prefix list.</help>
+    <help>Filters inbound route advertisements using a prefix list. If multiple items with the same name exist, choosing one of them will apply all items with the same name.</help>
     <grid_view>
       <visible>false</visible>
     </grid_view>
@@ -49,7 +49,7 @@
     <id>network.linkedPrefixlistOut</id>
     <label>Prefix-List Out</label>
     <type>dropdown</type>
-    <help>Filters outbound route advertisements using a prefix list.</help>
+    <help>Filters outbound route advertisements using a prefix list. If multiple items with the same name exist, choosing one of them will apply all items with the same name.</help>
     <grid_view>
       <visible>false</visible>
     </grid_view>

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditOSPFRouteMaps.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditOSPFRouteMaps.xml
@@ -32,7 +32,7 @@
     <label>Prefix List</label>
     <type>select_multiple</type>
     <allownew>true</allownew>
-    <help>Allows for matching based on prefix lists, multiple selections enabled.</help>
+    <help>Allows for matching based on prefix lists, multiple selections enabled. If multiple items with the same name exist, choosing one of them will apply all items with the same name.</help>
   </field>
     <field>
     <id>routemap.set</id>

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditRedistribution.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditRedistribution.xml
@@ -19,7 +19,7 @@
         <id>redistribution.linkedRoutemap</id>
         <label>Route-Map</label>
         <type>dropdown</type>
-        <help>Optional Route-map to apply to this redistribution.</help>
+        <help>Optional Route-map to apply to this redistribution. If multiple items with the same name exist, choosing one of them will apply all items with the same name.</help>
     </field>
     <field>
         <id>redistribution.description</id>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF.xml
@@ -97,23 +97,23 @@
                 <arearange type="NetworkField"/>
                 <linkedPrefixlistIn type="ModelRelationField">
                     <Model>
-                        <template>
+                        <prefixlists>
                             <source>OPNsense.quagga.ospf</source>
                             <items>prefixlists.prefixlist</items>
-                            <display>name</display>
-                            <group>name</group>
-                        </template>
+                            <display>name,seqnumber</display>
+                            <display_format>%s:%s</display_format>
+                        </prefixlists>
                     </Model>
                     <ValidationMessage>Related Prefix-List item not found.</ValidationMessage>
                 </linkedPrefixlistIn>
                 <linkedPrefixlistOut type="ModelRelationField">
                     <Model>
-                        <template>
+                        <prefixlists>
                             <source>OPNsense.quagga.ospf</source>
                             <items>prefixlists.prefixlist</items>
-                            <display>name</display>
-                            <group>name</group>
-                        </template>
+                            <display>name,seqnumber</display>
+                            <display_format>%s:%s</display_format>
+                        </prefixlists>
                     </Model>
                     <ValidationMessage>Related Prefix-List item not found.</ValidationMessage>
                 </linkedPrefixlistOut>
@@ -308,12 +308,12 @@
                 </redistribute>
                 <linkedRoutemap type="ModelRelationField">
                     <Model>
-                        <template>
+                        <routemaps>
                             <source>OPNsense.quagga.ospf</source>
                             <items>routemaps.routemap</items>
-                            <display>name</display>
-                            <group>name</group>
-                        </template>
+                            <display>name,id</display>
+                            <display_format>%s:%s</display_format>
+                        </routemaps>
                     </Model>
                     <ValidationMessage>Related Route-Map item not found.</ValidationMessage>
                 </linkedRoutemap>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF6.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF6.xml
@@ -54,23 +54,23 @@
                 <arearange type="TextField"/>
                 <linkedPrefixlistIn type="ModelRelationField">
                     <Model>
-                        <template>
+                        <prefixlists>
                             <source>OPNsense.quagga.ospf6</source>
                             <items>prefixlists.prefixlist</items>
-                            <display>name</display>
-                            <group>name</group>
-                        </template>
+                            <display>name,seqnumber</display>
+                            <display_format>%s:%s</display_format>
+                        </prefixlists>
                     </Model>
                     <ValidationMessage>Related Prefix-List item not found.</ValidationMessage>
                 </linkedPrefixlistIn>
                 <linkedPrefixlistOut type="ModelRelationField">
                     <Model>
-                        <template>
+                        <prefixlists>
                             <source>OPNsense.quagga.ospf6</source>
                             <items>prefixlists.prefixlist</items>
-                            <display>name</display>
-                            <group>name</group>
-                        </template>
+                            <display>name,seqnumber</display>
+                            <display_format>%s:%s</display_format>
+                        </prefixlists>
                     </Model>
                     <ValidationMessage>Related Prefix-List item not found.</ValidationMessage>
                 </linkedPrefixlistOut>
@@ -227,12 +227,12 @@
                 </redistribute>
                 <linkedRoutemap type="ModelRelationField">
                     <Model>
-                        <template>
+                        <routemaps>
                             <source>OPNsense.quagga.ospf6</source>
                             <items>routemaps.routemap</items>
-                            <display>name</display>
-                            <group>name</group>
-                        </template>
+                            <display>name,id</display>
+                            <display_format>%s:%s</display_format>
+                        </routemaps>
                     </Model>
                     <ValidationMessage>Related Route-Map item not found.</ValidationMessage>
                 </linkedRoutemap>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF6.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/OSPF6.xml
@@ -194,12 +194,14 @@
                 </id>
                 <match2 type="ModelRelationField">
                     <Model>
-                        <template>
+                        <prefixlists>
                             <source>OPNsense.quagga.ospf6</source>
                             <items>prefixlists.prefixlist</items>
-                            <display>name</display>
-                        </template>
+                            <display>name,seqnumber</display>
+                            <display_format>%s:%s</display_format>
+                        </prefixlists>
                     </Model>
+                    <Multiple>Y</Multiple>
                     <ValidationMessage>Related item not found.</ValidationMessage>
                 </match2>
                 <set type="TextField"/>

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospf6d.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/ospf6d.conf
@@ -80,12 +80,16 @@ ipv6 prefix-list {{ prefixlist.name }} seq {{ prefixlist.seqnumber }} {{ prefixl
 {%     for routemap in helpers.sortDictList(OPNsense.quagga.ospf6.routemaps.routemap, 'name', 'id' ) %}
 {%       if routemap.enabled == '1' %}
 route-map {{ routemap.name }} {{ routemap.action }} {{ routemap.id }}
+{# XXX: Multiple prefix lists that have the same name can be selected (intentionally), but each is stored as unique item. #}
+{# The relationship is a bit loose, unique solves part of this issue. #}
 {%         if routemap.match2|default("") != "" %}
+{%           set prefixlist_names = [] %}
 {%           for prefixlist in routemap.match2.split(",") %}
 {%             set prefixlist_data = helpers.getUUID(prefixlist) %}
-{%             if 'match2' in routemap and routemap.match2 != '' %}
- match ipv6 address prefix-list {{ prefixlist_data.name }}
-{%             endif %}
+{%             do prefixlist_names.append(prefixlist_data.name) %}
+{%           endfor %}
+{%           for prefixlist_name in prefixlist_names | unique %}
+ match ip address prefix-list {{ prefixlist_name }}
 {%           endfor %}
 {%         endif %}
 {%         if routemap.set|default("") != "" %}


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

Problem is best described here:
https://github.com/opnsense/plugins/issues/5456

This improves visibility (Which item has been chosen) and prevents the wrong item from being deleted accidentally when working with the references.

Builds upon this commit:
https://github.com/opnsense/plugins/commit/0798cde9041fe7aa9316eda966e19b2b5c5b5506
