### PR TITLE
security/acme-client: fix incomplete permissions

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/ACL/ACL.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/ACL/ACL.xml
@@ -3,6 +3,7 @@
         <name>Services: ACME Client</name>
         <patterns>
             <pattern>ui/acmeclient/*</pattern>
+            <pattern>api/diagnostics/log/core/acmeclient/*</pattern>
             <pattern>api/acmeclient/*</pattern>
         </patterns>
     </page-services-acmeclient>


### PR DESCRIPTION
https://github.com/opnsense/plugins/issues/5458

**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

Model used: Google Gemini

Extent of AI involvement: AI was used as a troubleshooting partner to help trace the OPNsense redirect loop to the missing API endpoint in the ACL.xml file, and to assist in drafting this pull request description. The actual environment testing, code verification, and identification of the missing granular privilege were done manually by me.

Describe the problem

Currently, non-admin users who are granted the Services: ACME Client privilege experience an "access denied" error and a redirect loop when attempting to view the ACME logs via the UI (ui/acmeclient/logs).

This occurs because modern OPNsense versions rely on granular backend API endpoints for logging. While the os-acme-client plugin's ACL.xml successfully grants access to the frontend interface via the <pattern>ui/acmeclient/*</pattern> wildcard, it is missing the explicit permission for the backend logging API. Because the API route is unregistered in the ACL, OPNsense's security framework defaults it to admin-only access, causing the log viewer to fail for restricted users.

Describe the proposed solution

This PR adds the missing backend API routing pattern to the plugin's Access Control List (ACL.xml).

By adding <pattern>api/diagnostics/log/core/acmeclient/*</pattern> under the existing AcmeClient privilege, users who are granted access to the ACME client will automatically inherit the necessary API permissions to fetch and view the logs. This aligns the plugin with current OPNsense logging architectures (similar to how os-wireguard handles its logging endpoints) and resolves the redirect loop for non-admin users.



---

**Related issue**

https://github.com/opnsense/plugins/issues/5458
