### PR TITLE
Update maltrail.conf

### DIFF
--- a/security/maltrail/src/opnsense/service/templates/OPNsense/Maltrail/maltrail.conf
+++ b/security/maltrail/src/opnsense/service/templates/OPNsense/Maltrail/maltrail.conf
@@ -9,6 +9,8 @@ USE_SSL false
 
 # Regular expression to be used in external /fail2ban calls for extraction of attacker source IPs
 FAIL2BAN_REGEX attacker|reputation|potential[^"]*(web scan|directory traversal|injection|remote code)|spammer|mass scanner
+# Allow localhost to access fail2ban endpoint
+FAIL2BAN_ALLOWLIST 127.0.0.1
 
 {%   if helpers.exists('OPNsense.maltrail.server.loglistenaddress') and OPNsense.maltrail.server.loglistenaddress != '' %}
 UDP_ADDRESS {{ OPNsense.maltrail.server.loglistenaddress }}


### PR DESCRIPTION
security/maltrail: add FAIL2BAN_ALLOWLIST to server config template to allow localhost access to fail2ban endpoint

**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [X] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [X] I opened an issue first for non-trivial changes and linked it below.
- [X] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:  Claude Sonnet 4.6
- Extent of AI involvement:  Recommended lines to add to template

---

**Describe the problem**

A clear and concise description of the problem this pull request addresses.
BlocklistMaltrail alias was not updated (Issue #5462)

---

**Describe the proposed solution**

Added the line
FAIL2BAN_ALLOWLIST 127.0.0.1
to /usr/local/opnsense/service/templates/OPNsense/Maltrail/maltrail.conf

---

**Related issue**

Issue #5462 