### PR TITLE
sysutils/nut: fix upsstatus diagnostics and netclient model definition

### DIFF
--- a/sysutils/nut/src/opnsense/mvc/app/controllers/OPNsense/Nut/Api/DiagnosticsController.php
+++ b/sysutils/nut/src/opnsense/mvc/app/controllers/OPNsense/Nut/Api/DiagnosticsController.php
@@ -29,7 +29,6 @@
 namespace OPNsense\Nut\Api;
 
 use OPNsense\Base\ApiControllerBase;
-use OPNsense\Core\Backend;
 use OPNsense\Nut\Nut;
 
 class DiagnosticsController extends ApiControllerBase
@@ -41,12 +40,40 @@ class DiagnosticsController extends ApiControllerBase
         if (!empty((string)$mdl->netclient->address)) {
             $host = (string)$mdl->netclient->address;
         }
+        $port = 3493;
+        if (!empty((string)$mdl->netclient->port)) {
+            $port = (int)(string)$mdl->netclient->port;
+        }
         $upsname = 'UPSName';
         if (!empty((string)$mdl->general->name)) {
             $upsname = (string)$mdl->general->name;
         }
-        $backend = new Backend();
-        $response = $backend->configdpRun('nut upsstatus', array("{$upsname}@{$host}"));
+
+        $response = '';
+        $socket = @fsockopen($host, $port, $errno, $errstr, 5);
+        if ($socket) {
+            fwrite($socket, "LIST VAR {$upsname}\n");
+            $raw = '';
+            while (!feof($socket)) {
+                $raw .= fgets($socket, 1024);
+                if (strpos($raw, "END LIST VAR") !== false) break;
+            }
+            fclose($socket);
+
+            // Transform "VAR upsname key "value"" to "key: value"
+            foreach (explode("\n", $raw) as $line) {
+                if (strpos($line, "VAR {$upsname} ") === 0) {
+                    $line = substr($line, strlen("VAR {$upsname} "));
+                    $parts = explode(' ', $line, 2);
+                    if (count($parts) == 2) {
+                        $key = $parts[0];
+                        $value = trim($parts[1], " \"\r\n");
+                        $response .= "{$key}: {$value}\n";
+                    }
+                }
+            }
+        }
+
         return array("response" => $response);
     }
 }

--- a/sysutils/nut/src/opnsense/mvc/app/models/OPNsense/Nut/Nut.xml
+++ b/sysutils/nut/src/opnsense/mvc/app/models/OPNsense/Nut/Nut.xml
@@ -105,7 +105,10 @@
                 <Required>Y</Required>
                 <Default>0</Default>
             </enable>
-            <address type="HostnameField"/>
+            <address type="HostnameField">
+                <Required>N</Required>
+                <IpWithPrefix>N</IpWithPrefix>
+            </address>
             <port type="PortField">
                 <Default>3493</Default>
                 <Required>N</Required>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: Claude Sonet 4.6
- Extent of AI involvement: Claude did pretty much all the work. I just followed along. Seriously.

---

This PR covers issue #5470

**Description**

This PR fixes two issues with the NUT plugin that prevent the diagnostics page, dashboard widget, and API endpoint from returning UPS status data when running in netclient mode.

Problem 1: upsc binary segfaults on FreeBSD 14.x with NUT 2.8.5

The DiagnosticsController::upsstatusAction() method called /usr/local/bin/upsc via configd to retrieve UPS status. This approach fails for two reasons:

1.) configd sanitizes the @ symbol in parameters, making it impossible to pass upsname@host as an argument via configdpRun().

2.) On FreeBSD 14.x with NUT 2.8.5, upsc segfaults (SIGSEGV, exit code 11) when querying a remote upsd server, producing no output before crashing.

This bug has been reported to the NUT project: networkupstools/nut#3454

Fix: Replace the upsc call with a direct TCP socket connection to the remote upsd server using the NUT protocol. This is more reliable, faster, and bypasses both issues entirely.

Problem 2: Bare HostnameField definition in netclient model

The netclient->address field in Nut.xml was defined as a bare address type="HostnameField" with no configuration, which is inconsistent with how other fields in the model are defined.

Fix: Add explicit Required and IpWithPrefix attributes to properly define the field.

**Files changed**

sysutils/nut/src/opnsense/mvc/app/controllers/OPNsense/Nut/Api/DiagnosticsController.php — replaced upsc call with direct NUT protocol socket connection
sysutils/nut/src/opnsense/mvc/app/models/OPNsense/Nut/Nut.xml — properly defined netclient address HostnameField


**Testing**

Tested on OPNsense 26.1 (FreeBSD 14.3-RELEASE-p12) with NUT 2.8.5 in netclient mode, monitoring a CyberPower CP1500PFCLCDa connected to a Raspberry Pi NUT server. After this fix:

Services > NUT > Diagnostics > UPS Status displays full UPS data
Dashboard NUT widget displays UPS status, battery level, and runtime
/api/nut/diagnostics/upsstatus API endpoint returns correct data