### PR TITLE
net/nebula: new plugin — Slack Nebula mesh overlay VPN

### DIFF
--- a/net/nebula/.claude/manual-test-procedures.md
+++ b/net/nebula/.claude/manual-test-procedures.md
@@ -1,0 +1,89 @@
+# Manual / live test procedures
+
+Model data paths are covered by phpunit. Everything else — configd scripts, the
+daemon lifecycle, the debug server, the Volt UI, and OPNsense integration
+(interfaces, firewall) — is verified live on a disposable OPNsense test box. This
+file holds the cross-cutting procedures; per-page checks live in
+`.claude/pages/<page>.md`.
+
+## Standard loop
+
+1. Deploy changed files (see `AGENTS.md` → Build / deploy).
+2. If you touched GUI PHP (controllers, models, `nebula.inc`):
+   `configctl webgui restart` (clears opcache). `.volt` and form/model XML are
+   read fresh — no restart needed for those.
+3. Hard-refresh the browser (Cmd/Ctrl-Shift-R) to drop cached page JS.
+4. Exercise the change; check `nebula` syslog and the daemon state.
+
+## Live model-bootstrap recipe (CLI, no browser)
+
+To exercise model logic against a scratch config without the HTTP layer, bootstrap
+the MVC env in a CLI PHP script (standard appliance paths only):
+
+```php
+require_once '/usr/local/opnsense/mvc/app/config/AppConfig.php';
+$scratch = '/tmp/scratch-conf'; @mkdir($scratch, 0700, true);
+copy('/usr/local/opnsense/mvc/tests/app/models/OPNsense/Nebula/NebulaConfig/config.xml',
+     $scratch . '/config.xml');
+$config = new OPNsense\Core\AppConfig([
+  'application' => [
+    'baseUri' => '/', 'controllersDir' => '/usr/local/opnsense/mvc/app/controllers/',
+    'modelsDir' => '/usr/local/opnsense/mvc/app/models/', 'viewsDir' => '/usr/local/opnsense/mvc/app/views/',
+    'pluginsDir' => '/usr/local/opnsense/mvc/app/plugins/', 'libraryDir' => '/usr/local/opnsense/mvc/app/library/',
+    'contribDir' => '/usr/local/opnsense/contrib', 'configDefault' => $scratch . '/config.xml',
+    'configDir' => $scratch, 'cacheDir' => '/tmp/sc', 'tempDir' => '/tmp/st',
+  ],
+  'globals' => ['debug' => false, 'owner' => 'root:wheel', 'simulate_mode' => false],
+]);
+require_once '/usr/local/opnsense/mvc/app/config/loader.php';
+@mkdir('/tmp/sc', 0700, true); @mkdir('/tmp/st', 0700, true);
+use OPNsense\Nebula\Nebula;
+$m = new Nebula();
+// … add nodes, call model methods, assert …
+```
+
+Notes:
+- Assign the `AppConfig` to a variable and keep it; the autoloader relies on it.
+  Without it `new Nebula()` throws "class not found".
+- `scp` the script to the box and run it; do **not** build it via a nested
+  here-doc (the inner here-doc mangles the bootstrap).
+- Use a scratch `configDir` (never `/conf`) so a test never touches the appliance
+  config.
+- `serializeToConfig()` validates relation fields; an in-memory `trusted_cas` /
+  `certref` to a freshly-added node can raise a validation error in this harness.
+  Assert on the model in memory, or save+reload, rather than round-tripping
+  relation fields through serialize.
+
+## Daemon lifecycle (any change to `setup.php` / `nebula.inc`)
+
+Per instance, confirm:
+- **start** creates the tun and a live pid; `nebula -test -config <file>` passes.
+- **Apply** (`configctl nebula reconfigure`) HUP-reloads in place — pid unchanged,
+  tunnels stay up — unless a structural key (listen host/port, cipher, tun dev)
+  changed, which restarts that instance (new pid).
+- **restart** (`configctl nebula restart [<uuid>]`) recreates the tun.
+- **stop** kills the daemon and destroys the tun (no orphan `nebulaX` lingers).
+- No duplicate daemons: exactly one `nebula` process per enabled instance.
+
+## OPNsense interface integration (the `_devices` / `_interfaces` hooks)
+
+After assigning an instance's tun in Interfaces → Assignments:
+- It lists as `<dev> (Nebula - <descr>)`; **no IP config** is offered
+  (`configurable=false`); the cert-derived address shows on the interface.
+- Enabling the assigned interface yields a firewall tab for it.
+- "Nebula (Group)" is selectable as a rule Interface (Firewall → Rules), matching
+  every nebula tun via the kernel `nebula` group.
+- **Reboot test (boot ordering):** with an instance assigned + the interface
+  enabled, reboot. It must come up clean — assigned interface UP, tun recreated,
+  no "interface mismatch" warning. This proves `nebula_prepare()` creates the
+  device before interface bring-up.
+- Disabling the instance removes its device from Assignments (the assignment
+  orphans gracefully); re-enabling restores it. The device name is system-managed
+  and not user-editable.
+
+## Debug-server / live-peer pages
+
+Status and Tunnels read the always-on nebula sshd debug server. Validate every
+per-peer action button against a real second peer (handshake, then
+close/query-lighthouse/change-remote/connect). Some commands can crash older
+daemon versions — re-validate after a nebula upgrade (`.claude/nebula-upgrade.md`).

--- a/net/nebula/.claude/nebula-upgrade.md
+++ b/net/nebula/.claude/nebula-upgrade.md
@@ -1,0 +1,73 @@
+# Runbook: upgrading the bundled nebula version
+
+The plugin drives external `nebula` binaries; it does not vendor them. Upgrading
+"the nebula version" means: (1) the appliance ships a newer `nebula` /
+`nebula-cert`, and (2) the plugin still renders valid configs, drives the daemon,
+and speaks the debug protocol for that version.
+
+## Binaries the plugin depends on
+
+- `/usr/local/bin/nebula` — the daemon (`NEBULA_BIN` in `setup.php`).
+- `/usr/local/bin/nebula-cert` — PKI (`NEBULA_CERT_BIN` in `pki.php`).
+- `/usr/sbin/daemon` — FreeBSD supervisor wrapping the daemon (`DAEMON_BIN`).
+
+These come from the FreeBSD `security/nebula` port (→ the OPNsense pkg set), not
+from this repo. So a version bump is really a ports/pkg update; the plugin work
+is making sure nothing regressed against the new version.
+
+## Steps
+
+1. **Read the upstream release notes** for every version between the current and
+   target nebula release. Note added / changed / removed **config keys**, any
+   **`nebula-cert` flag** changes, **debug-server command** changes, and behaviour
+   changes to the tun/listen/cipher handling.
+
+2. **Get the new binaries onto a test box** (build the updated port, or install
+   the pkg) and confirm `nebula -version` / `nebula-cert -version`.
+
+3. **Audit config-knob coverage.** The plugin renders the nebula YAML from the
+   model (`ConfigMap.php` field→yaml map + `Nebula.php::generateConfig`). Drift in
+   nebula's config schema is the most common upgrade breakage.
+   - `tools/audit_knobs.py` reports handled / deferred / n-a / deprecated knobs
+     against a nebula reference config (`tools/nebula_config_reference.yaml`).
+   - Update the reference to the new version, re-run, and resolve any newly
+     surfaced keys: add a field + ConfigMap entry (or a hand-rendered block) for
+     new keys; mark removed keys deprecated.
+   - `tools/gen_knobs.py` / `tools/gen_knobs_test.py` back the generated knob set.
+
+4. **Re-run the model tests**, especially the rendered-YAML pins:
+   `phpunit app/models/OPNsense/Nebula` (GenerateConfigTest asserts the emitted
+   config shape). Update expectations only for intended schema changes.
+
+5. **Validate live config generation:** on the test box, render an instance and
+   run `nebula -test -config <file>` (this is exactly what `nebula_validate()`
+   does). A new required/renamed key shows up here.
+
+6. **Exercise the daemon lifecycle:** start, Apply (HUP reload), structural-change
+   restart, stop. Confirm the tun is created/destroyed and the instance comes back
+   (see `.claude/pages/instances.md`).
+
+7. **Re-validate the debug-server surface.** Status/Tunnels drive the always-on
+   nebula sshd debug server (`list-hostmap`, `list-pending-hostmap`,
+   `reload`, `query-lighthouse`, `change-remote`, `create-tunnel`, `close-tunnel`,
+   `device-info`, `print-cert`, …). `ssh … <user>@127.0.0.1 -p <port> help` lists
+   the commands the running version supports; diff against what the pages call.
+   Watch for renamed/removed commands and for output-format (JSON) changes the
+   parsers depend on.
+
+8. **Re-test PKI** (`pki.php` / Authorities / Certificates): generate a CA, sign a
+   cert, import, print — `nebula-cert` flags and cert versions can change between
+   releases.
+
+## Known version-specific notes
+
+- The `reload` debug command acks `"Reloading config"` then drops the ssh
+  connection (exit 255 even on success) — the plugin treats that ack as success.
+  Re-check this if the debug protocol changes.
+- `create-tunnel -address` crashed the daemon in older releases; the plugin uses
+  the address-less form. The full note — and how to restore the `-address` form
+  once the fix is in a released nebula — is the `PENDING` comment on the
+  `create-tunnel` branch of `nebula_instance_debug` in `setup.php` (slackhq/nebula
+  PR #1749). Re-check this on every upgrade.
+- Keep any version-pinned assumptions (cipher defaults, initiating cert version,
+  blocklist/encrypted-CA features) in step 1's diff.

--- a/net/nebula/.claude/pages/authorities.md
+++ b/net/nebula/.claude/pages/authorities.md
@@ -1,0 +1,46 @@
+# Page: Authorities (`/ui/nebula/authorities`)
+
+Nebula CAs (certificate authorities). Generate or import a CA; sign host certs
+against it on the Certificates page.
+
+## Files
+
+- Model: `Nebula.xml` → `pki.authorities.authority` array (`Nebula.php`,
+  `ConfigMap.php` not involved — PKI is its own subtree).
+- Page controller: `controllers/OPNsense/Nebula/AuthoritiesController.php`.
+- API controller: `controllers/OPNsense/Nebula/Api/AuthorityController.php`
+  (search/get/del + `generate`, `import`, `info`, `generate_file`,
+  `purge_expired`; `caReferencedBy`).
+- Forms: `forms/dialogAuthority.xml`, `dialogAuthorityGenerate.xml`,
+  `dialogAuthorityImport.xml`.
+- View: `views/OPNsense/Nebula/authorities.volt`.
+- PKI script: `scripts/OPNsense/Nebula/pki.php` (`generate-ca`, `print-cert`),
+  run via the `pki_generate_ca` / `pki_print_cert` configd actions.
+
+## Maintenance notes
+
+- **Generate** calls `nebula-cert ca` through configd (`pki_generate_ca`); the
+  resulting crt+key are stored on the model node. Curve (25519/P256), duration,
+  groups/networks are passed through.
+- **Import** accepts an existing CA cert and (optionally) its key. A **keyless**
+  CA (`has_key=0`) can still be trusted but cannot sign — surfaced in the
+  "Can sign" grid column.
+- **Encrypted CA** (`key_encrypted`): a passphrase is required to sign with it;
+  the grid marks it with a lock icon.
+- **Fingerprint column** shows the first 8 hex of the sha256 (disambiguates
+  like-named CAs). CA references elsewhere render as `name: XXXXXXXX`.
+- **Purge expired** (footer button) deletes CAs past `valid_to`, but **skips any
+  still referenced** — a cert's `caref` or an instance's `trusted_cas` — and names
+  them. Single delete uses the same `caReferencedBy` guard. Don't let purge or
+  delete remove a referenced CA.
+- Per-row commands: download cert / download key (hidden when `has_key=0`) /
+  inspect (parsed `print-cert`).
+
+## Live test strategy
+
+- Model: `phpunit --filter AuthorityCRUDTest`.
+- PKI round-trips (generate/import/encrypted) are exercised by the `tools/test_*_live.php`
+  guest scripts (they hit `nebula-cert` via configd, which phpunit can't).
+- Browser: generate a CA → sign a cert under it (Certificates page) → import a
+  keyless CA (confirm "Can sign" = no) → seed an expired CA and Purge expired
+  (confirm a referenced one is skipped + reported).

--- a/net/nebula/.claude/pages/blocklist.md
+++ b/net/nebula/.claude/pages/blocklist.md
@@ -1,0 +1,43 @@
+# Page: Blocklist (`/ui/nebula/blocklist`)
+
+Certificate fingerprints this node refuses to talk to. Each entry blocks one cert
+by its sha256 fingerprint, scoped globally or to one instance.
+
+## Files
+
+- Model: `Nebula.xml` → `pki.blocklist.entry` array. Rendered into each instance's
+  `pki.blocklist` by `Nebula.php::generateConfig`.
+- Page controller: `controllers/OPNsense/Nebula/BlocklistController.php`.
+- API controller: `controllers/OPNsense/Nebula/Api/BlocklistController.php`
+  (CRUD + `toggle_item`, `block_cert`, `import`, `purge_expired`).
+- Forms: `forms/dialogBlocklistEntry.xml`, `dialogBlocklistImport.xml`.
+- View: `views/OPNsense/Nebula/blocklist.volt`.
+
+## Maintenance notes
+
+- **Fingerprint** must be 64 lowercase hex (sha256) and is **immutable once
+  saved** (changing it would silently re-target the block — add a new entry
+  instead). Validated in `addItem`/`setItem`.
+- **Scope** is explicit: `global` (every instance) or `instance` (requires an
+  instance). Search supports a `__global__` sentinel for the global-only view.
+- **Certificate column** resolves the fingerprint to a held cert's description
+  (`name: XXXXXXXX`, else `unknown: XXXXXXXX`). Picking a known cert in the dialog
+  fills + locks the fingerprint.
+- **Block until purged:** the renderer **ignores `expiry`** — an enabled, in-scope
+  entry always blocks. `expiry` is only a *purge-eligibility* date. The
+  **Purge expired** button is the only thing that removes a past-expiry entry
+  (no reference guard — nothing references a blocklist entry). Don't reintroduce a
+  render-time expiry skip.
+- **Bulk import**: one fingerprint per line (optional `, description`), normalised
+  to bare lowercase hex; idempotent at the chosen scope.
+- `block_cert` (called from the Certificates page) creates an idempotent global
+  block prefilled from a cert's fingerprint + expiry.
+
+## Live test strategy
+
+- Model: `phpunit --filter BlocklistCRUDTest` — covers fingerprint
+  validation/immutability, scope filtering, block-until-purged render, and
+  `purgeExpiredBlocklist` (incl. non-ISO date parsing).
+- Browser: add an entry, bulk import, block-from-cert, set a past expiry and Purge
+  expired; confirm an expired-but-unpurged entry still blocks (rendered config /
+  `nebula -test`).

--- a/net/nebula/.claude/pages/certificates.md
+++ b/net/nebula/.claude/pages/certificates.md
@@ -1,0 +1,45 @@
+# Page: Host Certificates (`/ui/nebula/certificates`)
+
+Nebula host certificates — the identity an instance presents. Signed under a CA
+(Authorities page), CSR-signed, or imported.
+
+## Files
+
+- Model: `Nebula.xml` → `pki.certificates.certificate` array.
+- Page controller: `controllers/OPNsense/Nebula/CertificatesController.php`.
+- API controller: `controllers/OPNsense/Nebula/Api/CertificateController.php`
+  (search/get/del + `sign`/`sign_csr`, `import`, `info`, `generate_file`,
+  `purge_expired`; `certReferencedBy`).
+- Forms: `forms/dialogCertificate.xml`, `dialogCertificateSign.xml`,
+  `dialogCertificateImport.xml`.
+- View: `views/OPNsense/Nebula/certificates.volt`.
+- PKI script: `scripts/OPNsense/Nebula/pki.php` (`sign-cert`), via the
+  `pki_sign_cert` configd action.
+
+## Maintenance notes
+
+- **Sign** generates a key + cert under a chosen CA via `nebula-cert sign`
+  (configd `pki_sign_cert`). Empty duration = expire just before the CA
+  (recommended default).
+- **CSR signing** signs from a supplied public key / CSR so the **private key
+  never leaves the requesting device**. The result is a **keyless** cert
+  (`has_key=0`): it is flagged not-**Assignable** and is **excluded from the
+  instance certificate picker** (an instance needs the key to run). The picker
+  filter keys off `has_key` — keep that filter when touching the instance form.
+- **Import** accepts a pre-signed cert (+ optional key).
+- **Fingerprint column** = first 8 hex of sha256; the signing CA shows as
+  `name: XXXXXXXX`. `valid_to` is the cert's notAfter.
+- **Block this certificate** (per-row) posts to `blocklist/block_cert` — an
+  idempotent global blocklist entry prefilled with the fingerprint + expiry.
+- **Purge expired** deletes certs past `valid_to`, skipping any still referenced
+  by an instance (`certref`) and naming them; single delete uses the same
+  `certReferencedBy` guard.
+
+## Live test strategy
+
+- Model: `phpunit --filter CertificateCRUDTest`.
+- PKI + CSR semantics: `tools/test_certificate_live.php`, `test_csr_live.php`,
+  `test_pki_semantics_live.php` (drive `nebula-cert`).
+- Browser: sign a cert; CSR-sign and confirm it is not selectable as an instance
+  certificate; import; Block a cert and verify it appears on Blocklist; Purge
+  expired (referenced cert skipped).

--- a/net/nebula/.claude/pages/firewall.md
+++ b/net/nebula/.claude/pages/firewall.md
@@ -1,0 +1,42 @@
+# Page: Firewall (`/ui/nebula/firewall`)
+
+The **Nebula overlay firewall** — the `firewall:` block inside each instance's
+nebula config. This is NOT the OPNsense firewall; it controls traffic *inside* the
+mesh, per instance.
+
+## Files
+
+- Model: `Nebula.xml` → `fwrules.rule` array + the per-instance firewall scalar
+  knobs (default in/outbound action, conntrack timeouts, default_local_cidr_any).
+  Rendered by `Nebula.php::generateConfig` into `firewall.inbound` /
+  `firewall.outbound`.
+- Page controller: `controllers/OPNsense/Nebula/FirewallController.php`.
+- API controller: `controllers/OPNsense/Nebula/Api/FirewallRuleController.php`
+  (CRUD + `toggle_item`; `checkCaReferences`).
+- Form: `forms/dialogFirewallRule.xml`.
+- View: `views/OPNsense/Nebula/firewall.volt`.
+
+## Maintenance notes
+
+- **Deny-by-default:** nebula rejects a config with no `firewall` block, and a
+  node with no rules passes nothing. `generateConfig` emits a permissive fallback
+  (`port any / proto any / host any`) for a direction that has no enabled rules —
+  keep that, or a rule-less instance becomes unreachable.
+- Per rule: `direction` (inbound/outbound), `port`, `proto`, and matchers
+  `host` / `cidr` / `local_cidr` / `groups` / `ca_name` / `ca_sha`. Rules are
+  per-instance.
+- `ca_sha` references a CA fingerprint; `checkCaReferences` validates it on
+  save. `groups` renders as a YAML list (a single group still renders as a
+  one-element list).
+- Group matchers use the chip widget in the grid.
+- This is overlay policy only; it has nothing to do with `nebula_firewall()` (the
+  OPNsense `_firewall` hook that opens the UDP listen port) or the OPNsense
+  firewall tabs.
+
+## Live test strategy
+
+- Model/render: `phpunit --filter 'FirewallRuleCRUDTest|GenerateConfigTest'` —
+  GenerateConfigTest pins per-direction rendering, the permissive fallback, and
+  group-list rendering.
+- Browser: add inbound + outbound rules (and clear one direction to see the
+  fallback), Apply, confirm the emitted `firewall:` block and `nebula -test`.

--- a/net/nebula/.claude/pages/instances.md
+++ b/net/nebula/.claude/pages/instances.md
@@ -1,0 +1,64 @@
+# Page: Instances (`/ui/nebula/instances`)
+
+The core page: one row per nebula daemon instance. Owns the daemon lifecycle, the
+rendered config, the tun device, and the OPNsense interface integration.
+
+## Files
+
+- Model: `models/OPNsense/Nebula/Nebula.xml` (`instances.instance` array + the
+  `general` block), `Nebula.php` (`generateConfig`, `serializeToConfig`,
+  `assignDeviceNames`, `sshdPortFor`), `ConfigMap.php` (field→yaml map).
+- Page controller: `controllers/OPNsense/Nebula/InstancesController.php` — builds
+  the grid columns explicitly (see Maintenance).
+- API controller: `controllers/OPNsense/Nebula/Api/InstanceController.php`
+  (search/get/add/set/del/toggle + `checkUniqueListener`, `reload`).
+- Dialog form: `controllers/OPNsense/Nebula/forms/dialogInstance.xml`.
+- View: `views/OPNsense/Nebula/instances.volt`.
+- Daemon/config: `scripts/OPNsense/Nebula/setup.php` (start/stop/restart/apply,
+  render, validate, debug).
+- Hooks: `etc/inc/plugins.inc.d/nebula.inc` (`nebula_services`, `nebula_firewall`,
+  `nebula_devices`, `nebula_interfaces`, `nebula_prepare`, `nebula_configure`).
+
+## Maintenance notes
+
+- **Grid columns are built in the controller, not the form.** `getFormGrid()`
+  makes a column for every form field with an `<id>` (unless
+  `grid_view/ignore=true`), so the page would otherwise show the whole config
+  surface. `InstancesController::indexAction` takes `getFormGrid()`'s output and
+  assembles an explicit whitelist (Enabled, Interface, Description, Lighthouse,
+  Listen, Certificate, Status). `Listen` and `Status` are computed columns
+  (formatters `nebula_listen` / `nebula_status`); `Interface` is injected
+  (sourced from `tun_name`, which the search action returns). To change visible
+  columns, edit that whitelist — not the form.
+- **Device name (`tun_name`) is system-managed.** Auto-assigned at save by
+  `Nebula::assignDeviceNames()` as `nebula` + `substr(md5(uuid),0,6)` — derived
+  from the immutable instance UUID, so it is stable and never reused. It is NOT in
+  the dialog (removed, like WireGuard's `interface` field) and not user-editable;
+  it shows only as the Interface grid column. Don't reintroduce it as an editable
+  field — renaming a device that's assigned would silently break the assignment.
+- **Apply reloads, doesn't restart.** `[reconfigure]` → `setup.php apply` →
+  per-instance HUP reload via the debug server; only a structural change (listen
+  host/port, cipher, tun dev) restarts. Keep `nebula_needs_restart`'s structural
+  key set in sync with what nebula can apply live.
+- **OPNsense interface integration:** `nebula_devices` (assignable, labelled,
+  `configurable=false`, `volatile=true`), `nebula_prepare` (creates the tun at
+  interface bring-up — nebula owns tun creation, so prepare starts the daemon and
+  waits, it can't pre-create), `nebula_interfaces` (the "Nebula (Group)" firewall
+  group). The tun joins the kernel `nebula` group on start.
+- **`firewall_interfaces`** drives `nebula_firewall` (auto inbound rule for the
+  UDP listen port). Default empty; the dialog pre-selects WAN on Add via JS (a
+  hard `InterfaceField` default of `wan` would fail validation on boxes without a
+  `wan` interface).
+- Per-instance start is idempotent (guards on a live pid). Don't start a second
+  daemon for a running instance.
+
+## Live test strategy
+
+- Model: `phpunit --filter 'InstanceCRUDTest|GenerateConfigTest|InstanceUniqueListenerTest'`.
+  Covers naming stability, unique listener/device, and the rendered YAML.
+- Daemon lifecycle + interface integration + reboot: see the corresponding
+  sections of `.claude/manual-test-procedures.md`.
+- Quick render check on the box: render an instance and run
+  `nebula -test -config <file>`.
+- After editing `InstancesController` or `nebula.inc`: `configctl webgui restart`
+  (opcache) then confirm the grid columns and Assignments labels in the browser.

--- a/net/nebula/.claude/pages/routes.md
+++ b/net/nebula/.claude/pages/routes.md
@@ -1,0 +1,41 @@
+# Page: Routes (`/ui/nebula/routes`)
+
+Three related per-instance route tables in one page: the lighthouse **static host
+map**, **unsafe routes** (route non-Nebula subnets over the overlay), and **tun
+routes** (per-route MTU overrides).
+
+## Files
+
+- Models: `Nebula.xml` → the static-host-map, `unsafe_routes.route`, and
+  `tun_routes.route` arrays. Rendered by `Nebula.php::generateConfig`
+  (`static_host_map`, `tun.unsafe_routes`, `tun.routes`).
+- Page controller: `controllers/OPNsense/Nebula/RoutesController.php`.
+- API controllers: `Api/StaticHostMapController.php`, `Api/UnsafeRouteController.php`,
+  `Api/TunRouteController.php`.
+- Forms: `forms/dialogStaticHostMap.xml`, `dialogUnsafeRoute.xml`,
+  `dialogTunRoute.xml`.
+- View: `views/OPNsense/Nebula/routes.volt` (one grid per table, each filtered by
+  instance).
+
+## Maintenance notes
+
+- All three are **per-instance** (an `instance` field); each grid filters by the
+  selected instance and renders only that instance's rows into its config.
+- **Static host map**: maps a Nebula IP → underlay `host:port` entries (how a node
+  finds a lighthouse / fixed peer). Goes into the nebula `static_host_map` block.
+- **Unsafe routes** (`tun.unsafe_routes`): advertise/route a non-Nebula subnet
+  over the overlay — `route`, `via` (a Nebula IP), `install` (add to the system
+  route table), optional MTU/metric.
+- **Tun routes** (`tun.routes`): per-overlay-route MTU override (`route` + `mtu`).
+- These only affect the rendered config; changes apply on Apply (HUP reload, no
+  tunnel drop). After editing the rendering in `generateConfig`, re-check
+  `nebula -test`.
+
+## Live test strategy
+
+- Model/render: the relevant assertions live in `GenerateConfigTest` (the
+  `tun.unsafe_routes` / `tun.routes` / static-map blocks). Add cases there when
+  changing rendering.
+- Browser: add a route in each table, Apply, and confirm it lands in the rendered
+  instance config and passes `nebula -test`; for unsafe routes with `install`,
+  confirm the system route appears.

--- a/net/nebula/.claude/pages/status.md
+++ b/net/nebula/.claude/pages/status.md
@@ -1,0 +1,37 @@
+# Page: Status (`/ui/nebula/status`)
+
+Per-instance health summary + service controls. Links to Tunnels for live peers.
+
+## Files
+
+- Page controller: `controllers/OPNsense/Nebula/StatusController.php`.
+- API: `Api/InstanceController.php` (`snapshot`, `debug`), `Api/ServiceController.php`
+  (start/stop/restart + `dirty`/`reconfigure`).
+- View: `views/OPNsense/Nebula/status.volt`.
+- Backend: `scripts/OPNsense/Nebula/setup.php` — `snapshot` builds the per-instance
+  status (running/pid, config-valid, tun device + addresses via `device-info`,
+  resolved certificate summary, listen host:port).
+
+## Maintenance notes
+
+- The snapshot is a one-shot fan-out over all instances; it does **not** query the
+  hostmaps (live peers moved to Tunnels — that was the real scaling fix). Keep
+  heavy/per-peer work off this page.
+- **Listen** is rendered host:port with IPv6 literals bracketed
+  (`nebula_format_listen` → `[::]:4242`) — `::` and `:::4242` are different
+  strings; keep the bracketing.
+- Body shows running/pid, config-valid (plain text, no green), Interface, cert
+  expiry. Watch text contrast (avoid hard-to-read grey on grey).
+- Service start/restart/stop use the page-header service controls
+  (`updateServiceControlUI('nebula')`), rendered on load.
+- An Apply on any page goes through `service/reconfigure` → `setup.php apply`
+  (HUP reload, see `pages/instances.md`); the dirty marker raises the apply notice
+  until reconfigured.
+
+## Live test strategy
+
+- No model tests. Browser: confirm the snapshot reflects running vs stopped,
+  config-valid, the bracketed Listen, and cert expiry; exercise the
+  start/restart/stop controls and confirm the apply-needed notice clears after
+  Apply. A quick backend check: `configctl nebula snapshot` returns the per-instance
+  JSON.

--- a/net/nebula/.claude/pages/tunnels.md
+++ b/net/nebula/.claude/pages/tunnels.md
@@ -1,0 +1,47 @@
+# Page: Tunnels (`/ui/nebula/tunnels`)
+
+Live peer/tunnel view across all instances. No model — data comes from the
+always-on nebula sshd debug server.
+
+## Files
+
+- Page controller: `controllers/OPNsense/Nebula/TunnelsController.php`.
+- API controller: `controllers/OPNsense/Nebula/Api/PeerController.php`
+  (`peer/search`).
+- View: `views/OPNsense/Nebula/tunnels.volt`.
+- Backend: `scripts/OPNsense/Nebula/setup.php` — `peers_all` (configd
+  `peers_all`) fans out `list-hostmap -json` + `list-pending-hostmap -json` across
+  running instances **in parallel** (proc_open + stream_select, per-process
+  timeout) and returns instance-tagged rows; `debug` for per-peer actions.
+
+## Maintenance notes
+
+- **Static (client-side) UIBootgrid:** built once with
+  `UIBootgrid({datakey, options:{ajax:false, …, formatters:{…}}})`, then data is
+  pushed with `bootgrid('replace', rows)` (it **throws on an empty array** — use
+  `'clear'`). Direct `$.fn.bootgrid({…})` is unsupported.
+- One grid for all instances + an instance filter + search + a manual Refresh
+  (no auto-poll — a lighthouse can have thousands of peers). Static-mode
+  search/sort act on row DATA, so ship a searchable string field for any
+  compact-rendered column.
+- Per-peer buttons via `$(document)` delegation (UIBootgrid replaces the `<table>`
+  with a `<div>`): Close / Query-LH / Change-remote / Connect. **Handshaking**
+  (pending) rows are folded into the same grid and show only Query-LH.
+- `list-hostmap -json` already carries **groups** (`cert.details.groups`), **all
+  known remotes** (`remoteAddrs`), and `messageCounter` for every peer in ONE
+  call — do NOT add per-peer `print-cert`/`print-tunnel` enrichment. Nebula
+  exposes **no rx/tx bytes** (only `messageCounter`).
+- `change-remote` uses `-address <ip:port> <vpn>`; `create-tunnel` is **vpn-only**
+  (its `-address` form SEGV-panics older nebula). The full note — why, and how to
+  restore the `-address` form once the upstream fix ships — is the `PENDING`
+  comment on the `create-tunnel` branch of `nebula_instance_debug` in `setup.php`
+  (slackhq/nebula PR #1749).
+- `stream_select` needs a non-negative timeout: clamp with `max(0.0, …)`.
+
+## Live test strategy
+
+- No model tests. Needs a real second peer: bring up a peer, let it handshake,
+  then exercise every action button (Close / Query-LH / Change-remote / Connect)
+  and confirm the handshaking-row path. Re-validate the debug command surface
+  after a nebula upgrade (`.claude/nebula-upgrade.md`). See the debug-server
+  section of `.claude/manual-test-procedures.md`.

--- a/net/nebula/AGENTS.md
+++ b/net/nebula/AGENTS.md
@@ -1,0 +1,101 @@
+# os-nebula — agent guide
+
+OPNsense GUI plugin for the [Nebula](https://github.com/slackhq/nebula) mesh
+overlay VPN. Multi-instance: each instance is one `nebula` daemon with its own
+config, certificate, and tun device. This file is the entry point for working in
+this plugin; deeper runbooks live in `.claude/`.
+
+> Keep everything in this repo generic and public-safe. No site-specific IPs,
+> hostnames, or infrastructure details — those belong in local notes, never in
+> committed files.
+
+## Layout
+
+Files under `src/` install relative to `/usr/local/` on the appliance:
+
+| Repo path | Installs to | What |
+|---|---|---|
+| `src/opnsense/mvc/app/models/OPNsense/Nebula/` | `/usr/local/opnsense/mvc/app/models/…` | model (`Nebula.xml`, `Nebula.php`, `ConfigMap.php`), ACL, Menu |
+| `src/opnsense/mvc/app/controllers/OPNsense/Nebula/` | `…/controllers/…` | page controllers + `Api/` controllers + `forms/` dialog XML |
+| `src/opnsense/mvc/app/views/OPNsense/Nebula/` | `…/views/…` | Volt page templates |
+| `src/opnsense/scripts/OPNsense/Nebula/` | `…/scripts/…` | `setup.php` (daemon lifecycle), `pki.php` (nebula-cert) — run by configd |
+| `src/opnsense/service/conf/actions.d/actions_nebula.conf` | `…/service/conf/actions.d/` | configd actions |
+| `src/opnsense/mvc/tests/` | `…/mvc/tests/` | phpunit model tests |
+| `src/etc/inc/plugins.inc.d/nebula.inc` | **`/usr/local/etc/inc/plugins.inc.d/`** | plugin hooks (services, syslog, firewall, devices, interfaces, configure) |
+| `src/etc/rc.syshook.d/start/20-nebula` | `/usr/local/etc/rc.syshook.d/start/` | boot start hook |
+
+**Deploy-path gotcha:** `src/opnsense/…` → `/usr/local/opnsense/…`, but
+`src/etc/…` → **`/usr/local/etc/…`** (NOT `/usr/local/opnsense/etc/…`). Putting
+`nebula.inc` under the wrong path makes the hooks silently never fire, and
+`php -l` still passes on the misplaced copy. `make install` handles this; only
+hand-deploys get it wrong.
+
+## Build / deploy to a test box
+
+Develop against a disposable OPNsense VM. Two ways to get code onto it:
+
+- **Full install** (mirrors `make install`): from `src/`, stream the tree to
+  `/usr/local/`:
+  ```sh
+  tar -cf - -C src . | ssh root@TESTBOX 'tar xf - -C /usr/local'
+  ```
+- **Single files**: `scp` to the mapped path (mind the `src/etc` → `/usr/local/etc`
+  rule above).
+
+After deploying **PHP that the GUI runs** (controllers, models, `nebula.inc`),
+clear opcache or the change won't take effect — the GUI runs php-cgi with
+`opcache.validate_timestamps=0`:
+```sh
+ssh root@TESTBOX 'configctl webgui restart'   # cycles php-cgi workers, clears opcache
+```
+`.volt` templates and form/model XML are read fresh per request (no restart
+needed). After deploying `nebula.inc`, the webgui restart also reloads
+`plugins_devices()`/`plugins_interfaces()`.
+
+macOS `tar` prints harmless `com.apple.provenance` xattr warnings (exit 1) but
+extracts fine; pass `--no-mac-metadata` and delete stray `._*` files on the box.
+
+The appliance root shell is **csh** — wrap remote shell logic as
+`ssh root@TESTBOX 'sh -s' <<'EOF' … EOF` (redirects/`for`/`&&` misbehave under
+csh).
+
+## Test
+
+- **Model unit tests (phpunit):** `cd /usr/local/opnsense/mvc/tests && phpunit
+  app/models/OPNsense/Nebula` (or `--filter <Class>`). Tests instantiate
+  `new Nebula()` against a fixture config; they cover the data paths the API
+  controllers use. Controller HTTP paths and configd scripts are NOT unit-tested
+  — verify those live (see `.claude/manual-test-procedures.md`).
+- **Live model checks:** bootstrap the MVC env in a CLI script and exercise the
+  model directly — see the pattern in `.claude/manual-test-procedures.md`
+  ("live bootstrap recipe").
+- **Manual / browser acceptance:** `.claude/manual-test-procedures.md`.
+
+## Idioms that bite (full detail in `.claude/`)
+
+- **Grid columns:** `getFormGrid()` makes a column for EVERY form field with an
+  `<id>` unless it has `<grid_view><ignore>true</ignore></grid_view>`. You cannot
+  prune columns by removing `grid_view` (that ADDS them). Curate grids in the page
+  controller (whitelist), as `InstancesController` does.
+- **Live/non-model grids:** use `UIBootgrid({datakey, options:{ajax:false,…}})`
+  + `bootgrid('replace', rows)` (throws on empty → use `'clear'`). Direct
+  `$.fn.bootgrid({…})` is unsupported on OPNsense.
+- **`InterfaceField` defaults:** a hard `<Default>wan</Default>` throws on boxes
+  with no `wan`; default empty and pre-select in JS.
+- **Idempotent daemon start:** `setup.php start [<uuid>]` guards on a live pid;
+  don't launch a second daemon for a running instance.
+- **Apply = reload, not restart:** Apply HUP-reloads each instance in place; only
+  a structural change (listen host/port, cipher, tun dev) restarts. See
+  `.claude/pages/instances.md` and the reload design doc.
+
+## Per-page guides
+
+Each UI page has a maintenance + live-test guide under `.claude/pages/`:
+`instances`, `authorities`, `certificates`, `blocklist`, `routes`, `firewall`,
+`tunnels`, `status`. Read the relevant one before changing a page.
+
+## Upgrading the bundled nebula
+
+See `.claude/nebula-upgrade.md` — covers the FreeBSD `security/nebula` port, the
+`nebula` / `nebula-cert` binaries, config-schema (knob) drift, and the debug
+server command surface.

--- a/net/nebula/BUGS.md
+++ b/net/nebula/BUGS.md
@@ -1,0 +1,33 @@
+# Known issues & limitations
+
+Known bugs, limitations, and upstream-blocked items in os-nebula. Most are
+limitations of the underlying `nebula` daemon rather than of the plugin.
+
+## create-tunnel: no explicit remote address (upstream, PR #1749)
+
+On the **Tunnels** page, creating a tunnel to a peer resolves the peer's address
+through the lighthouse; you cannot create a tunnel to an **explicit remote
+address** in one step.
+
+- **Why:** `nebula`'s debug command `create-tunnel -address <ip:port> <vpn>`
+  SEGV-panics the daemon on affected releases. To avoid crashing a running
+  instance, the plugin issues `create-tunnel <vpn>` only (lighthouse-resolved).
+- **Workaround:** let the lighthouse resolve the peer (the normal case), then use
+  **Change remote** (`change-remote`, which does *not* crash) to point the tunnel
+  at a specific underlay address.
+- **Status:** fixed upstream in [slackhq/nebula PR #1749](https://github.com/slackhq/nebula/pull/1749).
+  Once that fix is in a released `nebula`, the plugin will restore the
+  `-address` form. The exact restore steps live in the `PENDING` comment on the
+  `create-tunnel` branch of `nebula_instance_debug()` in
+  `src/opnsense/scripts/OPNsense/Nebula/setup.php`.
+
+## No per-peer byte counters (upstream limitation)
+
+The Tunnels page cannot show per-peer throughput (rx/tx bytes). `nebula` exposes
+only a per-peer message counter, not byte counts, so there is nothing to display.
+
+---
+
+Found something not listed here? Please open an issue (and, for daemon-level
+behaviour, check whether it reproduces with `nebula` directly — it may belong
+upstream).

--- a/net/nebula/Makefile
+++ b/net/nebula/Makefile
@@ -1,0 +1,13 @@
+PLUGIN_NAME=		nebula
+PLUGIN_VERSION=		1.0
+PLUGIN_COMMENT=		Nebula mesh overlay network
+PLUGIN_DEPENDS=		nebula
+PLUGIN_MAINTAINER=	henry@stern.ca
+
+knobs:
+	python3 tools/gen_knobs.py
+
+knobs-check:
+	python3 tools/gen_knobs.py --check
+
+.include "../../Mk/plugins.mk"

--- a/net/nebula/README.md
+++ b/net/nebula/README.md
@@ -1,0 +1,68 @@
+# os-nebula
+
+Manage [Nebula](https://github.com/slackhq/nebula) mesh overlay VPNs from the
+OPNsense web GUI.
+
+Nebula is a scalable overlay networking tool: hosts authenticate to each other
+with certificates issued by a private CA, discover each other through
+*lighthouses*, and form encrypted peer-to-peer tunnels on a private overlay
+network. This plugin brings the whole workflow — PKI, daemon instances, overlay
+firewall, routing, and live monitoring — into OPNsense, and makes each Nebula
+tunnel a first-class OPNsense interface.
+
+## Features
+
+- **Multiple instances** — run several independent Nebula daemons on one box
+  (e.g. a lighthouse and a separate client overlay), each with its own
+  certificate, listen port, and overlay firewall.
+- **Built-in PKI** — create or import Certificate Authorities, sign host
+  certificates (including CSR signing where the private key never leaves the
+  requesting device), and revoke by fingerprint with a blocklist.
+- **First-class interfaces** — assign a Nebula tunnel in *Interfaces →
+  Assignments* like a WireGuard interface; write firewall rules and gateways
+  against it, or against the whole `nebula` group.
+- **Overlay firewall** — Nebula's own inbound/outbound policy per instance.
+- **Routing** — lighthouse static host maps, routes for non-Nebula subnets over
+  the overlay, and per-route MTU overrides.
+- **Live monitoring** — a Tunnels page showing peers, groups and known remotes
+  across all instances, and a per-instance Status page.
+
+## Requirements
+
+- OPNsense (recent release).
+- The `nebula` and `nebula-cert` binaries installed on the firewall (from the
+  FreeBSD `security/nebula` port / the OPNsense package set).
+
+## Install
+
+This plugin lives under `net/nebula` in an `opnsense/plugins`-style tree. Build
+and install it the standard OPNsense plugin way (`make install` from the plugin
+directory on a build host, or via your plugin repository once packaged). After
+installation, enable it under **VPN → Nebula**.
+
+## Quickstart
+
+1. **Authorities** → create a CA.
+2. **Host Certificates** → sign a certificate under that CA (set the Nebula
+   overlay IP/networks and any groups).
+3. **Instances** → add an instance, select the certificate, set whether it's a
+   lighthouse and its listen port, and enable it.
+4. **Apply.** The daemon starts and the tunnel device comes up.
+5. (Optional) **Interfaces → Assignments** → assign the Nebula device to give it
+   a firewall tab and gateway.
+
+See [`docs/getting-started.md`](docs/getting-started.md) for the full walkthrough.
+
+## Documentation
+
+- **Using the plugin:** [`docs/`](docs/) — getting started, PKI, instances,
+  interface assignment, overlay firewall, blocklist, routes, monitoring.
+- **Contributing / development:** [`docs/development.md`](docs/development.md).
+- **Known issues & limitations:** [`BUGS.md`](BUGS.md).
+
+(AI coding assistants additionally pick up `AGENTS.md` and `.claude/` at the repo
+root — the same knowledge written for tools.)
+
+## License
+
+BSD 2-Clause (see source file headers).

--- a/net/nebula/docs/README.md
+++ b/net/nebula/docs/README.md
@@ -1,0 +1,21 @@
+# os-nebula documentation
+
+User and admin documentation for the os-nebula OPNsense plugin. New to it? Start
+with the project [README](../README.md), then:
+
+## Using the plugin
+
+- [Getting started](getting-started.md) — stand up a lighthouse + client end to
+  end.
+- [Certificates & PKI](pki.md) — CAs, host certificates, CSR signing.
+- [Instances](instances.md) — configuring a Nebula daemon.
+- [Interface assignment](interfaces.md) — opening the listen port, and assigning
+  the tunnel as an OPNsense interface.
+- [Overlay firewall](firewall.md) — Nebula's per-instance inbound/outbound policy.
+- [Blocklist](blocklist.md) — revoking certificates.
+- [Routing](routes.md) — static host maps, unsafe routes, MTU.
+- [Monitoring](status-tunnels.md) — the Status and Tunnels pages.
+
+## Contributing
+
+- [Development guide](development.md) — architecture, build, test, conventions.

--- a/net/nebula/docs/blocklist.md
+++ b/net/nebula/docs/blocklist.md
@@ -1,0 +1,35 @@
+# Blocklist (revocation)
+
+Nebula certificates can't be un-signed, so to revoke a node before its certificate
+expires you **block its fingerprint**. A blocked certificate is refused by the
+instances that carry the block. **VPN → Nebula → Blocklist.**
+
+## Adding a block
+
+- **Add** — paste the certificate's 64-character SHA-256 fingerprint, or pick a
+  certificate you hold (which fills the fingerprint for you). Choose a **scope**:
+  - **Global** — every instance refuses it.
+  - **Instance** — only the selected instance refuses it.
+- **Block** from the [Host Certificates](pki.md) page — one click adds a global
+  block for that certificate.
+- **Import** — paste many fingerprints at once (one per line, optionally
+  `fingerprint, description`).
+
+The **Certificate** column resolves a fingerprint to a certificate you hold
+(`name: XXXXXXXX`), or shows `unknown: XXXXXXXX` for a foreign one.
+
+## Expiry & purging
+
+An entry may carry an optional **Expiry** date, but note: **a block stays in
+effect until you remove it.** Expiry is only a marker for the **Purge expired**
+button, which deletes past-expiry entries on demand. This keeps revocations from
+silently lapsing — you decide when to clean them up. (A natural time to purge is
+once the blocked certificate would itself have expired.)
+
+## Notes
+
+- A fingerprint is the entry's identity and can't be edited after saving — delete
+  and re-add to block a different certificate.
+- Blocking takes effect on **Apply** (in place).
+- Revocation is fingerprint-based, so it targets one specific certificate; if you
+  re-sign a node with a new certificate, that new one is not blocked.

--- a/net/nebula/docs/development.md
+++ b/net/nebula/docs/development.md
@@ -1,0 +1,79 @@
+# Developing the plugin
+
+A guide for people hacking on os-nebula. (If you use an AI coding assistant, it
+will also pick up `AGENTS.md` and `.claude/` at the plugin root — those are the
+same knowledge written for tools. This document is the human-readable version and
+stands on its own.)
+
+## Architecture
+
+It's a standard OPNsense MVC plugin plus a couple of system pieces:
+
+- **Model** (`src/opnsense/mvc/app/models/OPNsense/Nebula/`) — `Nebula.xml`
+  defines the config schema (a `general` block, an `instances` array, and a `pki`
+  subtree for CAs/certs/blocklist, plus routes and firewall rules). `Nebula.php`
+  holds logic, most importantly `generateConfig()` which renders an instance's
+  Nebula YAML, and `ConfigMap.php` which maps model fields to YAML paths.
+- **Controllers** (`…/controllers/OPNsense/Nebula/`) — one page controller per UI
+  page, and an `Api/` controller per resource (the AJAX/CRUD endpoints). Dialog
+  forms are XML under `forms/`.
+- **Views** (`…/views/OPNsense/Nebula/`) — Volt templates, one per page.
+- **Scripts** (`src/opnsense/scripts/OPNsense/Nebula/`) — `setup.php` manages the
+  daemon lifecycle (start/stop/restart/apply, render, validate) and `pki.php`
+  wraps `nebula-cert`. These are invoked by **configd** (see
+  `service/conf/actions.d/actions_nebula.conf`).
+- **Hooks** (`src/etc/inc/plugins.inc.d/nebula.inc`) — integrate with OPNsense:
+  services, syslog, the underlay firewall rule, and the interface registration
+  (`_devices` / `_interfaces` / `prepare`) that makes a tunnel an assignable
+  interface.
+
+Each running instance is one `nebula` daemon (under `/usr/sbin/daemon`) with its
+own rendered config and tunnel device.
+
+## Repo layout → install paths
+
+Files under `src/` install relative to `/usr/local/`:
+`src/opnsense/…` → `/usr/local/opnsense/…`, and `src/etc/…` →
+**`/usr/local/etc/…`** (not under `/usr/local/opnsense/`). `make install` handles
+this.
+
+## Build, install, iterate
+
+- Develop against a disposable OPNsense VM.
+- Install via the standard plugin build (`make install` from the plugin
+  directory), or copy `src/` onto the box under `/usr/local/` for quick
+  iteration.
+- After changing PHP that the GUI runs (controllers, models, `nebula.inc`),
+  restart the web GUI so the new code loads (`configctl webgui restart`); Volt
+  templates and form/model XML are picked up without a restart.
+
+## Testing
+
+- **Unit tests** (PHPUnit) live in `src/opnsense/mvc/tests/`. On the box:
+  `cd /usr/local/opnsense/mvc/tests && phpunit app/models/OPNsense/Nebula`. They
+  exercise the model/render logic against a fixture config.
+- **The config renderer is the most test-worthy part** — `GenerateConfigTest`
+  pins the emitted Nebula YAML. Add cases there when you change rendering.
+- **Live/manual testing** matters because the configd scripts, the daemon
+  lifecycle, the GUI, and OPNsense integration aren't unit-tested. Validate a
+  rendered config with `nebula -test -config <file>` and exercise the daemon
+  (start → apply → restart → stop). For UI/integration changes, test in a browser
+  on the VM.
+
+## Conventions
+
+- Match the surrounding code style; keep each file focused.
+- New source files carry the BSD 2-Clause header used throughout.
+- Keep site-specific details (your test box, your network) out of committed files.
+- Prefer small, reviewable changes; the renderer and the daemon lifecycle are the
+  load-bearing parts — test them.
+
+## Where to look first
+
+- Changing a page's behaviour → that page's controller + view + form, and (for
+  rendered config) `generateConfig()`/`ConfigMap.php`.
+- Adding a config knob → a model field + a `ConfigMap` entry (or a hand-rendered
+  block in `generateConfig`) + a `GenerateConfigTest` case.
+- Daemon/interface behaviour → `setup.php` and `nebula.inc`.
+- Upgrading the bundled Nebula → check config-schema drift against the new
+  release and re-run the renderer tests.

--- a/net/nebula/docs/firewall.md
+++ b/net/nebula/docs/firewall.md
@@ -1,0 +1,41 @@
+# Overlay firewall
+
+**VPN → Nebula → Firewall** controls Nebula's *own* firewall — the policy applied
+to traffic **inside** the overlay, per instance. This is separate from the
+OPNsense firewall (which you can also apply if you [assign the tunnel as an
+interface](interfaces.md)).
+
+## Deny-by-default
+
+Nebula passes **nothing** until you allow it. A node with no inbound rules accepts
+no overlay traffic. So every instance needs at least one **inbound** rule to be
+reachable. (Outbound defaults are more permissive, but you can lock those down
+too.)
+
+## Rules
+
+Each rule is **inbound** or **outbound** and matches on:
+
+- **Port / protocol** — e.g. allow `tcp/22`, or `any`.
+- **Host / CIDR** — a peer overlay IP or subnet (`local_cidr` matches the local
+  side).
+- **Groups** — match peers whose certificate carries a group (e.g. `workstation`,
+  `servers`). Group-based rules are the idiomatic way to write policy: tag nodes
+  with groups when you sign their certificates, then allow by group.
+- **CA name / CA fingerprint** — restrict to peers signed by a specific CA.
+
+Rules are per-instance and take effect on **Apply** (in place, no tunnel drop).
+
+## Examples
+
+- *Allow management from admins:* inbound, `tcp/22`, group `admins`.
+- *Allow all traffic between workstations:* inbound, `any`, group `workstation`.
+- *Lighthouse that only relays discovery:* keep inbound minimal; the lighthouse
+  doesn't need to accept general traffic.
+
+## Tips
+
+- Prefer **groups** over hard-coded IPs — they survive renumbering and scale.
+- Keep one explicit inbound rule even on a lighthouse, or it accepts nothing.
+- If you also assigned the interface, remember traffic must pass **both** the
+  Nebula firewall and the OPNsense interface rules.

--- a/net/nebula/docs/getting-started.md
+++ b/net/nebula/docs/getting-started.md
@@ -1,0 +1,82 @@
+# Getting started
+
+This walks through standing up a small Nebula overlay with the plugin: a
+lighthouse and one client, with a CA, certificates, and a firewall rule. It
+assumes the `nebula` binaries are installed and the plugin is enabled
+(**VPN → Nebula**).
+
+## Concepts in 60 seconds
+
+- **Overlay network** — a private IP range (e.g. `10.10.0.0/24`) that exists
+  only inside Nebula. Each node has one overlay IP.
+- **Certificate** — a node's identity. It encodes the node's overlay IP and its
+  *groups*, and is signed by your **CA**. Nodes only talk to peers whose
+  certificate chains to a CA they trust.
+- **Lighthouse** — a node with a stable, reachable address that others use to
+  find each other. At least one is required; it usually has a public/routable
+  address.
+- **Instance** — one running Nebula daemon on this firewall, using one
+  certificate and one listen port.
+
+## 1. Create a CA (Authorities)
+
+**VPN → Nebula → Authorities → Generate.** Give it a name and (optionally)
+networks/groups. The CA's private key stays on the firewall. Every certificate
+you sign with it, on any node, will be trusted by nodes that hold this CA.
+
+To use an existing CA, **Import** its certificate (and key, if this box will sign
+with it). A CA imported without its key can be *trusted* but not *signed with*.
+
+## 2. Sign host certificates (Host Certificates)
+
+**VPN → Nebula → Host Certificates → Sign.** For each node, choose the CA, set the
+node's overlay IP (e.g. `10.10.0.1/24` for the lighthouse, `10.10.0.10/24`
+for the client) and any groups (e.g. `lighthouse`, `workstation`). Leave duration
+empty to expire just before the CA.
+
+- Sign one certificate **per node** in your overlay. Certificates for other
+  firewalls/devices can be downloaded and copied to them.
+- **CSR signing** lets a remote node generate its own key and send only a public
+  key / CSR; you sign it here and the private key never touches this box. Such a
+  certificate is *keyless* on this box and can't be assigned to a local instance.
+
+## 3. Create the lighthouse instance (Instances)
+
+**VPN → Nebula → Instances → Add.**
+
+- **Certificate:** the lighthouse's certificate from step 2.
+- **Lighthouse:** enabled.
+- **Listen address/port:** `::` and e.g. `4242` (the UDP port peers reach it on;
+  make sure it's reachable — see [interfaces.md](interfaces.md) for opening it).
+- **Firewall interfaces:** the WAN (or whichever interface) to auto-open the
+  listen port on.
+
+Enable the instance and **Apply**. The daemon starts and a `nebula…` tunnel
+device comes up with the certificate's overlay IP.
+
+## 4. Create the client instance
+
+On the *client* firewall (or another instance on the same box for testing): add an
+instance with the client certificate, **Lighthouse: disabled**, and add the
+lighthouse to its **Lighthouse hosts** (the lighthouse's overlay IP) plus a
+**static host map** entry pointing that overlay IP at the lighthouse's real
+`address:port` (see [routes.md](routes.md)). Enable and Apply.
+
+## 5. Open the overlay firewall
+
+Nebula is **deny-by-default**. On each instance, add at least one **inbound** rule
+(VPN → Nebula → Firewall) — e.g. allow `any` from your `workstation` group — or the
+node accepts no overlay traffic. See [firewall.md](firewall.md).
+
+## 6. Verify
+
+- **Status** shows each instance running, its certificate, and its listen address.
+- **Tunnels** shows live peers once they handshake.
+- From a peer, ping the other node's overlay IP.
+
+## Next steps
+
+- [Assign the tunnel as an OPNsense interface](interfaces.md) for firewall
+  tabs, gateways, and group rules.
+- [Manage certificates and revocation](pki.md) and the [blocklist](blocklist.md).
+- [Route non-Nebula subnets over the overlay](routes.md).

--- a/net/nebula/docs/instances.md
+++ b/net/nebula/docs/instances.md
@@ -1,0 +1,57 @@
+# Instances
+
+An **instance** is one running Nebula daemon on this firewall. Most deployments
+need just one; run several when you want independent overlays (e.g. a lighthouse
+plus a separate client overlay) on the same box. **VPN → Nebula → Instances.**
+
+## Key settings
+
+- **Enabled** — master switch for this instance's daemon.
+- **Certificate** — the host certificate this node presents (from [Host
+  Certificates](pki.md)). Required. Its overlay IP becomes the tunnel's address.
+- **Lighthouse** — make this node a discovery server. Lighthouses should not list
+  other lighthouses; clients list the lighthouse(s) under **Lighthouse hosts**.
+- **Listen address / port** — the UDP socket Nebula binds. `::` listens on all
+  interfaces (IPv4+IPv6); the default port is `4242`. Port `0` picks a random port
+  (useful for roaming clients that don't accept inbound connections).
+- **Lighthouse hosts** — on a client, the overlay IPs of the lighthouse(s) it
+  reports to and queries.
+- **Firewall interfaces** — which OPNsense interface(s) to automatically open the
+  UDP listen port on (so peers can reach this node). Defaults to WAN on a new
+  instance; clear it to manage that rule yourself. See [interfaces.md](interfaces.md).
+
+Advanced options (relays, hole-punching, cipher, MTU, handshake tuning, logging,
+conntrack) are available but rarely need changing.
+
+## The interface name
+
+Each instance gets a system tunnel device named `nebula…` (e.g. `nebula3f9a2c`).
+It's assigned automatically, stable for the life of the instance, and not
+editable — much like WireGuard's `wgN`. You'll see it in the Instances grid and in
+**Interfaces → Assignments**.
+
+## Applying changes
+
+**Apply** reloads each running instance **in place** — existing tunnels stay up.
+Only a change that Nebula can't apply live (the listen address/port or cipher)
+restarts that instance, briefly dropping its tunnels. Adding/altering firewall
+rules, routes, lighthouse settings, or rotating the certificate all apply without
+a tunnel drop.
+
+## Enable / disable & lifecycle
+
+- Disabling an instance stops its daemon and removes its tunnel device (and drops
+  it from Interfaces → Assignments).
+- Re-enabling and applying recreates the device and reconnects.
+- Use the per-row **Restart** only when you want a full restart; normal edits just
+  need **Apply**.
+
+## Checklist for a working instance
+
+1. A valid, assigned **certificate** with the key (keyless CSR-signed certs can't
+   be assigned).
+2. **Lighthouse** set correctly (server vs client), with reachable lighthouse
+   hosts on clients.
+3. A reachable **listen port** (opened on the right interface).
+4. At least one **inbound** [firewall rule](firewall.md) — Nebula is
+   deny-by-default.

--- a/net/nebula/docs/interfaces.md
+++ b/net/nebula/docs/interfaces.md
@@ -1,0 +1,57 @@
+# Interface assignment & opening the listen port
+
+A Nebula instance creates a tunnel device (`nebula…`). There are two separate
+firewall concerns, often confused:
+
+1. **Reaching the node** — peers must be able to send UDP to the instance's
+   **listen port** on a *physical* interface (e.g. WAN). This is ordinary OPNsense
+   firewalling on the underlay.
+2. **Using the overlay as an interface** — optionally assign the `nebula…` device
+   as an OPNsense interface so you can route and firewall the overlay traffic.
+
+## Opening the listen port (underlay)
+
+Each instance's **Firewall interfaces** setting auto-creates an inbound rule
+allowing UDP to its listen port on the interface(s) you pick (defaults to WAN).
+Clear it to write the rule yourself. Without an open port, peers initiating to
+this node can't reach it (though it can still reach out to others).
+
+## Assigning the tunnel as an OPNsense interface (overlay)
+
+This makes the Nebula tunnel a first-class interface, like a WireGuard one.
+
+1. **Interfaces → Assignments.** In the device dropdown you'll see entries like
+   `nebula3f9a2c (Nebula - <description>)`. Add one; it becomes e.g. *OPT1*.
+2. Open the new interface, **Enable** it, and (optionally) rename it (e.g.
+   `NEBULA`). You do **not** set an IP — Nebula assigns the overlay address from
+   the certificate; OPNsense just tracks the interface.
+3. **Apply.** You now have:
+   - A **firewall tab** for that interface (Firewall → Rules → NEBULA) to control
+     traffic to/from the overlay at the OPNsense layer.
+   - A **gateway** you can define for routing.
+   - The interface in dashboards, Insight, etc.
+
+### The "Nebula (Group)"
+
+All Nebula tunnels join a `nebula` interface group. When adding a firewall rule,
+selecting **"Nebula (Group)"** as the Interface applies that rule to *every*
+Nebula tunnel at once — handy when you run several instances. (This is a
+packet-filter group, distinct from user-created Interface Groups under
+Firewall → Groups.)
+
+## Behaviour notes
+
+- The tunnel device is created by the Nebula daemon and is **volatile** — OPNsense
+  knows this, so an assigned-but-not-yet-up interface won't block boot. After a
+  reboot the device is recreated and the assignment reattaches automatically.
+- Disabling the instance removes the device; the assignment is left in place but
+  inactive until you re-enable the instance (or remove the assignment).
+- The device name never changes on its own, so assignments and the firewall rules
+  bound to them stay correct.
+
+## OPNsense firewall vs Nebula firewall
+
+Assigning the interface lets you filter overlay traffic with **OPNsense** rules.
+That is separate from the **Nebula overlay firewall** (VPN → Nebula → Firewall),
+which is Nebula's own per-instance policy and is always in effect regardless of
+assignment. See [firewall.md](firewall.md).

--- a/net/nebula/docs/pki.md
+++ b/net/nebula/docs/pki.md
@@ -1,0 +1,60 @@
+# Certificates & PKI
+
+Nebula identity is certificate-based. A private **Certificate Authority (CA)**
+signs a **host certificate** for each node; nodes trust peers whose certificate
+chains to a CA they hold. This plugin manages both, plus revocation via the
+[blocklist](blocklist.md).
+
+## Authorities (CAs)
+
+**VPN → Nebula → Authorities.**
+
+- **Generate** — create a new CA on this firewall. Set a name, curve (25519 is the
+  default; P256 for hardware/compat), validity, and optional default
+  networks/groups. The private key stays on the box.
+- **Import** — bring in an existing CA. Import the certificate alone to *trust* a
+  CA (verify peers), or the certificate **and** its key to also *sign* with it
+  here. A keyless CA shows **Can sign = no**.
+- **Encrypted CA** — a CA whose key is passphrase-protected; you'll be prompted
+  for the passphrase when signing. Shown with a lock marker.
+- The **Fingerprint** column shows the first 8 hex characters of the CA's SHA-256,
+  to tell apart CAs with similar names.
+- **Purge expired** removes CAs past their validity, but skips any still in use
+  (referenced by a certificate or trusted by an instance) and tells you which.
+
+## Host Certificates
+
+**VPN → Nebula → Host Certificates.**
+
+- **Sign** — issue a certificate under one of your CAs. Set the node's overlay IP
+  (e.g. `10.10.0.10/24`), groups, and validity (leave empty to expire just before
+  the CA). The plugin generates the key + certificate on the box; download them to
+  copy onto another node, or assign the certificate to a local instance.
+- **CSR signing** — sign from a public key or CSR generated **on the remote
+  node**, so that node's private key never leaves it. The resulting certificate is
+  *keyless* here: it can't be assigned to a local instance (an instance needs the
+  key to run), but it's perfect for issuing identities to other machines.
+- **Import** — add a pre-signed certificate (with or without its key).
+- Each certificate shows its **fingerprint** (first 8 hex of SHA-256) and the
+  signing CA as `name: XXXXXXXX`.
+- **Block** (per row) immediately revokes a certificate by adding it to the global
+  [blocklist](blocklist.md).
+- **Purge expired** removes expired certificates, skipping any still assigned to an
+  instance.
+
+## Typical lifecycle
+
+1. Generate (or import) a CA.
+2. Sign a certificate per node — locally for this firewall's instances, or via CSR
+   for remote nodes.
+3. Assign a certificate to an [instance](instances.md).
+4. To revoke a node before its certificate expires, [block its
+   fingerprint](blocklist.md).
+5. Rotate before expiry: sign a replacement, swap it on the instance, Apply.
+
+## Notes
+
+- Keep the CA's validity comfortably longer than the certificates it signs;
+  certificates default to expiring just before the CA.
+- Nodes must share at least one common CA to talk. Multiple CAs let you segment
+  trust; an instance can trust additional CAs beyond the one that signed it.

--- a/net/nebula/docs/routes.md
+++ b/net/nebula/docs/routes.md
@@ -1,0 +1,41 @@
+# Routing
+
+**VPN → Nebula → Routes** holds three per-instance route tables: the lighthouse
+**static host map**, **unsafe routes**, and **MTU routes**.
+
+## Static host map
+
+How a node finds a specific peer at a fixed underlay address (most importantly,
+how clients find a lighthouse). Each entry maps a **Nebula overlay IP** to one or
+more real **`address:port`** endpoints.
+
+Typical use: on a client, map the lighthouse's overlay IP (e.g. `10.10.0.1`) to
+its public `host:port` (e.g. `vpn.example.org:4242`), and list that overlay IP
+under the client instance's **Lighthouse hosts**. The client then reaches the
+lighthouse directly and discovers everyone else through it.
+
+## Unsafe routes
+
+Route traffic for a **non-Nebula subnet** over the overlay — e.g. reach a LAN
+behind another Nebula node without that LAN running Nebula itself.
+
+- **Route** — the destination subnet (e.g. `192.0.2.0/24`).
+- **Via** — the Nebula overlay IP of the node that fronts that subnet.
+- **Install** — also add the route to the firewall's system routing table.
+- Optional MTU/metric.
+
+The fronting node must be configured to forward for that subnet (and its own
+firewall/NAT must allow it).
+
+## MTU routes
+
+Override the MTU for specific overlay routes when a path needs a smaller packet
+size (e.g. to avoid fragmentation over a constrained link). Set the **route** and
+its **MTU**.
+
+## Notes
+
+- All three are per-instance; select the instance at the top of each table.
+- Changes apply on **Apply** (in place, no tunnel drop).
+- Static host maps are mainly for lighthouses and other fixed peers; ordinary
+  peer-to-peer discovery is handled by the lighthouse automatically.

--- a/net/nebula/docs/status-tunnels.md
+++ b/net/nebula/docs/status-tunnels.md
@@ -1,0 +1,48 @@
+# Monitoring: Status & Tunnels
+
+## Status
+
+**VPN → Nebula → Status** is the per-instance health summary:
+
+- **Running / stopped** and the process id.
+- **Config valid** — whether the rendered config passes Nebula's own check.
+- **Interface** — the tunnel device and its overlay address.
+- **Listen** — the bound address and port (IPv6 shown bracketed, e.g.
+  `[::]:4242`).
+- **Certificate** — the assigned certificate and its expiry (watch this for
+  upcoming rotations).
+
+Service **start / restart / stop** controls are in the page header. Most changes
+only need **Apply**; use restart only when you intend a full restart.
+
+## Tunnels
+
+**VPN → Nebula → Tunnels** shows live peers across all instances in one list:
+
+- One row per peer, with the instance it belongs to, the peer's overlay
+  address(es), its **groups**, and its **known remotes** (the underlay addresses
+  it's reachable at).
+- **Handshaking** peers (still negotiating) appear too.
+- An **instance filter** and search narrow the list; **Refresh** re-queries on
+  demand (there's no constant polling, so a busy lighthouse with many peers stays
+  responsive).
+
+### Per-peer actions
+
+- **Query lighthouse** — ask the lighthouses where a peer is.
+- **Change remote** — point a tunnel at a specific underlay address.
+- **Connect / Close** — establish or tear down a tunnel to a peer.
+
+These act on the live daemon and are useful for troubleshooting connectivity.
+
+## Troubleshooting flow
+
+1. **Status:** is the instance running and the config valid? Is the certificate
+   current?
+2. **Listen port reachable?** Confirm the [underlay rule](interfaces.md) opens the
+   UDP port; for clients, confirm the [static host map](routes.md) and lighthouse
+   hosts.
+3. **Tunnels:** does the peer appear and handshake? If it's stuck handshaking,
+   it's usually reachability (port/NAT) or trust (CA/blocklist).
+4. **Overlay firewall:** even with a tunnel up, traffic needs an allowing
+   [inbound rule](firewall.md) on the receiving node.

--- a/net/nebula/knobs.yaml
+++ b/net/nebula/knobs.yaml
@@ -1,0 +1,544 @@
+---
+# knobs.yaml — curated scalar Nebula config knobs (v1.10.3)
+# Source-of-truth for code-generation (model XML, form XML, ConfigMap.php).
+# SCALARS ONLY — list/map knobs (static_host_map, unsafe_routes, firewall rules,
+# lighthouse allow-lists, stats, sshd.authorized_users) are deferred; see
+# tools/nebula_config_reference.yaml for the full upstream coverage map and
+# tools/audit_knobs.py for the drift guard.
+# Field names under instances.instance; yaml = dotted nebula.yml path.
+#
+# `section` groups each knob for the instance dialog. Knobs are ordered, and
+# sections appear, in the documented order at https://nebula.defined.net/docs/config/.
+# tools/gen_knobs.py emits a section header before the first knob of each section
+# and requires each section to be contiguous (no interleaving).
+
+knobs:
+
+  # ---------------------------------------------------------------------------
+  # pki
+  # ---------------------------------------------------------------------------
+  - field: pki_disconnect_invalid
+    section: PKI
+    yaml: pki.disconnect_invalid
+    type: bool
+    default: "false"
+    label: Disconnect on invalid certificate
+    help: Disconnect any tunnel whose certificate becomes invalid (expired or revoked) while the tunnel is active.
+
+  - field: pki_initiating_version
+    section: PKI
+    yaml: pki.initiating_version
+    type: int
+    default: 1
+    min: 1
+    max: 2
+    label: Initiating cert version
+    advanced: true
+    help: Nebula handshake version to use when initiating a new tunnel (1 = legacy, 2 = post-quantum-resistant).
+
+  # ---------------------------------------------------------------------------
+  # static_map (DNS re-resolution for static lighthouses)
+  # ---------------------------------------------------------------------------
+  - field: static_map_cadence
+    section: Static map (DNS)
+    yaml: static_map.cadence
+    type: duration
+    default: 30s
+    label: Static map DNS cadence
+    advanced: true
+    help: How often to re-resolve hostnames listed in static_host_map via DNS.
+
+  - field: static_map_network
+    section: Static map (DNS)
+    yaml: static_map.network
+    type: enum
+    default: ip4
+    enum: [ip4, ip6, ip]
+    label: Static map address family
+    advanced: true
+    help: "Address family to use when re-resolving static_host_map hostnames: ip4, ip6, or ip (either)."
+
+  - field: static_map_lookup_timeout
+    section: Static map (DNS)
+    yaml: static_map.lookup_timeout
+    type: duration
+    default: 250ms
+    label: Static map lookup timeout
+    advanced: true
+    help: DNS lookup timeout for each static_host_map hostname resolution attempt.
+
+  # ---------------------------------------------------------------------------
+  # lighthouse (scalars; hosts/allow-lists deferred)
+  # ---------------------------------------------------------------------------
+  - field: am_lighthouse
+    section: Lighthouse
+    yaml: lighthouse.am_lighthouse
+    type: bool
+    default: "false"
+    required: Y
+    label: Lighthouse
+    grid: 4
+    grid_width: "6em"
+    help: Designate this node as a lighthouse (discovery server); lighthouse nodes should not list other lighthouses.
+
+  - field: lighthouse_serve_dns
+    section: Lighthouse
+    yaml: lighthouse.serve_dns
+    type: bool
+    default: "false"
+    label: Serve DNS
+    help: Enable the DNS server on this lighthouse so peers can resolve Nebula hostnames via DNS queries.
+
+  - field: lighthouse_interval
+    section: Lighthouse
+    yaml: lighthouse.interval
+    type: int
+    default: 60
+    label: Lighthouse update interval
+    help: How often (in seconds) non-lighthouse nodes send keepalive/update messages to their lighthouses.
+
+  - field: lighthouse_dns_host
+    section: Lighthouse
+    yaml: lighthouse.dns.host
+    type: host
+    default: "0.0.0.0"
+    label: DNS listen address
+    help: IP address the lighthouse DNS server binds to (only used when serve_dns is true).
+
+  - field: lighthouse_dns_port
+    section: Lighthouse
+    yaml: lighthouse.dns.port
+    type: int
+    default: 53
+    min: 1
+    max: 65535
+    label: DNS port
+    help: UDP port the lighthouse DNS server listens on (only used when serve_dns is true).
+
+  - field: lighthouse_hosts
+    section: Lighthouse
+    yaml: lighthouse.hosts
+    type: list
+    label: Lighthouse hosts
+    help: "Lighthouse nebula IPs this node reports to / queries. Add each as a tag. Leave empty on a lighthouse."
+
+  - field: lighthouse_advertise_addrs
+    section: Lighthouse
+    yaml: lighthouse.advertise_addrs
+    type: list
+    label: Advertise addresses
+    help: "Extra routable host:port (or host:0) to advertise to lighthouses. Add each as a tag."
+
+  # ---------------------------------------------------------------------------
+  # listen
+  # ---------------------------------------------------------------------------
+  - field: listen_host
+    section: Listen
+    yaml: listen.host
+    type: host
+    default: "::"
+    required: Y
+    label: Listen address
+    help: IP address (or hostname) Nebula binds its UDP listener to; "::" listens on all interfaces (IPv4+IPv6).
+
+  - field: listen_port
+    section: Listen
+    yaml: listen.port
+    type: int
+    default: 4242
+    min: 0
+    max: 65535
+    required: Y
+    label: Listen port
+    grid: 5
+    grid_width: "7em"
+    help: UDP port Nebula listens on; 0 lets the OS assign a random port (useful for roaming clients).
+
+  - field: listen_batch
+    section: Listen
+    yaml: listen.batch
+    type: int
+    default: 64
+    label: Listen batch size
+    advanced: true
+    help: Maximum number of packets to read from the UDP socket in a single syscall (Linux recvmmsg batch size).
+
+  - field: listen_read_buffer
+    section: Listen
+    yaml: listen.read_buffer
+    type: int
+    label: UDP receive buffer
+    advanced: true
+    help: SO_RCVBUF size in bytes for the UDP socket; leave unset to use the OS default.
+
+  - field: listen_write_buffer
+    section: Listen
+    yaml: listen.write_buffer
+    type: int
+    label: UDP send buffer
+    advanced: true
+    help: SO_SNDBUF size in bytes for the UDP socket; leave unset to use the OS default.
+
+  - field: listen_send_recv_error
+    section: Listen
+    yaml: listen.send_recv_error
+    type: enum
+    default: always
+    enum: [always, never, private]
+    label: Send error on write failure
+    advanced: true
+    help: "Controls when ICMP unreachable errors are sent back on write failures: always, never, or only to private IPs."
+
+  - field: listen_accept_recv_error
+    section: Listen
+    yaml: listen.accept_recv_error
+    type: enum
+    default: always
+    enum: [always, never, private]
+    label: Send error on read failure
+    advanced: true
+    help: "Controls when ICMP unreachable errors are sent back on read failures: always, never, or only to private IPs."
+
+  - field: listen_so_mark
+    section: Listen
+    yaml: listen.so_mark
+    type: int
+    default: 0
+    label: Socket mark (SO_MARK)
+    advanced: true
+    help: SO_MARK value to set on the UDP socket; useful for policy-based routing (0 = disabled).
+
+  # ---------------------------------------------------------------------------
+  # punchy
+  # ---------------------------------------------------------------------------
+  - field: punchy_punch
+    section: Punchy (NAT traversal)
+    yaml: punchy.punch
+    type: bool
+    default: "true"
+    label: Hole punching
+    help: Send UDP hole-punching packets to peers behind NAT to keep the path open.
+
+  - field: punchy_respond
+    section: Punchy (NAT traversal)
+    yaml: punchy.respond
+    type: bool
+    default: "false"
+    label: Respond to hole punch
+    advanced: true
+    help: Respond to hole-punch requests from peers (enables bidirectional hole-punching).
+
+  - field: punchy_delay
+    section: Punchy (NAT traversal)
+    yaml: punchy.delay
+    type: duration
+    default: 1s
+    label: Hole punch delay
+    advanced: true
+    help: How long to wait before sending the first hole-punch packet after a handshake.
+
+  - field: punchy_respond_delay
+    section: Punchy (NAT traversal)
+    yaml: punchy.respond_delay
+    type: duration
+    default: 5s
+    label: Hole punch respond delay
+    advanced: true
+    help: Delay before responding to a hole-punch request; adds jitter to avoid thundering-herd.
+
+  # ---------------------------------------------------------------------------
+  # cipher
+  # ---------------------------------------------------------------------------
+  - field: cipher
+    section: Cipher
+    yaml: cipher
+    type: enum
+    default: chachapoly
+    enum: [chachapoly, aes]
+    label: Cipher
+    help: "Encryption cipher for tunnel traffic: chachapoly (ChaCha20-Poly1305) or aes (AES-256-GCM)."
+
+  # ---------------------------------------------------------------------------
+  # preferred_ranges
+  # ---------------------------------------------------------------------------
+  - field: preferred_ranges
+    section: Preferred ranges
+    yaml: preferred_ranges
+    type: list
+    label: Preferred ranges
+    help: "Local network CIDRs preferred for handshakes. Add each as a tag."
+
+  # ---------------------------------------------------------------------------
+  # relay
+  # ---------------------------------------------------------------------------
+  - field: relay_am_relay
+    section: Relay
+    yaml: relay.am_relay
+    type: bool
+    default: "false"
+    label: Act as relay
+    help: Act as a relay node, forwarding encrypted traffic between peers that cannot reach each other directly.
+
+  - field: relay_use_relays
+    section: Relay
+    yaml: relay.use_relays
+    type: bool
+    default: "true"
+    label: Use relays
+    help: Allow this node to use relay nodes when a direct path to a peer is unavailable.
+
+  - field: relay_relays
+    section: Relay
+    yaml: relay.relays
+    type: list
+    label: Relays
+    help: "Nebula IPs to use as relays. Add each as a tag."
+
+  # ---------------------------------------------------------------------------
+  # tun
+  # ---------------------------------------------------------------------------
+  - field: tun_name
+    section: TUN interface
+    yaml: tun.dev
+    type: text
+    label: Interface
+    grid: 2
+    grid_width: "10em"
+    help: "Tunnel device name, e.g. nebula0. Leave empty to auto-assign."
+
+  - field: tun_disabled
+    section: TUN interface
+    yaml: tun.disabled
+    type: bool
+    default: "false"
+    label: Disable TUN interface
+    advanced: true
+    help: Disable the TUN interface entirely (node participates in the overlay as a relay/lighthouse only, no IP traffic).
+
+  - field: tun_drop_local_broadcast
+    section: TUN interface
+    yaml: tun.drop_local_broadcast
+    type: bool
+    default: "false"
+    label: Drop local broadcast
+    advanced: true
+    help: Drop packets destined for the local broadcast address of the Nebula subnet before they enter the TUN.
+
+  - field: tun_drop_multicast
+    section: TUN interface
+    yaml: tun.drop_multicast
+    type: bool
+    default: "false"
+    label: Drop multicast
+    advanced: true
+    help: Drop all multicast packets at the TUN interface.
+
+  - field: tun_tx_queue
+    section: TUN interface
+    yaml: tun.tx_queue
+    type: int
+    default: 500
+    label: TX queue length
+    advanced: true
+    help: Transmit queue length for the TUN device (Linux txqueuelen / number of packets buffered before dropping).
+
+  - field: tun_mtu
+    section: TUN interface
+    yaml: tun.mtu
+    type: int
+    default: 1300
+    label: MTU
+    help: MTU of the Nebula TUN interface; lower values leave headroom for the outer UDP/IP headers.
+
+  - field: tun_use_system_route_table
+    section: TUN interface
+    yaml: tun.use_system_route_table
+    type: bool
+    default: "false"
+    label: Use system route table
+    advanced: true
+    help: Install Nebula routes into the system routing table instead of handling them internally (useful on BSD/macOS).
+
+  - field: tun_use_system_route_table_buffer_size
+    section: TUN interface
+    yaml: tun.use_system_route_table_buffer_size
+    type: int
+    default: 0
+    label: System route table buffer size
+    advanced: true
+    help: Size of the route-change notification buffer when use_system_route_table is enabled; 0 = OS default.
+
+  # ---------------------------------------------------------------------------
+  # tunnels
+  # ---------------------------------------------------------------------------
+  - field: tunnels_drop_inactive
+    section: Tunnels
+    yaml: tunnels.drop_inactive
+    type: bool
+    default: "false"
+    label: Drop inactive tunnels
+    advanced: true
+    help: Tear down tunnels that have had no traffic for the inactivity_timeout period.
+
+  - field: tunnels_inactivity_timeout
+    section: Tunnels
+    yaml: tunnels.inactivity_timeout
+    type: duration
+    default: 10m
+    label: Inactivity timeout
+    advanced: true
+    help: How long a tunnel may be idle before it is considered inactive (only used when drop_inactive is true).
+
+  # ---------------------------------------------------------------------------
+  # sshd (embedded debug SSH server) — NOT user-configurable. The plugin always
+  # runs the debug server bound to 127.0.0.1 on a per-instance derived port, with
+  # only the plugin's diagnostics key authorized (see Nebula.php / setup.php). It
+  # is the internal management channel behind the Status page; there are no knobs.
+  # ---------------------------------------------------------------------------
+
+  # ---------------------------------------------------------------------------
+  # logging
+  # ---------------------------------------------------------------------------
+  - field: logging_level
+    section: Logging
+    yaml: logging.level
+    type: enum
+    default: info
+    enum: [debug, info, warning, error, fatal, panic]
+    label: Log level
+    help: "Log verbosity level: debug produces the most output; panic the least."
+
+  - field: logging_format
+    section: Logging
+    yaml: logging.format
+    type: enum
+    default: text
+    enum: [text, json]
+    label: Log format
+    advanced: true
+    help: "Log output format: text (human-readable) or json (structured, for log aggregators)."
+
+  - field: logging_disable_timestamp
+    section: Logging
+    yaml: logging.disable_timestamp
+    type: bool
+    default: "false"
+    label: Disable log timestamp
+    advanced: true
+    help: Omit the timestamp field from log entries (useful when the log collector adds its own timestamp).
+
+  - field: logging_timestamp_format
+    section: Logging
+    yaml: logging.timestamp_format
+    type: text
+    label: Log timestamp format
+    advanced: true
+    help: "Go time-format string for log timestamps (e.g. 2006-01-02T15:04:05Z07:00); leave empty for the default."
+
+  # ---------------------------------------------------------------------------
+  # firewall defaults + conntrack (rules handled by the Allow List page)
+  # ---------------------------------------------------------------------------
+  - field: firewall_outbound_action
+    section: Firewall defaults
+    yaml: firewall.outbound_action
+    type: enum
+    default: drop
+    enum: [drop, reject]
+    label: Default outbound action
+    help: "Default action for outbound packets that match no firewall rule: drop (silently) or reject (send ICMP unreachable)."
+
+  - field: firewall_inbound_action
+    section: Firewall defaults
+    yaml: firewall.inbound_action
+    type: enum
+    default: drop
+    enum: [drop, reject]
+    label: Default inbound action
+    help: "Default action for inbound packets that match no firewall rule: drop (silently) or reject (send ICMP unreachable)."
+
+  - field: firewall_default_local_cidr_any
+    section: Firewall defaults
+    yaml: firewall.default_local_cidr_any
+    type: bool
+    default: "false"
+    label: Default local CIDR = any
+    advanced: true
+    help: When true, firewall rules without an explicit local_cidr match any local address (pre-v1.9 behaviour).
+
+  - field: firewall_conntrack_tcp_timeout
+    section: Firewall defaults
+    yaml: firewall.conntrack.tcp_timeout
+    type: duration
+    default: 12m
+    label: Conntrack TCP timeout
+    advanced: true
+    help: Idle timeout for TCP conntrack entries; connections with no matching traffic are evicted after this period.
+
+  - field: firewall_conntrack_udp_timeout
+    section: Firewall defaults
+    yaml: firewall.conntrack.udp_timeout
+    type: duration
+    default: 3m
+    label: Conntrack UDP timeout
+    advanced: true
+    help: Idle timeout for UDP conntrack entries.
+
+  - field: firewall_conntrack_default_timeout
+    section: Firewall defaults
+    yaml: firewall.conntrack.default_timeout
+    type: duration
+    default: 10m
+    label: Conntrack default timeout
+    advanced: true
+    help: Idle timeout for conntrack entries that are neither TCP nor UDP.
+
+  # ---------------------------------------------------------------------------
+  # routines
+  # ---------------------------------------------------------------------------
+  - field: routines
+    section: Routines
+    yaml: routines
+    type: int
+    default: 1
+    label: Routines
+    advanced: true
+    help: Number of goroutine workers for packet I/O; increasing can improve throughput on multi-core hosts.
+
+  # ---------------------------------------------------------------------------
+  # handshakes
+  # ---------------------------------------------------------------------------
+  - field: handshakes_try_interval
+    section: Handshakes
+    yaml: handshakes.try_interval
+    type: duration
+    default: 100ms
+    label: Handshake retry interval
+    advanced: true
+    help: How long to wait between successive handshake attempts to the same peer.
+
+  - field: handshakes_retries
+    section: Handshakes
+    yaml: handshakes.retries
+    type: int
+    default: 20
+    label: Handshake retries
+    advanced: true
+    help: Maximum number of handshake attempts before giving up and waiting for the peer to initiate.
+
+  - field: handshakes_query_buffer
+    section: Handshakes
+    yaml: handshakes.query_buffer
+    type: int
+    default: 64
+    label: Handshake query buffer
+    advanced: true
+    help: Size of the channel buffer for outbound lighthouse queries triggered by pending handshakes.
+
+  - field: handshakes_trigger_buffer
+    section: Handshakes
+    yaml: handshakes.trigger_buffer
+    type: int
+    default: 64
+    label: Handshake trigger buffer
+    advanced: true
+    help: Size of the channel buffer that queues packets waiting to trigger a new handshake.

--- a/net/nebula/pkg-descr
+++ b/net/nebula/pkg-descr
@@ -1,0 +1,7 @@
+Nebula is a scalable overlay networking tool from Slack with a focus on
+performance, simplicity, and security. This plugin manages one or more
+Nebula instances, a Nebula certificate authority and host certificates,
+the per-host Nebula firewall, and registers each Nebula tunnel as an
+assignable OPNsense interface.
+
+WWW: https://github.com/slackhq/nebula

--- a/net/nebula/src/etc/inc/plugins.inc.d/nebula.inc
+++ b/net/nebula/src/etc/inc/plugins.inc.d/nebula.inc
@@ -1,0 +1,240 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+function nebula_enabled()
+{
+    return (string)(new \OPNsense\Nebula\Nebula())->general->enabled == '1';
+}
+
+function nebula_services()
+{
+    $services = [];
+
+    if (!nebula_enabled()) {
+        return $services;
+    }
+
+    $services[] = [
+        'description' => gettext('Nebula'),
+        'configd' => [
+            'start' => ['nebula start'],
+            'restart' => ['nebula restart'],
+            'stop' => ['nebula stop'],
+        ],
+        'nocheck' => true, /* multi-instance: no single pidfile to check */
+        'name' => 'nebula',
+    ];
+
+    return $services;
+}
+
+function nebula_syslog()
+{
+    return [
+        'nebula' => ['facility' => ['nebula']]
+    ];
+}
+
+/*
+ * Auto-add an inbound "allow UDP to the listen port" rule for each enabled
+ * instance, on the interface(s) the user selected (firewall_interfaces; default
+ * WAN). Empty selection = no rule. nebula binds dual-stack on "::" (the default),
+ * so open both families then; a specific listen address opens only its family.
+ */
+function nebula_firewall($fw)
+{
+    if (!nebula_enabled()) {
+        return;
+    }
+
+    foreach ((new \OPNsense\Nebula\Nebula())->instances->instance->iterateItems() as $uuid => $inst) {
+        if ((string)$inst->enabled !== '1') {
+            continue;
+        }
+        $ifaces = array_filter(explode(',', (string)$inst->firewall_interfaces));
+        if (empty($ifaces)) {
+            continue;
+        }
+        $port = (int)(string)$inst->listen_port;
+        if ($port <= 0) {
+            continue; /* port 0 = OS-assigned ephemeral; no fixed port to open */
+        }
+        $descr = (string)$inst->description;
+        if ($descr === '') {
+            $descr = $uuid;
+        }
+
+        $host = trim((string)$inst->listen_host);
+        if ($host === '' || $host === '::') {
+            $families = ['inet', 'inet6'];
+        } elseif (strpos($host, ':') !== false) {
+            $families = ['inet6'];
+        } else {
+            $families = ['inet'];
+        }
+
+        foreach ($ifaces as $if) {
+            foreach ($families as $family) {
+                $fw->registerFilterRule(
+                    500000,
+                    [
+                        'direction'  => 'in',
+                        'interface'  => $if,
+                        'ipprotocol' => $family,
+                        'protocol'   => 'udp',
+                        'from'       => 'any',
+                        'to'         => '(self)',
+                        'to_port'    => $port,
+                        'descr'      => "Nebula {$descr}: allow listen port {$port}",
+                        '#ref'       => 'ui/nebula/instances',
+                    ]
+                );
+            }
+        }
+    }
+}
+
+/*
+ * Register a virtual 'nebula' interface group with OPNsense (the _interfaces
+ * hook, like wireguard_interfaces). This surfaces "Nebula (Group)" in the
+ * firewall — it appears in the Interface dropdown when adding a rule (Firewall >
+ * Rules), letting you write one rule against every nebula tun at once. (It is a
+ * kernel/pf interface group, NOT a user-created Firewall > Groups entry, so it
+ * does not appear under Firewall > Groups.) The group is backed by the real
+ * `ifconfig <dev> group nebula` membership joined at instance start / prepare.
+ */
+function nebula_interfaces()
+{
+    $interfaces = [];
+    if (!nebula_enabled()) {
+        return $interfaces;
+    }
+    $interfaces['nebula'] = [
+        'descr'    => gettext('Nebula (Group)'),
+        'if'       => 'nebula',
+        'virtual'  => true,
+        'enable'   => true,
+        'type'     => 'group',
+        'networks' => [],
+    ];
+    return $interfaces;
+}
+
+/*
+ * Register each enabled instance's tun device with OPNsense so it is a
+ * first-class, idiomatic interface (like wireguard's wgN): it shows up in
+ * Interfaces > Assignments labelled "<dev> (Nebula - <descr>)", joins the
+ * 'nebula' group, and is marked non-configurable (nebula owns the cert-derived
+ * IP) and volatile (the daemon recreates it). Names come from the stable,
+ * per-instance tun_name (nebula + md5(uuid) hex), so only real instances appear
+ * — stale/test tun devices do not.
+ */
+function nebula_devices()
+{
+    $names = [];
+    if (nebula_enabled()) {
+        foreach ((new \OPNsense\Nebula\Nebula())->instances->instance->iterateItems() as $uuid => $node) {
+            if ((string)$node->enabled !== '1') {
+                continue;
+            }
+            $dev = trim((string)$node->tun_name);
+            if ($dev === '') {
+                continue;
+            }
+            $descr = (string)$node->description !== '' ? (string)$node->description : $dev;
+            $names[$dev] = [
+                'name'    => $dev,
+                'descr'   => sprintf('%s (Nebula - %s)', $dev, $descr),
+                'ifdescr' => $descr,
+            ];
+        }
+    }
+
+    return [[
+        'function'     => 'nebula_prepare',
+        'configurable' => false, /* nebula assigns the overlay IP from the cert */
+        'pattern'      => '^nebula',
+        'type'         => 'nebula',
+        'volatile'     => true,  /* the daemon creates/destroys the tun */
+        'names'        => $names,
+    ]];
+}
+
+/*
+ * Device-creation callback OPNsense invokes during interface bring-up, before
+ * configuring an assigned interface — this is what fixes boot ordering. Nebula
+ * owns tun creation (it opens /dev/tun and renames to tun.dev; FreeBSD refuses to
+ * rename onto an existing name), so we cannot pre-create the device the way
+ * wireguard_prepare() does. Instead start the matching instance's daemon (which
+ * creates the tun) and wait briefly for it, then join the 'nebula' group. Run
+ * setup.php directly rather than via configd to avoid reentrancy from inside
+ * interfaces_configure().
+ */
+function nebula_prepare($device)
+{
+    if (!nebula_enabled()) {
+        return null;
+    }
+    foreach ((new \OPNsense\Nebula\Nebula())->instances->instance->iterateItems() as $uuid => $node) {
+        if ((string)$node->enabled !== '1' || trim((string)$node->tun_name) !== $device) {
+            continue;
+        }
+        if (!does_interface_exist($device)) {
+            mwexecf('/usr/local/opnsense/scripts/OPNsense/Nebula/setup.php start %s', [$uuid]);
+            for ($i = 0; $i < 15 && !does_interface_exist($device); $i++) {
+                usleep(200 * 1000); /* up to ~3s; nebula creates the tun early */
+            }
+        }
+        if (does_interface_exist($device)) {
+            mwexecf('/sbin/ifconfig %s group nebula', [$device]);
+            return $device;
+        }
+        return null;
+    }
+    return null;
+}
+
+function nebula_configure()
+{
+    return [
+        'vpn' => ['nebula_configure_do:2'],
+    ];
+}
+
+function nebula_configure_do($verbose = false)
+{
+    if (!nebula_enabled()) {
+        return;
+    }
+
+    service_log('Configuring Nebula overlay...', $verbose);
+
+    configd_run('nebula start');
+
+    service_log("done.\n", $verbose);
+}

--- a/net/nebula/src/etc/inc/plugins.inc.d/nebula.inc
+++ b/net/nebula/src/etc/inc/plugins.inc.d/nebula.inc
@@ -28,7 +28,15 @@
 
 function nebula_enabled()
 {
-    return (string)(new \OPNsense\Nebula\Nebula())->general->enabled == '1';
+    /* Nebula has no global enable: each instance is its own daemon. The plugin's
+     * services / devices / interface hooks early-out via nebula_enabled() when
+     * there's nothing to run, so map "enabled" to "at least one instance is on." */
+    foreach ((new \OPNsense\Nebula\Nebula())->instances->instance->iterateItems() as $node) {
+        if ((string)$node->enabled === '1') {
+            return true;
+        }
+    }
+    return false;
 }
 
 function nebula_services()

--- a/net/nebula/src/etc/rc.syshook.d/start/20-nebula
+++ b/net/nebula/src/etc/rc.syshook.d/start/20-nebula
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/usr/local/sbin/configctl nebula start

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/Api/AuthorityController.php
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/Api/AuthorityController.php
@@ -1,0 +1,576 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Nebula\Api;
+
+use OPNsense\Base\ApiMutableModelControllerBase;
+use OPNsense\Core\Backend;
+use OPNsense\Core\Config;
+
+/**
+ * Authority API — CA CRUD, generate, and import for the Nebula PKI.
+ *
+ * Endpoints:
+ *   GET  /api/nebula/authority/searchItem
+ *   GET  /api/nebula/authority/getItem/<uuid>
+ *   POST /api/nebula/authority/setItem/<uuid>
+ *   POST /api/nebula/authority/delItem/<uuid>
+ *   POST /api/nebula/authority/generate    — invoke nebula-cert ca via configd
+ *   POST /api/nebula/authority/import      — store a pre-existing CA cert + key
+ *
+ * @package OPNsense\Nebula\Api
+ */
+class AuthorityController extends ApiMutableModelControllerBase
+{
+    protected static $internalModelName = 'nebula';
+    protected static $internalModelClass = 'OPNsense\Nebula\Nebula';
+
+    // -------------------------------------------------------------------------
+    // Standard CRUD (no plain addItem — use generate or import)
+    // -------------------------------------------------------------------------
+
+    public function searchItemAction()
+    {
+        // The grid needs descr, cn, curve, valid_to, networks, unsafe_networks and
+        // can_sign.  We also expose has_key (drives the Download-key button), plus
+        // fingerprint + can_sign so the Sign-dialog dropdown in certificates.volt can
+        // filter to signable CAs and disambiguate same-named ones by short fingerprint.
+        // searchBase()'s field list governs *searching*, not which columns are
+        // serialised, so we post-filter every row to strip the PEM material — in
+        // particular the private 'key' must NEVER reach the grid JSON.
+        // key_encrypted is also returned so the Sign dialog can decide whether to
+        // require a passphrase for the selected CA.
+        $result = $this->searchBase(
+            'pki.authorities.authority',
+            ['descr', 'cn', 'curve', 'valid_to', 'has_key', 'can_sign', 'key_encrypted', 'fingerprint', 'networks', 'unsafe_networks']
+        );
+        if (!empty($result['rows'])) {
+            foreach ($result['rows'] as &$row) {
+                unset($row['key'], $row['crt']);
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * Parse a nebula-cert print result and populate the computed read-only
+     * model fields (cn, valid_from, valid_to, fingerprint, is_ca) on $node.
+     *
+     * $printRes is the decoded ['info' => [...]] returned by pki_print_cert,
+     * where info[0] = {curve, details:{name,isCa,networks,groups,notBefore,
+     * notAfter,...}, fingerprint, ...}.
+     */
+    private function storeComputedFields($node, array $printRes): void
+    {
+        $entry   = $printRes['info'][0] ?? [];
+        $details = $entry['details'] ?? [];
+
+        $node->cn          = (string)($details['name'] ?? '');
+        $node->valid_from  = (string)($details['notBefore'] ?? '');
+        $node->valid_to    = (string)($details['notAfter'] ?? '');
+        $node->fingerprint = (string)($entry['fingerprint'] ?? '');
+        $node->is_ca       = !empty($details['isCa']) ? '1' : '0';
+
+        // Curve as embedded in the cert (info[0].curve, e.g. "CURVE25519" / "P256").
+        // Normalise to the model's option values: 25519 / P256.
+        if (isset($entry['curve'])) {
+            $node->curve = (stripos((string)$entry['curve'], 'P256') !== false) ? 'P256' : '25519';
+        }
+
+        // Network constraints embedded in the CA cert (empty = unrestricted).
+        $nets = $details['networks'] ?? [];
+        $node->networks = is_array($nets) ? implode(',', $nets) : (string)$nets;
+
+        $unsafeNets = $details['unsafeNetworks'] ?? [];
+        $node->unsafe_networks = is_array($unsafeNets) ? implode(',', $unsafeNets) : (string)$unsafeNets;
+    }
+
+    /**
+     * Whether a stored PEM private key is encrypted (passphrase-protected).
+     *
+     * Nebula encrypted keys carry an "ENCRYPTED" token in the PEM header, e.g.
+     * "-----BEGIN NEBULA ED25519 ENCRYPTED PRIVATE KEY-----".  As of INFRA-163 an
+     * encrypted CA IS signable: the passphrase is supplied per signing operation
+     * and passed to nebula-cert via NEBULA_CA_PASSPHRASE (never stored).  This
+     * flag drives the Sign dialog's conditional passphrase prompt (key_encrypted),
+     * not whether the CA can sign.
+     */
+    private function keyIsEncrypted(string $key): bool
+    {
+        return stripos($key, 'ENCRYPTED') !== false;
+    }
+
+    public function getItemAction($uuid = null)
+    {
+        return $this->getBase('authority', 'pki.authorities.authority', $uuid);
+    }
+
+    public function setItemAction($uuid = null)
+    {
+        return $this->setBase('authority', 'pki.authorities.authority', $uuid);
+    }
+
+    public function delItemAction($uuid = null)
+    {
+        // Referential integrity: refuse to delete a CA still signing a cert
+        // (caref) or trusted by an instance (trusted_cas). The check lives on the
+        // model so delete and purge share it.
+        $ref = $this->getModel()->caReferencedBy((string)$uuid);
+        if ($ref !== null) {
+            return [
+                'result'  => 'failed',
+                'message' => sprintf('CA is in use by %s and cannot be deleted.', $ref),
+            ];
+        }
+        return $this->delBase('pki.authorities.authority', $uuid);
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /api/nebula/authority/purge_expired
+    // -------------------------------------------------------------------------
+
+    /**
+     * Delete every expired CA that is not still referenced; an expired-but-
+     * referenced CA is kept and named in the result so the admin can resolve the
+     * reference first. The selection/deletion lives on the model
+     * (Nebula::purgeExpiredAuthorities); this action just persists and reports.
+     *
+     * Returns {"result":"saved","removed":N,"skipped":M,"skippedNames":[...]}.
+     */
+    public function purgeExpiredAction()
+    {
+        if (!$this->request->isPost()) {
+            return ['result' => 'failed', 'error' => 'POST required'];
+        }
+
+        $mdl = $this->getModel();
+        $res = $mdl->purgeExpiredAuthorities();
+
+        if ($res['removed'] > 0) {
+            $valMsgs = $mdl->performValidation();
+            if (count($valMsgs) > 0) {
+                $validations = [];
+                foreach ($valMsgs as $msg) {
+                    $parts = explode('.', $msg->getField());
+                    $validations[end($parts)] = $msg->getMessage();
+                }
+                return ['result' => 'failed', 'validations' => $validations];
+            }
+            $mdl->serializeToConfig();
+            Config::getInstance()->save();
+        }
+
+        return [
+            'result'       => 'saved',
+            'removed'      => $res['removed'],
+            'skipped'      => count($res['skippedNames']),
+            'skippedNames' => $res['skippedNames'],
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /api/nebula/authority/generate
+    // -------------------------------------------------------------------------
+
+    /**
+     * Generate a new Nebula CA via configd → pki.php generate-ca → nebula-cert.
+     *
+     * Request body (JSON or form-encoded):
+     *   name           string  required  Nebula CA name embedded in the certificate
+     *   descr          string  optional  Human-readable OPNsense label (defaults to name)
+     *   curve          string  optional  25519 (default) or P256
+     *   duration_days  int     optional  Validity in days (default 365)
+     *   groups         string  optional  Comma-separated group list
+     *   networks       string  optional  Comma-separated CIDR list
+     *   unsafe_networks string optional  Comma-separated unsafe CIDR list
+     *   passphrase     string  optional  When non-empty the CA private key is
+     *                                    encrypted with this passphrase (passed to
+     *                                    nebula-cert via NEBULA_CA_PASSPHRASE, never
+     *                                    stored).  Empty → unencrypted key as before.
+     *
+     * Returns:
+     *   {"result":"saved","uuid":"<uuid>"}  on success
+     *   {"result":"failed","error":"..."}   on configd / nebula-cert failure
+     *   {"result":"failed","validations":{...}}  on model validation failure
+     */
+    public function generateAction()
+    {
+        if (!$this->request->isPost()) {
+            return ['result' => 'failed', 'error' => 'POST required'];
+        }
+
+        $name            = trim($this->request->getPost('name', 'string', ''));
+        $descr           = trim($this->request->getPost('descr', 'string', ''));
+        $curve           = $this->request->getPost('curve', 'string', '25519');
+        $duration_days   = (int)$this->request->getPost('duration_days', 'int', 365);
+        $groups          = $this->request->getPost('groups', 'string', '');
+        $networks        = $this->request->getPost('networks', 'string', '');
+        $unsafe_networks = $this->request->getPost('unsafe_networks', 'string', '');
+        // Optional CA-key passphrase: NOT trimmed (a passphrase may legitimately
+        // contain leading/trailing whitespace) and NEVER stored — only forwarded
+        // to pki.php, which hands it to nebula-cert via NEBULA_CA_PASSPHRASE.
+        $passphrase      = $this->request->getPost('passphrase', 'string', '');
+
+        if ($name === '') {
+            return ['result' => 'failed', 'validations' => ['name' => 'name is required']];
+        }
+
+        // descr defaults to name if the user left it blank.
+        if ($descr === '') {
+            $descr = $name;
+        }
+
+        // duration_hours is passed as an integer; pki.php formats the "Nh" string.
+        $pkiParams = [
+            'name'           => $name,
+            'curve'          => $curve,
+            'duration_hours' => $duration_days * 24,
+        ];
+        if ($groups !== '') {
+            $pkiParams['groups'] = $groups;
+        }
+        if ($networks !== '') {
+            $pkiParams['networks'] = $networks;
+        }
+        if ($unsafe_networks !== '') {
+            $pkiParams['unsafe_networks'] = $unsafe_networks;
+        }
+        // Non-empty passphrase → pki.php adds -encrypt and runs nebula-cert with
+        // NEBULA_CA_PASSPHRASE set.  The passphrase is forwarded but never stored.
+        if ($passphrase !== '') {
+            $pkiParams['passphrase'] = $passphrase;
+        }
+
+        $b64 = base64_encode(json_encode($pkiParams));
+        $out = (new Backend())->configdpRun('nebula pki_generate_ca', [$b64]);
+        $res = json_decode($out, true);
+
+        if (!is_array($res) || !empty($res['error']) || empty($res['crt']) || empty($res['key'])) {
+            $err = (is_array($res) && !empty($res['error'])) ? $res['error'] : 'configd returned no result';
+            return ['result' => 'failed', 'error' => $err];
+        }
+
+        $mdl  = $this->getModel();
+        $node = $mdl->pki->authorities->authority->Add();
+        $node->descr  = $descr;
+        $node->origin = 'generated';
+        $node->curve  = $curve;
+        $node->crt    = $res['crt'];
+        $node->key    = $res['key'];
+        $node->has_key = '1';
+        // key_encrypted reflects whether the stored key PEM is passphrase-protected.
+        // It is true exactly when the user supplied a passphrase; we also confirm it
+        // against the returned PEM header so the two never drift.
+        $node->key_encrypted = ($passphrase !== '' || $this->keyIsEncrypted((string)$res['key'])) ? '1' : '0';
+
+        // Parse the freshly minted CA cert once and store its computed fields.
+        $printB64 = base64_encode(json_encode(['crt' => $res['crt']]));
+        $printOut = (new Backend())->configdpRun('nebula pki_print_cert', [$printB64]);
+        $printRes = json_decode($printOut, true);
+        if (is_array($printRes) && empty($printRes['error']) && !empty($printRes['info'])) {
+            $this->storeComputedFields($node, $printRes);
+        }
+
+        // A freshly generated CA has its private key stored (encrypted or not), so it
+        // is a valid signer as long as the cert is a CA (always true for
+        // nebula-cert ca).  Encrypted CAs sign with a per-operation passphrase.
+        $node->can_sign = ((string)$node->is_ca === '1') ? '1' : '0';
+
+        $uuid = $node->getAttribute('uuid');
+
+        $valMsgs = $mdl->performValidation();
+        if (count($valMsgs) > 0) {
+            $validations = [];
+            foreach ($valMsgs as $msg) {
+                $field = $msg->getField();
+                // Strip the model prefix (e.g. "nebula.pki.authorities.authority.<uuid>.descr")
+                // down to just the leaf field for a friendly response.
+                $parts = explode('.', $field);
+                $leaf  = end($parts);
+                $validations[$leaf] = $msg->getMessage();
+            }
+            return ['result' => 'failed', 'validations' => $validations];
+        }
+
+        $mdl->serializeToConfig();
+        Config::getInstance()->save();
+
+        return ['result' => 'saved', 'uuid' => $uuid];
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /api/nebula/authority/generate_file/<uuid>/<type>
+    // -------------------------------------------------------------------------
+
+    /**
+     * Return the stored PEM for a CA as a downloadable payload (Trust idiom).
+     *
+     * Mirrors Trust\Api\CaController::generateFileAction — the response is JSON
+     * so the caller can use download_content() in JS.
+     *
+     * @param string $uuid CA authority uuid
+     * @param string $type 'crt' (default) or 'key'
+     * @return array {'status':'ok','payload':'<PEM>','descr':'<name>'} or error
+     */
+    public function generateFileAction($uuid = null, $type = 'crt')
+    {
+        $result = ['status' => 'failed'];
+        if ($this->request->isPost() && !empty($uuid)) {
+            $node = null;
+            foreach ($this->getModel()->pki->authorities->authority->iterateItems() as $item) {
+                if ($item->getAttribute('uuid') === $uuid) {
+                    $node = $item;
+                    break;
+                }
+            }
+            if ($node === null) {
+                $result['error'] = 'authority not found';
+                return $result;
+            }
+            $result['descr'] = (string)$node->descr;
+            if ($type === 'crt') {
+                $crt = (string)$node->crt;
+                if ($crt === '') {
+                    $result['error'] = 'no certificate stored';
+                } else {
+                    $result['status']  = 'ok';
+                    $result['payload'] = $crt;
+                }
+            } elseif ($type === 'key') {
+                $key = (string)$node->key;
+                if ($key === '') {
+                    $result['error'] = 'no private key stored for this authority';
+                } else {
+                    $result['status']  = 'ok';
+                    $result['payload'] = $key;
+                }
+            } else {
+                $result['error'] = 'unsupported type';
+            }
+        }
+        return $result;
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /api/nebula/authority/info/<uuid>
+    // -------------------------------------------------------------------------
+
+    /**
+     * Return parsed certificate details for the GUI inspect view.
+     *
+     * Mirrors CertificateController::infoAction — calls pki_print_cert on the
+     * stored crt and returns the parsed info array.
+     *
+     * @param string $uuid CA authority uuid
+     * @return array {'info':[...]} or {'result':'failed','error':'...'}
+     */
+    public function infoAction($uuid = null)
+    {
+        if (empty($uuid)) {
+            return ['result' => 'failed', 'error' => 'uuid is required'];
+        }
+
+        $node = null;
+        foreach ($this->getModel()->pki->authorities->authority->iterateItems() as $item) {
+            if ($item->getAttribute('uuid') === $uuid) {
+                $node = $item;
+                break;
+            }
+        }
+
+        if ($node === null) {
+            return ['result' => 'failed', 'error' => 'authority not found'];
+        }
+
+        $crt = (string)$node->crt;
+        if ($crt === '') {
+            return ['result' => 'failed', 'error' => 'authority has no crt data'];
+        }
+
+        $b64      = base64_encode(json_encode(['crt' => $crt]));
+        $out      = (new Backend())->configdpRun('nebula pki_print_cert', [$b64]);
+        $printRes = json_decode($out, true);
+
+        if (!is_array($printRes) || !empty($printRes['error']) || empty($printRes['info'])) {
+            $err = (is_array($printRes) && !empty($printRes['error'])) ? $printRes['error'] : 'pki_print_cert returned no info';
+            return ['result' => 'failed', 'error' => $err];
+        }
+
+        return ['info' => $printRes['info']];
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /api/nebula/authority/import
+    // -------------------------------------------------------------------------
+
+    /**
+     * Import an existing Nebula CA certificate (and optionally its private key).
+     *
+     * Request body (JSON or form-encoded):
+     *   descr  string  required  Human-readable name
+     *   crt    string  required  PEM-encoded Nebula CA certificate
+     *   key    string  optional  PEM-encoded private key (may be omitted for
+     *                            cert-only imports, e.g. trust anchors)
+     *
+     * Returns:
+     *   {"result":"saved","uuid":"<uuid>"}                     on success
+     *   {"result":"failed","validations":{"crt":"..."}}        if crt is invalid
+     *   {"result":"failed","validations":{"descr":"..."}}      if descr is missing
+     */
+    /**
+     * Validate a PEM-encoded Nebula private key string.
+     *
+     * Accepts any "-----BEGIN NEBULA ... PRIVATE KEY-----" header (ED25519,
+     * X25519, P256 variants), INCLUDING encrypted keys
+     * ("-----BEGIN NEBULA ... ENCRYPTED PRIVATE KEY-----").  Encrypted keys are
+     * stored as-is; the CA simply cannot sign until the passphrase plumbing lands
+     * (INFRA-163), reflected by can_sign='0'.  Only a string that is not a Nebula
+     * private key PEM at all is rejected.
+     *
+     * Returns null on success, or a user-facing error string on failure.
+     */
+    private function validateKeyPem(string $key): ?string
+    {
+        // Must contain a NEBULA * PRIVATE KEY PEM header (encrypted variants too).
+        if (!preg_match('/-----BEGIN NEBULA [A-Z0-9 ]*PRIVATE KEY-----/', $key)) {
+            return 'not a valid Nebula private key';
+        }
+        return null;
+    }
+
+    public function importAction()
+    {
+        if (!$this->request->isPost()) {
+            return ['result' => 'failed', 'error' => 'POST required'];
+        }
+
+        $descr = trim($this->request->getPost('descr', 'string', ''));
+        $crt   = $this->request->getPost('crt', 'string', '');
+        $key   = $this->request->getPost('key', 'string', '');
+
+        if ($descr === '') {
+            return ['result' => 'failed', 'validations' => ['descr' => 'descr is required']];
+        }
+        if ($crt === '') {
+            return ['result' => 'failed', 'validations' => ['crt' => 'crt is required']];
+        }
+
+        // Validate crt by asking pki.php print-cert (exit ≠ 0 → invalid).
+        $printParams = ['crt' => $crt];
+        $b64         = base64_encode(json_encode($printParams));
+        $out         = (new Backend())->configdpRun('nebula pki_print_cert', [$b64]);
+        $printRes    = json_decode($out, true);
+
+        if (!is_array($printRes) || !empty($printRes['error']) || empty($printRes['info'])) {
+            return [
+                'result'      => 'failed',
+                'validations' => ['crt' => 'not a valid Nebula certificate'],
+            ];
+        }
+
+        // A CA must actually be a CA certificate (isCa=true).  Reject host certs.
+        $details = $printRes['info'][0]['details'] ?? [];
+        if (empty($details['isCa'])) {
+            return [
+                'result'      => 'failed',
+                'validations' => ['crt' => 'this certificate is not a CA (isCa=false)'],
+            ];
+        }
+
+        // Validate the private key if one was supplied (encrypted keys are accepted).
+        if ($key !== '') {
+            $keyErr = $this->validateKeyPem($key);
+            if ($keyErr !== null) {
+                return ['result' => 'failed', 'validations' => ['key' => $keyErr]];
+            }
+        }
+
+        $mdl  = $this->getModel();
+
+        // Reject a duplicate import (same CA cert fingerprint already in the pool).
+        // This also covers "I imported the cert alone, now I want to add its key":
+        // the user must delete the existing cert-only entry first and re-import the
+        // pair, rather than us silently creating a second row or mutating an
+        // existing one.
+        $fingerprint = (string)($printRes['info'][0]['fingerprint'] ?? '');
+        if ($fingerprint !== '') {
+            foreach ($mdl->pki->authorities->authority->iterateItems() as $existing) {
+                if ((string)$existing->fingerprint === $fingerprint) {
+                    return [
+                        'result'      => 'failed',
+                        'validations' => ['crt' => 'this CA is already imported (delete the existing entry first to replace it)'],
+                    ];
+                }
+            }
+        }
+
+        $node = $mdl->pki->authorities->authority->Add();
+        $node->descr  = $descr;
+        $node->origin = 'imported';
+        $node->crt    = $crt;
+        if ($key !== '') {
+            $node->key           = $key;
+            $node->has_key       = '1';
+            // Detect encryption from the imported key PEM header so the Sign dialog
+            // knows whether to prompt for a passphrase.
+            $node->key_encrypted = $this->keyIsEncrypted($key) ? '1' : '0';
+        } else {
+            $node->has_key       = '0';
+            $node->key_encrypted = '0';
+        }
+
+        // Store computed fields (cn, valid_*, fingerprint, is_ca, curve, networks)
+        // from the print output we already obtained above.
+        $this->storeComputedFields($node, $printRes);
+
+        // can_sign = is_ca AND a private key is present.  Encrypted keys ARE
+        // signable now (INFRA-163): the passphrase is supplied per signing
+        // operation via NEBULA_CA_PASSPHRASE and never stored, so encryption no
+        // longer excludes a CA from signing.
+        $canSign = ((string)$node->is_ca === '1') && $key !== '';
+        $node->can_sign = $canSign ? '1' : '0';
+
+        $uuid = $node->getAttribute('uuid');
+
+        $valMsgs = $mdl->performValidation();
+        if (count($valMsgs) > 0) {
+            $validations = [];
+            foreach ($valMsgs as $msg) {
+                $parts = explode('.', $msg->getField());
+                $leaf  = end($parts);
+                $validations[$leaf] = $msg->getMessage();
+            }
+            return ['result' => 'failed', 'validations' => $validations];
+        }
+
+        $mdl->serializeToConfig();
+        Config::getInstance()->save();
+
+        return ['result' => 'saved', 'uuid' => $uuid];
+    }
+}

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/Api/BlocklistController.php
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/Api/BlocklistController.php
@@ -1,0 +1,540 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Nebula\Api;
+
+use OPNsense\Base\ApiMutableModelControllerBase;
+use OPNsense\Core\Config;
+
+/**
+ * Certificate blocklist API — fingerprints this node refuses to talk to.
+ *
+ * Each entry blocks one certificate by its sha256 fingerprint.  Scope is
+ * explicit: a `scope` of `global` applies the block to every instance, while
+ * `instance` scopes it to the single instance named in `instance` (required in
+ * that case).  The fingerprint of an existing entry is immutable (changing it
+ * would silently re-target the block), and every fingerprint must be 64
+ * lowercase hex characters (sha256).  The grid cross-references each fingerprint
+ * against the configured certificates so a blocked local cert is named.
+ *
+ * Endpoints:
+ *   GET  /api/nebula/blocklist/search_item[?instance=<uuid>]
+ *   GET  /api/nebula/blocklist/get_item/<uuid>
+ *   POST /api/nebula/blocklist/add_item
+ *   POST /api/nebula/blocklist/set_item/<uuid>
+ *   POST /api/nebula/blocklist/del_item/<uuid>
+ *   POST /api/nebula/blocklist/toggle_item/<uuid>[/<enabled>]
+ *   POST /api/nebula/blocklist/block_cert/<certref> — block a cert globally
+ *
+ * @package OPNsense\Nebula\Api
+ */
+class BlocklistController extends ApiMutableModelControllerBase
+{
+    protected static $internalModelName = 'nebula';
+    protected static $internalModelClass = 'OPNsense\Nebula\Nebula';
+
+    // -------------------------------------------------------------------------
+    // Fingerprint validation
+    // -------------------------------------------------------------------------
+
+    /**
+     * Validate the posted entry's fingerprint as a 64-char lowercase hex sha256.
+     *
+     * The form posts the entry fields nested under the "entry" key, e.g.
+     * {"entry": {"fingerprint": "abc...", ...}} — so we read from there, mirroring
+     * FirewallRuleController's checkCaReferences (which validates ca_sha the same
+     * way).  Returns null when valid, or a validations error array on failure.
+     *
+     * @return array|null  null = valid; array = ['result'=>'failed','validations'=>[...]]
+     */
+    private function checkFingerprintFormat(): ?array
+    {
+        $entry = $this->request->getPost('entry');
+        if (!is_array($entry)) {
+            $entry = [];
+        }
+        $fp = isset($entry['fingerprint']) ? trim((string)$entry['fingerprint']) : '';
+        if (!preg_match('/^[0-9a-f]{64}$/', $fp)) {
+            return [
+                'result'      => 'failed',
+                'validations' => [
+                    'entry.fingerprint' =>
+                        'Fingerprint must be 64 lowercase hex characters (sha256).',
+                ],
+            ];
+        }
+        return null;
+    }
+
+    /**
+     * Reject an attempt to change the fingerprint of an existing entry.
+     *
+     * The fingerprint is the entry's identity; mutating it on an edit would
+     * silently re-point the block at a different certificate.  We compare the
+     * posted fingerprint against the value stored on the entry being edited and
+     * fail with a validation error keyed on entry.fingerprint when they differ.
+     *
+     * @param string $uuid uuid of the entry being edited
+     * @return array|null  null = unchanged/ok; array = ['result'=>'failed', ...]
+     */
+    private function checkFingerprintImmutable(string $uuid): ?array
+    {
+        $entry = $this->request->getPost('entry');
+        if (!is_array($entry)) {
+            $entry = [];
+        }
+        $posted = isset($entry['fingerprint']) ? trim((string)$entry['fingerprint']) : '';
+
+        $stored = null;
+        foreach ($this->getModel()->pki->blocklist->entry->iterateItems() as $node) {
+            if ($node->getAttribute('uuid') === $uuid) {
+                $stored = trim((string)$node->fingerprint);
+                break;
+            }
+        }
+
+        if ($stored !== null && $posted !== $stored) {
+            return [
+                'result'      => 'failed',
+                'validations' => [
+                    'entry.fingerprint' =>
+                        'Fingerprint cannot be changed on an existing blocklist entry. ' .
+                        'Delete this entry and add a new one for a different certificate.',
+                ],
+            ];
+        }
+        return null;
+    }
+
+    /**
+     * When scope is "instance", an instance must be chosen.  A global block needs
+     * no instance.  Keeps the explicit-scope model honest (no instance-scoped
+     * entry that silently behaves global because its instance was left blank).
+     *
+     * @return array|null  null = valid; array = ['result'=>'failed', ...]
+     */
+    private function checkScope(): ?array
+    {
+        $entry = $this->request->getPost('entry');
+        if (!is_array($entry)) {
+            $entry = [];
+        }
+        $scope = isset($entry['scope']) ? (string)$entry['scope'] : 'global';
+        if ($scope === 'instance') {
+            $inst = isset($entry['instance']) ? trim((string)$entry['instance']) : '';
+            if ($inst === '') {
+                return [
+                    'result'      => 'failed',
+                    'validations' => [
+                        'entry.instance' =>
+                            'Select an instance, or set Scope to Global.',
+                    ],
+                ];
+            }
+        }
+        return null;
+    }
+
+    // -------------------------------------------------------------------------
+    // Standard CRUD
+    // -------------------------------------------------------------------------
+
+    /**
+     * Search blocklist entries, optionally scoped to one instance.
+     *
+     * Pass ?instance=<uuid> to restrict the result set to entries that apply to
+     * that instance: global entries (instance == '') OR entries whose instance
+     * field equals the given uuid.  Without the parameter every entry is
+     * returned.  The instance uuid is resolved to its description for display
+     * ("global" when empty), mirroring InstanceController's certref resolution.
+     */
+    public function searchItemAction()
+    {
+        $instanceUuid = trim($this->request->get('instance', 'string', ''));
+
+        $filter_funct = null;
+        if ($instanceUuid === '__global__') {
+            // "Global" filter: only the global blocklist (no instance-scoped rows).
+            $filter_funct = function ($record) {
+                return (string)$record->scope !== 'instance';
+            };
+        } elseif ($instanceUuid !== '') {
+            // A specific instance: the entries that apply to it — Global ones plus
+            // those explicitly scoped to it (the concatenated view it renders).
+            $filter_funct = function ($record) use ($instanceUuid) {
+                if ((string)$record->scope === 'instance') {
+                    return (string)$record->instance === $instanceUuid;
+                }
+                return true;
+            };
+        }
+
+        $result = $this->searchBase(
+            'pki.blocklist.entry',
+            ['enabled', 'scope', 'instance', 'fingerprint', 'descr', 'expiry'],
+            null,
+            $filter_funct
+        );
+
+        if (!empty($result['rows']) && is_array($result['rows'])) {
+            // Resolve the "Applies to" column: a Global entry renders as
+            // "Global (all instances)"; an instance-scoped entry renders the
+            // instance description ("(deleted)" if the uuid is dangling).
+            $instByUuid = [];
+            foreach ($this->getModel()->instances->instance->iterateItems() as $inst) {
+                $instByUuid[$inst->getAttribute('uuid')] = (string)$inst->description;
+            }
+            // Cross-reference fingerprints against configured certificates so a
+            // blocked local cert is named in the grid (foreign fingerprints stay
+            // blank — they belong to peers whose certs we do not hold).
+            $certByFp = [];
+            foreach ($this->getModel()->pki->certificates->certificate->iterateItems() as $crt) {
+                $fp = strtolower(trim((string)$crt->fingerprint));
+                if ($fp !== '') {
+                    $certByFp[$fp] = (string)$crt->descr;
+                }
+            }
+            foreach ($result['rows'] as &$row) {
+                // Overwrite the raw instance uuid with the "Applies to" display
+                // (the grid's instance column is labelled "Applies to").
+                if ((string)($row['scope'] ?? '') === 'instance') {
+                    $uuid = trim((string)($row['instance'] ?? ''));
+                    $row['instance'] = array_key_exists($uuid, $instByUuid)
+                        ? $instByUuid[$uuid] : '(deleted)';
+                } else {
+                    $row['instance'] = gettext('Global (all instances)');
+                }
+                // Single "Certificate" column: resolve the fingerprint to a cert
+                // name when we hold it, else "unknown", always suffixed with the
+                // first 8 hex of the fingerprint to disambiguate like-named certs
+                // ("name: 0123abcd" / "unknown: 0123abcd"). The raw 64-char column
+                // is hidden in the dialog grid_view in favour of this.
+                $fp = strtolower(trim((string)($row['fingerprint'] ?? '')));
+                if ($fp === '') {
+                    $row['certificate'] = '';
+                } else {
+                    $short = substr($fp, 0, 8);
+                    $name = $certByFp[$fp] ?? gettext('unknown');
+                    $row['certificate'] = sprintf('%s: %s', $name, $short);
+                }
+            }
+            unset($row);
+        }
+        return $result;
+    }
+
+    public function getItemAction($uuid = null)
+    {
+        return $this->getBase('entry', 'pki.blocklist.entry', $uuid);
+    }
+
+    /**
+     * Add a new blocklist entry.
+     *
+     * The fingerprint must be 64 lowercase hex characters (sha256).
+     */
+    public function addItemAction()
+    {
+        if (!$this->request->isPost()) {
+            return ['result' => 'failed'];
+        }
+        $fpErr = $this->checkFingerprintFormat();
+        if ($fpErr !== null) {
+            return $fpErr;
+        }
+        $scopeErr = $this->checkScope();
+        if ($scopeErr !== null) {
+            return $scopeErr;
+        }
+        return $this->addBase('entry', 'pki.blocklist.entry');
+    }
+
+    /**
+     * Update an existing blocklist entry.
+     *
+     * The fingerprint is immutable (rejected if changed) and must remain a valid
+     * 64-char lowercase hex sha256.
+     */
+    public function setItemAction($uuid = null)
+    {
+        if (!$this->request->isPost()) {
+            return ['result' => 'failed'];
+        }
+        $immutErr = $this->checkFingerprintImmutable((string)$uuid);
+        if ($immutErr !== null) {
+            return $immutErr;
+        }
+        $fpErr = $this->checkFingerprintFormat();
+        if ($fpErr !== null) {
+            return $fpErr;
+        }
+        $scopeErr = $this->checkScope();
+        if ($scopeErr !== null) {
+            return $scopeErr;
+        }
+        return $this->setBase('entry', 'pki.blocklist.entry', $uuid);
+    }
+
+    public function delItemAction($uuid = null)
+    {
+        return $this->delBase('pki.blocklist.entry', $uuid);
+    }
+
+    public function toggleItemAction($uuid = null, $enabled = null)
+    {
+        return $this->toggleBase('pki.blocklist.entry', $uuid, $enabled);
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /api/nebula/blocklist/block_cert/<certref>
+    // -------------------------------------------------------------------------
+
+    /**
+     * Block a certificate globally by its certref.
+     *
+     * Looks up the certificate's fingerprint and expiry (valid_to) and adds a
+     * GLOBAL blocklist entry (empty instance) prefilled from them.  Idempotent:
+     * if that fingerprint is already globally blocked nothing is added and the
+     * call still reports success, so the "Block" button on the certificates page
+     * can be pressed more than once without creating duplicates.
+     *
+     * Returns:
+     *   {"result":"saved","uuid":"<uuid>"}        a new global block was created
+     *   {"result":"exists","uuid":"<uuid>"}       already globally blocked
+     *   {"result":"failed","error":"..."}         certref unknown / no fingerprint
+     */
+    public function blockCertAction($certref = null)
+    {
+        if (!$this->request->isPost()) {
+            return ['result' => 'failed', 'error' => 'POST required'];
+        }
+        if (empty($certref)) {
+            return ['result' => 'failed', 'error' => 'certref is required'];
+        }
+
+        $mdl = $this->getModel();
+
+        // Resolve the certificate node and pull its fingerprint + expiry.
+        $cert = null;
+        foreach ($mdl->pki->certificates->certificate->iterateItems() as $item) {
+            if ($item->getAttribute('uuid') === $certref) {
+                $cert = $item;
+                break;
+            }
+        }
+        if ($cert === null) {
+            return ['result' => 'failed', 'error' => 'certificate not found'];
+        }
+
+        $fingerprint = trim((string)$cert->fingerprint);
+        if (!preg_match('/^[0-9a-f]{64}$/', $fingerprint)) {
+            return ['result' => 'failed', 'error' => 'certificate has no usable fingerprint'];
+        }
+        // valid_to is stored as the cert's notAfter; copy it as the block expiry
+        // so a block for an expired cert is itself dropped at render time.
+        $expiry = trim((string)$cert->valid_to);
+
+        // Idempotency: skip if this fingerprint is already globally blocked.
+        foreach ($mdl->pki->blocklist->entry->iterateItems() as $entry) {
+            if (
+                (string)$entry->scope !== 'instance' &&
+                trim((string)$entry->fingerprint) === $fingerprint
+            ) {
+                return ['result' => 'exists', 'uuid' => $entry->getAttribute('uuid')];
+            }
+        }
+
+        // Create the global block (explicit global scope).
+        $node = $mdl->pki->blocklist->entry->Add();
+        $node->enabled     = '1';
+        $node->scope       = 'global';
+        $node->instance    = '';
+        $node->fingerprint = $fingerprint;
+        $node->expiry      = $expiry;
+        $node->certref     = $certref;
+        $node->descr       = sprintf('Blocked: %s', (string)$cert->descr);
+
+        $valMsgs = $mdl->performValidation();
+        if (count($valMsgs) > 0) {
+            $validations = [];
+            foreach ($valMsgs as $msg) {
+                $parts = explode('.', $msg->getField());
+                $validations[end($parts)] = $msg->getMessage();
+            }
+            return ['result' => 'failed', 'validations' => $validations];
+        }
+
+        $mdl->serializeToConfig();
+        Config::getInstance()->save();
+
+        return ['result' => 'saved', 'uuid' => $node->getAttribute('uuid')];
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /api/nebula/blocklist/import
+    // -------------------------------------------------------------------------
+
+    /**
+     * Bulk-import blocklist entries from a textarea — one fingerprint per line,
+     * optionally "fingerprint, description" (or "fingerprint description"). Each
+     * fingerprint is normalised to bare lowercase hex (colons/spaces stripped)
+     * and must be 64 hex chars. Lines that don't yield a valid fingerprint are
+     * reported in `invalid` and skipped; a fingerprint already blocked at the
+     * same scope is counted in `skipped`. All accepted entries are created at the
+     * chosen scope (global, or a single instance).
+     *
+     * Returns {result:'saved', added:int, skipped:int, invalid:[...]} or a
+     * failed-validation payload.
+     */
+    public function importAction()
+    {
+        if (!$this->request->isPost()) {
+            return ['result' => 'failed'];
+        }
+
+        $scope = $this->request->getPost('scope', 'string', 'global');
+        $instance = trim((string)$this->request->getPost('instance', 'string', ''));
+        $defaultDescr = trim((string)$this->request->getPost('descr', 'string', ''));
+        $raw = (string)$this->request->getPost('fingerprints', 'string', '');
+
+        if ($scope === 'instance' && $instance === '') {
+            return [
+                'result'      => 'failed',
+                'validations' => ['import.instance' => 'Select an instance, or set Scope to Global.'],
+            ];
+        }
+        if ($scope !== 'instance') {
+            $scope = 'global';
+            $instance = '';
+        }
+
+        $mdl = $this->getModel();
+
+        // Existing entries at this same scope, keyed by fingerprint, so a re-import
+        // is idempotent (already-blocked fingerprints are skipped, not duplicated).
+        $existing = [];
+        foreach ($mdl->pki->blocklist->entry->iterateItems() as $e) {
+            $eScope = (string)$e->scope === 'instance' ? 'instance' : 'global';
+            $eInst  = $eScope === 'instance' ? (string)$e->instance : '';
+            if ($eScope === $scope && $eInst === $instance) {
+                $existing[strtolower(trim((string)$e->fingerprint))] = true;
+            }
+        }
+
+        $added = 0;
+        $skipped = 0;
+        $invalid = [];
+        foreach (preg_split('/\r\n|\r|\n/', $raw) as $line) {
+            $line = trim($line);
+            if ($line === '') {
+                continue;
+            }
+            // Split off the first token (the fingerprint); the remainder, if any,
+            // is a per-line description that overrides the dialog default.
+            $parts = preg_split('/[\s,]+/', $line, 2);
+            $fp = strtolower(preg_replace('/[^0-9a-f]/i', '', $parts[0]));
+            $lineDescr = (count($parts) > 1) ? trim($parts[1]) : $defaultDescr;
+            if (!preg_match('/^[0-9a-f]{64}$/', $fp)) {
+                $invalid[] = $parts[0];
+                continue;
+            }
+            if (isset($existing[$fp])) {
+                $skipped++;
+                continue;
+            }
+            $node = $mdl->pki->blocklist->entry->Add();
+            $node->enabled     = '1';
+            $node->scope       = $scope;
+            $node->instance    = $instance;
+            $node->fingerprint = $fp;
+            $node->descr       = $lineDescr;
+            $existing[$fp] = true;
+            $added++;
+        }
+
+        if ($added > 0) {
+            $valMsgs = $mdl->performValidation();
+            if (count($valMsgs) > 0) {
+                $validations = [];
+                foreach ($valMsgs as $msg) {
+                    $parts = explode('.', $msg->getField());
+                    $validations[end($parts)] = $msg->getMessage();
+                }
+                return ['result' => 'failed', 'validations' => $validations];
+            }
+            $mdl->serializeToConfig();
+            Config::getInstance()->save();
+        }
+
+        return [
+            'result'  => 'saved',
+            'added'   => $added,
+            'skipped' => $skipped,
+            'invalid' => $invalid,
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /api/nebula/blocklist/purge_expired
+    // -------------------------------------------------------------------------
+
+    /**
+     * Delete every blocklist entry whose Expiry date has passed. The selection/
+     * deletion lives on the model (Nebula::purgeExpiredBlocklist); this action
+     * just persists and reports. Blocklist entries are referenced by nothing, so
+     * none are skipped — and this is the ONLY thing that removes an expired block
+     * (the renderer keeps blocking until the entry is purged).
+     *
+     * Returns {"result":"saved","removed":N}.
+     */
+    public function purgeExpiredAction()
+    {
+        if (!$this->request->isPost()) {
+            return ['result' => 'failed', 'error' => 'POST required'];
+        }
+
+        $mdl = $this->getModel();
+        $res = $mdl->purgeExpiredBlocklist();
+
+        if ($res['removed'] > 0) {
+            $valMsgs = $mdl->performValidation();
+            if (count($valMsgs) > 0) {
+                $validations = [];
+                foreach ($valMsgs as $msg) {
+                    $parts = explode('.', $msg->getField());
+                    $validations[end($parts)] = $msg->getMessage();
+                }
+                return ['result' => 'failed', 'validations' => $validations];
+            }
+            $mdl->serializeToConfig();
+            Config::getInstance()->save();
+        }
+
+        return ['result' => 'saved', 'removed' => $res['removed']];
+    }
+}

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/Api/CertificateController.php
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/Api/CertificateController.php
@@ -1,0 +1,657 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Nebula\Api;
+
+use OPNsense\Base\ApiMutableModelControllerBase;
+use OPNsense\Core\Backend;
+use OPNsense\Core\Config;
+
+/**
+ * Certificate API — host certificate CRUD, sign, import, and info for the Nebula PKI.
+ *
+ * Endpoints:
+ *   GET  /api/nebula/certificate/searchItem
+ *   GET  /api/nebula/certificate/getItem/<uuid>
+ *   POST /api/nebula/certificate/setItem/<uuid>
+ *   POST /api/nebula/certificate/delItem/<uuid>
+ *   POST /api/nebula/certificate/sign      — nebula-cert sign via configd
+ *   POST /api/nebula/certificate/import    — store a pre-signed cert + key
+ *   GET  /api/nebula/certificate/info/<uuid> — pki_print_cert details for GUI
+ *
+ * @package OPNsense\Nebula\Api
+ */
+class CertificateController extends ApiMutableModelControllerBase
+{
+    protected static $internalModelName = 'nebula';
+    protected static $internalModelClass = 'OPNsense\Nebula\Nebula';
+
+    // -------------------------------------------------------------------------
+    // Standard CRUD (no plain addItem — use sign or import)
+    // -------------------------------------------------------------------------
+
+    public function searchItemAction()
+    {
+        // The grid needs descr, cn, CA (resolved), curve, networks, unsafe_networks
+        // and valid_to.  searchBase()'s field list governs *searching*, not which
+        // columns are serialised, so we post-filter every row to strip the PEM
+        // material — in particular the private 'key' must NEVER reach the grid JSON.
+        $result = $this->searchBase(
+            'pki.certificates.certificate',
+            ['descr', 'cn', 'issuer', 'curve', 'networks', 'unsafe_networks', 'valid_to', 'has_key', 'fingerprint']
+        );
+
+        if (!empty($result['rows'])) {
+            // Build a fingerprint → display-name map of the current authorities so we
+            // can resolve each cert's CA dynamically from its stored issuer fingerprint.
+            // A cert whose issuer is not (yet) in the pool shows "unknown: <fingerprint>";
+            // it auto-resolves once that CA is imported.  We never rely on a stored
+            // ca_name — the issuer fingerprint is the source of truth.
+            $caByFingerprint = [];
+            foreach ($this->getModel()->pki->authorities->authority->iterateItems() as $ca) {
+                $fp = (string)$ca->fingerprint;
+                if ($fp !== '') {
+                    $caByFingerprint[$fp] = (string)$ca->cn !== '' ? (string)$ca->cn : (string)$ca->descr;
+                }
+            }
+
+            foreach ($result['rows'] as &$row) {
+                // Render the issuing CA as "name: 0123abcd" (CA name + first 8 hex
+                // of its fingerprint, which is the cert's stored issuer) so
+                // like-named CAs are distinguishable; "unknown: 0123abcd" when the
+                // issuer CA is not (yet) in the pool.
+                $issuer = (string)($row['issuer'] ?? '');
+                if ($issuer !== '' && isset($caByFingerprint[$issuer])) {
+                    $row['ca_name'] = $caByFingerprint[$issuer] . ': ' . substr($issuer, 0, 8);
+                } elseif ($issuer !== '') {
+                    $row['ca_name'] = gettext('unknown') . ': ' . substr($issuer, 0, 8);
+                } else {
+                    $row['ca_name'] = '';
+                }
+                unset($row['key'], $row['crt']);
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * Parse a nebula-cert print result and populate the computed read-only
+     * model fields (cn, valid_from, valid_to, fingerprint, is_ca) on $node.
+     *
+     * $printRes is the decoded ['info' => [...]] returned by pki_print_cert,
+     * where info[0] = {curve, details:{name,isCa,networks,groups,notBefore,
+     * notAfter,...}, fingerprint, ...}.
+     */
+    private function storeComputedFields($node, array $printRes): void
+    {
+        $entry   = $printRes['info'][0] ?? [];
+        $details = $entry['details'] ?? [];
+
+        $node->cn          = (string)($details['name'] ?? '');
+        $node->valid_from  = (string)($details['notBefore'] ?? '');
+        $node->valid_to    = (string)($details['notAfter'] ?? '');
+        $node->fingerprint = (string)($entry['fingerprint'] ?? '');
+        $node->is_ca       = !empty($details['isCa']) ? '1' : '0';
+        // issuer = fingerprint of the signing CA; the CA's display name is resolved
+        // dynamically at render in searchItemAction (never stored as ca_name).
+        $node->issuer      = (string)($details['issuer'] ?? '');
+
+        // Curve as embedded in the cert (info[0].curve, e.g. "CURVE25519" / "P256").
+        if (isset($entry['curve'])) {
+            $node->curve = (stripos((string)$entry['curve'], 'P256') !== false) ? 'P256' : '25519';
+        }
+    }
+
+    public function getItemAction($uuid = null)
+    {
+        return $this->getBase('certificate', 'pki.certificates.certificate', $uuid);
+    }
+
+    public function setItemAction($uuid = null)
+    {
+        return $this->setBase('certificate', 'pki.certificates.certificate', $uuid);
+    }
+
+    public function delItemAction($uuid = null)
+    {
+        // Referential integrity: refuse to delete a cert still referenced by an
+        // instance (certref). The check lives on the model so delete and purge
+        // share it.
+        $ref = $this->getModel()->certReferencedBy((string)$uuid);
+        if ($ref !== null) {
+            return [
+                'result'  => 'failed',
+                'message' => sprintf('Certificate is in use by %s and cannot be deleted.', $ref),
+            ];
+        }
+        return $this->delBase('pki.certificates.certificate', $uuid);
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /api/nebula/certificate/purge_expired
+    // -------------------------------------------------------------------------
+
+    /**
+     * Delete every expired certificate that is not still referenced by an
+     * instance; an expired-but-referenced cert is kept and named in the result.
+     * The selection/deletion lives on the model
+     * (Nebula::purgeExpiredCertificates); this action just persists and reports.
+     *
+     * Returns {"result":"saved","removed":N,"skipped":M,"skippedNames":[...]}.
+     */
+    public function purgeExpiredAction()
+    {
+        if (!$this->request->isPost()) {
+            return ['result' => 'failed', 'error' => 'POST required'];
+        }
+
+        $mdl = $this->getModel();
+        $res = $mdl->purgeExpiredCertificates();
+
+        if ($res['removed'] > 0) {
+            $valMsgs = $mdl->performValidation();
+            if (count($valMsgs) > 0) {
+                $validations = [];
+                foreach ($valMsgs as $msg) {
+                    $parts = explode('.', $msg->getField());
+                    $validations[end($parts)] = $msg->getMessage();
+                }
+                return ['result' => 'failed', 'validations' => $validations];
+            }
+            $mdl->serializeToConfig();
+            Config::getInstance()->save();
+        }
+
+        return [
+            'result'       => 'saved',
+            'removed'      => $res['removed'],
+            'skipped'      => count($res['skippedNames']),
+            'skippedNames' => $res['skippedNames'],
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Resolve a CA authority node from the model by UUID.
+     * Returns the authority node, or null if not found.
+     */
+    private function findCaByUuid($mdl, string $caref)
+    {
+        foreach ($mdl->pki->authorities->authority->iterateItems() as $node) {
+            if ($node->getAttribute('uuid') === $caref) {
+                return $node;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Call a nebula pki configd action with base64-encoded JSON params.
+     * Returns the decoded result array, or ['error' => '...'] on failure.
+     */
+    private function callPki(string $action, array $params): array
+    {
+        $b64 = base64_encode(json_encode($params));
+        $out = (new Backend())->configdpRun("nebula {$action}", [$b64]);
+        $res = json_decode($out, true);
+        if (!is_array($res)) {
+            return ['error' => 'configd returned non-JSON: ' . var_export($out, true)];
+        }
+        return $res;
+    }
+
+    /**
+     * Persist a certificate node: run validation, serialize, save.
+     * Returns ['result'=>'saved','uuid'=>...] or ['result'=>'failed','validations'=>[...]].
+     */
+    private function saveCertNode($mdl, $node): array
+    {
+        $uuid = $node->getAttribute('uuid');
+        $valMsgs = $mdl->performValidation();
+        if (count($valMsgs) > 0) {
+            $validations = [];
+            foreach ($valMsgs as $msg) {
+                $parts = explode('.', $msg->getField());
+                $leaf  = end($parts);
+                $validations[$leaf] = $msg->getMessage();
+            }
+            return ['result' => 'failed', 'validations' => $validations];
+        }
+
+        $mdl->serializeToConfig();
+        Config::getInstance()->save();
+
+        return ['result' => 'saved', 'uuid' => $uuid];
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /api/nebula/certificate/generate_file/<uuid>/<type>
+    // -------------------------------------------------------------------------
+
+    /**
+     * Return the stored PEM for a host certificate as a downloadable payload.
+     *
+     * Mirrors Trust\Api\CaController::generateFileAction — response is JSON so
+     * the caller uses download_content() in JS (Trust idiom).
+     *
+     * @param string $uuid certificate uuid
+     * @param string $type 'crt' (default) or 'key'
+     * @return array {'status':'ok','payload':'<PEM>','descr':'<name>'} or error
+     */
+    public function generateFileAction($uuid = null, $type = 'crt')
+    {
+        $result = ['status' => 'failed'];
+        if ($this->request->isPost() && !empty($uuid)) {
+            $node = null;
+            foreach ($this->getModel()->pki->certificates->certificate->iterateItems() as $item) {
+                if ($item->getAttribute('uuid') === $uuid) {
+                    $node = $item;
+                    break;
+                }
+            }
+            if ($node === null) {
+                $result['error'] = 'certificate not found';
+                return $result;
+            }
+            $result['descr'] = (string)$node->descr;
+            if ($type === 'crt') {
+                $crt = (string)$node->crt;
+                if ($crt === '') {
+                    $result['error'] = 'no certificate stored';
+                } else {
+                    $result['status']  = 'ok';
+                    $result['payload'] = $crt;
+                }
+            } elseif ($type === 'key') {
+                $key = (string)$node->key;
+                if ($key === '') {
+                    $result['error'] = 'no private key stored for this certificate';
+                } else {
+                    $result['status']  = 'ok';
+                    $result['payload'] = $key;
+                }
+            } else {
+                $result['error'] = 'unsupported type';
+            }
+        }
+        return $result;
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /api/nebula/certificate/sign
+    // -------------------------------------------------------------------------
+
+    /**
+     * Validate a Nebula PUBLIC key PEM string.
+     *
+     * Accepts any "-----BEGIN NEBULA ... PUBLIC KEY-----" header (ED25519,
+     * X25519, P256 variants).  Returns null on success, or a user-facing
+     * error string on failure.
+     */
+    private function validatePublicKeyPem(string $pub): ?string
+    {
+        if (!preg_match('/-----BEGIN NEBULA [A-Z0-9 ]*PUBLIC KEY-----/', $pub)) {
+            return 'not a valid Nebula public key';
+        }
+        return null;
+    }
+
+    /**
+     * Sign a new Nebula host certificate under an existing CA via configd.
+     *
+     * Request body (JSON or form-encoded):
+     *   descr          string  required  Human-readable label stored in the model
+     *   caref          string  required  UUID of the CA authority to sign with
+     *   name           string  required  Nebula cert name / hostname
+     *   networks       string  required  Comma-separated CIDR(s) — e.g. 10.10.0.1/24
+     *   groups         string  optional  Comma-separated group list
+     *   unsafe_networks string optional  Comma-separated unsafe CIDR(s)
+     *   duration_days  int     optional  Validity in days (omit or 0 to expire just before the CA)
+     *   public_key     string  optional  PEM public key from `nebula-cert keygen` (CSR flow).
+     *                                    When provided the private key is never sent to or stored
+     *                                    on the CA; the returned cert has has_key='0'.
+     *   passphrase     string  optional  Required only when the chosen CA's key is encrypted.
+     *                                    Forwarded to nebula-cert via NEBULA_CA_PASSPHRASE to
+     *                                    decrypt the CA key for this signing operation; never stored.
+     *
+     * Returns:
+     *   {"result":"saved","uuid":"<uuid>"}
+     *   {"result":"failed","error":"..."}
+     *   {"result":"failed","validations":{...}}
+     */
+    public function signAction()
+    {
+        if (!$this->request->isPost()) {
+            return ['result' => 'failed', 'error' => 'POST required'];
+        }
+
+        $descr           = trim($this->request->getPost('descr', 'string', ''));
+        $caref           = trim($this->request->getPost('caref', 'string', ''));
+        $name            = trim($this->request->getPost('name', 'string', ''));
+        $networks        = trim($this->request->getPost('networks', 'string', ''));
+        $groups          = $this->request->getPost('groups', 'string', '');
+        $unsafe_networks = $this->request->getPost('unsafe_networks', 'string', '');
+        $duration_days   = (int)$this->request->getPost('duration_days', 'int', 0);
+        $public_key      = $this->request->getPost('public_key', 'string', '');
+        // CA-key passphrase: NOT trimmed (whitespace may be significant) and NEVER
+        // stored — only forwarded to pki.php for an encrypted CA key.
+        $passphrase      = $this->request->getPost('passphrase', 'string', '');
+
+        // Input guards.
+        if ($name === '') {
+            return ['result' => 'failed', 'validations' => ['name' => 'name is required']];
+        }
+        // Description defaults to the certificate name when left blank (matches CA generate).
+        if ($descr === '') {
+            $descr = $name;
+        }
+        if ($caref === '') {
+            return ['result' => 'failed', 'validations' => ['caref' => 'caref is required']];
+        }
+        if ($networks === '') {
+            return ['result' => 'failed', 'validations' => ['networks' => 'networks is required']];
+        }
+
+        // Validate public_key PEM when provided (CSR flow).
+        if ($public_key !== '') {
+            $pubErr = $this->validatePublicKeyPem($public_key);
+            if ($pubErr !== null) {
+                return ['result' => 'failed', 'validations' => ['public_key' => $pubErr]];
+            }
+        }
+
+        // Resolve the CA authority from the model.
+        $mdl = $this->getModel();
+        $ca  = $this->findCaByUuid($mdl, $caref);
+        if ($ca === null) {
+            return ['result' => 'failed', 'validations' => ['caref' => 'unknown CA']];
+        }
+
+        $caCrt = (string)$ca->crt;
+        $caKey = (string)$ca->key;
+
+        if ($caCrt === '' || $caKey === '') {
+            return ['result' => 'failed', 'error' => 'CA has no certificate or key stored'];
+        }
+
+        // If the CA key is encrypted, a passphrase is mandatory to decrypt it for
+        // signing.  We trust the model's key_encrypted flag but also fall back to
+        // inspecting the PEM header so an older un-flagged row still behaves.
+        $caEncrypted = ((string)$ca->key_encrypted === '1') || (stripos($caKey, 'ENCRYPTED') !== false);
+        if ($caEncrypted && $passphrase === '') {
+            return [
+                'result'      => 'failed',
+                'validations' => ['passphrase' => 'this CA is encrypted; a passphrase is required'],
+            ];
+        }
+
+        // Build sign params and call configd.
+        // When duration_days is 0 / unset we omit duration_hours entirely so that
+        // nebula-cert uses its built-in default: the cert expires just before the CA.
+        $pkiParams = [
+            'name'     => $name,
+            'networks' => $networks,
+            'ca_crt'   => $caCrt,
+            'ca_key'   => $caKey,
+        ];
+        if ($duration_days > 0) {
+            $pkiParams['duration_hours'] = $duration_days * 24;
+        }
+        if ($groups !== '') {
+            $pkiParams['groups'] = $groups;
+        }
+        if ($unsafe_networks !== '') {
+            $pkiParams['unsafe_networks'] = $unsafe_networks;
+        }
+        // CSR flow: pass the public key; pki.php will use -in-pub and omit -out-key.
+        if ($public_key !== '') {
+            $pkiParams['in_pub'] = $public_key;
+        }
+        // Forward the passphrase for an encrypted CA key (never stored).
+        if ($passphrase !== '') {
+            $pkiParams['passphrase'] = $passphrase;
+        }
+
+        $res = $this->callPki('pki_sign_cert', $pkiParams);
+
+        // CSR mode returns key=''; generate-here mode returns a non-empty key.
+        if (!empty($res['error']) || empty($res['crt'])) {
+            $err = $res['error'] ?? 'configd returned no result';
+            // Map nebula-cert's encrypted-key failure to a friendly passphrase
+            // validation so the GUI highlights the passphrase field rather than a
+            // generic error banner.  nebula reports e.g.
+            // "error while parsing encrypted ca-key: invalid passphrase or corrupt
+            // private key".
+            if (stripos($err, 'invalid passphrase') !== false || stripos($err, 'encrypted ca-key') !== false) {
+                return ['result' => 'failed', 'validations' => ['passphrase' => 'invalid CA passphrase']];
+            }
+            return ['result' => 'failed', 'error' => $err];
+        }
+
+        // In generate-here mode the key must be present.
+        if ($public_key === '' && empty($res['key'])) {
+            return ['result' => 'failed', 'error' => 'configd returned no private key'];
+        }
+
+        // Store the signed certificate in the model.
+        $node = $mdl->pki->certificates->certificate->Add();
+        $node->descr           = $descr;
+        $node->origin          = 'signed';
+        $node->caref           = $caref;
+        $node->crt             = $res['crt'];
+        $node->key             = $res['key'] ?? '';
+        $node->networks        = $networks;
+        $node->groups          = $groups;
+        $node->unsafe_networks = $unsafe_networks;
+        $node->has_key         = ($res['key'] !== '') ? '1' : '0';
+
+        // Parse the freshly signed cert once and store its computed fields
+        // (including issuer = the signing CA's fingerprint, uniform with import).
+        // The CA's display name is resolved dynamically at render from issuer,
+        // so we do NOT store ca_name here.
+        $printRes = $this->callPki('pki_print_cert', ['crt' => $res['crt']]);
+        if (empty($printRes['error']) && !empty($printRes['info'])) {
+            $this->storeComputedFields($node, $printRes);
+        }
+
+        return $this->saveCertNode($mdl, $node);
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /api/nebula/certificate/import
+    // -------------------------------------------------------------------------
+
+    /**
+     * Validate a PEM-encoded Nebula private key string.
+     *
+     * Accepts any "-----BEGIN NEBULA ... PRIVATE KEY-----" header (ED25519,
+     * X25519, P256 variants).  Rejects encrypted keys (header contains
+     * "ENCRYPTED") and anything that does not look like a Nebula key PEM.
+     *
+     * Returns null on success, or a user-facing error string on failure.
+     */
+    private function validateKeyPem(string $key): ?string
+    {
+        // Must contain a NEBULA * PRIVATE KEY PEM header.
+        if (!preg_match('/-----BEGIN NEBULA [A-Z0-9 ]*PRIVATE KEY-----/', $key)) {
+            return 'not a valid Nebula private key';
+        }
+        // Encrypted keys are not supported (we store keys in plain config).
+        if (stripos($key, 'ENCRYPTED') !== false) {
+            return 'encrypted keys are not supported';
+        }
+        return null;
+    }
+
+    /**
+     * Import a pre-existing Nebula host certificate.
+     *
+     * Request body (JSON or form-encoded):
+     *   descr  string  required  Human-readable label
+     *   crt    string  required  PEM-encoded Nebula host certificate
+     *   key    string  optional  PEM-encoded private key
+     *
+     * The crt is validated via pki_print_cert before storage.  If the cert
+     * prints cleanly the networks/groups from the cert details are stored back
+     * into the model fields for display convenience.  The signing CA is NOT
+     * selected by the user — it is derived from the cert's issuer fingerprint
+     * (stored by storeComputedFields) and resolved to a name at render time.
+     *
+     * Returns:
+     *   {"result":"saved","uuid":"<uuid>"}
+     *   {"result":"failed","validations":{"crt":"..."}}
+     *   {"result":"failed","validations":{"descr":"..."}}
+     *   {"result":"failed","validations":{"key":"..."}}
+     */
+    public function importAction()
+    {
+        if (!$this->request->isPost()) {
+            return ['result' => 'failed', 'error' => 'POST required'];
+        }
+
+        $descr = trim($this->request->getPost('descr', 'string', ''));
+        $crt   = $this->request->getPost('crt', 'string', '');
+        $key   = $this->request->getPost('key', 'string', '');
+
+        if ($descr === '') {
+            return ['result' => 'failed', 'validations' => ['descr' => 'descr is required']];
+        }
+        if ($crt === '') {
+            return ['result' => 'failed', 'validations' => ['crt' => 'crt is required']];
+        }
+
+        // Validate the cert by calling pki_print_cert — rejects garbage.
+        $printRes = $this->callPki('pki_print_cert', ['crt' => $crt]);
+
+        if (!empty($printRes['error']) || empty($printRes['info'])) {
+            return [
+                'result'      => 'failed',
+                'validations' => ['crt' => 'not a valid Nebula certificate'],
+            ];
+        }
+
+        // Validate the private key if one was supplied.
+        if ($key !== '') {
+            $keyErr = $this->validateKeyPem($key);
+            if ($keyErr !== null) {
+                return ['result' => 'failed', 'validations' => ['key' => $keyErr]];
+            }
+        }
+
+        // Extract networks/groups/unsafe_networks from the print output if available.
+        // nebula-cert print -json returns an array; cert details are at [0].details.
+        $details              = $printRes['info'][0]['details'] ?? [];
+        $cert_networks        = '';
+        $cert_groups          = '';
+        $cert_unsafe_networks = '';
+        if (!empty($details['networks'])) {
+            $cert_networks = is_array($details['networks'])
+                ? implode(',', $details['networks'])
+                : (string)$details['networks'];
+        }
+        if (!empty($details['groups'])) {
+            $cert_groups = is_array($details['groups'])
+                ? implode(',', $details['groups'])
+                : (string)$details['groups'];
+        }
+        if (!empty($details['unsafeNetworks'])) {
+            $cert_unsafe_networks = is_array($details['unsafeNetworks'])
+                ? implode(',', $details['unsafeNetworks'])
+                : (string)$details['unsafeNetworks'];
+        }
+
+        $mdl  = $this->getModel();
+        $node = $mdl->pki->certificates->certificate->Add();
+        $node->descr           = $descr;
+        $node->origin          = 'imported';
+        $node->crt             = $crt;
+        $node->networks        = $cert_networks;
+        $node->groups          = $cert_groups;
+        $node->unsafe_networks = $cert_unsafe_networks;
+
+        if ($key !== '') {
+            $node->key     = $key;
+            $node->has_key = '1';
+        } else {
+            $node->has_key = '0';
+        }
+
+        // Store computed fields from the print output we already obtained above.
+        $this->storeComputedFields($node, $printRes);
+
+        return $this->saveCertNode($mdl, $node);
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /api/nebula/certificate/info/<uuid>
+    // -------------------------------------------------------------------------
+
+    /**
+     * Return parsed certificate details for the GUI details view.
+     *
+     * Returns:
+     *   {"info": [...]}   the array returned by pki_print_cert
+     *   {"result":"failed","error":"..."}  if uuid unknown or cert invalid
+     */
+    public function infoAction($uuid = null)
+    {
+        if (empty($uuid)) {
+            return ['result' => 'failed', 'error' => 'uuid is required'];
+        }
+
+        $mdl  = $this->getModel();
+        $node = null;
+        foreach ($mdl->pki->certificates->certificate->iterateItems() as $item) {
+            if ($item->getAttribute('uuid') === $uuid) {
+                $node = $item;
+                break;
+            }
+        }
+
+        if ($node === null) {
+            return ['result' => 'failed', 'error' => 'certificate not found'];
+        }
+
+        $crt = (string)$node->crt;
+        if ($crt === '') {
+            return ['result' => 'failed', 'error' => 'certificate has no crt data'];
+        }
+
+        $printRes = $this->callPki('pki_print_cert', ['crt' => $crt]);
+
+        if (!empty($printRes['error']) || empty($printRes['info'])) {
+            $err = $printRes['error'] ?? 'pki_print_cert returned no info';
+            return ['result' => 'failed', 'error' => $err];
+        }
+
+        return ['info' => $printRes['info']];
+    }
+}

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/Api/FirewallRuleController.php
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/Api/FirewallRuleController.php
@@ -1,0 +1,244 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Nebula\Api;
+
+use OPNsense\Base\ApiMutableModelControllerBase;
+use OPNsense\Core\Config;
+
+/**
+ * Firewall rule API — per-instance, identity-aware host firewall rules.
+ *
+ * Each rule targets one Nebula instance and may match traffic by host IP,
+ * certificate groups, CIDR, CA name, or CA fingerprint (sha).  At least one
+ * matcher field (host / groups / cidr / ca_name / ca_sha) must be non-empty
+ * for the rule to be valid.
+ *
+ * Endpoints:
+ *   GET  /api/nebula/firewall_rule/search_item[?instance=<uuid>]
+ *   GET  /api/nebula/firewall_rule/get_item/<uuid>
+ *   POST /api/nebula/firewall_rule/add_item
+ *   POST /api/nebula/firewall_rule/set_item/<uuid>
+ *   POST /api/nebula/firewall_rule/del_item/<uuid>
+ *   POST /api/nebula/firewall_rule/toggle_item/<uuid>[/<enabled>]
+ *
+ * @package OPNsense\Nebula\Api
+ */
+class FirewallRuleController extends ApiMutableModelControllerBase
+{
+    protected static $internalModelName = 'nebula';
+    protected static $internalModelClass = 'OPNsense\Nebula\Nebula';
+
+    // -------------------------------------------------------------------------
+    // Matcher-field validation
+    // -------------------------------------------------------------------------
+
+    /**
+     * The set of identity-matcher fields.  At least one must be non-empty on
+     * every rule (validated in addItemAction / setItemAction before save).
+     */
+    private static $matcherFields = ['host', 'groups', 'cidr', 'ca_name', 'ca_sha'];
+
+    /**
+     * Return a validations error array when the posted data has no matcher, or
+     * null when at least one matcher field is populated.
+     *
+     * @return array|null  null = valid; array = ['validations' => [...]]
+     */
+    private function checkMatcherPresent(): ?array
+    {
+        // The form posts the rule fields nested under the "rule" key, e.g.
+        // {"rule": {"host": "any", "group": "", ...}} — so we must read from
+        // there, NOT getPost('host'). A matcher counts as present when it is
+        // non-empty; `host: any` is the legitimate "match every host" choice
+        // and must satisfy the requirement.
+        $rule = $this->request->getPost('rule');
+        if (!is_array($rule)) {
+            $rule = [];
+        }
+        foreach (self::$matcherFields as $f) {
+            if (isset($rule[$f]) && trim((string)$rule[$f]) !== '') {
+                return null;
+            }
+        }
+        // Key the error with the model prefix (rule.<field>) on EVERY matcher so
+        // the dialog highlights the whole group (it's a "fill at least one" set).
+        $msg = 'Fill at least one matcher: host, groups, cidr, ca_name, or ca_sha.';
+        $validations = [];
+        foreach (self::$matcherFields as $f) {
+            $validations['rule.' . $f] = $msg;
+        }
+        return ['result' => 'failed', 'validations' => $validations];
+    }
+
+    /**
+     * Set of Nebula CA names (the cert-embedded `cn`) for every configured
+     * authority.  Used for ca_name referential integrity: a rule's ca_name
+     * matcher only makes sense when it names a CA this node actually trusts —
+     * a peer can only connect if its certificate chains to one of these.
+     *
+     * @return array<string,bool>  CA name => true
+     */
+    private function configuredCaNames(): array
+    {
+        $names = [];
+        foreach ($this->getModel()->pki->authorities->authority->iterateItems() as $auth) {
+            $cn = trim((string)$auth->cn);
+            if ($cn !== '') {
+                $names[$cn] = true;
+            }
+        }
+        return $names;
+    }
+
+    /**
+     * Validate the CA matchers on the posted rule:
+     *   - ca_name, when set, must name a configured CA (referential integrity);
+     *   - ca_sha, when set, must be a 64-char lowercase hex sha256 fingerprint.
+     *
+     * @return array|null  null = valid; array = ['validations' => [...]]
+     */
+    private function checkCaReferences(): ?array
+    {
+        $rule = $this->request->getPost('rule');
+        if (!is_array($rule)) {
+            $rule = [];
+        }
+        $validations = [];
+
+        $caName = isset($rule['ca_name']) ? trim((string)$rule['ca_name']) : '';
+        if ($caName !== '') {
+            $known = $this->configuredCaNames();
+            if (!isset($known[$caName])) {
+                $validations['rule.ca_name'] = sprintf(
+                    'No configured CA named "%s". Pick one from the list, or add the CA under Authorities.',
+                    $caName
+                );
+            }
+        }
+
+        $caSha = isset($rule['ca_sha']) ? trim((string)$rule['ca_sha']) : '';
+        if ($caSha !== '' && !preg_match('/^[0-9a-f]{64}$/', $caSha)) {
+            $validations['rule.ca_sha'] =
+                'CA fingerprint must be 64 lowercase hex characters (sha256).';
+        }
+
+        return empty($validations) ? null : ['result' => 'failed', 'validations' => $validations];
+    }
+
+    // -------------------------------------------------------------------------
+    // Standard CRUD
+    // -------------------------------------------------------------------------
+
+    /**
+     * Search firewall rules, optionally scoped to one instance.
+     *
+     * Pass ?instance=<uuid> to restrict the result set to rules whose
+     * `instance` field equals the given UUID.  Without the parameter all
+     * rules are returned.
+     */
+    public function searchItemAction()
+    {
+        $instanceUuid = trim($this->request->get('instance', 'string', ''));
+
+        $filter_funct = null;
+        if ($instanceUuid !== '') {
+            $filter_funct = function ($record) use ($instanceUuid) {
+                return (string)$record->instance === $instanceUuid;
+            };
+        }
+
+        return $this->searchBase(
+            'fwrules.rule',
+            [
+                'enabled', 'instance', 'direction', 'protocol', 'port', 'description',
+                // matcher fields — surfaced so the grid can render a "Match" summary
+                'host', 'groups', 'cidr', 'local_cidr', 'ca_name', 'ca_sha',
+            ],
+            null,
+            $filter_funct
+        );
+    }
+
+    public function getItemAction($uuid = null)
+    {
+        return $this->getBase('rule', 'fwrules.rule', $uuid);
+    }
+
+    /**
+     * Add a new firewall rule.
+     *
+     * Requires at least one matcher field (host/groups/cidr/ca_name/ca_sha).
+     */
+    public function addItemAction()
+    {
+        if (!$this->request->isPost()) {
+            return ['result' => 'failed'];
+        }
+        $matcherErr = $this->checkMatcherPresent();
+        if ($matcherErr !== null) {
+            return $matcherErr;
+        }
+        $caErr = $this->checkCaReferences();
+        if ($caErr !== null) {
+            return $caErr;
+        }
+        return $this->addBase('rule', 'fwrules.rule');
+    }
+
+    /**
+     * Update an existing firewall rule.
+     *
+     * Requires at least one matcher field (host/groups/cidr/ca_name/ca_sha).
+     */
+    public function setItemAction($uuid = null)
+    {
+        if (!$this->request->isPost()) {
+            return ['result' => 'failed'];
+        }
+        $matcherErr = $this->checkMatcherPresent();
+        if ($matcherErr !== null) {
+            return $matcherErr;
+        }
+        $caErr = $this->checkCaReferences();
+        if ($caErr !== null) {
+            return $caErr;
+        }
+        return $this->setBase('rule', 'fwrules.rule', $uuid);
+    }
+
+    public function delItemAction($uuid = null)
+    {
+        return $this->delBase('fwrules.rule', $uuid);
+    }
+
+    public function toggleItemAction($uuid = null, $enabled = null)
+    {
+        return $this->toggleBase('fwrules.rule', $uuid, $enabled);
+    }
+}

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/Api/InstanceController.php
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/Api/InstanceController.php
@@ -1,0 +1,386 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Nebula\Api;
+
+use OPNsense\Base\ApiMutableModelControllerBase;
+use OPNsense\Core\Backend;
+
+class InstanceController extends ApiMutableModelControllerBase
+{
+    protected static $internalModelName = 'nebula';
+    protected static $internalModelClass = 'OPNsense\Nebula\Nebula';
+
+    public function searchItemAction()
+    {
+        $result = $this->searchBase(
+            'instances.instance',
+            ['enabled', 'tun_name', 'description', 'listen_host', 'listen_port', 'am_lighthouse', 'certref']
+        );
+        // Enrich each visible row with the live daemon status so the grid's
+        // Status column renders data-driven. (The Tabulator-based bootgrid
+        // re-renders cells from the formatter, so an async per-row fill on the
+        // 'loaded' event does not persist — the value must be in the row data.)
+        if (!empty($result['rows']) && is_array($result['rows'])) {
+            $backend = new Backend();
+
+            // Build a certificate uuid -> description map so we can resolve each
+            // instance's certref to a readable name here.  A certref that points
+            // to a certificate which no longer exists (a dangling reference left
+            // by a deleted cert) is surfaced as "(deleted)" rather than rendering
+            // as a phantom name or an empty cell.
+            $certByUuid = [];
+            foreach ($this->getModel()->pki->certificates->certificate->iterateItems() as $cert) {
+                $certByUuid[$cert->getAttribute('uuid')] = [
+                    'descr' => (string)$cert->descr,
+                    'fp'    => (string)$cert->fingerprint,
+                ];
+            }
+
+            foreach ($result['rows'] as &$row) {
+                $uuid = $row['uuid'] ?? '';
+                $row['running'] = '0';
+                $row['pid'] = '';
+                if ($uuid !== '') {
+                    $st = json_decode(trim($backend->configdpRun('nebula status_instance', [$uuid])), true);
+                    if (is_array($st)) {
+                        $row['running'] = !empty($st['running']) ? '1' : '0';
+                        $row['pid'] = (isset($st['pid']) && $st['pid'] !== null) ? (string)$st['pid'] : '';
+                    }
+                }
+
+                // Resolve certref -> certificate description for the grid.  The
+                // searchBase 'certref' value is the raw stored uuid string.
+                $certref = trim((string)($row['certref'] ?? ''));
+                if ($certref === '') {
+                    $row['certificate'] = '';
+                } elseif (array_key_exists($certref, $certByUuid)) {
+                    // "name: 0123abcd" (descr + first 8 hex of the fingerprint) so
+                    // like-named host certs are distinguishable in the grid.
+                    $c = $certByUuid[$certref];
+                    $row['certificate'] = $c['fp'] !== ''
+                        ? $c['descr'] . ': ' . substr($c['fp'], 0, 8)
+                        : $c['descr'];
+                } else {
+                    $row['certificate'] = '(deleted)';
+                }
+            }
+            unset($row);
+        }
+        return $result;
+    }
+
+    public function getItemAction($uuid = null)
+    {
+        return $this->getBase('instance', 'instances.instance', $uuid);
+    }
+
+    /**
+     * Reject a posted instance whose listen_port or tun_name collides with an
+     * existing instance on the same host.  Two daemons cannot share a UDP listen
+     * port or a tun device name.
+     *
+     * The form posts the instance fields nested under the "instance" key (same
+     * gotcha as the firewall matcher validation), so we read from there.
+     *
+     * @param string|null $editUuid uuid being edited (excluded from the scan), or null on add
+     * @return array|null  null = no collision; array = ['result'=>'failed','validations'=>[...]]
+     */
+    private function checkUniqueListener(?string $editUuid): ?array
+    {
+        $instance = $this->request->getPost('instance');
+        if (!is_array($instance)) {
+            $instance = [];
+        }
+
+        $listenPort = isset($instance['listen_port']) ? trim((string)$instance['listen_port']) : '';
+        $tunName    = isset($instance['tun_name']) ? trim((string)$instance['tun_name']) : '';
+
+        // Port 0 = "random port"; it is allowed to repeat across instances.
+        $checkPort = ($listenPort !== '' && (int)$listenPort !== 0);
+        $checkTun  = ($tunName !== '');
+
+        if (!$checkPort && !$checkTun) {
+            return null;
+        }
+
+        foreach ($this->getModel()->instances->instance->iterateItems() as $node) {
+            if ($node->getAttribute('uuid') === $editUuid) {
+                continue; // exclude the row being edited
+            }
+            if ($checkPort && trim((string)$node->listen_port) === $listenPort) {
+                return [
+                    'result'      => 'failed',
+                    'validations' => ['instance.listen_port' => 'port already used by another instance'],
+                ];
+            }
+            if ($checkTun && trim((string)$node->tun_name) === $tunName) {
+                return [
+                    'result'      => 'failed',
+                    'validations' => ['instance.tun_name' => 'interface name already used by another instance'],
+                ];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Reject a posted instance whose stats telemetry block is missing the
+     * destination required by its selected type. nebula needs stats.host for
+     * graphite and stats.listen for prometheus; catching it here gives a field
+     * error instead of a late `nebula -test` failure on Apply. Blank stats_type
+     * (telemetry disabled) imposes no requirement.
+     *
+     * @return array|null  null = ok; array = failed-validation payload
+     */
+    private function checkStatsRequired(): ?array
+    {
+        $instance = $this->request->getPost('instance');
+        if (!is_array($instance)) {
+            return null;
+        }
+        $type = isset($instance['stats_type']) ? trim((string)$instance['stats_type']) : '';
+        if ($type === 'graphite' && trim((string)($instance['stats_host'] ?? '')) === '') {
+            return [
+                'result'      => 'failed',
+                'validations' => ['instance.stats_host' => 'host is required when stats type is graphite'],
+            ];
+        }
+        if ($type === 'prometheus' && trim((string)($instance['stats_listen'] ?? '')) === '') {
+            return [
+                'result'      => 'failed',
+                'validations' => ['instance.stats_listen' => 'listen is required when stats type is prometheus'],
+            ];
+        }
+        return null;
+    }
+
+    public function addItemAction()
+    {
+        if (!$this->request->isPost()) {
+            return ['result' => 'failed'];
+        }
+        $collision = $this->checkUniqueListener(null);
+        if ($collision !== null) {
+            return $collision;
+        }
+        $stats = $this->checkStatsRequired();
+        if ($stats !== null) {
+            return $stats;
+        }
+        return $this->addBase('instance', 'instances.instance');
+    }
+
+    public function setItemAction($uuid = null)
+    {
+        if (!$this->request->isPost()) {
+            return ['result' => 'failed'];
+        }
+        $collision = $this->checkUniqueListener($uuid);
+        if ($collision !== null) {
+            return $collision;
+        }
+        $stats = $this->checkStatsRequired();
+        if ($stats !== null) {
+            return $stats;
+        }
+        return $this->setBase('instance', 'instances.instance', $uuid);
+    }
+
+    public function delItemAction($uuid = null)
+    {
+        return $this->delBase('instances.instance', $uuid);
+    }
+
+    public function toggleItemAction($uuid = null, $enabled = null)
+    {
+        return $this->toggleBase('instances.instance', $uuid, $enabled);
+    }
+
+    /**
+     * Reload (restart) a single instance daemon by uuid.
+     * Mirrors the per-row reload button on Interfaces : Overview.
+     */
+    public function reloadAction($uuid = null)
+    {
+        if ($this->request->isPost() && $uuid != null) {
+            $backend = new Backend();
+            $output = trim((string)$backend->configdpRun('nebula restart_instance', [$uuid]));
+            // restart_instance (type:script_output) emits a JSON result line:
+            //   {"started":true}  or  {"started":false,"error":"<reason>"}
+            // Surface it to the UI so a failed (re)start shows the real reason
+            // instead of silently doing nothing.
+            $decoded = json_decode($output, true);
+            if (is_array($decoded) && array_key_exists('started', $decoded)) {
+                $started = !empty($decoded['started']);
+                return [
+                    'status'  => $started ? 'ok' : 'failed',
+                    'started' => $started,
+                    'error'   => $started ? '' : (string)($decoded['error'] ?? 'instance failed to start'),
+                ];
+            }
+            // Fall back to the raw output if it wasn't the expected JSON shape.
+            return ['status' => $output !== '' ? $output : 'ok', 'started' => true, 'error' => ''];
+        }
+        return ['status' => 'failed', 'started' => false, 'error' => 'bad request'];
+    }
+
+    /**
+     * Report the running status of a single instance by uuid.
+     * Returns ['running' => bool, 'pid' => int|null] (decoded from the
+     * status_instance configd action's JSON output).
+     */
+    public function statusAction($uuid = null)
+    {
+        if ($uuid != null) {
+            $backend = new Backend();
+            $output = (string)$backend->configdpRun('nebula status_instance', [$uuid]);
+            $decoded = json_decode(trim($output), true);
+            if (is_array($decoded)) {
+                return $decoded;
+            }
+        }
+        return ['running' => false, 'pid' => null];
+    }
+
+    /**
+     * Full diagnostics for one instance (Status page): the runtime data from the
+     * diag_instance configd action (process/tun/config-test), enriched with the
+     * model-held config and the resolved host certificate summary.
+     */
+    public function diagAction($uuid = null)
+    {
+        if (empty($uuid)) {
+            return ['found' => false];
+        }
+        $backend = new Backend();
+        $diag = json_decode(trim((string)$backend->configdpRun('nebula diag_instance', [$uuid])), true);
+        if (!is_array($diag)) {
+            $diag = ['running' => false, 'pid' => null];
+        }
+        $diag['found'] = false;
+
+        $mdl = $this->getModel();
+        foreach ($mdl->instances->instance->iterateItems() as $inst) {
+            if ($inst->getAttribute('uuid') !== $uuid) {
+                continue;
+            }
+            $diag['found'] = true;
+            $diag['description'] = (string)$inst->description;
+            $diag['enabled'] = ((string)$inst->enabled === '1');
+            $diag['am_lighthouse'] = ((string)$inst->am_lighthouse === '1');
+            // The sshd debug server is always on; diagnostics are available
+            // whenever the instance is running (no per-instance opt-in).
+            $diag['diag_available'] = !empty($diag['running']);
+            $diag['listen'] = (string)$inst->listen_host . ':' . (string)$inst->listen_port;
+
+            // Resolve the host certificate summary (certref -> certificate).
+            $certref = (string)$inst->certref;
+            $diag['cert'] = null;
+            if ($certref !== '') {
+                foreach ($mdl->pki->certificates->certificate->iterateItems() as $crt) {
+                    if ($crt->getAttribute('uuid') === $certref) {
+                        $diag['cert'] = [
+                            'name' => (string)$crt->cn,
+                            'descr' => (string)$crt->descr,
+                            'groups' => (string)$crt->groups,
+                            'networks' => (string)$crt->networks,
+                            'valid_to' => (string)$crt->valid_to,
+                        ];
+                        break;
+                    }
+                }
+            }
+            break;
+        }
+        return $diag;
+    }
+
+    /**
+     * Live tunnels/peers for one instance, read from its always-on nebula sshd
+     * debug server. Returns {ok:bool, peers?:..., error?:string}.
+     */
+    public function peersAction($uuid = null)
+    {
+        if (empty($uuid)) {
+            return ['ok' => false, 'error' => 'missing uuid'];
+        }
+        $backend = new Backend();
+        $decoded = json_decode(trim((string)$backend->configdpRun('nebula peers_instance', [$uuid])), true);
+        if (!is_array($decoded)) {
+            return ['ok' => false, 'error' => 'no response'];
+        }
+        return $decoded;
+    }
+
+    /**
+     * One-shot Status-page snapshot for all instances (status + diagnostics +
+     * cert + live peers/handshaking, one debug-server SSH per instance). Lets
+     * the Status page poll with a single request instead of ~4 per instance.
+     */
+    public function snapshotAction()
+    {
+        $backend = new Backend();
+        $decoded = json_decode(trim((string)$backend->configdpRun('nebula snapshot')), true);
+        if (!is_array($decoded)) {
+            return ['instances' => []];
+        }
+        return $decoded;
+    }
+
+    /**
+     * Run a whitelisted debug-server sub-action against a running instance (the
+     * Status page enrichment + verbs). POST so the mutating verbs (close,
+     * change-remote, create-tunnel) are not triggerable by a bare GET.
+     *
+     * @param string|null $uuid   instance uuid
+     * @param string|null $action sub-action (tunnel|cert|pending|deviceinfo|querylh|close|changeremote|createtunnel)
+     * @return array {ok:bool, ...}
+     */
+    public function debugAction($uuid = null, $action = null)
+    {
+        if (!$this->request->isPost()) {
+            return ['ok' => false, 'error' => 'POST required'];
+        }
+        if (empty($uuid) || empty($action)) {
+            return ['ok' => false, 'error' => 'missing parameters'];
+        }
+        $vpn = trim((string)$this->request->getPost('vpn', 'string', ''));
+        $remote = trim((string)$this->request->getPost('remote', 'string', ''));
+        $backend = new Backend();
+        $decoded = json_decode(
+            trim((string)$backend->configdpRun('nebula debug_instance', [$uuid, $action, $vpn, $remote])),
+            true
+        );
+        if (!is_array($decoded)) {
+            return ['ok' => false, 'error' => 'no response'];
+        }
+        return $decoded;
+    }
+}

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/Api/PeerController.php
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/Api/PeerController.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Nebula\Api;
+
+use OPNsense\Base\ApiControllerBase;
+use OPNsense\Core\Backend;
+
+/**
+ * Read-only live-peer feed for the Tunnels page. Returns every running
+ * instance's peers in one shot ({rows:[...]}); the browser fetches this once
+ * per Refresh and does all sort/filter/search/paging client-side.
+ */
+class PeerController extends ApiControllerBase
+{
+    public function searchAction()
+    {
+        $backend = new Backend();
+        $decoded = json_decode(trim((string)$backend->configdpRun('nebula peers_all')), true);
+        if (!is_array($decoded) || empty($decoded['ok']) || !isset($decoded['rows']) || !is_array($decoded['rows'])) {
+            return ['rows' => []];
+        }
+        return ['rows' => $decoded['rows']];
+    }
+}

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/Api/ServiceController.php
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/Api/ServiceController.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Nebula\Api;
+
+use OPNsense\Base\ApiMutableServiceControllerBase;
+use OPNsense\Nebula\Nebula;
+
+/**
+ * Class ServiceController
+ *
+ * Exposes /api/nebula/service/{start,stop,restart,reconfigure,status,dirty}. The
+ * base class drives each via the matching configd action (actions_nebula.conf),
+ * which shells out to scripts/OPNsense/Nebula/setup.php.
+ *
+ * $internalServiceTemplate is intentionally NOT set: setup.php renders each
+ * instance's YAML itself, so there is no template-engine target to reload (a
+ * non-existent template would make reconfigureAction throw). reconfigure still
+ * works via the default reconfigureForceRestart()==1 stop/start cycle.
+ *
+ * @package OPNsense\Nebula
+ */
+class ServiceController extends ApiMutableServiceControllerBase
+{
+    protected static $internalServiceClass = 'OPNsense\Nebula\Nebula';
+    protected static $internalServiceEnabled = 'general.enabled';
+    protected static $internalServiceName = 'nebula';
+
+    /**
+     * Apply pending config, then clear the subsystem-dirty marker so the "apply
+     * needed" banner goes away (and stays away across reloads).
+     */
+    public function reconfigureAction()
+    {
+        $result = parent::reconfigureAction();
+        if (is_array($result) && ($result['status'] ?? '') === 'ok') {
+            @unlink(Nebula::RECONFIGURE_MARKER);
+        }
+        return $result;
+    }
+
+    /**
+     * Report whether the Nebula config has unapplied changes. Consumed on page
+     * load so the apply banner persists until a reconfigure (mirrors IPsec's
+     * legacy_subsystem/status isDirty).
+     */
+    public function dirtyAction()
+    {
+        return ['isDirty' => file_exists(Nebula::RECONFIGURE_MARKER)];
+    }
+}

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/Api/ServiceController.php
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/Api/ServiceController.php
@@ -48,8 +48,24 @@ use OPNsense\Nebula\Nebula;
 class ServiceController extends ApiMutableServiceControllerBase
 {
     protected static $internalServiceClass = 'OPNsense\Nebula\Nebula';
-    protected static $internalServiceEnabled = 'general.enabled';
     protected static $internalServiceName = 'nebula';
+
+    /**
+     * Nebula has no global enable: each instance is its own daemon, gated by
+     * its own enabled flag (mirrors WireGuard's per-server/per-client model).
+     * The base class needs *some* answer to "is the service enabled?" so the
+     * standard reconfigure / status / widget plumbing works — answer "yes if
+     * any instance is enabled."
+     */
+    protected function serviceEnabled()
+    {
+        foreach (($this->getModel())->instances->instance->iterateItems() as $node) {
+            if ((string)$node->enabled === '1') {
+                return true;
+            }
+        }
+        return false;
+    }
 
     /**
      * Apply pending config, then clear the subsystem-dirty marker so the "apply

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/Api/StaticHostMapController.php
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/Api/StaticHostMapController.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Nebula\Api;
+
+use OPNsense\Base\ApiMutableModelControllerBase;
+
+/**
+ * Static-host-map API — per-instance "how to reach a peer before discovery"
+ * entries, mapping a peer's Nebula overlay IP to one or more underlay
+ * host:port addresses.
+ *
+ * Each entry targets one instance and is rendered into that instance's
+ * static_host_map map-of-lists (unioned with the legacy free-text field).
+ *
+ * Endpoints:
+ *   GET  /api/nebula/static_host_map/search_item[?instance=<uuid>]
+ *   GET  /api/nebula/static_host_map/get_item/<uuid>
+ *   POST /api/nebula/static_host_map/add_item
+ *   POST /api/nebula/static_host_map/set_item/<uuid>
+ *   POST /api/nebula/static_host_map/del_item/<uuid>
+ *   POST /api/nebula/static_host_map/toggle_item/<uuid>[/<enabled>]
+ *
+ * @package OPNsense\Nebula\Api
+ */
+class StaticHostMapController extends ApiMutableModelControllerBase
+{
+    protected static $internalModelName = 'nebula';
+    protected static $internalModelClass = 'OPNsense\Nebula\Nebula';
+
+    /**
+     * Search entries, optionally scoped to one instance (?instance=<uuid>).
+     * Resolves the instance uuid to its description for the grid.
+     */
+    public function searchItemAction()
+    {
+        $instanceUuid = trim($this->request->get('instance', 'string', ''));
+
+        $filter_funct = null;
+        if ($instanceUuid !== '') {
+            $filter_funct = function ($record) use ($instanceUuid) {
+                return (string)$record->instance === $instanceUuid;
+            };
+        }
+
+        $result = $this->searchBase(
+            'static_hostmap.entry',
+            ['enabled', 'instance', 'nebula_ip', 'addresses', 'description'],
+            null,
+            $filter_funct
+        );
+
+        if (!empty($result['rows']) && is_array($result['rows'])) {
+            $instByUuid = [];
+            foreach ($this->getModel()->instances->instance->iterateItems() as $inst) {
+                $instByUuid[$inst->getAttribute('uuid')] = (string)$inst->description;
+            }
+            foreach ($result['rows'] as &$row) {
+                $u = trim((string)($row['instance'] ?? ''));
+                $row['instance'] = array_key_exists($u, $instByUuid)
+                    ? $instByUuid[$u] : '(deleted)';
+            }
+            unset($row);
+        }
+        return $result;
+    }
+
+    public function getItemAction($uuid = null)
+    {
+        return $this->getBase('entry', 'static_hostmap.entry', $uuid);
+    }
+
+    public function addItemAction()
+    {
+        return $this->addBase('entry', 'static_hostmap.entry');
+    }
+
+    public function setItemAction($uuid = null)
+    {
+        return $this->setBase('entry', 'static_hostmap.entry', $uuid);
+    }
+
+    public function delItemAction($uuid = null)
+    {
+        return $this->delBase('static_hostmap.entry', $uuid);
+    }
+
+    public function toggleItemAction($uuid = null, $enabled = null)
+    {
+        return $this->toggleBase('static_hostmap.entry', $uuid, $enabled);
+    }
+}

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/Api/TunRouteController.php
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/Api/TunRouteController.php
@@ -1,0 +1,212 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Nebula\Api;
+
+use OPNsense\Base\ApiMutableModelControllerBase;
+use OPNsense\Firewall\Util;
+
+/**
+ * Tun-route API — per-instance per-route MTU overrides for Nebula overlay routes.
+ *
+ * Each entry targets one instance and renders into that instance's tun.routes
+ * list as {route, mtu}. These are overlay routes (the node's own subnets), not
+ * unsafe routes — see UnsafeRouteController for routing non-Nebula subnets.
+ *
+ * Endpoints:
+ *   GET  /api/nebula/tun_route/search_item[?instance=<uuid>]
+ *   GET  /api/nebula/tun_route/get_item/<uuid>
+ *   POST /api/nebula/tun_route/add_item
+ *   POST /api/nebula/tun_route/set_item/<uuid>
+ *   POST /api/nebula/tun_route/del_item/<uuid>
+ *   POST /api/nebula/tun_route/toggle_item/<uuid>[/<enabled>]
+ *
+ * @package OPNsense\Nebula\Api
+ */
+class TunRouteController extends ApiMutableModelControllerBase
+{
+    protected static $internalModelName = 'nebula';
+    protected static $internalModelClass = 'OPNsense\Nebula\Nebula';
+
+    public function searchItemAction()
+    {
+        $instanceUuid = trim($this->request->get('instance', 'string', ''));
+
+        $filter_funct = null;
+        if ($instanceUuid !== '') {
+            $filter_funct = function ($record) use ($instanceUuid) {
+                return (string)$record->instance === $instanceUuid;
+            };
+        }
+
+        $result = $this->searchBase(
+            'tun_routes.route',
+            ['enabled', 'instance', 'route', 'mtu', 'description'],
+            null,
+            $filter_funct
+        );
+
+        if (!empty($result['rows']) && is_array($result['rows'])) {
+            $instByUuid = [];
+            foreach ($this->getModel()->instances->instance->iterateItems() as $inst) {
+                $instByUuid[$inst->getAttribute('uuid')] = (string)$inst->description;
+            }
+            foreach ($result['rows'] as &$row) {
+                $u = trim((string)($row['instance'] ?? ''));
+                $row['instance'] = array_key_exists($u, $instByUuid)
+                    ? $instByUuid[$u] : '(deleted)';
+            }
+            unset($row);
+        }
+        return $result;
+    }
+
+    public function getItemAction($uuid = null)
+    {
+        // Use the "tunroute" wrapper key (not "route") so this dialog's field ids
+        // (tunroute.*) don't collide with the unsafe-route dialog (route.*) — both
+        // base_dialogs render on the same Routes page, so duplicate DOM ids would
+        // break form serialization and suppress the save/apply alert.
+        return $this->getBase('tunroute', 'tun_routes.route', $uuid);
+    }
+
+    /**
+     * Is $route (a CIDR) contained within one of the cert's $networks? Mirrors
+     * nebula's rule (overlay/route.go): the route's address must be inside a
+     * network AND the route must be at least as specific (bits >= network bits).
+     */
+    private function routeWithinNetworks(string $route, array $networks): bool
+    {
+        if (strpos($route, '/') === false) {
+            return false;
+        }
+        [$addr, $bits] = explode('/', $route, 2);
+        foreach ($networks as $net) {
+            $net = trim($net);
+            if ($net === '' || strpos($net, '/') === false) {
+                continue;
+            }
+            [, $netBits] = explode('/', $net, 2);
+            if (Util::isIPInCIDR($addr, $net) && (int)$bits >= (int)$netBits) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Reject a tun.route whose CIDR is not inside the instance certificate's VPN
+     * networks. Nebula enforces this only at daemon start (NOT in `nebula -test`),
+     * so without this check the GUI would accept a route that then fails to start
+     * with "Could not parse tun.routes ... not contained within the configured
+     * vpn networks". Unsafe routes are exempt — those are for external subnets.
+     *
+     * @return array|null  null = valid; array = ['result'=>'failed', ...]
+     */
+    private function checkRouteContainment(): ?array
+    {
+        $entry = $this->request->getPost('tunroute');
+        if (!is_array($entry)) {
+            $entry = [];
+        }
+        $route = isset($entry['route']) ? trim((string)$entry['route']) : '';
+        $instUuid = isset($entry['instance']) ? trim((string)$entry['instance']) : '';
+        if ($route === '' || $instUuid === '') {
+            return null; // required-ness handled by the model validators
+        }
+
+        // instance -> certref -> certificate -> networks
+        $mdl = $this->getModel();
+        $certref = '';
+        foreach ($mdl->instances->instance->iterateItems() as $inst) {
+            if ($inst->getAttribute('uuid') === $instUuid) {
+                $certref = (string)$inst->certref;
+                break;
+            }
+        }
+        $networks = [];
+        if ($certref !== '') {
+            foreach ($mdl->pki->certificates->certificate->iterateItems() as $crt) {
+                if ($crt->getAttribute('uuid') === $certref) {
+                    $networks = array_values(array_filter(
+                        array_map('trim', explode(',', (string)$crt->networks)),
+                        fn($s) => $s !== ''
+                    ));
+                    break;
+                }
+            }
+        }
+        if (empty($networks)) {
+            // No cert/networks to validate against (e.g. instance has no cert yet);
+            // let nebula surface any issue rather than block on incomplete data.
+            return null;
+        }
+        if (!$this->routeWithinNetworks($route, $networks)) {
+            return [
+                'result'      => 'failed',
+                'validations' => [
+                    'tunroute.route' => sprintf(
+                        'Route %s must be inside this instance\'s certificate network(s): %s. ' .
+                        'tun.routes only set the MTU for overlay routes — use Unsafe Routes for external subnets.',
+                        $route,
+                        implode(', ', $networks)
+                    ),
+                ],
+            ];
+        }
+        return null;
+    }
+
+    public function addItemAction()
+    {
+        $err = $this->checkRouteContainment();
+        if ($err !== null) {
+            return $err;
+        }
+        return $this->addBase('tunroute', 'tun_routes.route');
+    }
+
+    public function setItemAction($uuid = null)
+    {
+        $err = $this->checkRouteContainment();
+        if ($err !== null) {
+            return $err;
+        }
+        return $this->setBase('tunroute', 'tun_routes.route', $uuid);
+    }
+
+    public function delItemAction($uuid = null)
+    {
+        return $this->delBase('tun_routes.route', $uuid);
+    }
+
+    public function toggleItemAction($uuid = null, $enabled = null)
+    {
+        return $this->toggleBase('tun_routes.route', $uuid, $enabled);
+    }
+}

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/Api/UnsafeRouteController.php
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/Api/UnsafeRouteController.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Nebula\Api;
+
+use OPNsense\Base\ApiMutableModelControllerBase;
+
+/**
+ * Unsafe-routes API — per-instance routes for non-Nebula subnets reached over
+ * the overlay via a Nebula peer.
+ *
+ * Each route targets one instance and is rendered into that instance's
+ * tun.unsafe_routes list as {route, via, [mtu], [metric], install}. The peer
+ * named by `via` must carry the route as a subnet in its certificate.
+ *
+ * Endpoints:
+ *   GET  /api/nebula/unsafe_route/search_item[?instance=<uuid>]
+ *   GET  /api/nebula/unsafe_route/get_item/<uuid>
+ *   POST /api/nebula/unsafe_route/add_item
+ *   POST /api/nebula/unsafe_route/set_item/<uuid>
+ *   POST /api/nebula/unsafe_route/del_item/<uuid>
+ *   POST /api/nebula/unsafe_route/toggle_item/<uuid>[/<enabled>]
+ *
+ * @package OPNsense\Nebula\Api
+ */
+class UnsafeRouteController extends ApiMutableModelControllerBase
+{
+    protected static $internalModelName = 'nebula';
+    protected static $internalModelClass = 'OPNsense\Nebula\Nebula';
+
+    /**
+     * Search routes, optionally scoped to one instance (?instance=<uuid>).
+     * Resolves the instance uuid to its description for the grid.
+     */
+    public function searchItemAction()
+    {
+        $instanceUuid = trim($this->request->get('instance', 'string', ''));
+
+        $filter_funct = null;
+        if ($instanceUuid !== '') {
+            $filter_funct = function ($record) use ($instanceUuid) {
+                return (string)$record->instance === $instanceUuid;
+            };
+        }
+
+        $result = $this->searchBase(
+            'unsafe_routes.route',
+            ['enabled', 'instance', 'route', 'via', 'mtu', 'metric', 'install', 'description'],
+            null,
+            $filter_funct
+        );
+
+        if (!empty($result['rows']) && is_array($result['rows'])) {
+            $instByUuid = [];
+            foreach ($this->getModel()->instances->instance->iterateItems() as $inst) {
+                $instByUuid[$inst->getAttribute('uuid')] = (string)$inst->description;
+            }
+            foreach ($result['rows'] as &$row) {
+                $u = trim((string)($row['instance'] ?? ''));
+                $row['instance'] = array_key_exists($u, $instByUuid)
+                    ? $instByUuid[$u] : '(deleted)';
+            }
+            unset($row);
+        }
+        return $result;
+    }
+
+    public function getItemAction($uuid = null)
+    {
+        return $this->getBase('route', 'unsafe_routes.route', $uuid);
+    }
+
+    public function addItemAction()
+    {
+        return $this->addBase('route', 'unsafe_routes.route');
+    }
+
+    public function setItemAction($uuid = null)
+    {
+        return $this->setBase('route', 'unsafe_routes.route', $uuid);
+    }
+
+    public function delItemAction($uuid = null)
+    {
+        return $this->delBase('unsafe_routes.route', $uuid);
+    }
+
+    public function toggleItemAction($uuid = null, $enabled = null)
+    {
+        return $this->toggleBase('unsafe_routes.route', $uuid, $enabled);
+    }
+}

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/AuthoritiesController.php
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/AuthoritiesController.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Nebula;
+
+use OPNsense\Base\IndexController as BaseIndexController;
+
+class AuthoritiesController extends BaseIndexController
+{
+    public function indexAction()
+    {
+        $this->view->title = gettext('Nebula');
+
+        // Authority grid (uses dialogAuthority for edit); default table id.
+        $this->view->formDialogAuthority   = $this->getForm('dialogAuthority');
+        // Insert a "Fingerprint" column (first 8 hex, client-side formatter) as
+        // the second column — right after Name — so like-named CAs are
+        // distinguishable. The search endpoint already returns each CA's
+        // fingerprint. Splice rather than append so it lands second, not last.
+        $grid = $this->getFormGrid('dialogAuthority');
+        array_splice($grid['fields'], 1, 0, [[
+            'column-id'  => 'fingerprint',
+            'label'      => gettext('Fingerprint'),
+            'type'       => 'string',
+            'visible'    => 'true',
+            'sortable'   => 'false',
+            'identifier' => 'false',
+            'width'      => '9em',
+            'formatter'  => 'nebula_fp8',
+        ]]);
+        $this->view->formGridAuthority     = $grid;
+
+        // Custom-action dialogs (generate / import — not standard CRUD).
+        $this->view->formAuthorityGenerate = $this->getForm('dialogAuthorityGenerate');
+        $this->view->formAuthorityImport   = $this->getForm('dialogAuthorityImport');
+
+        $this->view->pick('OPNsense/Nebula/authorities');
+    }
+}

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/BlocklistController.php
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/BlocklistController.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Nebula;
+
+use OPNsense\Base\IndexController as BaseIndexController;
+
+class BlocklistController extends BaseIndexController
+{
+    public function indexAction()
+    {
+        $this->view->title = gettext('Nebula');
+
+        // Blocklist-entry grid + edit dialog (standard CRUD via UIBootgrid).
+        $this->view->formDialogBlocklistEntry = $this->getForm('dialogBlocklistEntry');
+        // The "Applies to" column resolves scope/instance to a description in
+        // BlocklistController (API) searchItemAction, so it renders straight from
+        // the row data. The "Certificate" column is computed (each fingerprint
+        // cross-referenced against the configured certs); append it in PHP because
+        // a Volt `formGrid + {'fields': ...}` merge silently drops the override
+        // (same reason as the Firewall "Match" column).
+        $grid = $this->getFormGrid('dialogBlocklistEntry');
+        $grid['fields'][] = [
+            'column-id'  => 'certificate',
+            'label'      => gettext('Certificate'),
+            'type'       => 'string',
+            'visible'    => 'true',
+            'sortable'   => 'false',
+            'identifier' => 'false',
+        ];
+        $this->view->formGridBlocklistEntry = $grid;
+
+        // Bulk-import dialog (custom action — manual POST, not standard CRUD).
+        $this->view->formBlocklistImport = $this->getForm('dialogBlocklistImport');
+
+        $this->view->pick('OPNsense/Nebula/blocklist');
+    }
+}

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/CertificatesController.php
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/CertificatesController.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Nebula;
+
+use OPNsense\Base\IndexController as BaseIndexController;
+
+class CertificatesController extends BaseIndexController
+{
+    public function indexAction()
+    {
+        $this->view->title = gettext('Nebula');
+
+        // Certificate grid (uses dialogCertificate for edit); default table id.
+        $this->view->formDialogCertificate = $this->getForm('dialogCertificate');
+        // Insert a "Fingerprint" column (first 8 hex) as the second column — right
+        // after Name — to disambiguate like-named certs. searchItemAction now
+        // returns each cert's own fingerprint. Splice so it lands second.
+        $grid = $this->getFormGrid('dialogCertificate');
+        array_splice($grid['fields'], 1, 0, [[
+            'column-id'  => 'fingerprint',
+            'label'      => gettext('Fingerprint'),
+            'type'       => 'string',
+            'visible'    => 'true',
+            'sortable'   => 'false',
+            'identifier' => 'false',
+            'width'      => '9em',
+            'formatter'  => 'nebula_fp8',
+        ]]);
+        $this->view->formGridCertificate   = $grid;
+
+        // Custom-action dialogs (sign / import — not standard CRUD).
+        $this->view->formCertificateSign   = $this->getForm('dialogCertificateSign');
+        $this->view->formCertificateImport = $this->getForm('dialogCertificateImport');
+
+        $this->view->pick('OPNsense/Nebula/certificates');
+    }
+}

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/FirewallController.php
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/FirewallController.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Nebula;
+
+use OPNsense\Base\IndexController as BaseIndexController;
+
+class FirewallController extends BaseIndexController
+{
+    public function indexAction()
+    {
+        $this->view->title = gettext('Nebula');
+
+        // Firewall-rule grid + edit dialog (standard CRUD via UIBootgrid).
+        $this->view->formDialogFirewallRule = $this->getForm('dialogFirewallRule');
+        // Append a computed "Match" column (rendered by the nebula_fw_match
+        // formatter). Done here in PHP: a Volt `formGrid + {'fields': ...}` merge
+        // is a PHP array union that keeps the LEFT operand's existing 'fields'
+        // and silently drops the override, so the extra column never renders.
+        $grid = $this->getFormGrid('dialogFirewallRule');
+        $grid['fields'][] = [
+            'column-id'  => 'match',
+            'label'      => gettext('Match'),
+            'type'       => 'string',
+            'visible'    => 'true',
+            'sortable'   => 'false',
+            'identifier' => 'false',
+            'formatter'  => 'nebula_fw_match',
+        ];
+        $this->view->formGridFirewallRule = $grid;
+
+        $this->view->pick('OPNsense/Nebula/firewall');
+    }
+}

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/IndexController.php
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/IndexController.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Nebula;
+
+use OPNsense\Base\IndexController as BaseIndexController;
+
+class IndexController extends BaseIndexController
+{
+    /**
+     * Pull in the bootstrap date picker so the blocklist Expiry field (and any
+     * other date field) gets a calendar affordance. Loaded for every Nebula page;
+     * the library is small and shared across core.
+     */
+    protected function templateJSIncludes()
+    {
+        $result = parent::templateJSIncludes();
+        $result[] = '/ui/js/bootstrap-datepicker.min.js';
+        return $result;
+    }
+
+    protected function templateCssIncludes()
+    {
+        $result = parent::templateCssIncludes();
+        $result[] = '/ui/css/bootstrap-datepicker3.min.css';
+        return $result;
+    }
+
+    public function indexAction()
+    {
+        // The GUI is split into three submenu pages (Instances / Authorities /
+        // Host Certificates). Keep the bare /ui/nebula/ URL working by sending
+        // it to the Instances page.
+        $this->response->redirect('/ui/nebula/instances', true);
+    }
+}

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/InstancesController.php
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/InstancesController.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Nebula;
+
+use OPNsense\Base\IndexController as BaseIndexController;
+
+class InstancesController extends BaseIndexController
+{
+    public function indexAction()
+    {
+        $this->view->title = gettext('Nebula');
+
+        // NOTE: do NOT pass a grid_id to getFormGrid() — let the table id default
+        // to the form name ('dialogInstance'). With separate pages there is no
+        // tab-pane <div> to collide with, so the default id is unique.
+        $this->view->formDialogInstance = $this->getForm('dialogInstance');
+
+        // Build the Instances grid columns EXPLICITLY rather than from the form.
+        // getFormGrid() turns every <field> with an <id> into a column unless it
+        // carries <grid_view><ignore>true</ignore></grid_view> — and the model
+        // exposes the whole Nebula config surface (60+ fields, several with no
+        // grid_view at all), so left to itself the grid is unusably wide. Instead
+        // we take getFormGrid's output only to reuse its column definitions
+        // (label/formatter/width for the fields we want), then assemble a short,
+        // ordered whitelist. Every other field stays editable in the dialog; it
+        // just is not a grid column. Two columns are computed (no backing model
+        // field) so they could not be declared in the form at all:
+        //   - "Listen"  combined host:port, IPv6-bracketed (nebula_listen)
+        //   - "Status"  live running indicator (nebula_status)
+        $grid = $this->getFormGrid('dialogInstance');
+
+        // Index the auto-generated columns by id, and keep the hidden uuid
+        // identifier column bootgrid needs for row identity.
+        $byId = [];
+        $identifier = null;
+        foreach ($grid['fields'] as $field) {
+            if (($field['identifier'] ?? '') === 'true') {
+                $identifier = $field;
+            }
+            if (!empty($field['column-id'])) {
+                $byId[$field['column-id']] = $field;
+            }
+        }
+
+        // "Interface" — the system device name (tun_name). It is no longer an
+        // editable form field (auto-managed, read-only, like wireguard's wgN), so
+        // it is injected here as a plain column; the search endpoint returns
+        // tun_name in the row data.
+        $interfaceCol = [
+            'column-id'  => 'tun_name',
+            'label'      => gettext('Interface'),
+            'type'       => 'string',
+            'visible'    => 'true',
+            'sortable'   => 'true',
+            'identifier' => 'false',
+            'width'      => '10em',
+        ];
+        $listenCol = [
+            'column-id'  => 'listen',
+            'label'      => gettext('Listen'),
+            'type'       => 'string',
+            'visible'    => 'true',
+            'sortable'   => 'false',
+            'identifier' => 'false',
+            'formatter'  => 'nebula_listen',
+        ];
+        $statusCol = [
+            'column-id'  => 'status',
+            'label'      => gettext('Status'),
+            'type'       => 'string',
+            'visible'    => 'true',
+            'sortable'   => 'false',
+            'identifier' => 'false',
+            'width'      => '5em',
+            'formatter'  => 'nebula_status',
+        ];
+
+        // The visible column set, left to right. 'listen' and 'status' are the
+        // computed columns; the rest reuse the form-derived definitions.
+        $fields = [];
+        if ($identifier !== null) {
+            $fields[] = $identifier; // hidden uuid column (row identity)
+        }
+        if (isset($byId['enabled'])) {
+            $fields[] = $byId['enabled'];
+        }
+        $fields[] = $interfaceCol; // Interface (device name) — injected, not in form
+        foreach (['description', 'am_lighthouse'] as $id) {
+            if (isset($byId[$id])) {
+                $fields[] = $byId[$id];
+            }
+        }
+        $fields[] = $listenCol;
+        if (isset($byId['certref'])) {
+            $fields[] = $byId['certref'];
+        }
+        $fields[] = $statusCol;
+
+        $grid['fields'] = $fields;
+        $this->view->formGridInstance = $grid;
+
+        $this->view->pick('OPNsense/Nebula/instances');
+    }
+}

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/RoutesController.php
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/RoutesController.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Nebula;
+
+use OPNsense\Base\IndexController as BaseIndexController;
+
+class RoutesController extends BaseIndexController
+{
+    public function indexAction()
+    {
+        $this->view->title = gettext('Nebula');
+
+        // Tab 1: unsafe routes (route non-Nebula subnets over the overlay).
+        $this->view->formDialogUnsafeRoute = $this->getForm('dialogUnsafeRoute');
+        $this->view->formGridUnsafeRoute = $this->getFormGrid('dialogUnsafeRoute');
+
+        // Tab 2: per-route MTU overrides for overlay routes (tun.routes).
+        $this->view->formDialogTunRoute = $this->getForm('dialogTunRoute');
+        $this->view->formGridTunRoute = $this->getFormGrid('dialogTunRoute');
+
+        // Tab 3: static host map (reach a peer by its Nebula IP before discovery).
+        $this->view->formDialogStaticHostMap = $this->getForm('dialogStaticHostMap');
+        $this->view->formGridStaticHostMap = $this->getFormGrid('dialogStaticHostMap');
+
+        $this->view->pick('OPNsense/Nebula/routes');
+    }
+}

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/StatusController.php
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/StatusController.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Nebula;
+
+use OPNsense\Base\IndexController as BaseIndexController;
+
+class StatusController extends BaseIndexController
+{
+    public function indexAction()
+    {
+        $this->view->title = gettext('Nebula');
+        $this->view->pick('OPNsense/Nebula/status');
+    }
+}

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/TunnelsController.php
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/TunnelsController.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Nebula;
+
+use OPNsense\Base\IndexController as BaseIndexController;
+
+class TunnelsController extends BaseIndexController
+{
+    public function indexAction()
+    {
+        $this->view->title = gettext('Nebula');
+        $this->view->pick('OPNsense/Nebula/tunnels');
+    }
+}

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/forms/dialogAuthority.xml
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/forms/dialogAuthority.xml
@@ -1,0 +1,63 @@
+<form>
+    <!-- Computed / read-only grid columns. type=ignore keeps them out of the
+         edit form (only descr is editable) while still rendering as columns. -->
+    <field>
+        <id>authority.cn</id>
+        <label>Name</label>
+        <type>ignore</type>
+        <grid_view>
+            <sequence>10</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>authority.descr</id>
+        <label>Description</label>
+        <type>text</type>
+        <help>Human-readable label for this certificate authority (stored in OPNsense only).</help>
+        <grid_view>
+            <sequence>20</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>authority.curve</id>
+        <label>Curve</label>
+        <type>ignore</type>
+        <grid_view>
+            <sequence>23</sequence>
+            <width>80</width>
+        </grid_view>
+    </field>
+    <field>
+        <id>authority.networks</id>
+        <label>Networks</label>
+        <type>ignore</type>
+        <grid_view>
+            <sequence>25</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>authority.unsafe_networks</id>
+        <label>Unsafe networks</label>
+        <type>ignore</type>
+        <grid_view>
+            <sequence>27</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>authority.valid_to</id>
+        <label>Valid until</label>
+        <type>ignore</type>
+        <grid_view>
+            <sequence>30</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>authority.can_sign</id>
+        <label>Can sign</label>
+        <type>ignore</type>
+        <grid_view>
+            <sequence>40</sequence>
+            <formatter>boolean</formatter>
+        </grid_view>
+    </field>
+</form>

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/forms/dialogAuthorityGenerate.xml
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/forms/dialogAuthorityGenerate.xml
@@ -1,0 +1,56 @@
+<form>
+    <field>
+        <id>authority.name</id>
+        <label>Name</label>
+        <type>text</type>
+        <help>Nebula CA name embedded in the certificate (required).</help>
+    </field>
+    <field>
+        <id>authority.descr</id>
+        <label>Description</label>
+        <type>text</type>
+        <help>Optional human-readable label stored only in the OPNsense model. Defaults to Name if left blank.</help>
+    </field>
+    <field>
+        <id>authority.curve</id>
+        <label>Curve</label>
+        <type>dropdown</type>
+        <help>Elliptic-curve algorithm to use when generating the CA key pair.</help>
+    </field>
+    <field>
+        <id>authority.duration_days</id>
+        <label>Duration (days)</label>
+        <type>text</type>
+        <help>Validity period in days. Default is 365.</help>
+    </field>
+    <field>
+        <id>authority.networks</id>
+        <label>Networks</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <allownew>true</allownew>
+        <help>Optional CIDRs this CA is restricted to sign for. Add each as a tag.</help>
+    </field>
+    <field>
+        <id>authority.unsafe_networks</id>
+        <label>Unsafe Networks</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <allownew>true</allownew>
+        <help>Optional CIDRs excluded from this CA's signing scope. Add each as a tag.</help>
+    </field>
+    <field>
+        <id>authority.groups</id>
+        <label>Groups</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <allownew>true</allownew>
+        <help>Optional groups this CA is restricted to sign for. Add each as a tag.</help>
+    </field>
+    <field>
+        <id>authority.passphrase</id>
+        <label>Passphrase</label>
+        <type>password</type>
+        <help>Optional: encrypt the CA private key with this passphrase. You'll be asked for it each time you sign. Leave empty for an unencrypted key.</help>
+    </field>
+</form>

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/forms/dialogAuthorityImport.xml
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/forms/dialogAuthorityImport.xml
@@ -1,0 +1,20 @@
+<form>
+    <field>
+        <id>authority.descr</id>
+        <label>Description</label>
+        <type>text</type>
+        <help>Human-readable name for this certificate authority.</help>
+    </field>
+    <field>
+        <id>authority.crt</id>
+        <label>Certificate (PEM)</label>
+        <type>textbox</type>
+        <help>PEM-encoded Nebula CA certificate.</help>
+    </field>
+    <field>
+        <id>authority.key</id>
+        <label>Private Key (PEM)</label>
+        <type>textbox</type>
+        <help>PEM-encoded CA private key. May be omitted for trust-anchor-only imports.</help>
+    </field>
+</form>

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/forms/dialogBlocklistEntry.xml
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/forms/dialogBlocklistEntry.xml
@@ -1,0 +1,69 @@
+<form>
+    <field>
+        <id>entry.enabled</id>
+        <label>Enabled</label>
+        <type>checkbox</type>
+        <grid_view>
+            <width>6em</width>
+            <type>boolean</type>
+            <formatter>rowtoggle</formatter>
+            <sequence>1</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>entry.scope</id>
+        <label>Scope</label>
+        <type>dropdown</type>
+        <help>Global blocks the certificate on every instance; This instance blocks it on only the selected instance.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+    <field>
+        <id>entry.instance</id>
+        <label>Applies to</label>
+        <type>dropdown</type>
+        <help>The instance this block applies to. Used only when Scope is &quot;This instance&quot;.</help>
+        <allownull>true</allownull>
+        <grid_view>
+            <sequence>2</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>entry.certref</id>
+        <label>Certificate</label>
+        <type>dropdown</type>
+        <help>Pick a known certificate to block — this fills and locks the fingerprint (and expiry) below. To block a certificate you do not hold, leave this blank and paste its fingerprint instead.</help>
+        <allownull>true</allownull>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+    <field>
+        <id>entry.fingerprint</id>
+        <label>Fingerprint (sha256)</label>
+        <type>text</type>
+        <help>The 64-character lowercase hex sha256 fingerprint of the certificate to block. Editable only when no certificate is chosen above; colons/spaces are stripped automatically. Immutable once saved.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+    <field>
+        <id>entry.descr</id>
+        <label>Description</label>
+        <type>text</type>
+        <help>Optional human-readable label for this blocklist entry.</help>
+        <grid_view>
+            <sequence>4</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>entry.expiry</id>
+        <label>Expiry</label>
+        <type>text</type>
+        <help>Optional date after which this entry becomes eligible for "Purge expired" (pick from the calendar, or type YYYY-MM-DD). The block stays in effect until you purge it. Leave empty to keep it indefinitely.</help>
+        <grid_view>
+            <sequence>5</sequence>
+        </grid_view>
+    </field>
+</form>

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/forms/dialogBlocklistImport.xml
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/forms/dialogBlocklistImport.xml
@@ -1,0 +1,26 @@
+<form>
+    <field>
+        <id>import.scope</id>
+        <label>Scope</label>
+        <type>dropdown</type>
+        <help>Global blocks the certificates on every instance; This instance blocks them on only the selected instance.</help>
+    </field>
+    <field>
+        <id>import.instance</id>
+        <label>Applies to</label>
+        <type>dropdown</type>
+        <help>The instance these blocks apply to. Used only when Scope is &quot;This instance&quot;.</help>
+    </field>
+    <field>
+        <id>import.descr</id>
+        <label>Default description</label>
+        <type>text</type>
+        <help>Optional label applied to every imported entry that does not carry its own description.</help>
+    </field>
+    <field>
+        <id>import.fingerprints</id>
+        <label>Fingerprints</label>
+        <type>textbox</type>
+        <help>One sha256 fingerprint per line, optionally followed by a comma (or space) and a description, e.g. &quot;0123abcd...ef, compromised laptop&quot;. Colons/spaces inside a fingerprint are stripped; each must resolve to 64 hex characters. Invalid lines are reported and skipped; fingerprints already blocked at this scope are skipped.</help>
+    </field>
+</form>

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/forms/dialogCertificate.xml
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/forms/dialogCertificate.xml
@@ -1,0 +1,75 @@
+<form>
+    <!-- Computed / read-only grid columns. type=ignore keeps them out of the
+         edit form (only descr is editable) while still rendering as columns. -->
+    <field>
+        <id>certificate.cn</id>
+        <label>Name</label>
+        <type>ignore</type>
+        <grid_view>
+            <sequence>10</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>certificate.descr</id>
+        <label>Description</label>
+        <type>text</type>
+        <help>Human-readable label for this host certificate (stored in OPNsense only).</help>
+        <grid_view>
+            <sequence>20</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>certificate.ca_name</id>
+        <label>CA</label>
+        <type>ignore</type>
+        <grid_view>
+            <sequence>30</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>certificate.curve</id>
+        <label>Curve</label>
+        <type>ignore</type>
+        <grid_view>
+            <sequence>35</sequence>
+            <width>80</width>
+        </grid_view>
+    </field>
+    <field>
+        <id>certificate.networks</id>
+        <label>Networks</label>
+        <type>ignore</type>
+        <grid_view>
+            <sequence>40</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>certificate.unsafe_networks</id>
+        <label>Unsafe networks</label>
+        <type>ignore</type>
+        <grid_view>
+            <sequence>45</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>certificate.valid_to</id>
+        <label>Valid until</label>
+        <type>ignore</type>
+        <grid_view>
+            <sequence>50</sequence>
+        </grid_view>
+    </field>
+    <!-- Assignable = a private key is held locally (has_key), so this cert can be
+         assigned to an instance. CSR-signed / external certs are keyless and show
+         "no" (record only; the requester holds the key). Mirrors the Authorities
+         "Can sign" column. -->
+    <field>
+        <id>certificate.has_key</id>
+        <label>Assignable</label>
+        <type>ignore</type>
+        <grid_view>
+            <sequence>55</sequence>
+            <formatter>boolean</formatter>
+        </grid_view>
+    </field>
+</form>

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/forms/dialogCertificateImport.xml
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/forms/dialogCertificateImport.xml
@@ -1,0 +1,20 @@
+<form>
+    <field>
+        <id>certificate.descr</id>
+        <label>Description</label>
+        <type>text</type>
+        <help>Human-readable label for this host certificate.</help>
+    </field>
+    <field>
+        <id>certificate.crt</id>
+        <label>Certificate (PEM)</label>
+        <type>textbox</type>
+        <help>PEM-encoded Nebula host certificate.</help>
+    </field>
+    <field>
+        <id>certificate.key</id>
+        <label>Private Key (PEM)</label>
+        <type>textbox</type>
+        <help>PEM-encoded host private key. Required if this node will run Nebula.</help>
+    </field>
+</form>

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/forms/dialogCertificateSign.xml
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/forms/dialogCertificateSign.xml
@@ -1,0 +1,62 @@
+<form>
+    <field>
+        <id>certificate.name</id>
+        <label>Name</label>
+        <type>text</type>
+        <help>Nebula certificate name / hostname (embedded in the certificate).</help>
+    </field>
+    <field>
+        <id>certificate.descr</id>
+        <label>Description</label>
+        <type>text</type>
+        <help>Human-readable label for this host certificate. Defaults to the name if left empty.</help>
+    </field>
+    <field>
+        <id>certificate.caref</id>
+        <label>Certificate Authority</label>
+        <type>dropdown</type>
+        <help>The Nebula CA that will sign this host certificate.</help>
+    </field>
+    <field>
+        <id>certificate.passphrase</id>
+        <label>CA Passphrase</label>
+        <type>password</type>
+        <help>Required when the selected CA's private key is encrypted. Supplied per signing operation and never stored.</help>
+    </field>
+    <field>
+        <id>certificate.public_key</id>
+        <label>Public Key (CSR)</label>
+        <type>textbox</type>
+        <help>Optional: paste a node's Nebula public key (from `nebula-cert keygen`) to sign it as a CSR — the private key stays on the node and is never sent to or stored on this CA (recommended). Leave empty to generate the key here and download it.</help>
+    </field>
+    <field>
+        <id>certificate.networks</id>
+        <label>Networks</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <allownew>true</allownew>
+        <help>CIDR(s) assigned to this node, e.g. 10.10.0.1/24. Add each as a tag.</help>
+    </field>
+    <field>
+        <id>certificate.unsafe_networks</id>
+        <label>Unsafe Networks</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <allownew>true</allownew>
+        <help>Optional unsafe (excluded) CIDRs. Add each as a tag.</help>
+    </field>
+    <field>
+        <id>certificate.groups</id>
+        <label>Groups</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <allownew>true</allownew>
+        <help>Optional group membership. Add each as a tag.</help>
+    </field>
+    <field>
+        <id>certificate.duration_days</id>
+        <label>Duration (days)</label>
+        <type>text</type>
+        <help>Days the certificate is valid. Leave empty to expire just before the signing CA (recommended).</help>
+    </field>
+</form>

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/forms/dialogFirewallRule.xml
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/forms/dialogFirewallRule.xml
@@ -1,0 +1,125 @@
+<form>
+    <field>
+        <id>rule.enabled</id>
+        <label>Enabled</label>
+        <type>checkbox</type>
+        <grid_view>
+            <width>6em</width>
+            <type>boolean</type>
+            <formatter>rowtoggle</formatter>
+            <sequence>1</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>rule.instance</id>
+        <label>Instance</label>
+        <type>dropdown</type>
+        <help>The Nebula instance this rule applies to.</help>
+        <grid_view>
+            <sequence>2</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>rule.direction</id>
+        <label>Direction</label>
+        <type>dropdown</type>
+        <help>Whether this rule governs inbound or outbound traffic on the overlay.</help>
+        <grid_view>
+            <width>7em</width>
+            <sequence>3</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>rule.protocol</id>
+        <label>Protocol</label>
+        <type>dropdown</type>
+        <help>IP protocol this rule matches (any, tcp, udp or icmp).</help>
+        <grid_view>
+            <width>6em</width>
+            <sequence>4</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>rule.port</id>
+        <label>Port</label>
+        <type>text</type>
+        <help>Port or port range this rule matches. Use &apos;any&apos; for all ports, &apos;0&apos; for fragments, or a range like &apos;200-300&apos;.</help>
+        <grid_view>
+            <width>6em</width>
+            <sequence>5</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>rule.description</id>
+        <label>Description</label>
+        <type>text</type>
+        <help>Optional human-readable label for this rule.</help>
+        <grid_view>
+            <sequence>6</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Match (fill at least one)</label>
+    </field>
+    <field>
+        <id>rule.host</id>
+        <label>Host</label>
+        <type>text</type>
+        <help>A remote certificate name, or &apos;any&apos; to match every host.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+    <field>
+        <id>rule.groups</id>
+        <label>Groups</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <allownew>true</allownew>
+        <help>Match peers in ALL of these groups (AND logic). Add each group as a tag. A single group matches peers in that group.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+    <field>
+        <id>rule.cidr</id>
+        <label>CIDR</label>
+        <type>text</type>
+        <help>Match peers whose overlay IP is within this remote CIDR.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+    <field>
+        <id>rule.ca_name</id>
+        <label>CA name</label>
+        <type>text</type>
+        <help>Match peers whose certificate was issued by a CA with this name. Type a name or pick one of your configured CAs; it must name a CA this node trusts.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+    <field>
+        <id>rule.ca_sha</id>
+        <label>CA fingerprint (sha)</label>
+        <type>text</type>
+        <help>Match peers whose issuing CA has this fingerprint.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Local side (optional)</label>
+    </field>
+    <field>
+        <id>rule.local_cidr</id>
+        <label>Local CIDR</label>
+        <type>text</type>
+        <help>Optional: restrict the rule to traffic for this local-side CIDR (used with unsafe routes). Leave empty for the node&apos;s own address.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+</form>

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/forms/dialogInstance.xml
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/forms/dialogInstance.xml
@@ -1,0 +1,835 @@
+<form>
+    <field>
+        <type>header</type>
+        <label>General</label>
+    </field>
+    <field>
+        <id>instance.enabled</id>
+        <label>Enabled</label>
+        <type>checkbox</type>
+        <grid_view>
+            <width>6em</width>
+            <type>boolean</type>
+            <formatter>rowtoggle</formatter>
+            <sequence>1</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>instance.description</id>
+        <label>Description</label>
+        <type>text</type>
+        <grid_view>
+            <sequence>3</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>instance.certref</id>
+        <label>Certificate</label>
+        <type>dropdown</type>
+        <help>The Nebula host certificate this instance uses. Required to run.</help>
+        <grid_view>
+            <sequence>6</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>instance.trusted_cas</id>
+        <label>Trusted CAs</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <help>Additional CAs whose peers this instance accepts. The CA that signed this instance&apos;s own certificate is always trusted; leave empty to trust only that one. Select more to accept peers issued by other CAs (cross-CA trust).</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+    <!-- GENERATED:instance-fields START -->
+    <field>
+        <type>header</type>
+        <label>PKI</label>
+    </field>
+    <field>
+        <id>instance.pki_disconnect_invalid</id>
+        <label>Disconnect on invalid certificate</label>
+        <type>checkbox</type>
+        <help>Disconnect any tunnel whose certificate becomes invalid (expired or revoked) while the tunnel is active.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.pki_initiating_version</id>
+        <label>Initiating cert version</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>Nebula handshake version to use when initiating a new tunnel (1 = legacy, 2 = post-quantum-resistant).</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <type>header</type>
+        <label>Static map (DNS)</label>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>instance.static_map_cadence</id>
+        <label>Static map DNS cadence</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>How often to re-resolve hostnames listed in static_host_map via DNS.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.static_map_network</id>
+        <label>Static map address family</label>
+        <type>dropdown</type>
+        <advanced>true</advanced>
+        <help>Address family to use when re-resolving static_host_map hostnames: ip4, ip6, or ip (either).</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.static_map_lookup_timeout</id>
+        <label>Static map lookup timeout</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>DNS lookup timeout for each static_host_map hostname resolution attempt.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <type>header</type>
+        <label>Lighthouse</label>
+    </field>
+    <field>
+        <id>instance.am_lighthouse</id>
+        <label>Lighthouse</label>
+        <type>checkbox</type>
+        <help>Designate this node as a lighthouse (discovery server); lighthouse nodes should not list other lighthouses.</help>
+        <grid_view>
+            <width>6em</width>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+            <sequence>4</sequence>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.lighthouse_serve_dns</id>
+        <label>Serve DNS</label>
+        <type>checkbox</type>
+        <help>Enable the DNS server on this lighthouse so peers can resolve Nebula hostnames via DNS queries.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.lighthouse_interval</id>
+        <label>Lighthouse update interval</label>
+        <type>text</type>
+        <help>How often (in seconds) non-lighthouse nodes send keepalive/update messages to their lighthouses.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.lighthouse_dns_host</id>
+        <label>DNS listen address</label>
+        <type>text</type>
+        <help>IP address the lighthouse DNS server binds to (only used when serve_dns is true).</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.lighthouse_dns_port</id>
+        <label>DNS port</label>
+        <type>text</type>
+        <help>UDP port the lighthouse DNS server listens on (only used when serve_dns is true).</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.lighthouse_hosts</id>
+        <label>Lighthouse hosts</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <allownew>true</allownew>
+        <help>Lighthouse nebula IPs this node reports to / queries. Add each as a tag. Leave empty on a lighthouse.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.lighthouse_advertise_addrs</id>
+        <label>Advertise addresses</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <allownew>true</allownew>
+        <help>Extra routable host:port (or host:0) to advertise to lighthouses. Add each as a tag.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <type>header</type>
+        <label>Listen</label>
+    </field>
+    <field>
+        <id>instance.listen_host</id>
+        <label>Listen address</label>
+        <type>text</type>
+        <help>IP address (or hostname) Nebula binds its UDP listener to; &quot;::&quot; listens on all interfaces (IPv4+IPv6).</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.listen_port</id>
+        <label>Listen port</label>
+        <type>text</type>
+        <help>UDP port Nebula listens on; 0 lets the OS assign a random port (useful for roaming clients).</help>
+        <grid_view>
+            <width>7em</width>
+            <sequence>5</sequence>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.firewall_interfaces</id>
+        <label>Firewall interfaces</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <help>Interface(s) on which to automatically allow inbound traffic to this instance's UDP listen port. Defaults to WAN; clear to add no firewall rule (e.g. if you manage the rule yourself).</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.listen_batch</id>
+        <label>Listen batch size</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>Maximum number of packets to read from the UDP socket in a single syscall (Linux recvmmsg batch size).</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.listen_read_buffer</id>
+        <label>UDP receive buffer</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>SO_RCVBUF size in bytes for the UDP socket; leave unset to use the OS default.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.listen_write_buffer</id>
+        <label>UDP send buffer</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>SO_SNDBUF size in bytes for the UDP socket; leave unset to use the OS default.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.listen_send_recv_error</id>
+        <label>Send error on write failure</label>
+        <type>dropdown</type>
+        <advanced>true</advanced>
+        <help>Controls when ICMP unreachable errors are sent back on write failures: always, never, or only to private IPs.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.listen_accept_recv_error</id>
+        <label>Send error on read failure</label>
+        <type>dropdown</type>
+        <advanced>true</advanced>
+        <help>Controls when ICMP unreachable errors are sent back on read failures: always, never, or only to private IPs.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.listen_so_mark</id>
+        <label>Socket mark (SO_MARK)</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>SO_MARK value to set on the UDP socket; useful for policy-based routing (0 = disabled).</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <type>header</type>
+        <label>Punchy (NAT traversal)</label>
+    </field>
+    <field>
+        <id>instance.punchy_punch</id>
+        <label>Hole punching</label>
+        <type>checkbox</type>
+        <help>Send UDP hole-punching packets to peers behind NAT to keep the path open.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.punchy_respond</id>
+        <label>Respond to hole punch</label>
+        <type>checkbox</type>
+        <advanced>true</advanced>
+        <help>Respond to hole-punch requests from peers (enables bidirectional hole-punching).</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.punchy_delay</id>
+        <label>Hole punch delay</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>How long to wait before sending the first hole-punch packet after a handshake.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.punchy_respond_delay</id>
+        <label>Hole punch respond delay</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>Delay before responding to a hole-punch request; adds jitter to avoid thundering-herd.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <type>header</type>
+        <label>Cipher</label>
+    </field>
+    <field>
+        <id>instance.cipher</id>
+        <label>Cipher</label>
+        <type>dropdown</type>
+        <help>Encryption cipher for tunnel traffic: chachapoly (ChaCha20-Poly1305) or aes (AES-256-GCM).</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <type>header</type>
+        <label>Preferred ranges</label>
+    </field>
+    <field>
+        <id>instance.preferred_ranges</id>
+        <label>Preferred ranges</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <allownew>true</allownew>
+        <help>Local network CIDRs preferred for handshakes. Add each as a tag.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <type>header</type>
+        <label>Relay</label>
+    </field>
+    <field>
+        <id>instance.relay_am_relay</id>
+        <label>Act as relay</label>
+        <type>checkbox</type>
+        <help>Act as a relay node, forwarding encrypted traffic between peers that cannot reach each other directly.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.relay_use_relays</id>
+        <label>Use relays</label>
+        <type>checkbox</type>
+        <help>Allow this node to use relay nodes when a direct path to a peer is unavailable.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.relay_relays</id>
+        <label>Relays</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <allownew>true</allownew>
+        <help>Nebula IPs to use as relays. Add each as a tag.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <type>header</type>
+        <label>TUN interface</label>
+    </field>
+    <!-- instance.tun_name (the system device name, e.g. nebula3f9a2c) is NOT
+         shown here: it is system-managed (auto-assigned, stable, not renameable,
+         like WireGuard's wgN) so there is nothing to edit. It appears only as the
+         "Interface" grid column (injected in InstancesController). -->
+    <field>
+        <id>instance.tun_disabled</id>
+        <label>Disable TUN interface</label>
+        <type>checkbox</type>
+        <advanced>true</advanced>
+        <help>Disable the TUN interface entirely (node participates in the overlay as a relay/lighthouse only, no IP traffic).</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.tun_drop_local_broadcast</id>
+        <label>Drop local broadcast</label>
+        <type>checkbox</type>
+        <advanced>true</advanced>
+        <help>Drop packets destined for the local broadcast address of the Nebula subnet before they enter the TUN.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.tun_drop_multicast</id>
+        <label>Drop multicast</label>
+        <type>checkbox</type>
+        <advanced>true</advanced>
+        <help>Drop all multicast packets at the TUN interface.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.tun_tx_queue</id>
+        <label>TX queue length</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>Transmit queue length for the TUN device (Linux txqueuelen / number of packets buffered before dropping).</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.tun_mtu</id>
+        <label>MTU</label>
+        <type>text</type>
+        <help>MTU of the Nebula TUN interface; lower values leave headroom for the outer UDP/IP headers.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.tun_use_system_route_table</id>
+        <label>Use system route table</label>
+        <type>checkbox</type>
+        <advanced>true</advanced>
+        <help>Install Nebula routes into the system routing table instead of handling them internally (useful on BSD/macOS).</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.tun_use_system_route_table_buffer_size</id>
+        <label>System route table buffer size</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>Size of the route-change notification buffer when use_system_route_table is enabled; 0 = OS default.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <type>header</type>
+        <label>Tunnels</label>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>instance.tunnels_drop_inactive</id>
+        <label>Drop inactive tunnels</label>
+        <type>checkbox</type>
+        <advanced>true</advanced>
+        <help>Tear down tunnels that have had no traffic for the inactivity_timeout period.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.tunnels_inactivity_timeout</id>
+        <label>Inactivity timeout</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>How long a tunnel may be idle before it is considered inactive (only used when drop_inactive is true).</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <type>header</type>
+        <label>Logging</label>
+    </field>
+    <field>
+        <id>instance.logging_level</id>
+        <label>Log level</label>
+        <type>dropdown</type>
+        <help>Log verbosity level: debug produces the most output; panic the least.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.logging_format</id>
+        <label>Log format</label>
+        <type>dropdown</type>
+        <advanced>true</advanced>
+        <help>Log output format: text (human-readable) or json (structured, for log aggregators).</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.logging_disable_timestamp</id>
+        <label>Disable log timestamp</label>
+        <type>checkbox</type>
+        <advanced>true</advanced>
+        <help>Omit the timestamp field from log entries (useful when the log collector adds its own timestamp).</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.logging_timestamp_format</id>
+        <label>Log timestamp format</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>Go time-format string for log timestamps (e.g. 2006-01-02T15:04:05Z07:00); leave empty for the default.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <type>header</type>
+        <label>Firewall defaults</label>
+    </field>
+    <field>
+        <id>instance.firewall_outbound_action</id>
+        <label>Default outbound action</label>
+        <type>dropdown</type>
+        <help>Default action for outbound packets that match no firewall rule: drop (silently) or reject (send ICMP unreachable).</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.firewall_inbound_action</id>
+        <label>Default inbound action</label>
+        <type>dropdown</type>
+        <help>Default action for inbound packets that match no firewall rule: drop (silently) or reject (send ICMP unreachable).</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.firewall_default_local_cidr_any</id>
+        <label>Default local CIDR = any</label>
+        <type>checkbox</type>
+        <advanced>true</advanced>
+        <help>When true, firewall rules without an explicit local_cidr match any local address (pre-v1.9 behaviour).</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.firewall_conntrack_tcp_timeout</id>
+        <label>Conntrack TCP timeout</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>Idle timeout for TCP conntrack entries; connections with no matching traffic are evicted after this period.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.firewall_conntrack_udp_timeout</id>
+        <label>Conntrack UDP timeout</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>Idle timeout for UDP conntrack entries.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.firewall_conntrack_default_timeout</id>
+        <label>Conntrack default timeout</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>Idle timeout for conntrack entries that are neither TCP nor UDP.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <type>header</type>
+        <label>Routines</label>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>instance.routines</id>
+        <label>Routines</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>Number of goroutine workers for packet I/O; increasing can improve throughput on multi-core hosts.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <type>header</type>
+        <label>Handshakes</label>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>instance.handshakes_try_interval</id>
+        <label>Handshake retry interval</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>How long to wait between successive handshake attempts to the same peer.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.handshakes_retries</id>
+        <label>Handshake retries</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>Maximum number of handshake attempts before giving up and waiting for the peer to initiate.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.handshakes_query_buffer</id>
+        <label>Handshake query buffer</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>Size of the channel buffer for outbound lighthouse queries triggered by pending handshakes.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+
+    <field>
+        <id>instance.handshakes_trigger_buffer</id>
+        <label>Handshake trigger buffer</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>Size of the channel buffer that queues packets waiting to trigger a new handshake.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+<!-- GENERATED:instance-fields END -->
+    <field>
+        <type>header</type>
+        <label>Lighthouse allow-lists</label>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>instance.lighthouse_remote_allow_list</id>
+        <label>Remote allow list</label>
+        <type>textbox</type>
+        <advanced>true</advanced>
+        <help>Filter which lighthouse-reported remote addresses this node will try. One &apos;CIDR = true|false&apos; per line; the most specific match wins. Example: 10.0.0.0/8 = false then 10.42.42.0/24 = true.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+    <field>
+        <id>instance.lighthouse_local_allow_list</id>
+        <label>Local allow list</label>
+        <type>textbox</type>
+        <advanced>true</advanced>
+        <help>Filter which local addresses are advertised to lighthouses. One &apos;CIDR = true|false&apos; per line. To match by interface name, write &apos;interface &lt;regex&gt; = true|false&apos; (rendered under the interfaces: key). Example: 10.0.0.0/8 = true / interface docker.* = false.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+    <field>
+        <id>instance.lighthouse_remote_allow_ranges</id>
+        <label>Remote allow ranges (experimental)</label>
+        <type>textbox</type>
+        <advanced>true</advanced>
+        <help>Experimental. Per-VPN-network remote allow lists. One &apos;&lt;vpn-cidr&gt; &lt;remote-cidr&gt; = true|false&apos; per line. Example: 10.42.42.0/24 192.168.0.0/16 = true.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+    <field>
+        <id>instance.lighthouse_calculated_remotes</id>
+        <label>Calculated remotes (experimental)</label>
+        <type>textbox</type>
+        <advanced>true</advanced>
+        <help>Experimental. Derive a remote address for hosts you have no lighthouse for. One &apos;&lt;vpn-cidr&gt; &lt;mask-cidr&gt; &lt;port&gt;&apos; per line; repeat the vpn-cidr for multiple entries. Example: 192.168.1.0/24 192.168.1.0/24 4242.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Telemetry (stats)</label>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>instance.stats_type</id>
+        <label>Stats type</label>
+        <type>dropdown</type>
+        <advanced>true</advanced>
+        <help>Export Nebula runtime metrics. &apos;graphite&apos; pushes metrics to a Graphite/Carbon server; &apos;prometheus&apos; exposes an HTTP endpoint to be scraped. Leave Disabled for no telemetry. The fields below apply only to the selected type.</help>
+    </field>
+    <field>
+        <id>instance.stats_interval</id>
+        <label>Interval</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>How often metrics are collected/emitted, e.g. 10s. Applies to both types.</help>
+    </field>
+    <field>
+        <id>instance.stats_message_metrics</id>
+        <label>Per-message metrics</label>
+        <type>checkbox</type>
+        <advanced>true</advanced>
+        <help>Emit detailed per-message-type counters (higher cardinality). Applies to both types; off by default.</help>
+    </field>
+    <field>
+        <id>instance.stats_lighthouse_metrics</id>
+        <label>Lighthouse metrics</label>
+        <type>checkbox</type>
+        <advanced>true</advanced>
+        <help>Emit per-lighthouse metrics. Applies to both types; off by default.</help>
+    </field>
+    <field>
+        <id>instance.stats_prefix</id>
+        <label>Graphite: prefix</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>Graphite metric-name prefix, e.g. nebula. Used only when type is graphite.</help>
+    </field>
+    <field>
+        <id>instance.stats_protocol</id>
+        <label>Graphite: protocol</label>
+        <type>dropdown</type>
+        <advanced>true</advanced>
+        <help>Transport used to reach the Graphite server. Used only when type is graphite.</help>
+    </field>
+    <field>
+        <id>instance.stats_host</id>
+        <label>Graphite: host</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>Graphite/Carbon server as host:port, e.g. 127.0.0.1:9999. Required when type is graphite.</help>
+    </field>
+    <field>
+        <id>instance.stats_listen</id>
+        <label>Prometheus: listen</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>Address to expose the metrics endpoint on, as host:port, e.g. 127.0.0.1:8080. Required when type is prometheus.</help>
+    </field>
+    <field>
+        <id>instance.stats_path</id>
+        <label>Prometheus: path</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>HTTP path for the metrics endpoint, e.g. /metrics. Used only when type is prometheus.</help>
+    </field>
+    <field>
+        <id>instance.stats_namespace</id>
+        <label>Prometheus: namespace</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>Prometheus metric namespace. Used only when type is prometheus.</help>
+    </field>
+    <field>
+        <id>instance.stats_subsystem</id>
+        <label>Prometheus: subsystem</label>
+        <type>text</type>
+        <advanced>true</advanced>
+        <help>Prometheus metric subsystem. Used only when type is prometheus.</help>
+    </field>
+    <field>
+        <type>header</type>
+        <label>Advanced</label>
+    </field>
+    <field>
+        <id>instance.advanced</id>
+        <label>Advanced (raw YAML)</label>
+        <type>textbox</type>
+        <help>Raw nebula.yml fragment appended to the generated config, for knobs not yet in the GUI (e.g. lighthouse allow-lists). Must be valid YAML and must NOT redefine a top-level key already emitted above (nebula rejects duplicate keys). Validated on Apply via &apos;nebula -test&apos;.</help>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+</form>

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/forms/dialogStaticHostMap.xml
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/forms/dialogStaticHostMap.xml
@@ -1,0 +1,61 @@
+<form>
+    <field>
+        <id>entry.enabled</id>
+        <label>Enabled</label>
+        <type>checkbox</type>
+        <grid_view>
+            <width>6em</width>
+            <type>boolean</type>
+            <formatter>rowtoggle</formatter>
+            <sequence>1</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>entry.instance</id>
+        <label>Instance</label>
+        <type>dropdown</type>
+        <help>The Nebula instance this static host map entry belongs to.</help>
+        <grid_view>
+            <sequence>2</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>entry.certref</id>
+        <label>Lighthouse certificate</label>
+        <type>dropdown</type>
+        <help>Optionally pick the peer&apos;s host certificate to auto-fill its Nebula IP below from the certificate&apos;s networks. A convenience only — the Nebula IP is what is stored.</help>
+        <allownull>true</allownull>
+        <grid_view>
+            <ignore>true</ignore>
+        </grid_view>
+    </field>
+    <field>
+        <id>entry.nebula_ip</id>
+        <label>Nebula IP</label>
+        <type>text</type>
+        <help>The peer&apos;s Nebula overlay IP (a single host address, e.g. 192.168.100.1) — the key of this static host map entry.</help>
+        <grid_view>
+            <sequence>3</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>entry.addresses</id>
+        <label>Underlay addresses</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <allownew>true</allownew>
+        <help>One or more underlay host:port addresses to reach the peer before discovery. Type each address and press Enter to add it as a tag, e.g. 198.51.100.1:4242 then 203.0.113.5:4242.</help>
+        <grid_view>
+            <sequence>4</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>entry.description</id>
+        <label>Description</label>
+        <type>text</type>
+        <help>Optional human-readable label for this entry.</help>
+        <grid_view>
+            <sequence>5</sequence>
+        </grid_view>
+    </field>
+</form>

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/forms/dialogTunRoute.xml
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/forms/dialogTunRoute.xml
@@ -1,0 +1,50 @@
+<form>
+    <field>
+        <id>tunroute.enabled</id>
+        <label>Enabled</label>
+        <type>checkbox</type>
+        <grid_view>
+            <width>6em</width>
+            <type>boolean</type>
+            <formatter>rowtoggle</formatter>
+            <sequence>1</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>tunroute.instance</id>
+        <label>Instance</label>
+        <type>dropdown</type>
+        <help>The Nebula instance this MTU override belongs to.</help>
+        <grid_view>
+            <sequence>2</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>tunroute.route</id>
+        <label>Route CIDR</label>
+        <type>text</type>
+        <help>An overlay CIDR (a subnet from this node&apos;s certificate) to give a non-default MTU, e.g. 10.0.0.0/16.</help>
+        <grid_view>
+            <sequence>3</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>tunroute.mtu</id>
+        <label>MTU</label>
+        <type>text</type>
+        <help>MTU for this route (576–9000). Overrides the tunnel MTU for traffic to this CIDR.</help>
+        <grid_view>
+            <width>6em</width>
+            <sequence>4</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>tunroute.description</id>
+        <label>Description</label>
+        <type>text</type>
+        <help>Optional human-readable label for this MTU override.</help>
+        <grid_view>
+            <sequence>5</sequence>
+        </grid_view>
+    </field>
+</form>

--- a/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/forms/dialogUnsafeRoute.xml
+++ b/net/nebula/src/opnsense/mvc/app/controllers/OPNsense/Nebula/forms/dialogUnsafeRoute.xml
@@ -1,0 +1,81 @@
+<form>
+    <field>
+        <id>route.enabled</id>
+        <label>Enabled</label>
+        <type>checkbox</type>
+        <grid_view>
+            <width>6em</width>
+            <type>boolean</type>
+            <formatter>rowtoggle</formatter>
+            <sequence>1</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>route.instance</id>
+        <label>Instance</label>
+        <type>dropdown</type>
+        <help>The Nebula instance this route belongs to.</help>
+        <grid_view>
+            <sequence>2</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>route.route</id>
+        <label>Destination CIDR</label>
+        <type>text</type>
+        <help>The non-Nebula destination network (e.g. 172.16.1.0/24) to route over the overlay.</help>
+        <grid_view>
+            <sequence>3</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>route.via</id>
+        <label>Via (Nebula IP)</label>
+        <type>text</type>
+        <help>The overlay IP of the Nebula peer that hosts this route. That peer&apos;s certificate must include the destination as a subnet.</help>
+        <grid_view>
+            <sequence>4</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>route.mtu</id>
+        <label>MTU</label>
+        <type>text</type>
+        <help>Optional MTU for this route. Defaults to the tunnel MTU when empty.</help>
+        <grid_view>
+            <width>6em</width>
+            <sequence>5</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>route.metric</id>
+        <label>Metric</label>
+        <type>text</type>
+        <help>Optional route metric (defaults to 0 when empty).</help>
+        <grid_view>
+            <width>6em</width>
+            <sequence>6</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>route.install</id>
+        <label>Install in system route table</label>
+        <type>checkbox</type>
+        <help>Install this route into the host routing table. Disable to let Nebula handle it internally only.</help>
+        <grid_view>
+            <width>6em</width>
+            <type>boolean</type>
+            <formatter>boolean</formatter>
+            <sequence>7</sequence>
+        </grid_view>
+    </field>
+    <field>
+        <id>route.description</id>
+        <label>Description</label>
+        <type>text</type>
+        <help>Optional human-readable label for this route.</help>
+        <grid_view>
+            <sequence>8</sequence>
+        </grid_view>
+    </field>
+</form>

--- a/net/nebula/src/opnsense/mvc/app/models/OPNsense/Nebula/ACL/ACL.xml
+++ b/net/nebula/src/opnsense/mvc/app/models/OPNsense/Nebula/ACL/ACL.xml
@@ -1,0 +1,9 @@
+<acl>
+    <page-services-nebula>
+        <name>Services: Nebula</name>
+        <patterns>
+            <pattern>ui/nebula*</pattern>
+            <pattern>api/nebula/*</pattern>
+        </patterns>
+    </page-services-nebula>
+</acl>

--- a/net/nebula/src/opnsense/mvc/app/models/OPNsense/Nebula/ConfigMap.php
+++ b/net/nebula/src/opnsense/mvc/app/models/OPNsense/Nebula/ConfigMap.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+/* GENERATED from knobs.yaml by tools/gen_knobs.py — do not edit by hand. */
+return [
+    'pki_disconnect_invalid' => ['yaml' => 'pki.disconnect_invalid', 'type' => 'bool'],
+    'pki_initiating_version' => ['yaml' => 'pki.initiating_version', 'type' => 'int'],
+    'static_map_cadence' => ['yaml' => 'static_map.cadence', 'type' => 'duration'],
+    'static_map_network' => ['yaml' => 'static_map.network', 'type' => 'enum'],
+    'static_map_lookup_timeout' => ['yaml' => 'static_map.lookup_timeout', 'type' => 'duration'],
+    'am_lighthouse' => ['yaml' => 'lighthouse.am_lighthouse', 'type' => 'bool'],
+    'lighthouse_serve_dns' => ['yaml' => 'lighthouse.serve_dns', 'type' => 'bool'],
+    'lighthouse_interval' => ['yaml' => 'lighthouse.interval', 'type' => 'int'],
+    'lighthouse_dns_host' => ['yaml' => 'lighthouse.dns.host', 'type' => 'host'],
+    'lighthouse_dns_port' => ['yaml' => 'lighthouse.dns.port', 'type' => 'int'],
+    'lighthouse_hosts' => ['yaml' => 'lighthouse.hosts', 'type' => 'list'],
+    'lighthouse_advertise_addrs' => ['yaml' => 'lighthouse.advertise_addrs', 'type' => 'list'],
+    'listen_host' => ['yaml' => 'listen.host', 'type' => 'host'],
+    'listen_port' => ['yaml' => 'listen.port', 'type' => 'int'],
+    'listen_batch' => ['yaml' => 'listen.batch', 'type' => 'int'],
+    'listen_read_buffer' => ['yaml' => 'listen.read_buffer', 'type' => 'int'],
+    'listen_write_buffer' => ['yaml' => 'listen.write_buffer', 'type' => 'int'],
+    'listen_send_recv_error' => ['yaml' => 'listen.send_recv_error', 'type' => 'enum'],
+    'listen_accept_recv_error' => ['yaml' => 'listen.accept_recv_error', 'type' => 'enum'],
+    'listen_so_mark' => ['yaml' => 'listen.so_mark', 'type' => 'int'],
+    'punchy_punch' => ['yaml' => 'punchy.punch', 'type' => 'bool'],
+    'punchy_respond' => ['yaml' => 'punchy.respond', 'type' => 'bool'],
+    'punchy_delay' => ['yaml' => 'punchy.delay', 'type' => 'duration'],
+    'punchy_respond_delay' => ['yaml' => 'punchy.respond_delay', 'type' => 'duration'],
+    'cipher' => ['yaml' => 'cipher', 'type' => 'enum'],
+    'preferred_ranges' => ['yaml' => 'preferred_ranges', 'type' => 'list'],
+    'relay_am_relay' => ['yaml' => 'relay.am_relay', 'type' => 'bool'],
+    'relay_use_relays' => ['yaml' => 'relay.use_relays', 'type' => 'bool'],
+    'relay_relays' => ['yaml' => 'relay.relays', 'type' => 'list'],
+    'tun_name' => ['yaml' => 'tun.dev', 'type' => 'text'],
+    'tun_disabled' => ['yaml' => 'tun.disabled', 'type' => 'bool'],
+    'tun_drop_local_broadcast' => ['yaml' => 'tun.drop_local_broadcast', 'type' => 'bool'],
+    'tun_drop_multicast' => ['yaml' => 'tun.drop_multicast', 'type' => 'bool'],
+    'tun_tx_queue' => ['yaml' => 'tun.tx_queue', 'type' => 'int'],
+    'tun_mtu' => ['yaml' => 'tun.mtu', 'type' => 'int'],
+    'tun_use_system_route_table' => ['yaml' => 'tun.use_system_route_table', 'type' => 'bool'],
+    'tun_use_system_route_table_buffer_size' => ['yaml' => 'tun.use_system_route_table_buffer_size', 'type' => 'int'],
+    'tunnels_drop_inactive' => ['yaml' => 'tunnels.drop_inactive', 'type' => 'bool'],
+    'tunnels_inactivity_timeout' => ['yaml' => 'tunnels.inactivity_timeout', 'type' => 'duration'],
+    'logging_level' => ['yaml' => 'logging.level', 'type' => 'enum'],
+    'logging_format' => ['yaml' => 'logging.format', 'type' => 'enum'],
+    'logging_disable_timestamp' => ['yaml' => 'logging.disable_timestamp', 'type' => 'bool'],
+    'logging_timestamp_format' => ['yaml' => 'logging.timestamp_format', 'type' => 'text'],
+    'firewall_outbound_action' => ['yaml' => 'firewall.outbound_action', 'type' => 'enum'],
+    'firewall_inbound_action' => ['yaml' => 'firewall.inbound_action', 'type' => 'enum'],
+    'firewall_default_local_cidr_any' => ['yaml' => 'firewall.default_local_cidr_any', 'type' => 'bool'],
+    'firewall_conntrack_tcp_timeout' => ['yaml' => 'firewall.conntrack.tcp_timeout', 'type' => 'duration'],
+    'firewall_conntrack_udp_timeout' => ['yaml' => 'firewall.conntrack.udp_timeout', 'type' => 'duration'],
+    'firewall_conntrack_default_timeout' => ['yaml' => 'firewall.conntrack.default_timeout', 'type' => 'duration'],
+    'routines' => ['yaml' => 'routines', 'type' => 'int'],
+    'handshakes_try_interval' => ['yaml' => 'handshakes.try_interval', 'type' => 'duration'],
+    'handshakes_retries' => ['yaml' => 'handshakes.retries', 'type' => 'int'],
+    'handshakes_query_buffer' => ['yaml' => 'handshakes.query_buffer', 'type' => 'int'],
+    'handshakes_trigger_buffer' => ['yaml' => 'handshakes.trigger_buffer', 'type' => 'int'],
+];

--- a/net/nebula/src/opnsense/mvc/app/models/OPNsense/Nebula/Menu/Menu.xml
+++ b/net/nebula/src/opnsense/mvc/app/models/OPNsense/Nebula/Menu/Menu.xml
@@ -1,0 +1,14 @@
+<menu>
+    <VPN>
+        <Nebula order="80" VisibleName="Nebula" cssClass="fa fa-project-diagram fa-fw">
+            <Instances order="1" url="/ui/nebula/instances"/>
+            <Routes order="10" VisibleName="Routes" url="/ui/nebula/routes" cssClass="fa fa-route fa-fw"/>
+            <Firewall order="15" url="/ui/nebula/firewall" cssClass="fa fa-fire fa-fw"/>
+            <Authorities order="20" url="/ui/nebula/authorities"/>
+            <Certificates order="21" VisibleName="Host Certificates" url="/ui/nebula/certificates"/>
+            <Blocklist order="22" url="/ui/nebula/blocklist" cssClass="fa fa-ban fa-fw"/>
+            <Tunnels order="29" VisibleName="Tunnels" url="/ui/nebula/tunnels" cssClass="fa fa-sitemap fa-fw"/>
+            <Status order="30" VisibleName="Status" url="/ui/nebula/status" cssClass="fa fa-heartbeat fa-fw"/>
+        </Nebula>
+    </VPN>
+</menu>

--- a/net/nebula/src/opnsense/mvc/app/models/OPNsense/Nebula/Nebula.php
+++ b/net/nebula/src/opnsense/mvc/app/models/OPNsense/Nebula/Nebula.php
@@ -1,0 +1,851 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Nebula;
+
+use OPNsense\Base\BaseModel;
+
+class Nebula extends BaseModel
+{
+    /**
+     * Subsystem-dirty marker — the legacy is_subsystem_dirty('nebula') idiom
+     * (same mechanism IPsec uses with /tmp/ipsec.dirty). Touched whenever the
+     * model persists a change, removed by ServiceController on a successful
+     * reconfigure, and reported via /api/nebula/service/dirty so the "apply
+     * needed" banner survives page reloads and cross-page navigation.
+     */
+    public const RECONFIGURE_MARKER = '/tmp/nebula.dirty';
+
+    /**
+     * Persist the model, then mark the Nebula subsystem dirty so the apply
+     * banner is shown until the user reconfigures. Single choke point: every
+     * CRUD save and every PKI custom action (generate/sign/import) serializes
+     * through here, so none can change config without flagging an apply.
+     *
+     * @return bool whether changes were persisted
+     */
+    public function serializeToConfig($validateFullModel = false, $disable_validation = false)
+    {
+        $this->assignDeviceNames();
+        $persisted = parent::serializeToConfig($validateFullModel, $disable_validation);
+        if ($persisted) {
+            @touch(self::RECONFIGURE_MARKER);
+        }
+        return $persisted;
+    }
+
+    /**
+     * Ensure every instance has a concrete, stable tun device name BEFORE the
+     * config is written. An instance with an empty tun_name gets
+     * "nebula" + the first 6 hex of md5(uuid) — derived from the instance's
+     * immutable, unique UUID, so the name is unique by construction and never
+     * reused by a different instance (a freed name cannot come back, which would
+     * otherwise let a new instance inherit firewall/gateway settings bound to the
+     * old assignment). md5 is uniformly distributed regardless of UUID
+     * version/bits (same technique as sshdPortFor()). The realif name is
+     * therefore stable for the instance's life; deleting one instance never
+     * renumbers another. Names already set (typed by the admin, or pre-existing)
+     * are left untouched. On the ≈impossible md5-prefix collision, widen the hex
+     * slice up to the 15-char IFNAMSIZ limit ("nebula" + 9 hex).
+     */
+    public function assignDeviceNames(): void
+    {
+        $used = [];
+        foreach ($this->instances->instance->iterateItems() as $node) {
+            $name = trim((string)$node->tun_name);
+            if ($name !== '') {
+                $used[$name] = true;
+            }
+        }
+        foreach ($this->instances->instance->iterateItems() as $node) {
+            if (trim((string)$node->tun_name) !== '') {
+                continue;
+            }
+            $digest = md5((string)$node->getAttribute('uuid'));
+            $len = 6;
+            $name = 'nebula' . substr($digest, 0, $len);
+            while (isset($used[$name]) && $len < 9) {
+                $len++;
+                $name = 'nebula' . substr($digest, 0, $len);
+            }
+            $node->tun_name = $name;
+            $used[$name] = true;
+        }
+    }
+
+    /**
+     * Generate a nebula YAML config for the given instance node, driven by the
+     * scalar field -> yaml-path map in ConfigMap.php. The fixed pki: block (per
+     * uuid cert paths) and the minimal permissive firewall: rule lists are
+     * merged on top (Plan 5 replaces the rule lists with the per-rule grid).
+     *
+     * The PHP CLI on the appliance has no yaml extension, so YAML is hand-emitted.
+     *
+     * @param \OPNsense\Base\FieldTypes\ArrayField $instanceNode an instance from instances->instance
+     * @return string YAML configuration text
+     */
+    public function generateConfig($instanceNode, ?string $diagPubKey = null): string
+    {
+        $map = require __DIR__ . '/ConfigMap.php';
+
+        $cfg = [];
+        foreach ($map as $field => $spec) {
+            $v = (string)$instanceNode->$field;
+            if ($v === '') {
+                // Unset optional (e.g. read_buffer) -> omit from output.
+                continue;
+            }
+            switch ($spec['type']) {
+                case 'bool':
+                    $val = ($v === '1');
+                    break;
+                case 'int':
+                    $val = (int)$v;
+                    break;
+                case 'list':
+                    // Split on newlines and commas, trim each token, drop empties.
+                    $items = array_values(array_filter(
+                        array_map('trim', preg_split('/[\n,]+/', $v)),
+                        fn($s) => $s !== ''
+                    ));
+                    if (empty($items)) {
+                        // Omit the key entirely when the list is empty.
+                        continue 2;
+                    }
+                    $val = $items;
+                    break;
+                default:
+                    $val = $v;
+                    break;
+            }
+            $this->assignPath($cfg, $spec['yaml'], $val);
+        }
+
+        // Fixed pki: block, keyed by the instance uuid.
+        $uuid = $instanceNode->getAttribute('uuid');
+        $certDir = '/usr/local/etc/nebula/' . $uuid;
+        $cfg['pki'] = [
+            'ca' => $certDir . '/ca.crt',
+            'cert' => $certDir . '/host.crt',
+            'key' => $certDir . '/host.key',
+        ];
+
+        // pki.blocklist: certificate fingerprints this node refuses to talk to.
+        // An entry applies when it is enabled and in scope (Global, or scoped to
+        // this exact instance uuid). The block stays in effect regardless of the
+        // entry's `expiry`: expiry is only a purge-eligibility date for the
+        // "Purge expired" button (block-until-purged), not an effective end date,
+        // so it is intentionally NOT consulted here.
+        // The key is omitted entirely when no entry is in effect so a node with no
+        // blocklist emits no blocklist: key (matching nebula's optional schema).
+        $blocklist = [];
+        foreach ($this->pki->blocklist->entry->iterateItems() as $entry) {
+            if ((string)$entry->enabled !== '1') {
+                continue;
+            }
+            // 'instance'-scoped entries apply only to their own instance; Global
+            // entries apply to every node. Scope is explicit (see model comment).
+            if ((string)$entry->scope === 'instance' && (string)$entry->instance !== $uuid) {
+                continue;
+            }
+            $fp = trim((string)$entry->fingerprint);
+            if ($fp !== '') {
+                $blocklist[] = $fp;
+            }
+        }
+        if (!empty($blocklist)) {
+            $cfg['pki']['blocklist'] = $blocklist;
+        }
+
+        // Nebula is deny-by-default: a node with no firewall rules passes zero
+        // traffic and `nebula -test` rejects a config without a firewall block.
+        // The firewall scalar knobs (outbound_action/inbound_action/...) and the
+        // nested conntrack map were already placed under firewall by the map walk;
+        // build the inbound/outbound rule lists from the per-instance fwrules grid.
+        if (!isset($cfg['firewall']) || !is_array($cfg['firewall'])) {
+            $cfg['firewall'] = [];
+        }
+
+        // Permissive fallback used when a direction has no enabled rules.
+        $permissive = [['port' => 'any', 'proto' => 'any', 'host' => 'any']];
+
+        // Scalar matcher fields emitted as-is when non-empty.
+        $scalarMatchers = ['host', 'cidr', 'local_cidr', 'ca_name', 'ca_sha'];
+
+        $inbound = [];
+        $outbound = [];
+        foreach ($this->fwrules->rule->iterateItems() as $rule) {
+            if ((string)$rule->instance !== $uuid) {
+                continue;
+            }
+            if ((string)$rule->enabled !== '1') {
+                continue;
+            }
+
+            $map = [
+                'port'  => (string)$rule->port  !== '' ? (string)$rule->port  : 'any',
+                'proto' => (string)$rule->protocol !== '' ? (string)$rule->protocol : 'any',
+            ];
+
+            // Scalar matchers: include only when non-empty.
+            foreach ($scalarMatchers as $f) {
+                $v = (string)$rule->$f;
+                if ($v !== '') {
+                    $map[$f] = $v;
+                }
+            }
+
+            // groups: stored as comma/newline-separated; render as a YAML list.
+            $groupsRaw = (string)$rule->groups;
+            if ($groupsRaw !== '') {
+                $items = array_values(array_filter(
+                    array_map('trim', preg_split('/[\n,]+/', $groupsRaw)),
+                    fn($s) => $s !== ''
+                ));
+                if (!empty($items)) {
+                    $map['groups'] = $items;
+                }
+            }
+
+            $direction = (string)$rule->direction;
+            if ($direction === 'outbound') {
+                $outbound[] = $map;
+            } else {
+                $inbound[] = $map;
+            }
+        }
+
+        $cfg['firewall']['outbound'] = empty($outbound) ? $permissive : $outbound;
+        $cfg['firewall']['inbound']  = empty($inbound)  ? $permissive : $inbound;
+
+        // static_host_map: a map of nebula-IP => list-of-underlay-addresses, built
+        // from this instance's enabled static_hostmap grid entries (one nebula_ip
+        // -> comma/newline-separated addresses per row). Addresses are
+        // de-duplicated per overlay IP; the key is omitted when there are none.
+        $shm = [];
+        foreach ($this->static_hostmap->entry->iterateItems() as $e) {
+            if ((string)$e->instance !== $uuid || (string)$e->enabled !== '1') {
+                continue;
+            }
+            $overlayIp = trim((string)$e->nebula_ip);
+            if ($overlayIp === '') {
+                continue;
+            }
+            foreach (preg_split('/[\n,]+/', (string)$e->addresses) as $a) {
+                $a = trim($a);
+                if ($a === '') {
+                    continue;
+                }
+                if (!isset($shm[$overlayIp])) {
+                    $shm[$overlayIp] = [];
+                }
+                if (!in_array($a, $shm[$overlayIp], true)) {
+                    $shm[$overlayIp][] = $a;
+                }
+            }
+        }
+        if (!empty($shm)) {
+            $cfg['static_host_map'] = $shm;
+        }
+
+        // tun.unsafe_routes: route non-Nebula subnets over the overlay via a
+        // Nebula peer. Built from the per-instance unsafe-routes grid; each
+        // enabled route emits {route, via, [mtu], [metric], install}.
+        $unsafe = [];
+        foreach ($this->unsafe_routes->route->iterateItems() as $r) {
+            if ((string)$r->instance !== $uuid || (string)$r->enabled !== '1') {
+                continue;
+            }
+            $route = trim((string)$r->route);
+            $via   = trim((string)$r->via);
+            if ($route === '' || $via === '') {
+                continue;
+            }
+            $entry = ['route' => $route, 'via' => $via];
+            $mtu = trim((string)$r->mtu);
+            if ($mtu !== '') {
+                $entry['mtu'] = (int)$mtu;
+            }
+            $metric = trim((string)$r->metric);
+            if ($metric !== '') {
+                $entry['metric'] = (int)$metric;
+            }
+            // install defaults true in nebula; emit it explicitly so the routing
+            // intent is unambiguous in the rendered config.
+            $entry['install'] = ((string)$r->install === '1');
+            $unsafe[] = $entry;
+        }
+        if (!empty($unsafe)) {
+            if (!isset($cfg['tun']) || !is_array($cfg['tun'])) {
+                $cfg['tun'] = [];
+            }
+            $cfg['tun']['unsafe_routes'] = $unsafe;
+        }
+
+        // tun.routes: per-route MTU overrides for Nebula overlay routes (the
+        // node's own subnets). Each enabled route emits {route, mtu}.
+        $tunRoutes = [];
+        foreach ($this->tun_routes->route->iterateItems() as $r) {
+            if ((string)$r->instance !== $uuid || (string)$r->enabled !== '1') {
+                continue;
+            }
+            $route = trim((string)$r->route);
+            $mtu   = trim((string)$r->mtu);
+            if ($route === '' || $mtu === '') {
+                continue;
+            }
+            $tunRoutes[] = ['route' => $route, 'mtu' => (int)$mtu];
+        }
+        if (!empty($tunRoutes)) {
+            if (!isset($cfg['tun']) || !is_array($cfg['tun'])) {
+                $cfg['tun'] = [];
+            }
+            $cfg['tun']['routes'] = $tunRoutes;
+        }
+
+        // sshd debug server: ALWAYS on — the plugin's internal management channel
+        // behind the Status page (live peers, close/query tunnels, etc.). It is
+        // not user-configurable: bound to 127.0.0.1 on a per-instance derived
+        // port, with a per-instance host key and ONLY the plugin's diagnostics
+        // key authorized (no user access). $diagPubKey is supplied by setup.php
+        // at apply time; on a bare render (e.g. nebula -test) it may be absent,
+        // in which case the block still carries enabled/listen/host_key and
+        // setup.php injects the key before writing the live config.
+        $cfg['sshd'] = [
+            'enabled'  => true,
+            'listen'   => '127.0.0.1:' . $this->sshdPortFor($uuid),
+            'host_key' => $certDir . '/sshd_host_key',
+        ];
+        if (is_string($diagPubKey) && $diagPubKey !== '') {
+            $cfg['sshd']['authorized_users'] = [
+                ['user' => '_opnsense_diag', 'keys' => [$diagPubKey]],
+            ];
+        }
+
+        // lighthouse allow-lists: CIDR-keyed maps merged into the lighthouse:
+        // section (the lighthouse scalar knobs were placed by the map walk
+        // above). Each is a hand-authored textarea, one entry per line; malformed
+        // lines are skipped and left for `nebula -test` to surface. Emitted only
+        // when non-empty so a node with no allow-lists adds no keys.
+        $lighthouse = [];
+
+        // remote_allow_list / local_allow_list: "CIDR = true|false" per line.
+        // local_allow_list additionally accepts "interface <regex> = true|false",
+        // which lands under a nested interfaces: map (nebula's special key).
+        $remoteAllow = $this->parseAllowList((string)$instanceNode->lighthouse_remote_allow_list, false);
+        if (!empty($remoteAllow)) {
+            $lighthouse['remote_allow_list'] = $remoteAllow;
+        }
+        $localAllow = $this->parseAllowList((string)$instanceNode->lighthouse_local_allow_list, true);
+        if (!empty($localAllow)) {
+            $lighthouse['local_allow_list'] = $localAllow;
+        }
+
+        // remote_allow_ranges (experimental): "<vpn-cidr> <remote-cidr> = bool"
+        // per line -> map<vpn-cidr, map<remote-cidr, bool>>.
+        $ranges = [];
+        foreach (explode("\n", (string)$instanceNode->lighthouse_remote_allow_ranges) as $line) {
+            $eq = strpos($line, '=');
+            if ($eq === false) {
+                continue;
+            }
+            $cidrs = preg_split('/\s+/', trim(substr($line, 0, $eq)), -1, PREG_SPLIT_NO_EMPTY);
+            $bool = $this->parseYamlBool(substr($line, $eq + 1));
+            if ($bool === null || count($cidrs) !== 2) {
+                continue;
+            }
+            [$vpn, $remote] = $cidrs;
+            if (!isset($ranges[$vpn])) {
+                $ranges[$vpn] = [];
+            }
+            $ranges[$vpn][$remote] = $bool;
+        }
+        if (!empty($ranges)) {
+            $lighthouse['remote_allow_ranges'] = $ranges;
+        }
+
+        // calculated_remotes (experimental): "<vpn-cidr> <mask-cidr> <port>" per
+        // line -> map<vpn-cidr, list<{mask, port}>>. Repeat the vpn-cidr for
+        // multiple entries.
+        $calc = [];
+        foreach (explode("\n", (string)$instanceNode->lighthouse_calculated_remotes) as $line) {
+            $tok = preg_split('/\s+/', trim($line), -1, PREG_SPLIT_NO_EMPTY);
+            if (count($tok) !== 3 || !ctype_digit($tok[2])) {
+                continue;
+            }
+            [$vpn, $mask, $port] = $tok;
+            if (!isset($calc[$vpn])) {
+                $calc[$vpn] = [];
+            }
+            $calc[$vpn][] = ['mask' => $mask, 'port' => (int)$port];
+        }
+        if (!empty($calc)) {
+            $lighthouse['calculated_remotes'] = $calc;
+        }
+
+        if (!empty($lighthouse)) {
+            if (!isset($cfg['lighthouse']) || !is_array($cfg['lighthouse'])) {
+                $cfg['lighthouse'] = [];
+            }
+            $cfg['lighthouse'] = array_merge($cfg['lighthouse'], $lighthouse);
+        }
+
+        // stats: graphite/prometheus telemetry. Emitted only when a type is
+        // chosen (blank = no telemetry). graphite and prometheus share interval
+        // and the two metric toggles but otherwise have disjoint keys; we emit
+        // only the keys relevant to the selected type so nebula sees a valid
+        // sub-schema. Optional/empty sub-fields are omitted.
+        $statsType = (string)$instanceNode->stats_type;
+        if ($statsType === 'graphite' || $statsType === 'prometheus') {
+            $stats = ['type' => $statsType];
+            $interval = trim((string)$instanceNode->stats_interval);
+            if ($interval !== '') {
+                $stats['interval'] = $interval;
+            }
+            if ($statsType === 'graphite') {
+                foreach (['prefix' => 'stats_prefix', 'protocol' => 'stats_protocol', 'host' => 'stats_host'] as $key => $field) {
+                    $v = trim((string)$instanceNode->$field);
+                    if ($v !== '') {
+                        $stats[$key] = $v;
+                    }
+                }
+            } else { // prometheus
+                foreach (['listen' => 'stats_listen', 'path' => 'stats_path', 'namespace' => 'stats_namespace', 'subsystem' => 'stats_subsystem'] as $key => $field) {
+                    $v = trim((string)$instanceNode->$field);
+                    if ($v !== '') {
+                        $stats[$key] = $v;
+                    }
+                }
+            }
+            // Metric toggles (both types). Emit only when enabled so a default
+            // node stays terse; nebula defaults both to false.
+            if ((string)$instanceNode->stats_message_metrics === '1') {
+                $stats['message_metrics'] = true;
+            }
+            if ((string)$instanceNode->stats_lighthouse_metrics === '1') {
+                $stats['lighthouse_metrics'] = true;
+            }
+            $cfg['stats'] = $stats;
+        }
+
+        $out = "# Generated by os-nebula. Do not edit by hand.\n" . $this->emitYaml($cfg, 0);
+
+        // Append the free-form advanced YAML fragment, if set.
+        // Validation is deferred to `nebula -test` (no PHP YAML parser available).
+        $advanced = (string)$instanceNode->advanced;
+        if ($advanced !== '') {
+            $out .= "\n" . $advanced;
+            // Ensure the output ends with a newline.
+            if (substr($out, -1) !== "\n") {
+                $out .= "\n";
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * Insert $value into $cfg at the dotted $path (e.g. "listen.host"),
+     * creating nested associative maps as needed.
+     *
+     * @param array $cfg target array, modified by reference
+     * @param string $path dotted yaml path
+     * @param mixed $value scalar value to set at the leaf
+     */
+    private function assignPath(array &$cfg, string $path, $value): void
+    {
+        $keys = explode('.', $path);
+        $ref = &$cfg;
+        $last = array_pop($keys);
+        foreach ($keys as $key) {
+            if (!isset($ref[$key]) || !is_array($ref[$key])) {
+                $ref[$key] = [];
+            }
+            $ref = &$ref[$key];
+        }
+        $ref[$last] = $value;
+        unset($ref);
+    }
+
+    /**
+     * Recursively hand-emit YAML for $node at the given indent depth.
+     *
+     * - 2-space indent per level.
+     * - Maps: "key:" then nested, or "key: <scalar>" for leaf scalars.
+     * - Lists: "key:" then each item as "- " with the item's map inline-indented.
+     * - Scalars: bool -> bare true/false; int -> bare number; string -> double
+     *   quoted (so e.g. host: "::" is never mis-parsed as a bare YAML value).
+     *
+     * @param mixed $node array (map or list) at this level
+     * @param int $depth indent depth
+     * @return string emitted YAML (always ends with a newline for non-empty input)
+     */
+    private function emitYaml($node, int $depth): string
+    {
+        $indent = str_repeat('  ', $depth);
+        $out = '';
+        foreach ($node as $key => $value) {
+            $k = $this->emitKey($key);
+            if (is_array($value) && $this->isList($value)) {
+                $out .= $indent . $k . ":\n";
+                $dashIndent = str_repeat('  ', $depth + 1) . '- ';
+                if (!empty($value) && !is_array($value[0])) {
+                    // List of scalars (e.g. lighthouse.hosts, relay.relays).
+                    foreach ($value as $item) {
+                        $out .= $dashIndent . $this->emitScalar($item) . "\n";
+                    }
+                } else {
+                    // List of maps (the firewall rule lists).
+                    foreach ($value as $item) {
+                        $itemLines = $this->emitYaml($item, $depth + 2);
+                        // Replace the leading indent of the first line with "- ".
+                        $rest = substr($itemLines, strlen(str_repeat('  ', $depth + 2)));
+                        $out .= $dashIndent . $rest;
+                    }
+                }
+            } elseif (is_array($value)) {
+                // Nested map.
+                $out .= $indent . $k . ":\n";
+                $out .= $this->emitYaml($value, $depth + 1);
+            } else {
+                $out .= $indent . $k . ': ' . $this->emitScalar($value) . "\n";
+            }
+        }
+        return $out;
+    }
+
+    /**
+     * Format a map key for YAML. Bareword keys (the plugin's own section names
+     * and IPv4 CIDR/host keys) are emitted plain so existing output is
+     * unchanged; anything else — IPv6 CIDRs ("::1/128"), interface-name regexes
+     * ("docker.*"), keys with colons or spaces — is double-quoted so it can't be
+     * mis-parsed. The safe-plain set is deliberately conservative.
+     *
+     * @param string|int $key
+     * @return string
+     */
+    private function emitKey($key): string
+    {
+        $k = (string)$key;
+        if ($k !== '' && preg_match('#^[A-Za-z0-9_][A-Za-z0-9_./\-]*$#', $k)) {
+            return $k;
+        }
+        $escaped = str_replace(['\\', '"'], ['\\\\', '\\"'], $k);
+        return '"' . $escaped . '"';
+    }
+
+    /**
+     * Parse a "<CIDR> = true|false" allow-list textarea into a map<cidr,bool>.
+     * When $withInterfaces, lines of the form "interface <regex> = true|false"
+     * are collected under a nested `interfaces` map (nebula's local_allow_list
+     * special key). Malformed lines (no '=', empty key, unrecognized bool) are
+     * skipped.
+     *
+     * @param string $raw textarea contents
+     * @param bool $withInterfaces honour the "interface <regex>" prefix form
+     * @return array map<cidr,bool> (possibly with an 'interfaces' sub-map)
+     */
+    private function parseAllowList(string $raw, bool $withInterfaces): array
+    {
+        $map = [];
+        foreach (explode("\n", $raw) as $line) {
+            $eq = strpos($line, '=');
+            if ($eq === false) {
+                continue;
+            }
+            $left = trim(substr($line, 0, $eq));
+            $bool = $this->parseYamlBool(substr($line, $eq + 1));
+            if ($left === '' || $bool === null) {
+                continue;
+            }
+            if ($withInterfaces && preg_match('/^interface\s+(.+)$/i', $left, $m)) {
+                if (!isset($map['interfaces']) || !is_array($map['interfaces'])) {
+                    $map['interfaces'] = [];
+                }
+                $map['interfaces'][trim($m[1])] = $bool;
+                continue;
+            }
+            $map[$left] = $bool;
+        }
+        return $map;
+    }
+
+    /**
+     * Parse a boolean token (true/false/yes/no/on/off/1/0, case-insensitive) to
+     * a bool, or null when unrecognized.
+     *
+     * @param string $raw
+     * @return bool|null
+     */
+    private function parseYamlBool(string $raw): ?bool
+    {
+        $v = strtolower(trim($raw));
+        if (in_array($v, ['true', '1', 'yes', 'on'], true)) {
+            return true;
+        }
+        if (in_array($v, ['false', '0', 'no', 'off'], true)) {
+            return false;
+        }
+        return null;
+    }
+
+    /**
+     * The 127.0.0.1 TCP port this instance's always-on sshd debug server binds.
+     *
+     * Each instance runs its own debug server, so the ports must be distinct.
+     * The port is derived deterministically from the instance uuid (an md5-based
+     * base in [SSHD_PORT_BASE, +SSHD_PORT_SPAN)), and collisions are resolved in
+     * sorted-uuid order. Because the model holds every instance, both this
+     * renderer and the setup.php querier compute the identical mapping with no
+     * stored field and no port-discovery race.
+     *
+     * @param string $uuid the instance uuid
+     * @return int the derived 127.0.0.1 port
+     */
+    public function sshdPortFor(string $uuid): int
+    {
+        $base = 22000;
+        $span = 4000;
+        $portFor = fn(string $u): int => $base + (int)(hexdec(substr(md5($u), 0, 6)) % $span);
+
+        $uuids = [];
+        foreach ($this->instances->instance->iterateItems() as $inst) {
+            $u = (string)$inst->getAttribute('uuid');
+            if ($u !== '') {
+                $uuids[] = $u;
+            }
+        }
+        sort($uuids);
+
+        $used = [];
+        $assigned = [];
+        foreach ($uuids as $u) {
+            $p = $portFor($u);
+            while (isset($used[$p])) {
+                $p = $base + ((($p - $base) + 1) % $span);
+            }
+            $used[$p] = true;
+            $assigned[$u] = $p;
+        }
+
+        return $assigned[$uuid] ?? $portFor($uuid);
+    }
+
+    // -------------------------------------------------------------------------
+    // Referential integrity + expiry purge (shared by the API controllers and
+    // their tests; kept on the model so both exercise the same code).
+    // -------------------------------------------------------------------------
+
+    /**
+     * Is the CA $uuid still in use, and by whom? A CA cannot be removed while it
+     * signs a certificate (caref) or is trusted by an instance (trusted_cas).
+     * Returns a human-readable label for the first referencing entity, or null
+     * when the CA is unreferenced and safe to delete.
+     *
+     * @param string $uuid CA uuid
+     * @return string|null referencing-entity label, or null if unreferenced
+     */
+    public function caReferencedBy(string $uuid): ?string
+    {
+        if ($uuid === '') {
+            return null;
+        }
+        foreach ($this->pki->certificates->certificate->iterateItems() as $cert) {
+            if ((string)$cert->caref === $uuid) {
+                return sprintf('certificate "%s"', (string)$cert->descr);
+            }
+        }
+        foreach ($this->instances->instance->iterateItems() as $inst) {
+            $trusted = array_map('trim', explode(',', (string)$inst->trusted_cas));
+            if (in_array($uuid, $trusted, true)) {
+                return sprintf('instance "%s"', (string)$inst->description);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Is the certificate $uuid still referenced by an instance (certref)?
+     * Returns a label for the first referencing instance, or null if unreferenced.
+     *
+     * @param string $uuid certificate uuid
+     * @return string|null referencing-instance label, or null if unreferenced
+     */
+    public function certReferencedBy(string $uuid): ?string
+    {
+        if ($uuid === '') {
+            return null;
+        }
+        foreach ($this->instances->instance->iterateItems() as $inst) {
+            if ((string)$inst->certref === $uuid) {
+                return sprintf('instance "%s"', (string)$inst->description);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Has an ISO/`notAfter`-style timestamp passed? Empty or unparseable values
+     * are treated as NOT expired (we never purge what we cannot date).
+     *
+     * @param string $validTo notAfter timestamp (e.g. 2027-06-05T00:00:00Z)
+     */
+    private function validToExpired(string $validTo): bool
+    {
+        $validTo = trim($validTo);
+        if ($validTo === '') {
+            return false;
+        }
+        $ts = strtotime($validTo);
+        return $ts !== false && $ts < time();
+    }
+
+    /**
+     * Delete every expired CA that is not still referenced. Referenced-but-expired
+     * CAs are kept and their descriptions returned so the caller can report them.
+     * Mutates the model (does not save — the caller validates + serializes).
+     *
+     * @return array{removed:int, skippedNames:string[]}
+     */
+    public function purgeExpiredAuthorities(): array
+    {
+        $toDelete = [];
+        $skippedNames = [];
+        foreach ($this->pki->authorities->authority->iterateItems() as $ca) {
+            if (!$this->validToExpired((string)$ca->valid_to)) {
+                continue;
+            }
+            $uuid = $ca->getAttribute('uuid');
+            if ($this->caReferencedBy($uuid) !== null) {
+                $skippedNames[] = (string)$ca->descr;
+                continue;
+            }
+            $toDelete[] = $uuid;
+        }
+        foreach ($toDelete as $uuid) {
+            $this->pki->authorities->authority->del($uuid);
+        }
+        return [
+            'removed'      => count($toDelete),
+            'skippedNames' => array_values(array_unique($skippedNames)),
+        ];
+    }
+
+    /**
+     * Delete every expired certificate that is not still referenced by an
+     * instance. Referenced-but-expired certs are kept and named. Mutates the
+     * model (does not save).
+     *
+     * @return array{removed:int, skippedNames:string[]}
+     */
+    public function purgeExpiredCertificates(): array
+    {
+        $toDelete = [];
+        $skippedNames = [];
+        foreach ($this->pki->certificates->certificate->iterateItems() as $cert) {
+            if (!$this->validToExpired((string)$cert->valid_to)) {
+                continue;
+            }
+            $uuid = $cert->getAttribute('uuid');
+            if ($this->certReferencedBy($uuid) !== null) {
+                $skippedNames[] = (string)$cert->descr;
+                continue;
+            }
+            $toDelete[] = $uuid;
+        }
+        foreach ($toDelete as $uuid) {
+            $this->pki->certificates->certificate->del($uuid);
+        }
+        return [
+            'removed'      => count($toDelete),
+            'skippedNames' => array_values(array_unique($skippedNames)),
+        ];
+    }
+
+    /**
+     * Delete every blocklist entry whose Expiry date has passed (whole-day
+     * compare; empty or unparseable = never). Blocklist entries are referenced by
+     * nothing, so none are skipped. This is the only thing that removes an
+     * expired block — the renderer keeps blocking until purged. Mutates the model
+     * (does not save).
+     *
+     * @return array{removed:int, skippedNames:string[]}
+     */
+    public function purgeExpiredBlocklist(): array
+    {
+        $today = date('Y-m-d');
+        $toDelete = [];
+        foreach ($this->pki->blocklist->entry->iterateItems() as $entry) {
+            $expiry = trim((string)$entry->expiry);
+            if ($expiry === '') {
+                continue;
+            }
+            $ts = strtotime($expiry);
+            if ($ts !== false && date('Y-m-d', $ts) < $today) {
+                $toDelete[] = $entry->getAttribute('uuid');
+            }
+        }
+        foreach ($toDelete as $uuid) {
+            $this->pki->blocklist->entry->del($uuid);
+        }
+        return ['removed' => count($toDelete), 'skippedNames' => []];
+    }
+
+    /**
+     * Format a scalar for YAML: bool bare, int bare, string double-quoted with
+     * backslash and double-quote escaped.
+     *
+     * @param mixed $value
+     * @return string
+     */
+    private function emitScalar($value): string
+    {
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+        if (is_int($value)) {
+            return (string)$value;
+        }
+        $escaped = str_replace(['\\', '"'], ['\\\\', '\\"'], (string)$value);
+        return '"' . $escaped . '"';
+    }
+
+    /**
+     * Is $arr a sequential (list) array rather than an associative map?
+     *
+     * @param array $arr
+     * @return bool
+     */
+    private function isList(array $arr): bool
+    {
+        if ($arr === []) {
+            return false;
+        }
+        return array_keys($arr) === range(0, count($arr) - 1);
+    }
+}

--- a/net/nebula/src/opnsense/mvc/app/models/OPNsense/Nebula/Nebula.xml
+++ b/net/nebula/src/opnsense/mvc/app/models/OPNsense/Nebula/Nebula.xml
@@ -2,12 +2,6 @@
     <mount>//OPNsense/Nebula</mount>
     <description>Nebula mesh overlay</description>
     <items>
-        <general>
-            <enabled type="BooleanField">
-                <Default>0</Default>
-                <Required>Y</Required>
-            </enabled>
-        </general>
         <instances>
             <instance type="ArrayField">
                 <enabled type="BooleanField">

--- a/net/nebula/src/opnsense/mvc/app/models/OPNsense/Nebula/Nebula.xml
+++ b/net/nebula/src/opnsense/mvc/app/models/OPNsense/Nebula/Nebula.xml
@@ -1,0 +1,715 @@
+<model>
+    <mount>//OPNsense/Nebula</mount>
+    <description>Nebula mesh overlay</description>
+    <items>
+        <general>
+            <enabled type="BooleanField">
+                <Default>0</Default>
+                <Required>Y</Required>
+            </enabled>
+        </general>
+        <instances>
+            <instance type="ArrayField">
+                <enabled type="BooleanField">
+                    <Default>1</Default>
+                    <Required>Y</Required>
+                </enabled>
+                <description type="DescriptionField"/>
+                <certref type="ModelRelationField">
+                    <Model>
+                        <nebcertref>
+                            <source>OPNsense.Nebula.Nebula</source>
+                            <items>pki.certificates.certificate</items>
+                            <display>descr</display>
+                            <!-- Only certs whose private key is held here (has_key)
+                                 can run an instance; exclude keyless CSR-signed /
+                                 external certs from the picker. -->
+                            <filters>
+                                <has_key>/^1$/</has_key>
+                            </filters>
+                        </nebcertref>
+                    </Model>
+                </certref>
+                <!-- trusted_cas: additional CAs whose peers this instance accepts,
+                     beyond the CA that signed its own host certificate (which is
+                     always trusted). Empty = trust only the signing CA. The ca.crt
+                     bundle written by setup.php is the union of the two. -->
+                <trusted_cas type="ModelRelationField">
+                    <Multiple>Y</Multiple>
+                    <Model>
+                        <nebtrustedcas>
+                            <source>OPNsense.Nebula.Nebula</source>
+                            <items>pki.authorities.authority</items>
+                            <display>descr</display>
+                        </nebtrustedcas>
+                    </Model>
+                </trusted_cas>
+                <advanced type="TextField"/>
+                <!-- stats_*: graphite/prometheus telemetry block. Hand-authored
+                     (not a generated knob) because the sub-schema is conditional
+                     on stats_type — graphite and prometheus require disjoint sets
+                     of keys — and the whole stats: block is omitted when
+                     stats_type is blank. Rendered by Nebula.php::generateConfig().
+                     graphite-only: prefix/protocol/host. prometheus-only:
+                     listen/path/namespace/subsystem. Shared: interval and the two
+                     metric toggles. -->
+                <stats_type type="OptionField">
+                    <BlankDesc>Disabled</BlankDesc>
+                    <OptionValues>
+                        <graphite>graphite</graphite>
+                        <prometheus>prometheus</prometheus>
+                    </OptionValues>
+                </stats_type>
+                <stats_interval type="TextField">
+                    <Mask>/^\d+(ns|us|µs|ms|s|m|h)$/</Mask>
+                    <Default>10s</Default>
+                </stats_interval>
+                <stats_message_metrics type="BooleanField">
+                    <Default>0</Default>
+                </stats_message_metrics>
+                <stats_lighthouse_metrics type="BooleanField">
+                    <Default>0</Default>
+                </stats_lighthouse_metrics>
+                <stats_prefix type="TextField">
+                    <Default>nebula</Default>
+                </stats_prefix>
+                <stats_protocol type="OptionField">
+                    <Default>tcp</Default>
+                    <OptionValues>
+                        <tcp>tcp</tcp>
+                        <udp>udp</udp>
+                    </OptionValues>
+                </stats_protocol>
+                <stats_host type="TextField"/>
+                <stats_listen type="TextField"/>
+                <stats_path type="TextField">
+                    <Default>/metrics</Default>
+                </stats_path>
+                <stats_namespace type="TextField"/>
+                <stats_subsystem type="TextField"/>
+                <!-- lighthouse allow-lists: CIDR-keyed maps that filter which
+                     remote/local addresses a node uses. Hand-authored textareas
+                     (one entry per line) parsed by Nebula.php into nested maps
+                     under lighthouse.*. remote_allow_ranges and calculated_remotes
+                     are flagged experimental by nebula. -->
+                <lighthouse_remote_allow_list type="TextField"/>
+                <lighthouse_local_allow_list type="TextField"/>
+                <lighthouse_remote_allow_ranges type="TextField"/>
+                <lighthouse_calculated_remotes type="TextField"/>
+                <!-- GENERATED:instance-fields START -->
+                <pki_disconnect_invalid type="BooleanField">
+                    <Default>0</Default>
+                </pki_disconnect_invalid>
+
+                <pki_initiating_version type="IntegerField">
+                    <MinimumValue>1</MinimumValue>
+                    <MaximumValue>2</MaximumValue>
+                    <Default>1</Default>
+                </pki_initiating_version>
+
+                <static_map_cadence type="TextField">
+                    <Mask>/^\d+(ns|us|µs|ms|s|m|h)$/</Mask>
+                    <Default>30s</Default>
+                </static_map_cadence>
+
+                <static_map_network type="OptionField">
+                    <Default>ip4</Default>
+                    <OptionValues>
+                        <ip4>ip4</ip4>
+                        <ip6>ip6</ip6>
+                        <ip>ip</ip>
+                    </OptionValues>
+                </static_map_network>
+
+                <static_map_lookup_timeout type="TextField">
+                    <Mask>/^\d+(ns|us|µs|ms|s|m|h)$/</Mask>
+                    <Default>250ms</Default>
+                </static_map_lookup_timeout>
+
+                <am_lighthouse type="BooleanField">
+                    <Default>0</Default>
+                    <Required>Y</Required>
+                </am_lighthouse>
+
+                <lighthouse_serve_dns type="BooleanField">
+                    <Default>0</Default>
+                </lighthouse_serve_dns>
+
+                <lighthouse_interval type="IntegerField">
+                    <Default>60</Default>
+                </lighthouse_interval>
+
+                <lighthouse_dns_host type="HostnameField">
+                    <IpAllowed>Y</IpAllowed>
+                    <Default>0.0.0.0</Default>
+                </lighthouse_dns_host>
+
+                <lighthouse_dns_port type="IntegerField">
+                    <MinimumValue>1</MinimumValue>
+                    <MaximumValue>65535</MaximumValue>
+                    <Default>53</Default>
+                </lighthouse_dns_port>
+
+                <lighthouse_hosts type="CSVListField">
+                </lighthouse_hosts>
+
+                <lighthouse_advertise_addrs type="CSVListField">
+                </lighthouse_advertise_addrs>
+
+                <listen_host type="HostnameField">
+                    <IpAllowed>Y</IpAllowed>
+                    <Default>::</Default>
+                    <Required>Y</Required>
+                </listen_host>
+
+                <listen_port type="IntegerField">
+                    <MinimumValue>0</MinimumValue>
+                    <MaximumValue>65535</MaximumValue>
+                    <Default>4242</Default>
+                    <Required>Y</Required>
+                </listen_port>
+
+                <!-- firewall_interfaces: interface(s) on which the plugin auto-adds
+                     an inbound "allow UDP to the listen port" rule (nebula_firewall
+                     hook). Empty = no rule is added for this instance. -->
+                <firewall_interfaces type="InterfaceField">
+                    <Multiple>Y</Multiple>
+                </firewall_interfaces>
+
+                <listen_batch type="IntegerField">
+                    <Default>64</Default>
+                </listen_batch>
+
+                <listen_read_buffer type="IntegerField">
+                </listen_read_buffer>
+
+                <listen_write_buffer type="IntegerField">
+                </listen_write_buffer>
+
+                <listen_send_recv_error type="OptionField">
+                    <Default>always</Default>
+                    <OptionValues>
+                        <always>always</always>
+                        <never>never</never>
+                        <private>private</private>
+                    </OptionValues>
+                </listen_send_recv_error>
+
+                <listen_accept_recv_error type="OptionField">
+                    <Default>always</Default>
+                    <OptionValues>
+                        <always>always</always>
+                        <never>never</never>
+                        <private>private</private>
+                    </OptionValues>
+                </listen_accept_recv_error>
+
+                <listen_so_mark type="IntegerField">
+                    <Default>0</Default>
+                </listen_so_mark>
+
+                <punchy_punch type="BooleanField">
+                    <Default>1</Default>
+                </punchy_punch>
+
+                <punchy_respond type="BooleanField">
+                    <Default>0</Default>
+                </punchy_respond>
+
+                <punchy_delay type="TextField">
+                    <Mask>/^\d+(ns|us|µs|ms|s|m|h)$/</Mask>
+                    <Default>1s</Default>
+                </punchy_delay>
+
+                <punchy_respond_delay type="TextField">
+                    <Mask>/^\d+(ns|us|µs|ms|s|m|h)$/</Mask>
+                    <Default>5s</Default>
+                </punchy_respond_delay>
+
+                <cipher type="OptionField">
+                    <Default>chachapoly</Default>
+                    <OptionValues>
+                        <chachapoly>chachapoly</chachapoly>
+                        <aes>aes</aes>
+                    </OptionValues>
+                </cipher>
+
+                <preferred_ranges type="CSVListField">
+                </preferred_ranges>
+
+                <relay_am_relay type="BooleanField">
+                    <Default>0</Default>
+                </relay_am_relay>
+
+                <relay_use_relays type="BooleanField">
+                    <Default>1</Default>
+                </relay_use_relays>
+
+                <relay_relays type="CSVListField">
+                </relay_relays>
+
+                <tun_name type="TextField">
+                    <Mask>/^[A-Za-z0-9._-]{1,15}$/</Mask>
+                    <ValidationMessage>Interface name must be 1-15 characters (letters, digits, dot, dash, underscore) to fit the system interface-name limit. Leave empty to auto-assign.</ValidationMessage>
+                </tun_name>
+
+                <tun_disabled type="BooleanField">
+                    <Default>0</Default>
+                </tun_disabled>
+
+                <tun_drop_local_broadcast type="BooleanField">
+                    <Default>0</Default>
+                </tun_drop_local_broadcast>
+
+                <tun_drop_multicast type="BooleanField">
+                    <Default>0</Default>
+                </tun_drop_multicast>
+
+                <tun_tx_queue type="IntegerField">
+                    <Default>500</Default>
+                </tun_tx_queue>
+
+                <tun_mtu type="IntegerField">
+                    <Default>1300</Default>
+                </tun_mtu>
+
+                <tun_use_system_route_table type="BooleanField">
+                    <Default>0</Default>
+                </tun_use_system_route_table>
+
+                <tun_use_system_route_table_buffer_size type="IntegerField">
+                    <Default>0</Default>
+                </tun_use_system_route_table_buffer_size>
+
+                <tunnels_drop_inactive type="BooleanField">
+                    <Default>0</Default>
+                </tunnels_drop_inactive>
+
+                <tunnels_inactivity_timeout type="TextField">
+                    <Mask>/^\d+(ns|us|µs|ms|s|m|h)$/</Mask>
+                    <Default>10m</Default>
+                </tunnels_inactivity_timeout>
+
+                <logging_level type="OptionField">
+                    <Default>info</Default>
+                    <OptionValues>
+                        <debug>debug</debug>
+                        <info>info</info>
+                        <warning>warning</warning>
+                        <error>error</error>
+                        <fatal>fatal</fatal>
+                        <panic>panic</panic>
+                    </OptionValues>
+                </logging_level>
+
+                <logging_format type="OptionField">
+                    <Default>text</Default>
+                    <OptionValues>
+                        <text>text</text>
+                        <json>json</json>
+                    </OptionValues>
+                </logging_format>
+
+                <logging_disable_timestamp type="BooleanField">
+                    <Default>0</Default>
+                </logging_disable_timestamp>
+
+                <logging_timestamp_format type="TextField">
+                </logging_timestamp_format>
+
+                <firewall_outbound_action type="OptionField">
+                    <Default>drop</Default>
+                    <OptionValues>
+                        <drop>drop</drop>
+                        <reject>reject</reject>
+                    </OptionValues>
+                </firewall_outbound_action>
+
+                <firewall_inbound_action type="OptionField">
+                    <Default>drop</Default>
+                    <OptionValues>
+                        <drop>drop</drop>
+                        <reject>reject</reject>
+                    </OptionValues>
+                </firewall_inbound_action>
+
+                <firewall_default_local_cidr_any type="BooleanField">
+                    <Default>0</Default>
+                </firewall_default_local_cidr_any>
+
+                <firewall_conntrack_tcp_timeout type="TextField">
+                    <Mask>/^\d+(ns|us|µs|ms|s|m|h)$/</Mask>
+                    <Default>12m</Default>
+                </firewall_conntrack_tcp_timeout>
+
+                <firewall_conntrack_udp_timeout type="TextField">
+                    <Mask>/^\d+(ns|us|µs|ms|s|m|h)$/</Mask>
+                    <Default>3m</Default>
+                </firewall_conntrack_udp_timeout>
+
+                <firewall_conntrack_default_timeout type="TextField">
+                    <Mask>/^\d+(ns|us|µs|ms|s|m|h)$/</Mask>
+                    <Default>10m</Default>
+                </firewall_conntrack_default_timeout>
+
+                <routines type="IntegerField">
+                    <Default>1</Default>
+                </routines>
+
+                <handshakes_try_interval type="TextField">
+                    <Mask>/^\d+(ns|us|µs|ms|s|m|h)$/</Mask>
+                    <Default>100ms</Default>
+                </handshakes_try_interval>
+
+                <handshakes_retries type="IntegerField">
+                    <Default>20</Default>
+                </handshakes_retries>
+
+                <handshakes_query_buffer type="IntegerField">
+                    <Default>64</Default>
+                </handshakes_query_buffer>
+
+                <handshakes_trigger_buffer type="IntegerField">
+                    <Default>64</Default>
+                </handshakes_trigger_buffer>
+<!-- GENERATED:instance-fields END -->
+            </instance>
+        </instances>
+        <fwrules>
+            <rule type="ArrayField">
+                <enabled type="BooleanField">
+                    <Default>1</Default>
+                    <Required>Y</Required>
+                </enabled>
+                <instance type="ModelRelationField">
+                    <Model>
+                        <nebfwinst>
+                            <source>OPNsense.Nebula.Nebula</source>
+                            <items>instances.instance</items>
+                            <display>description</display>
+                        </nebfwinst>
+                    </Model>
+                    <Required>Y</Required>
+                </instance>
+                <direction type="OptionField">
+                    <Default>inbound</Default>
+                    <OptionValues>
+                        <inbound>inbound</inbound>
+                        <outbound>outbound</outbound>
+                    </OptionValues>
+                    <Required>Y</Required>
+                </direction>
+                <description type="DescriptionField"/>
+                <protocol type="OptionField">
+                    <Default>any</Default>
+                    <OptionValues>
+                        <any>any</any>
+                        <tcp>tcp</tcp>
+                        <udp>udp</udp>
+                        <icmp>icmp</icmp>
+                    </OptionValues>
+                </protocol>
+                <port type="TextField">
+                    <Default>any</Default>
+                </port>
+                <host type="TextField"/>
+                <!-- groups: match peers in ALL of these groups (AND). CSVListField
+                     so the dialog renders a tokenize chip input; rendered as a YAML
+                     list by Nebula.php. -->
+                <groups type="CSVListField"/>
+                <cidr type="TextField"/>
+                <local_cidr type="TextField"/>
+                <ca_name type="TextField"/>
+                <ca_sha type="TextField"/>
+            </rule>
+        </fwrules>
+        <unsafe_routes>
+            <route type="ArrayField">
+                <enabled type="BooleanField">
+                    <Default>1</Default>
+                    <Required>Y</Required>
+                </enabled>
+                <instance type="ModelRelationField">
+                    <Model>
+                        <nebunsafeinst>
+                            <source>OPNsense.Nebula.Nebula</source>
+                            <items>instances.instance</items>
+                            <display>description</display>
+                        </nebunsafeinst>
+                    </Model>
+                    <Required>Y</Required>
+                </instance>
+                <description type="DescriptionField"/>
+                <!-- route: the non-Nebula destination CIDR to send over the overlay. -->
+                <route type="NetworkField">
+                    <NetMaskRequired>Y</NetMaskRequired>
+                    <Required>Y</Required>
+                </route>
+                <!-- via: the Nebula overlay IP of the peer that hosts/forwards this
+                     route. That peer's certificate must include the route as a subnet. -->
+                <via type="NetworkField">
+                    <NetMaskAllowed>N</NetMaskAllowed>
+                    <Required>Y</Required>
+                </via>
+                <mtu type="IntegerField">
+                    <MinimumValue>576</MinimumValue>
+                    <MaximumValue>9000</MaximumValue>
+                </mtu>
+                <metric type="IntegerField">
+                    <MinimumValue>0</MinimumValue>
+                    <MaximumValue>4294967295</MaximumValue>
+                </metric>
+                <install type="BooleanField">
+                    <Default>1</Default>
+                    <Required>Y</Required>
+                </install>
+            </route>
+        </unsafe_routes>
+        <tun_routes>
+            <route type="ArrayField">
+                <enabled type="BooleanField">
+                    <Default>1</Default>
+                    <Required>Y</Required>
+                </enabled>
+                <instance type="ModelRelationField">
+                    <Model>
+                        <nebtunrouteinst>
+                            <source>OPNsense.Nebula.Nebula</source>
+                            <items>instances.instance</items>
+                            <display>description</display>
+                        </nebtunrouteinst>
+                    </Model>
+                    <Required>Y</Required>
+                </instance>
+                <description type="DescriptionField"/>
+                <!-- route: a Nebula overlay CIDR (a subnet from the node's own cert)
+                     to give a non-default MTU. NOT an unsafe route — see unsafe_routes. -->
+                <route type="NetworkField">
+                    <NetMaskRequired>Y</NetMaskRequired>
+                    <Required>Y</Required>
+                </route>
+                <mtu type="IntegerField">
+                    <MinimumValue>576</MinimumValue>
+                    <MaximumValue>9000</MaximumValue>
+                    <Required>Y</Required>
+                </mtu>
+            </route>
+        </tun_routes>
+        <!-- static_host_map grid: how to reach a lighthouse/node (by its Nebula
+             overlay IP) before discovery, via one or more underlay host:port
+             addresses. Replaces the per-instance free-text static_host_map field
+             (which the renderer still honours for back-compat). Rendered into the
+             top-level static_host_map: map-of-lists by Nebula.php. -->
+        <static_hostmap>
+            <entry type="ArrayField">
+                <enabled type="BooleanField">
+                    <Default>1</Default>
+                    <Required>Y</Required>
+                </enabled>
+                <instance type="ModelRelationField">
+                    <Model>
+                        <nebshminst>
+                            <source>OPNsense.Nebula.Nebula</source>
+                            <items>instances.instance</items>
+                            <display>description</display>
+                        </nebshminst>
+                    </Model>
+                    <Required>Y</Required>
+                </instance>
+                <!-- certref: optional pointer to the lighthouse's host certificate,
+                     used in the dialog to auto-fill nebula_ip from the cert's
+                     networks. A convenience picker only; nebula_ip is what is
+                     stored and rendered. -->
+                <certref type="ModelRelationField">
+                    <Model>
+                        <nebshmcert>
+                            <source>OPNsense.Nebula.Nebula</source>
+                            <items>pki.certificates.certificate</items>
+                            <display>descr</display>
+                        </nebshmcert>
+                    </Model>
+                </certref>
+                <description type="DescriptionField"/>
+                <!-- nebula_ip: the peer's Nebula overlay IP (a single host address,
+                     no mask) — the key of the static_host_map entry. -->
+                <nebula_ip type="NetworkField">
+                    <NetMaskAllowed>N</NetMaskAllowed>
+                    <Required>Y</Required>
+                </nebula_ip>
+                <!-- addresses: one or more underlay host:port addresses to reach
+                     that peer. CSVListField (AsList) so the dialog's tokenize
+                     select_multiple round-trips each address as a tag; stored
+                     comma-joined. Kept permissive (no per-item mask) — host:port
+                     forms vary (IPv4/IPv6/hostname); nebula -test validates. -->
+                <addresses type="CSVListField">
+                    <Required>Y</Required>
+                </addresses>
+            </entry>
+        </static_hostmap>
+        <pki>
+            <blocklist>
+                <entry type="ArrayField">
+                    <enabled type="BooleanField">
+                        <Default>1</Default>
+                        <Required>Y</Required>
+                    </enabled>
+                    <!-- scope: Global (every instance) or a single instance. Made
+                         explicit (not an empty instance) because a global block is
+                         inherited by every node, so it must be a deliberate choice. -->
+                    <scope type="OptionField">
+                        <Default>global</Default>
+                        <Required>Y</Required>
+                        <OptionValues>
+                            <global>Global (all instances)</global>
+                            <instance>This instance</instance>
+                        </OptionValues>
+                    </scope>
+                    <!-- instance: the single instance a non-global block applies to.
+                         Used only when scope = instance (enforced in the controller). -->
+                    <instance type="ModelRelationField">
+                        <Model>
+                            <nebblockinst>
+                                <source>OPNsense.Nebula.Nebula</source>
+                                <items>instances.instance</items>
+                                <display>description</display>
+                            </nebblockinst>
+                        </Model>
+                    </instance>
+                    <!-- 64-char lowercase hex sha256 fingerprint of the blocked cert.
+                         Enforced at the controller layer (add/set) and here via Mask. -->
+                    <fingerprint type="TextField">
+                        <Mask>/^[0-9a-f]{64}$/</Mask>
+                        <Required>Y</Required>
+                    </fingerprint>
+                    <descr type="DescriptionField"/>
+                    <!-- expiry: optional date the entry stops applying (empty = never).
+                         The cert's notAfter, when blocking by certref; a blocked cert
+                         that has expired no longer needs an explicit block. -->
+                    <expiry type="TextField"/>
+                    <!-- certref: optional pointer to the certificate this entry blocks,
+                         used to auto-fill fingerprint + expiry in the dialog. -->
+                    <certref type="ModelRelationField">
+                        <Model>
+                            <nebblockcertref>
+                                <source>OPNsense.Nebula.Nebula</source>
+                                <items>pki.certificates.certificate</items>
+                                <display>descr</display>
+                            </nebblockcertref>
+                        </Model>
+                    </certref>
+                </entry>
+            </blocklist>
+            <authorities>
+                <authority type="ArrayField">
+                    <descr type="DescriptionField">
+                        <Required>Y</Required>
+                    </descr>
+                    <origin type="OptionField">
+                        <Default>generated</Default>
+                        <OptionValues>
+                            <generated>generated</generated>
+                            <imported>imported</imported>
+                        </OptionValues>
+                    </origin>
+                    <curve type="OptionField">
+                        <Default>25519</Default>
+                        <OptionValues>
+                            <X25519 value="25519">25519</X25519>
+                            <P256>P256</P256>
+                        </OptionValues>
+                    </curve>
+                    <crt type="TextField"/>
+                    <key type="TextField"/>
+                    <!-- Computed, store-once read-only fields (populated by the controller
+                         from nebula-cert print at create time; never edited by hand). -->
+                    <cn type="TextField"/>
+                    <valid_from type="TextField"/>
+                    <valid_to type="TextField"/>
+                    <fingerprint type="TextField"/>
+                    <is_ca type="BooleanField">
+                        <Default>0</Default>
+                    </is_ca>
+                    <has_key type="BooleanField">
+                        <Default>0</Default>
+                    </has_key>
+                    <!-- key_encrypted = the stored private key PEM is passphrase-
+                         protected (its header contains "ENCRYPTED").  Drives the Sign
+                         dialog's conditional passphrase prompt: an encrypted CA needs a
+                         passphrase supplied per signing operation (never stored).
+                         Computed and stored by AuthorityController at generate/import. -->
+                    <key_encrypted type="BooleanField">
+                        <Default>0</Default>
+                    </key_encrypted>
+                    <!-- can_sign = this CA can currently sign new certs: is_ca AND a
+                         private key is present.  An encrypted key IS signable (the
+                         passphrase is supplied per-operation via NEBULA_CA_PASSPHRASE,
+                         never stored), so encryption no longer excludes a CA from
+                         signing.  Distinct from has_key (which only reflects "a key is
+                         stored").  Computed and stored by AuthorityController at
+                         generate/import time. -->
+                    <can_sign type="BooleanField">
+                        <Default>0</Default>
+                    </can_sign>
+                    <!-- Network constraints embedded in the CA cert (populated from
+                         pki_print_cert at generate/import; empty = unrestricted). -->
+                    <networks type="TextField"/>
+                    <unsafe_networks type="TextField"/>
+                </authority>
+            </authorities>
+            <certificates>
+                <certificate type="ArrayField">
+                    <descr type="DescriptionField">
+                        <Required>Y</Required>
+                    </descr>
+                    <origin type="OptionField">
+                        <Default>signed</Default>
+                        <OptionValues>
+                            <signed>signed</signed>
+                            <imported>imported</imported>
+                        </OptionValues>
+                    </origin>
+                    <caref type="ModelRelationField">
+                        <Model>
+                            <nebcaref>
+                                <source>OPNsense.Nebula.Nebula</source>
+                                <items>pki.authorities.authority</items>
+                                <display>descr</display>
+                            </nebcaref>
+                        </Model>
+                    </caref>
+                    <crt type="TextField"/>
+                    <key type="TextField"/>
+                    <curve type="OptionField">
+                        <Default>25519</Default>
+                        <OptionValues>
+                            <X25519 value="25519">25519</X25519>
+                            <P256>P256</P256>
+                        </OptionValues>
+                    </curve>
+                    <networks type="TextField"/>
+                    <groups type="TextField"/>
+                    <unsafe_networks type="TextField"/>
+                    <!-- Computed, store-once read-only fields (populated by the controller
+                         from nebula-cert print at create/sign time; never edited by hand). -->
+                    <cn type="TextField"/>
+                    <valid_from type="TextField"/>
+                    <valid_to type="TextField"/>
+                    <fingerprint type="TextField"/>
+                    <is_ca type="BooleanField">
+                        <Default>0</Default>
+                    </is_ca>
+                    <has_key type="BooleanField">
+                        <Default>0</Default>
+                    </has_key>
+                    <!-- issuer = fingerprint of the signing CA (details.issuer from
+                         pki_print_cert).  The signing CA's display name is resolved
+                         dynamically at render time (searchItemAction) by matching this
+                         issuer against the authorities' fingerprints — we never rely on
+                         a stored ca_name. -->
+                    <issuer type="TextField"/>
+                    <ca_name type="TextField"/>
+                </certificate>
+            </certificates>
+        </pki>
+    </items>
+</model>

--- a/net/nebula/src/opnsense/mvc/app/views/OPNsense/Nebula/authorities.volt
+++ b/net/nebula/src/opnsense/mvc/app/views/OPNsense/Nebula/authorities.volt
@@ -1,0 +1,410 @@
+{#
+ # Copyright (c) 2026 Henry Stern <henry@stern.ca>
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1. Redistributions of source code must retain the above copyright notice,
+ #    this list of conditions and the following disclaimer.
+ #
+ # 2. Redistributions in binary form must reproduce the above copyright notice,
+ #    this list of conditions and the following disclaimer in the documentation
+ #    and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+#}
+
+<style>
+    .monospace-dialog {
+        font-family: monospace;
+        white-space: pre;
+    }
+    .monospace-dialog > .modal-dialog {
+        width: 70% !important;
+    }
+    .modal-body {
+        max-height: calc(100vh - 210px);
+        overflow-y: auto;
+    }
+</style>
+
+<script>
+    'use strict';
+
+    /**
+     * Generic custom-dialog POST helper.
+     *
+     * @param {string} frm_id        — id of the <form> element (frm_XXX)
+     * @param {string} field_prefix  — field namespace used in form field ids (e.g. 'authority')
+     * @param {string} endpoint      — API endpoint to POST to
+     * @param {string} dialog_id     — Bootstrap modal id to hide on success
+     * @param {string} grid_id       — bootgrid table id to reload on success
+     */
+    function nebula_custom_save(frm_id, field_prefix, endpoint, dialog_id, grid_id) {
+        let params = {};
+        $("#" + frm_id + " input, #" + frm_id + " select, #" + frm_id + " textarea").each(function () {
+            let $el  = $(this);
+            let name = $el.attr('id');
+            if (name) {
+                // Strip the "field." prefix that base_dialog generates (e.g. "authority.descr" → "descr")
+                let parts = name.split('.');
+                let key   = parts.length > 1 ? parts.slice(1).join('.') : name;
+                // Tokenize select_multiple fields return an array; join them to a
+                // comma-separated string so the generate/import actions (which read
+                // these as strings) get the expected shape.
+                let val = $el.val();
+                params[key] = Array.isArray(val) ? val.join(',') : val;
+            }
+        });
+
+        clearFormValidation(frm_id);
+
+        let $save_btn  = $("#btn_" + dialog_id + "_save");
+        let $save_icon = $("#btn_" + dialog_id + "_save_progress");
+        $save_btn.prop('disabled', true);
+        $save_icon.addClass("fa fa-spinner fa-pulse");
+
+        ajaxCall(endpoint, params, function (data, status) {
+            $save_btn.prop('disabled', false);
+            $save_icon.removeClass("fa fa-spinner fa-pulse");
+
+            if (data && data.validations) {
+                // handleFormValidation matches against the full field id (e.g. "authority.descr"),
+                // but the API returns bare keys (e.g. "descr"). Re-prefix them.
+                let prefixed = {};
+                $.each(data.validations, function (k, v) {
+                    prefixed[field_prefix + '.' + k] = v;
+                });
+                handleFormValidation(frm_id, prefixed);
+            } else if (data && data.result === 'saved') {
+                $("#" + dialog_id).modal('hide');
+                $("#" + grid_id).bootgrid('reload');
+            } else {
+                let msg = (data && data.error) ? data.error : '{{ lang._('An unexpected error occurred.') }}';
+                BootstrapDialog.show({
+                    type: BootstrapDialog.TYPE_DANGER,
+                    title: '{{ lang._('Error') }}',
+                    message: $("<div/>").text(msg).html()
+                });
+            }
+        });
+    }
+
+    // Open the Generate CA dialog (reset + defaults).
+    function nebula_open_generate_ca() {
+        clearFormValidation('frm_DialogAuthorityGenerate');
+        $("#frm_DialogAuthorityGenerate")[0].reset();
+        // Populate curve dropdown if not already done (idempotent).
+        let $curve = $("#authority\\.curve");
+        if ($curve.find("option").length === 0) {
+            $curve.append($("<option/>").val("25519").text("25519 (Curve25519, default)"));
+            $curve.append($("<option/>").val("P256").text("P256 (NIST P-256)"));
+        }
+        // Set defaults
+        $curve.val('25519');
+        $("#authority\\.duration_days").val('365');
+        $(".selectpicker").selectpicker('refresh');
+        $("#DialogAuthorityGenerate").modal('show');
+        // Initialise the tokenize (chip) fields — this manually-shown dialog is
+        // not initialised by the bootgrid edit path. Idempotent.
+        formatTokenizersUI();
+    }
+
+    // Open the Import CA dialog (reset).
+    function nebula_open_import_ca() {
+        clearFormValidation('frm_DialogAuthorityImport');
+        $("#frm_DialogAuthorityImport")[0].reset();
+        $("#DialogAuthorityImport").modal('show');
+    }
+
+    /**
+     * Confirm-then-purge expired entries via the given API endpoint, reload the
+     * grid, raise the apply notice, and report the result. Shared shape across
+     * the Authorities / Certificates / Blocklist pages; `label` names the entries
+     * in the prompts. Endpoints that guard references return skipped/skippedNames,
+     * surfaced in the result; endpoints with nothing to guard simply omit them.
+     */
+    function nebula_purge_expired(url, label) {
+        BootstrapDialog.show({
+            type: BootstrapDialog.TYPE_WARNING,
+            title: '{{ lang._('Purge expired') }}',
+            message: '{{ lang._('Remove all expired') }} ' + label +
+                '? {{ lang._('Entries still in use are kept.') }}',
+            buttons: [
+                {
+                    label: '{{ lang._('Cancel') }}',
+                    action: function (d) { d.close(); }
+                },
+                {
+                    label: '{{ lang._('Purge expired') }}',
+                    cssClass: 'btn-primary',
+                    action: function (d) {
+                        d.close();
+                        ajaxCall(url, {}, function (data, status) {
+                            if (!data || data.result !== 'saved') {
+                                return;
+                            }
+                            $("#{{formGridAuthority['table_id']}}").bootgrid('reload');
+                            $(document).trigger('settings-changed');
+                            let msg = '{{ lang._('Purged') }} ' + (data.removed || 0) +
+                                ' ' + label + '.';
+                            if (data.skipped) {
+                                msg += ' {{ lang._('Skipped') }} ' + data.skipped +
+                                    ' {{ lang._('still in use') }} (' +
+                                    (data.skippedNames || []).join(', ') + ').';
+                            }
+                            BootstrapDialog.show({
+                                type: BootstrapDialog.TYPE_INFO,
+                                title: '{{ lang._('Purge expired') }}',
+                                message: $('<div/>').text(msg).html()
+                            });
+                        });
+                    }
+                }
+            ]
+        });
+    }
+
+    /**
+     * Helper: show a parsed cert-info dialog for an authority uuid.
+     */
+    function nebula_show_ca_info(uuid) {
+        ajaxGet('/api/nebula/authority/info/' + uuid, {}, function (data, status) {
+            if (data && data.info) {
+                let info  = data.info;
+                let lines = [];
+                $.each(info, function (i, cert) {
+                    $.each(cert, function (k, v) {
+                        if (typeof v === 'object') {
+                            lines.push(k + ':');
+                            $.each(v, function (dk, dv) {
+                                lines.push('  ' + dk + ': ' + dv);
+                            });
+                        } else {
+                            lines.push(k + ': ' + v);
+                        }
+                    });
+                    lines.push('');
+                });
+                BootstrapDialog.show({
+                    title: '{{ lang._('Authority Info') }}',
+                    type: BootstrapDialog.TYPE_INFO,
+                    message: $("<pre/>").text(lines.join("\n")).css({
+                        'max-height': '60vh',
+                        'overflow-y': 'auto',
+                        'font-size': '12px'
+                    }),
+                    cssClass: 'monospace-dialog'
+                });
+            } else {
+                let msg = (data && data.error) ? data.error : '{{ lang._('Could not retrieve authority info.') }}';
+                BootstrapDialog.show({
+                    type: BootstrapDialog.TYPE_DANGER,
+                    title: '{{ lang._('Error') }}',
+                    message: $("<div/>").text(msg).html()
+                });
+            }
+        });
+    }
+
+    /**
+     * Helper: download a PEM file for an authority uuid and type ('crt' or 'key').
+     */
+    function nebula_download_ca_file(uuid, type) {
+        ajaxCall('/api/nebula/authority/generate_file/' + uuid + '/' + type, {}, function (data, status) {
+            if (data && data.status === 'ok') {
+                let ext      = type === 'key' ? 'key' : 'crt';
+                let filename = (data.descr || uuid) + '.' + ext;
+                download_content(data.payload, filename, 'application/octet-stream');
+            } else {
+                let msg = (data && data.error) ? data.error : '{{ lang._('Download failed.') }}';
+                BootstrapDialog.show({
+                    type: BootstrapDialog.TYPE_DANGER,
+                    title: '{{ lang._('Error') }}',
+                    message: $("<div/>").text(msg).html()
+                });
+            }
+        });
+    }
+
+    $(document).ready(function () {
+
+        // -----------------------------------------------------------------------
+        // Authorities grid
+        //
+        // The toolbar actions (Generate CA / Import CA) are registered as bootgrid
+        // *footer commands* (footer:true, primary:true) rather than hand-rolled
+        // <tfoot> buttons. The new Tabulator-based UIBootgrid detaches any custom
+        // tfoot button on init and only re-appends it asynchronously on tableBuilt,
+        // so a direct $("#btn_x").click() bound right after .UIBootgrid() binds to a
+        // detached (empty) node and never fires. Registering via `commands` lets
+        // bootgrid render and bind the buttons itself, the way Trust/OpenVPN do.
+        // -----------------------------------------------------------------------
+        $("#{{formGridAuthority['table_id']}}").UIBootgrid({
+            search: '/api/nebula/authority/search_item',
+            get:    '/api/nebula/authority/get_item/',
+            set:    '/api/nebula/authority/set_item/',
+            del:    '/api/nebula/authority/del_item/',
+            options: {
+                selection: false,
+                formatters: {
+                    // First 8 hex of the fingerprint — enough to disambiguate
+                    // like-named CAs without showing the full 64-char digest.
+                    "nebula_fp8": function (column, row) {
+                        let fp = (row.fingerprint || '').toString();
+                        return fp ? $('<code/>').text(fp.substring(0, 8)).prop('outerHTML') : '';
+                    }
+                }
+            },
+            commands: {
+                download_crt: {
+                    method: function (event) {
+                        let uuid = $(this).data('row-id') !== undefined ? $(this).data('row-id') : '';
+                        nebula_download_ca_file(uuid, 'crt');
+                    },
+                    classname: 'fa fa-fw fa-cloud-download',
+                    title: '{{ lang._('Download certificate') }}',
+                    sequence: 10
+                },
+                download_key: {
+                    method: function (event) {
+                        let uuid = $(this).data('row-id') !== undefined ? $(this).data('row-id') : '';
+                        nebula_download_ca_file(uuid, 'key');
+                    },
+                    classname: 'fa fa-fw fa-key',
+                    title: '{{ lang._('Download key') }}',
+                    sequence: 20
+                },
+                view: {
+                    method: function (event) {
+                        let uuid = $(this).data('row-id') !== undefined ? $(this).data('row-id') : '';
+                        nebula_show_ca_info(uuid);
+                    },
+                    classname: 'fa fa-fw fa-search',
+                    title: '{{ lang._('Inspect') }}',
+                    sequence: 30
+                },
+                generate_ca: {
+                    method: nebula_open_generate_ca,
+                    classname: 'fa fa-fw fa-plus',
+                    title: '{{ lang._('Generate a new Nebula CA') }}',
+                    sequence: 10,
+                    footer: true,
+                    primary: true
+                },
+                import_ca: {
+                    method: nebula_open_import_ca,
+                    classname: 'fa fa-fw fa-cloud-upload',
+                    title: '{{ lang._('Import an existing Nebula CA') }}',
+                    sequence: 20,
+                    footer: true,
+                    primary: true
+                },
+                purge_expired: {
+                    method: function (event) {
+                        nebula_purge_expired(
+                            '/api/nebula/authority/purge_expired',
+                            '{{ lang._('certificate authorities') }}'
+                        );
+                    },
+                    classname: 'fa fa-fw fa-clock-o',
+                    title: '{{ lang._('Purge expired certificate authorities') }}',
+                    sequence: 30,
+                    footer: true,
+                    primary: false
+                }
+            }
+        });
+
+        // Hide the download-key button on rows that have no private key stored, and
+        // mark encrypted CAs with a small lock icon in the Can-sign cell so the user
+        // knows a passphrase is needed to sign with them.
+        $("#{{formGridAuthority['table_id']}}").on("loaded.rs.jquery.bootgrid", function () {
+            let $grid = $(this);
+            $.each($grid.bootgrid('getCurrentRows'), function (i, row) {
+                let $tr = $grid.find('tr[data-row-id="' + row.uuid + '"]');
+                if (row.has_key !== '1') {
+                    $tr.find('.command-download_key').hide();
+                }
+                if (row.key_encrypted === '1') {
+                    let $cell = $tr.find('td[data-column-id="can_sign"]');
+                    if ($cell.length && $cell.find('.fa-lock').length === 0) {
+                        $cell.append(
+                            $('<i class="fa fa-lock" style="margin-left:6px;"></i>')
+                                .attr('title', '{{ lang._('Encrypted CA — a passphrase is required to sign') }}')
+                        );
+                    }
+                }
+            });
+        });
+
+        // Save buttons for authority custom dialogs (live in static modal markup,
+        // never detached, so direct binding is safe here).
+        $("#btn_DialogAuthorityGenerate_save").click(function () {
+            nebula_custom_save(
+                'frm_DialogAuthorityGenerate',
+                'authority',
+                '/api/nebula/authority/generate',
+                'DialogAuthorityGenerate',
+                '{{formGridAuthority["table_id"]}}'
+            );
+        });
+
+        $("#btn_DialogAuthorityImport_save").click(function () {
+            nebula_custom_save(
+                'frm_DialogAuthorityImport',
+                'authority',
+                '/api/nebula/authority/import',
+                'DialogAuthorityImport',
+                '{{formGridAuthority["table_id"]}}'
+            );
+        });
+    });
+</script>
+
+<ul class="nav nav-tabs" data-tabs="tabs" id="maintabs">
+    <li class="active"><a data-toggle="tab" href="#authorities_tab">{{ lang._('Authorities') }}</a></li>
+</ul>
+<div class="tab-content content-box">
+    <div id="authorities_tab" class="tab-pane fade in active">
+        {{ partial('layout_partials/base_bootgrid_table', formGridAuthority + {
+            'command_width': '220',
+            'hide_add': true,
+            'hide_delete': true
+        }) }}
+    </div>
+</div>
+
+{# ============================================================================
+   Edit dialog (standard CRUD — base_dialog handles save via UIBootgrid)
+============================================================================ #}
+{{ partial("layout_partials/base_dialog", [
+    'fields': formDialogAuthority,
+    'id':     formGridAuthority['edit_dialog_id'],
+    'label':  lang._('Edit Authority')
+]) }}
+
+{# ============================================================================
+   Custom-action dialogs (generate / import — manual POST via ajaxCall)
+============================================================================ #}
+{{ partial("layout_partials/base_dialog", [
+    'fields': formAuthorityGenerate,
+    'id':     'DialogAuthorityGenerate',
+    'label':  lang._('Generate Certificate Authority')
+]) }}
+
+{{ partial("layout_partials/base_dialog", [
+    'fields': formAuthorityImport,
+    'id':     'DialogAuthorityImport',
+    'label':  lang._('Import Certificate Authority')
+]) }}

--- a/net/nebula/src/opnsense/mvc/app/views/OPNsense/Nebula/blocklist.volt
+++ b/net/nebula/src/opnsense/mvc/app/views/OPNsense/Nebula/blocklist.volt
@@ -1,0 +1,349 @@
+{#
+ # Copyright (c) 2026 Henry Stern <henry@stern.ca>
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1. Redistributions of source code must retain the above copyright notice,
+ #    this list of conditions and the following disclaimer.
+ #
+ # 2. Redistributions in binary form must reproduce the above copyright notice,
+ #    this list of conditions and the following disclaimer in the documentation
+ #    and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+#}
+
+<script>
+    'use strict';
+
+    $(document).ready(function () {
+
+        // -----------------------------------------------------------------------
+        // Deep-link filter: when arriving from the certificate "Block" button the
+        // URL may carry ?instance=<uuid>. Read it and scope the grid's search
+        // endpoint to that instance so only entries that apply to it are shown.
+        // (Blank = "All instances" = global entries plus every instance's entries.)
+        // -----------------------------------------------------------------------
+        const deepLinkInstance = new URLSearchParams(window.location.search).get('instance') || '';
+
+        // The instance the grid is currently scoped to. Read by the grid's
+        // requestHandler (below) and updated by the dropdown without ever tearing
+        // the grid down. Seeded from the deep-link, if present.
+        let scopedInstance = deepLinkInstance;
+
+        // Wire the bootgrid change-alert. UIBootgrid.showSaveAlert() (fired after
+        // every add/edit/delete/toggle) slides down the element named by the
+        // table's data-editAlert attribute — same mechanism core uses on
+        // OPNsense/IDS/index.volt. base_bootgrid_table does not forward editAlert,
+        // so set it on the table element BEFORE UIBootgrid() captures it.
+
+        // The grid is created ONCE. Instance scoping is applied per-request via a
+        // requestHandler that injects the selected uuid into the search POST
+        // (mirrors firewall.volt). The search endpoint reads the `instance` param
+        // via $request->get() and filters server-side (global OR this instance).
+        const grid_block = $("#{{formGridBlocklistEntry['table_id']}}").UIBootgrid({
+            search: '/api/nebula/blocklist/search_item',
+            get:    '/api/nebula/blocklist/get_item/',
+            set:    '/api/nebula/blocklist/set_item/',
+            add:    '/api/nebula/blocklist/add_item/',
+            del:    '/api/nebula/blocklist/del_item/',
+            toggle: '/api/nebula/blocklist/toggle_item/',
+            options: {
+                selection: false,
+                requestHandler: function (request) {
+                    if (scopedInstance) {
+                        request['instance'] = scopedInstance;
+                    }
+                    return request;
+                }
+            },
+            commands: {
+                import_block: {
+                    method: nebula_open_import_block,
+                    classname: 'fa fa-fw fa-cloud-upload',
+                    title: '{{ lang._('Import a list of fingerprints') }}',
+                    sequence: 10,
+                    footer: true,
+                    primary: true
+                },
+                purge_expired: {
+                    method: nebula_purge_expired_block,
+                    classname: 'fa fa-fw fa-clock-o',
+                    title: '{{ lang._('Purge expired blocklist entries') }}',
+                    sequence: 20,
+                    footer: true,
+                    primary: false
+                }
+            }
+        });
+
+        // -----------------------------------------------------------------------
+        // Instance filter dropdown (above the grid). Populated from the instance
+        // API plus an "All" option; changing it re-points the grid search and
+        // reloads in place. Pre-selects the deep-linked instance when present.
+        // -----------------------------------------------------------------------
+        const $filter = $("#nebula_block_instance_filter");
+
+        ajaxGet('/api/nebula/instance/search_item', {}, function (data, status) {
+            $filter.append($("<option/>").val('').text('{{ lang._('All instances') }}'));
+            // Explicit "Global" view: only the global blocklist (the list every
+            // instance inherits), via the __global__ sentinel the search endpoint
+            // recognises. Selecting an instance below shows global + that instance.
+            $filter.append($("<option/>").val('__global__').text('{{ lang._('Global') }}'));
+            if (data && data.rows) {
+                $.each(data.rows, function (i, row) {
+                    let label = row.description ? row.description : row.uuid;
+                    $filter.append($("<option/>").val(row.uuid).text(label));
+                });
+            }
+            // Pre-select the deep-linked instance, if any.
+            $filter.val(deepLinkInstance);
+            if ($filter.hasClass('selectpicker')) {
+                $filter.selectpicker('refresh');
+            }
+        });
+
+        // Changing the dropdown only updates the scope and reloads the existing
+        // grid in place — no destroy/recreate, so no orphaned search widgets.
+        $filter.on('changed.bs.select change', function () {
+            scopedInstance = $(this).val() || '';
+            $("#{{formGridBlocklistEntry['table_id']}}").bootgrid('reload');
+        });
+
+        // -----------------------------------------------------------------------
+        // Auto-fill: when the edit dialog's certificate dropdown changes, copy the
+        // chosen cert's fingerprint + expiry (valid_to) into those fields. The
+        // certref is a convenience picker; the fingerprint is what is stored and
+        // rendered. We fetch the cert list once and index by uuid.
+        // -----------------------------------------------------------------------
+        let nebula_cert_index = {};
+        ajaxGet('/api/nebula/certificate/search_item', {}, function (data, status) {
+            if (data && data.rows) {
+                $.each(data.rows, function (i, row) {
+                    nebula_cert_index[row.uuid] = row;
+                });
+            }
+        });
+
+        // base_dialog renders the certref field with id "entry.certref" (escape the
+        // dot). Certificate and fingerprint are MUTUALLY EXCLUSIVE: choosing a
+        // known certificate fills + locks the fingerprint (and expiry); clearing
+        // it re-enables manual fingerprint entry. This handler also fires when the
+        // dialog populates the selectpicker on open, so the locked/unlocked state
+        // is correct for edits too.
+        $(document).on('changed.bs.select change', '#entry\\.certref', function () {
+            let uuid = $(this).val() || '';
+            let cert = nebula_cert_index[uuid];
+            let $fp = $("#entry\\.fingerprint");
+            if (uuid && cert) {
+                if (cert.fingerprint) {
+                    $fp.val(cert.fingerprint);
+                }
+                if (cert.valid_to !== undefined) {
+                    // Store the date portion only (the model compares on YYYY-MM-DD).
+                    $("#entry\\.expiry").val(String(cert.valid_to).substring(0, 10));
+                }
+                // Cert chosen → fingerprint is derived; lock it.
+                $fp.prop('readonly', true);
+            } else {
+                // No cert → allow manual fingerprint entry.
+                $fp.prop('readonly', false);
+            }
+        });
+
+        // Normalise a pasted fingerprint to bare lowercase hex (strip the colons,
+        // spaces and uppercase that copy-from-a-cert-tool often carries) so it
+        // matches the 64-hex the model requires.
+        $(document).on('blur change', '#entry\\.fingerprint', function () {
+            let v = ($(this).val() || '').toLowerCase().replace(/[^0-9a-f]/g, '');
+            if (v !== $(this).val()) {
+                $(this).val(v);
+            }
+        });
+
+        // -----------------------------------------------------------------------
+        // Expiry date picker. The field is free text and the renderer now parses
+        // leniently (strtotime), but the picker keeps entries in the canonical
+        // yyyy-mm-dd the model expects. clearBtn lets the user wipe it back to
+        // "never expires".
+        // -----------------------------------------------------------------------
+        $("#entry\\.expiry").datepicker({
+            format: 'yyyy-mm-dd',
+            autoclose: true,
+            todayHighlight: true,
+            clearBtn: true,
+            orientation: 'bottom auto'
+        });
+
+        // -----------------------------------------------------------------------
+        // Purge expired blocklist entries — confirm, delete every entry past its
+        // Expiry date, reload the grid and raise the apply notice. Unlike the CA
+        // and certificate grids there is nothing referencing a blocklist entry,
+        // so none are ever skipped (the renderer keeps blocking until purged).
+        // -----------------------------------------------------------------------
+        function nebula_purge_expired_block() {
+            BootstrapDialog.show({
+                type: BootstrapDialog.TYPE_WARNING,
+                title: '{{ lang._('Purge expired') }}',
+                message: '{{ lang._('Remove all blocklist entries whose Expiry date has passed?') }}',
+                buttons: [
+                    {
+                        label: '{{ lang._('Cancel') }}',
+                        action: function (d) { d.close(); }
+                    },
+                    {
+                        label: '{{ lang._('Purge expired') }}',
+                        cssClass: 'btn-primary',
+                        action: function (d) {
+                            d.close();
+                            ajaxCall('/api/nebula/blocklist/purge_expired', {}, function (data, status) {
+                                if (!data || data.result !== 'saved') {
+                                    return;
+                                }
+                                $("#{{formGridBlocklistEntry['table_id']}}").bootgrid('reload');
+                                $(document).trigger('settings-changed');
+                                let msg = '{{ lang._('Purged') }} ' + (data.removed || 0) +
+                                    ' {{ lang._('expired blocklist entries.') }}';
+                                BootstrapDialog.show({
+                                    type: BootstrapDialog.TYPE_INFO,
+                                    title: '{{ lang._('Purge expired') }}',
+                                    message: $('<div/>').text(msg).html()
+                                });
+                            });
+                        }
+                    }
+                ]
+            });
+        }
+
+        // -----------------------------------------------------------------------
+        // Bulk import dialog — populate scope + instance dropdowns, then show it.
+        // Declared as a function so the grid's import_block command (above) can
+        // reference it before this line executes (hoisting).
+        // -----------------------------------------------------------------------
+        function nebula_open_import_block() {
+            clearFormValidation('frm_DialogBlocklistImport');
+            $("#frm_DialogBlocklistImport")[0].reset();
+
+            let $scope = $("#import\\.scope");
+            if ($scope.find('option').length === 0) {
+                $scope.append($("<option/>").val('global').text('{{ lang._('Global (all instances)') }}'));
+                $scope.append($("<option/>").val('instance').text('{{ lang._('This instance') }}'));
+            }
+            $scope.val('global');
+
+            let $inst = $("#import\\.instance");
+            $inst.empty();
+            ajaxGet('/api/nebula/instance/search_item', {}, function (data) {
+                if (data && data.rows) {
+                    $.each(data.rows, function (i, r) {
+                        $inst.append($("<option/>").val(r.uuid).text(r.description ? r.description : r.uuid));
+                    });
+                }
+                $("#DialogBlocklistImport .selectpicker").selectpicker('refresh');
+            });
+            $("#DialogBlocklistImport .selectpicker").selectpicker('refresh');
+            $("#DialogBlocklistImport").modal('show');
+        }
+
+        $("#btn_DialogBlocklistImport_save").click(function () {
+            clearFormValidation('frm_DialogBlocklistImport');
+            let params = {
+                scope:        $("#import\\.scope").val() || 'global',
+                instance:     $("#import\\.instance").val() || '',
+                descr:        $("#import\\.descr").val() || '',
+                fingerprints: $("#import\\.fingerprints").val() || ''
+            };
+            ajaxCall('/api/nebula/blocklist/import', params, function (data, status) {
+                if (data && data.result === 'saved') {
+                    $("#DialogBlocklistImport").modal('hide');
+                    $("#{{formGridBlocklistEntry['table_id']}}").bootgrid('reload');
+                    $(document).trigger('settings-changed');
+                    let msg = '{{ lang._('Imported') }} ' + (data.added || 0) +
+                        ', {{ lang._('skipped (already blocked)') }} ' + (data.skipped || 0);
+                    if (data.invalid && data.invalid.length) {
+                        msg += ', {{ lang._('invalid') }} ' + data.invalid.length +
+                            ' (' + data.invalid.slice(0, 5).join(', ') +
+                            (data.invalid.length > 5 ? ', …' : '') + ')';
+                    }
+                    BootstrapDialog.show({
+                        type: BootstrapDialog.TYPE_INFO,
+                        title: '{{ lang._('Blocklist import') }}',
+                        message: $('<div/>').text(msg).html()
+                    });
+                } else if (data && data.validations) {
+                    handleFormValidation('frm_DialogBlocklistImport', data.validations);
+                }
+            });
+        });
+
+        // -----------------------------------------------------------------------
+        // Apply / reconfigure button — re-render Nebula configs after edits.
+        // -----------------------------------------------------------------------
+        $("#reconfigureAct").SimpleActionButton();
+
+        // Persistent "apply needed": if a prior change has not been reconfigured,
+        // raise the change notice on load too (the marker is cleared on Apply).
+        ajaxGet('/api/nebula/service/dirty', {}, function (data) {
+            if (data && data.isDirty) {
+                $(document).trigger('settings-changed');
+            }
+        });
+
+        // Render the page-header service controls (start/restart/stop) on load —
+        // same as core OPNsense/IDS/index.volt. Without it the controls only
+        // appear after an Apply and vanish on reload.
+        updateServiceControlUI('nebula');
+    });
+</script>
+
+<ul class="nav nav-tabs" data-tabs="tabs" id="maintabs">
+    <li class="active"><a data-toggle="tab" href="#blocklist_tab">{{ lang._('Blocklist') }}</a></li>
+</ul>
+<div class="tab-content content-box">
+    <div id="blocklist_tab" class="tab-pane fade in active">
+        <div class="col-md-12" style="margin-top: 10px; margin-bottom: 10px;">
+            <label for="nebula_block_instance_filter">{{ lang._('Instance') }}</label>
+            <select id="nebula_block_instance_filter" class="selectpicker" data-width="300px"
+                    data-live-search="true"></select>
+        </div>
+        {{ partial('layout_partials/base_bootgrid_table', formGridBlocklistEntry + {
+            'command_width': '160'
+        }) }}
+    </div>
+</div>
+
+{{ partial('layout_partials/base_apply_button', {
+    'data_endpoint': '/api/nebula/service/reconfigure',
+    'data_service_widget': 'nebula',
+    'data_error_title': 'Error reconfiguring Nebula'
+}) }}
+
+{# ============================================================================
+   Edit dialog (standard CRUD — base_dialog handles save via UIBootgrid)
+============================================================================ #}
+{{ partial("layout_partials/base_dialog", [
+    'fields': formDialogBlocklistEntry,
+    'id':     formGridBlocklistEntry['edit_dialog_id'],
+    'label':  lang._('Edit Blocklist Entry')
+]) }}
+
+{# ============================================================================
+   Bulk-import dialog (custom action — manual POST via ajaxCall)
+============================================================================ #}
+{{ partial("layout_partials/base_dialog", [
+    'fields': formBlocklistImport,
+    'id':     'DialogBlocklistImport',
+    'label':  lang._('Import Blocklist Fingerprints')
+]) }}

--- a/net/nebula/src/opnsense/mvc/app/views/OPNsense/Nebula/certificates.volt
+++ b/net/nebula/src/opnsense/mvc/app/views/OPNsense/Nebula/certificates.volt
@@ -1,0 +1,569 @@
+{#
+ # Copyright (c) 2026 Henry Stern <henry@stern.ca>
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1. Redistributions of source code must retain the above copyright notice,
+ #    this list of conditions and the following disclaimer.
+ #
+ # 2. Redistributions in binary form must reproduce the above copyright notice,
+ #    this list of conditions and the following disclaimer in the documentation
+ #    and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+#}
+
+<style>
+    .monospace-dialog {
+        font-family: monospace;
+        white-space: pre;
+    }
+    .monospace-dialog > .modal-dialog {
+        width: 70% !important;
+    }
+    .modal-body {
+        max-height: calc(100vh - 210px);
+        overflow-y: auto;
+    }
+</style>
+
+<script>
+    'use strict';
+
+    /**
+     * CA network constraints indexed by UUID — populated when the Sign dialog
+     * fetches the authority list.  Used to update the hint below the caref dropdown.
+     * Each entry also carries key_encrypted ('1'/'0') so the passphrase field can be
+     * shown + marked required only for encrypted CAs.
+     */
+    let nebula_ca_networks = {};
+
+    /**
+     * Show or hide the Sign dialog's passphrase field based on whether the
+     * currently selected CA is encrypted.  An encrypted CA needs a passphrase to
+     * decrypt its key for signing (supplied per-operation, never stored); an
+     * unencrypted CA does not, so we hide the field and clear it to avoid sending a
+     * stray value.  We toggle the surrounding form-group (the <tr>/row that
+     * base_dialog renders) so the label hides with the input.
+     */
+    function nebula_update_passphrase_visibility() {
+        let uuid = $("#DialogCertificateSign #certificate\\.caref").val();
+        let $field = $("#DialogCertificateSign #certificate\\.passphrase");
+        // base_dialog renders each field inside a <tr>; fall back to the closest
+        // .form-group for non-table layouts.
+        let $row = $field.closest('tr');
+        if ($row.length === 0) {
+            $row = $field.closest('.form-group');
+        }
+        let encrypted = !!(uuid && nebula_ca_networks[uuid] && nebula_ca_networks[uuid].key_encrypted === '1');
+        if (encrypted) {
+            $row.show();
+            $field.prop('required', true);
+        } else {
+            $field.val('');
+            $field.prop('required', false);
+            $row.hide();
+        }
+    }
+
+    /**
+     * Update the CA-networks hint paragraph in the Sign dialog based on the
+     * currently selected caref value.
+     */
+    function nebula_update_ca_networks_hint() {
+        let uuid = $("#DialogCertificateSign #certificate\\.caref").val();
+        let $hint = $("#nebula_ca_networks_hint");
+        if (!uuid || !nebula_ca_networks[uuid]) {
+            $hint.text('{{ lang._('Selected CA allows networks: (none selected)') }}');
+            return;
+        }
+        let ca = nebula_ca_networks[uuid];
+        let nets   = ca.networks        || '';
+        let unsafe = ca.unsafe_networks || '';
+        let netStr   = nets   !== '' ? nets   : '{{ lang._('any (unrestricted)') }}';
+        let unsafeStr = unsafe !== '' ? unsafe : '{{ lang._('none') }}';
+        $hint.text('{{ lang._('Selected CA allows networks: ') }}' + netStr + ' {{ lang._('(unsafe: ') }}' + unsafeStr + ')');
+    }
+
+    /**
+     * Populate the CA <select> inside a specific dialog.
+     *
+     * Fetches /api/nebula/authority/search_item and fills the <select> whose id
+     * ends with the field name "caref" within the given dialog container.
+     *
+     * We scope the lookup to dialog_id because both the Sign and Import dialogs
+     * have a field with id="certificate.caref".  A bare $("#certificate\\.caref")
+     * only matches the first one in the DOM.  Scoping avoids duplicate-ID
+     * ambiguity and keeps each dialog independent.
+     *
+     * The selectpicker refresh is deferred until inside the AJAX callback so that
+     * it runs AFTER the <option> elements have been appended — calling it before
+     * the callback returns would leave the Bootstrap dropdown empty.
+     *
+     * When called for the Sign dialog, also caches each CA's networks/unsafe_networks
+     * so that nebula_update_ca_networks_hint() can display the constraint hint.
+     *
+     * @param {string} dialog_id  — id of the Bootstrap modal div (e.g. 'DialogCertificateSign')
+     * @param {string} field_id   — literal id attr of the <select> (e.g. 'certificate.caref')
+     */
+    function nebula_populate_caref(dialog_id, field_id) {
+        ajaxGet('/api/nebula/authority/search_item', {}, function (data, status) {
+            // Scope to the specific dialog to avoid duplicate-id ambiguity.
+            let $sel = $("#" + dialog_id).find("#" + field_id.replace(/\./g, '\\.'));
+            $sel.empty().append($("<option value=''/>").text('{{ lang._('— select CA —') }}'));
+            if (data && data.rows) {
+                $.each(data.rows, function (i, row) {
+                    // Only offer CAs that can currently sign (is_ca + a key present).
+                    // Encrypted CAs ARE signable now (can_sign='1') and appear here;
+                    // the passphrase field is shown for them on selection.  Cert-only
+                    // CAs have can_sign='0' and remain excluded.
+                    if (row.can_sign !== '1') {
+                        return;
+                    }
+                    // Disambiguate same-named CAs with the first 8 chars of the CA
+                    // fingerprint (git-short-hash style), e.g. "demo-ca (06a57199…)".
+                    let label = row.descr || row.cn || row.uuid;
+                    let fp    = row.fingerprint || '';
+                    if (fp !== '') {
+                        label += ' (' + fp.substring(0, 8) + '…)';
+                    }
+                    $sel.append($("<option/>").val(row.uuid).text(label));
+                    // Cache network constraints + encryption flag for the Sign dialog.
+                    if (dialog_id === 'DialogCertificateSign') {
+                        nebula_ca_networks[row.uuid] = {
+                            networks:        row.networks        || '',
+                            unsafe_networks: row.unsafe_networks || '',
+                            key_encrypted:   row.key_encrypted   || '0'
+                        };
+                    }
+                });
+            }
+            // Refresh AFTER options are added so Bootstrap-select renders them.
+            $sel.selectpicker('refresh');
+            // Update the networks hint for whichever CA is currently selected
+            // (after a reset the selection will be blank, so this shows "none selected").
+            if (dialog_id === 'DialogCertificateSign') {
+                nebula_update_ca_networks_hint();
+                nebula_update_passphrase_visibility();
+            }
+        });
+    }
+
+    /**
+     * Generic custom-dialog POST helper.
+     *
+     * @param {string} frm_id        — id of the <form> element (frm_XXX)
+     * @param {string} field_prefix  — field namespace used in form field ids (e.g. 'certificate')
+     * @param {string} endpoint      — API endpoint to POST to
+     * @param {string} dialog_id     — Bootstrap modal id to hide on success
+     * @param {string} grid_id       — bootgrid table id to reload on success
+     */
+    function nebula_custom_save(frm_id, field_prefix, endpoint, dialog_id, grid_id) {
+        let params = {};
+        $("#" + frm_id + " input, #" + frm_id + " select, #" + frm_id + " textarea").each(function () {
+            let $el  = $(this);
+            let name = $el.attr('id');
+            if (name) {
+                // Strip the "field." prefix that base_dialog generates (e.g. "certificate.descr" → "descr")
+                let parts = name.split('.');
+                let key   = parts.length > 1 ? parts.slice(1).join('.') : name;
+                // Tokenize select_multiple fields return an array; join them to a
+                // comma-separated string so the sign/import actions (which read
+                // these as strings) get the expected shape.
+                let val = $el.val();
+                params[key] = Array.isArray(val) ? val.join(',') : val;
+            }
+        });
+
+        clearFormValidation(frm_id);
+
+        let $save_btn  = $("#btn_" + dialog_id + "_save");
+        let $save_icon = $("#btn_" + dialog_id + "_save_progress");
+        $save_btn.prop('disabled', true);
+        $save_icon.addClass("fa fa-spinner fa-pulse");
+
+        ajaxCall(endpoint, params, function (data, status) {
+            $save_btn.prop('disabled', false);
+            $save_icon.removeClass("fa fa-spinner fa-pulse");
+
+            if (data && data.validations) {
+                // handleFormValidation matches against the full field id (e.g. "certificate.descr"),
+                // but the API returns bare keys (e.g. "descr"). Re-prefix them.
+                let prefixed = {};
+                $.each(data.validations, function (k, v) {
+                    prefixed[field_prefix + '.' + k] = v;
+                });
+                handleFormValidation(frm_id, prefixed);
+            } else if (data && data.result === 'saved') {
+                $("#" + dialog_id).modal('hide');
+                $("#" + grid_id).bootgrid('reload');
+            } else {
+                let msg = (data && data.error) ? data.error : '{{ lang._('An unexpected error occurred.') }}';
+                BootstrapDialog.show({
+                    type: BootstrapDialog.TYPE_DANGER,
+                    title: '{{ lang._('Error') }}',
+                    message: $("<div/>").text(msg).html()
+                });
+            }
+        });
+    }
+
+    // Open the Sign Certificate dialog (reset + defaults + CA list).
+    function nebula_open_sign_cert() {
+        clearFormValidation('frm_DialogCertificateSign');
+        $("#frm_DialogCertificateSign")[0].reset();
+        // duration_days is intentionally left blank after reset — an empty value
+        // causes the controller to omit -duration from nebula-cert sign, so the
+        // cert expires just before the CA (the recommended default).
+        // Hide the passphrase field up front (no CA selected yet); the populate
+        // callback re-evaluates visibility once the dropdown is filled and again on
+        // every caref change.
+        nebula_update_passphrase_visibility();
+        // Populate CA dropdown; selectpicker refresh and networks hint update
+        // happen inside the callback once options are actually appended (async AJAX).
+        nebula_populate_caref('DialogCertificateSign', 'certificate.caref');
+        $("#DialogCertificateSign").modal('show');
+        // Initialise the tokenize (chip) fields — this manually-shown dialog is
+        // not initialised by the bootgrid edit path. Idempotent.
+        formatTokenizersUI();
+    }
+
+    // Open the Import Certificate dialog (reset).  No CA dropdown — the signing CA
+    // is derived from the cert's issuer fingerprint at render time.
+    function nebula_open_import_cert() {
+        clearFormValidation('frm_DialogCertificateImport');
+        $("#frm_DialogCertificateImport")[0].reset();
+        $("#DialogCertificateImport").modal('show');
+    }
+
+    /**
+     * Confirm-then-purge expired entries via the given API endpoint, reload the
+     * grid, raise the apply notice, and report the result. Shared shape across
+     * the Authorities / Certificates / Blocklist pages; `label` names the entries
+     * in the prompts. Endpoints that guard references return skipped/skippedNames,
+     * surfaced in the result; endpoints with nothing to guard simply omit them.
+     */
+    function nebula_purge_expired(url, label) {
+        BootstrapDialog.show({
+            type: BootstrapDialog.TYPE_WARNING,
+            title: '{{ lang._('Purge expired') }}',
+            message: '{{ lang._('Remove all expired') }} ' + label +
+                '? {{ lang._('Entries still in use are kept.') }}',
+            buttons: [
+                {
+                    label: '{{ lang._('Cancel') }}',
+                    action: function (d) { d.close(); }
+                },
+                {
+                    label: '{{ lang._('Purge expired') }}',
+                    cssClass: 'btn-primary',
+                    action: function (d) {
+                        d.close();
+                        ajaxCall(url, {}, function (data, status) {
+                            if (!data || data.result !== 'saved') {
+                                return;
+                            }
+                            $("#{{formGridCertificate['table_id']}}").bootgrid('reload');
+                            $(document).trigger('settings-changed');
+                            let msg = '{{ lang._('Purged') }} ' + (data.removed || 0) +
+                                ' ' + label + '.';
+                            if (data.skipped) {
+                                msg += ' {{ lang._('Skipped') }} ' + data.skipped +
+                                    ' {{ lang._('still in use') }} (' +
+                                    (data.skippedNames || []).join(', ') + ').';
+                            }
+                            BootstrapDialog.show({
+                                type: BootstrapDialog.TYPE_INFO,
+                                title: '{{ lang._('Purge expired') }}',
+                                message: $('<div/>').text(msg).html()
+                            });
+                        });
+                    }
+                }
+            ]
+        });
+    }
+
+    /**
+     * Helper: download a PEM file for a certificate uuid and type ('crt' or 'key').
+     */
+    function nebula_download_cert_file(uuid, type) {
+        ajaxCall('/api/nebula/certificate/generate_file/' + uuid + '/' + type, {}, function (data, status) {
+            if (data && data.status === 'ok') {
+                let ext      = type === 'key' ? 'key' : 'crt';
+                let filename = (data.descr || uuid) + '.' + ext;
+                download_content(data.payload, filename, 'application/octet-stream');
+            } else {
+                let msg = (data && data.error) ? data.error : '{{ lang._('Download failed.') }}';
+                BootstrapDialog.show({
+                    type: BootstrapDialog.TYPE_DANGER,
+                    title: '{{ lang._('Error') }}',
+                    message: $("<div/>").text(msg).html()
+                });
+            }
+        });
+    }
+
+    /**
+     * Block a certificate by certref: create a GLOBAL blocklist entry (prefilled
+     * with the cert's fingerprint + expiry) via the blocklist API, then navigate
+     * to the Blocklist page. The endpoint is idempotent — re-blocking an already
+     * globally-blocked cert is a no-op that still lands the user on the page.
+     */
+    function nebula_block_cert(uuid) {
+        if (!uuid) {
+            return;
+        }
+        ajaxCall('/api/nebula/blocklist/block_cert/' + uuid, {}, function (data, status) {
+            if (data && (data.result === 'saved' || data.result === 'exists')) {
+                // Navigate to the Blocklist page so the new global entry is shown.
+                window.location.href = '/ui/nebula/blocklist';
+            } else {
+                let msg = (data && data.error) ? data.error : '{{ lang._('Could not block certificate.') }}';
+                BootstrapDialog.show({
+                    type: BootstrapDialog.TYPE_DANGER,
+                    title: '{{ lang._('Error') }}',
+                    message: $("<div/>").text(msg).html()
+                });
+            }
+        });
+    }
+
+    $(document).ready(function () {
+
+        // -----------------------------------------------------------------------
+        // Certificates grid
+        //
+        // Toolbar actions (Sign / Import) are registered as bootgrid *footer
+        // commands* (footer:true, primary:true) instead of hand-rolled <tfoot>
+        // buttons. UIBootgrid detaches custom tfoot buttons on init and only
+        // re-appends them async on tableBuilt, so a direct $("#btn_x").click()
+        // bound right after .UIBootgrid() lands on a detached node and never
+        // fires. Registering via `commands` lets bootgrid bind them itself.
+        // -----------------------------------------------------------------------
+        $("#{{formGridCertificate['table_id']}}").UIBootgrid({
+            search: '/api/nebula/certificate/search_item',
+            get:    '/api/nebula/certificate/get_item/',
+            set:    '/api/nebula/certificate/set_item/',
+            del:    '/api/nebula/certificate/del_item/',
+            options: {
+                selection: false,
+                formatters: {
+                    // First 8 hex of the certificate fingerprint — disambiguates
+                    // like-named certs without the full 64-char digest.
+                    "nebula_fp8": function (column, row) {
+                        let fp = (row.fingerprint || '').toString();
+                        return fp ? $('<code/>').text(fp.substring(0, 8)).prop('outerHTML') : '';
+                    }
+                }
+            },
+            commands: {
+                download_crt: {
+                    method: function (event) {
+                        let uuid = $(this).data('row-id') !== undefined ? $(this).data('row-id') : '';
+                        nebula_download_cert_file(uuid, 'crt');
+                    },
+                    classname: 'fa fa-fw fa-cloud-download',
+                    title: '{{ lang._('Download certificate') }}',
+                    sequence: 10
+                },
+                download_key: {
+                    method: function (event) {
+                        let uuid = $(this).data('row-id') !== undefined ? $(this).data('row-id') : '';
+                        nebula_download_cert_file(uuid, 'key');
+                    },
+                    classname: 'fa fa-fw fa-key',
+                    title: '{{ lang._('Download key') }}',
+                    sequence: 20
+                },
+                view: {
+                    method: function (event) {
+                        let uuid = $(this).data('row-id') !== undefined ? $(this).data('row-id') : '';
+                        ajaxGet('/api/nebula/certificate/info/' + uuid, {}, function (data, status) {
+                            if (data && data.info) {
+                                let info  = data.info;
+                                let lines = [];
+                                $.each(info, function (i, cert) {
+                                    $.each(cert, function (k, v) {
+                                        if (typeof v === 'object') {
+                                            lines.push(k + ':');
+                                            $.each(v, function (dk, dv) {
+                                                lines.push('  ' + dk + ': ' + dv);
+                                            });
+                                        } else {
+                                            lines.push(k + ': ' + v);
+                                        }
+                                    });
+                                    lines.push('');
+                                });
+                                BootstrapDialog.show({
+                                    title: '{{ lang._('Certificate Info') }}',
+                                    type: BootstrapDialog.TYPE_INFO,
+                                    message: $("<pre/>").text(lines.join("\n")).css({
+                                        'max-height': '60vh',
+                                        'overflow-y': 'auto',
+                                        'font-size': '12px'
+                                    }),
+                                    cssClass: 'monospace-dialog'
+                                });
+                            } else {
+                                let msg = (data && data.error) ? data.error : '{{ lang._('Could not retrieve certificate info.') }}';
+                                BootstrapDialog.show({
+                                    type: BootstrapDialog.TYPE_DANGER,
+                                    title: '{{ lang._('Error') }}',
+                                    message: $("<div/>").text(msg).html()
+                                });
+                            }
+                        });
+                    },
+                    classname: 'fa fa-fw fa-search',
+                    title: '{{ lang._('Inspect') }}',
+                    sequence: 30
+                },
+                block_cert: {
+                    method: function (event) {
+                        let uuid = $(this).data('row-id') !== undefined ? $(this).data('row-id') : '';
+                        nebula_block_cert(uuid);
+                    },
+                    classname: 'fa fa-fw fa-ban',
+                    title: '{{ lang._('Block this certificate (global blocklist entry)') }}',
+                    sequence: 40
+                },
+                sign_cert: {
+                    method: nebula_open_sign_cert,
+                    classname: 'fa fa-fw fa-certificate',
+                    title: '{{ lang._('Sign a new host certificate under a CA') }}',
+                    sequence: 10,
+                    footer: true,
+                    primary: true
+                },
+                import_cert: {
+                    method: nebula_open_import_cert,
+                    classname: 'fa fa-fw fa-cloud-upload',
+                    title: '{{ lang._('Import a pre-signed host certificate') }}',
+                    sequence: 20,
+                    footer: true,
+                    primary: true
+                },
+                purge_expired: {
+                    method: function (event) {
+                        nebula_purge_expired(
+                            '/api/nebula/certificate/purge_expired',
+                            '{{ lang._('certificates') }}'
+                        );
+                    },
+                    classname: 'fa fa-fw fa-clock-o',
+                    title: '{{ lang._('Purge expired certificates') }}',
+                    sequence: 30,
+                    footer: true,
+                    primary: false
+                }
+            }
+        });
+
+        // Hide the download-key button on rows that have no private key stored.
+        $("#{{formGridCertificate['table_id']}}").on("loaded.rs.jquery.bootgrid", function () {
+            let $grid = $(this);
+            $.each($grid.bootgrid('getCurrentRows'), function (i, row) {
+                if (row.has_key !== '1') {
+                    $grid.find('tr[data-row-id="' + row.uuid + '"] .command-download_key').hide();
+                }
+            });
+        });
+
+        // Update the CA-networks hint whenever the CA dropdown selection changes.
+        // The selectpicker fires a 'changed.bs.select' event; fall back to 'change'
+        // for non-selectpicker environments.
+        $("#DialogCertificateSign").on('changed.bs.select change', '#certificate\\.caref', function () {
+            nebula_update_ca_networks_hint();
+            nebula_update_passphrase_visibility();
+        });
+
+        // Save buttons for certificate custom dialogs (static modal markup, never
+        // detached, so direct binding is safe here).
+        $("#btn_DialogCertificateSign_save").click(function () {
+            nebula_custom_save(
+                'frm_DialogCertificateSign',
+                'certificate',
+                '/api/nebula/certificate/sign',
+                'DialogCertificateSign',
+                '{{formGridCertificate["table_id"]}}'
+            );
+        });
+
+        $("#btn_DialogCertificateImport_save").click(function () {
+            nebula_custom_save(
+                'frm_DialogCertificateImport',
+                'certificate',
+                '/api/nebula/certificate/import',
+                'DialogCertificateImport',
+                '{{formGridCertificate["table_id"]}}'
+            );
+        });
+    });
+</script>
+
+<ul class="nav nav-tabs" data-tabs="tabs" id="maintabs">
+    <li class="active"><a data-toggle="tab" href="#certificates_tab">{{ lang._('Host Certificates') }}</a></li>
+</ul>
+<div class="tab-content content-box">
+    <div id="certificates_tab" class="tab-pane fade in active">
+        {{ partial('layout_partials/base_bootgrid_table', formGridCertificate + {
+            'command_width': '220',
+            'hide_add': true,
+            'hide_delete': true
+        }) }}
+    </div>
+</div>
+
+{# ============================================================================
+   Edit dialog (standard CRUD — base_dialog handles save via UIBootgrid)
+============================================================================ #}
+{{ partial("layout_partials/base_dialog", [
+    'fields': formDialogCertificate,
+    'id':     formGridCertificate['edit_dialog_id'],
+    'label':  lang._('Edit Certificate')
+]) }}
+
+{# ============================================================================
+   Custom-action dialogs (sign / import — manual POST via ajaxCall)
+============================================================================ #}
+{{ partial("layout_partials/base_dialog", [
+    'fields': formCertificateSign,
+    'id':     'DialogCertificateSign',
+    'label':  lang._('Sign Host Certificate')
+]) }}
+
+{# Inject the CA-networks hint paragraph into the Sign dialog after it is rendered.
+   base_dialog renders a <div id="DialogCertificateSign"> containing a .modal-body > form.
+   We append a small help paragraph immediately after the caref field row via JS in
+   document.ready (see nebula_update_ca_networks_hint above), and pre-place the <p>
+   element here so the JS can find it by id. The element is hidden until the dialog
+   is opened; the JS shows and updates it when the CA selection changes. #}
+<script>
+    $(document).ready(function () {
+        // Insert the CA-networks hint paragraph into the Sign dialog's modal-body,
+        // after the last field in the form (a natural place for contextual info).
+        // We use append rather than a fixed field row so it does not interfere with
+        // the base_dialog form layout or validation.
+        let $hint = $('<p id="nebula_ca_networks_hint" class="text-muted" style="margin:8px 15px 0;font-size:12px;"></p>');
+        $("#DialogCertificateSign .modal-body form").append($hint);
+    });
+</script>
+
+{{ partial("layout_partials/base_dialog", [
+    'fields': formCertificateImport,
+    'id':     'DialogCertificateImport',
+    'label':  lang._('Import Host Certificate')
+]) }}

--- a/net/nebula/src/opnsense/mvc/app/views/OPNsense/Nebula/firewall.volt
+++ b/net/nebula/src/opnsense/mvc/app/views/OPNsense/Nebula/firewall.volt
@@ -1,0 +1,193 @@
+{#
+ # Copyright (c) 2026 Henry Stern <henry@stern.ca>
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1. Redistributions of source code must retain the above copyright notice,
+ #    this list of conditions and the following disclaimer.
+ #
+ # 2. Redistributions in binary form must reproduce the above copyright notice,
+ #    this list of conditions and the following disclaimer in the documentation
+ #    and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+#}
+
+<script>
+    'use strict';
+
+    $(document).ready(function () {
+
+        // -----------------------------------------------------------------------
+        // Deep-link filter: when arriving from the instance "Firewall rules" (fire)
+        // button, the URL carries ?instance=<uuid>. Read it and scope the grid's
+        // search endpoint to that instance so only its rules are shown.
+        // -----------------------------------------------------------------------
+        const deepLinkInstance = new URLSearchParams(window.location.search).get('instance') || '';
+
+        // The instance the grid is currently scoped to. Read by the grid's
+        // requestHandler (below) and updated by the dropdown without ever
+        // tearing the grid down. Seeded from the deep-link, if present.
+        let scopedInstance = deepLinkInstance;
+
+        // Wire the bootgrid change-alert. UIBootgrid.showSaveAlert() (fired after
+        // every add/edit/delete/toggle) slides down the element named by the
+        // table's data-editAlert attribute — same mechanism core uses on
+        // OPNsense/IDS/index.volt (<table data-editAlert="rulesetChangeMessage">).
+        // base_bootgrid_table (core-shared) does not forward editAlert, so set it
+        // on the table element BEFORE UIBootgrid() captures it as $compatElement.
+
+        // "Match" cell: a newline-delimited summary of the rule's non-empty
+        // matchers, e.g. "host=any\ngroup=db". Built from the matcher fields
+        // returned by searchItemAction.
+        function nebula_fw_match_formatter(column, row) {
+            let fields = ['host', 'groups', 'cidr', 'local_cidr', 'ca_name', 'ca_sha'];
+            let parts = [];
+            fields.forEach(function (f) {
+                let v = row[f];
+                if (v !== undefined && v !== null && String(v).trim() !== '') {
+                    parts.push($('<div/>').text(f + '=' + v).html());
+                }
+            });
+            return parts.join('<br/>');
+        }
+
+        // The grid is created ONCE. Instance scoping is applied per-request via
+        // a requestHandler that injects the selected uuid into the search POST
+        // (mirrors core OPNsense/Firewall/filter_rule.volt, which scopes its
+        // grid by interface/category the same way). The search endpoint reads
+        // the `instance` param via $request->get() and filters server-side.
+        const grid_fw = $("#{{formGridFirewallRule['table_id']}}").UIBootgrid({
+            search: '/api/nebula/firewall_rule/search_item',
+            get:    '/api/nebula/firewall_rule/get_item/',
+            set:    '/api/nebula/firewall_rule/set_item/',
+            add:    '/api/nebula/firewall_rule/add_item/',
+            del:    '/api/nebula/firewall_rule/del_item/',
+            toggle: '/api/nebula/firewall_rule/toggle_item/',
+            options: {
+                selection: false,
+                formatters: { nebula_fw_match: nebula_fw_match_formatter },
+                requestHandler: function (request) {
+                    if (scopedInstance) {
+                        request['instance'] = scopedInstance;
+                    }
+                    return request;
+                }
+            }
+        });
+
+        // -----------------------------------------------------------------------
+        // Instance filter dropdown (above the grid). Populated from the instance
+        // API plus an "All" option; changing it re-points the grid search and
+        // reloads. Pre-selects the deep-linked instance when present.
+        // -----------------------------------------------------------------------
+        const $filter = $("#nebula_fw_instance_filter");
+
+        ajaxGet('/api/nebula/instance/search_item', {}, function (data, status) {
+            $filter.append($("<option/>").val('').text('{{ lang._('All instances') }}'));
+            if (data && data.rows) {
+                $.each(data.rows, function (i, row) {
+                    let label = row.description ? row.description : row.uuid;
+                    $filter.append($("<option/>").val(row.uuid).text(label));
+                });
+            }
+            // Pre-select the deep-linked instance, if any.
+            $filter.val(deepLinkInstance);
+            if ($filter.hasClass('selectpicker')) {
+                $filter.selectpicker('refresh');
+            }
+        });
+
+        // Changing the dropdown only updates the scope and reloads the existing
+        // grid in place — no destroy/recreate, so no orphaned search widgets.
+        $filter.on('changed.bs.select change', function () {
+            scopedInstance = $(this).val() || '';
+            $("#{{formGridFirewallRule['table_id']}}").bootgrid('reload');
+        });
+
+        // -----------------------------------------------------------------------
+        // CA name typeahead: ca_name may be typed OR picked from the configured
+        // CAs. We attach an HTML5 <datalist> of CA names (the cert-embedded cn)
+        // to the rule dialog's ca_name input — the input stays free-text, the
+        // datalist just offers the known CAs as suggestions. Server-side
+        // referential integrity (FirewallRuleController::checkCaReferences) is
+        // what actually enforces that a typed ca_name names a configured CA.
+        // -----------------------------------------------------------------------
+        ajaxGet('/api/nebula/authority/search_item', {}, function (data, status) {
+            const $dl = $('<datalist id="nebula_ca_names"></datalist>');
+            const seen = {};
+            if (data && data.rows) {
+                $.each(data.rows, function (i, row) {
+                    const cn = row.cn;
+                    if (cn && !seen[cn]) {
+                        seen[cn] = true;
+                        $dl.append($("<option/>").val(cn));
+                    }
+                });
+            }
+            $('body').append($dl);
+            // base_dialog renders the field with id "rule.ca_name" (escape the dot).
+            $("#rule\\.ca_name").attr('list', 'nebula_ca_names');
+        });
+
+        // -----------------------------------------------------------------------
+        // Apply / reconfigure button — re-render Nebula configs after rule edits.
+        // -----------------------------------------------------------------------
+        $("#reconfigureAct").SimpleActionButton();
+
+        // Persistent "apply needed": if a prior change has not been reconfigured,
+        // raise the change notice on load too (the marker is cleared on Apply).
+        ajaxGet('/api/nebula/service/dirty', {}, function (data) {
+            if (data && data.isDirty) {
+                $(document).trigger('settings-changed');
+            }
+        });
+
+        // Render the page-header service controls (start/restart/stop) on load —
+        // same as core OPNsense/IPsec/tunnels.volt / OPNsense/IDS/index.volt.
+        // Without it the controls only appear after an Apply and vanish on reload.
+        updateServiceControlUI('nebula');
+    });
+</script>
+
+<ul class="nav nav-tabs" data-tabs="tabs" id="maintabs">
+    <li class="active"><a data-toggle="tab" href="#firewall_tab">{{ lang._('Allow List') }}</a></li>
+</ul>
+<div class="tab-content content-box">
+    <div id="firewall_tab" class="tab-pane fade in active">
+        <div class="col-md-12" style="margin-top: 10px; margin-bottom: 10px;">
+            <label for="nebula_fw_instance_filter">{{ lang._('Instance') }}</label>
+            <select id="nebula_fw_instance_filter" class="selectpicker" data-width="300px"
+                    data-live-search="true"></select>
+        </div>
+        {{ partial('layout_partials/base_bootgrid_table', formGridFirewallRule + {
+            'command_width': '160'
+        }) }}
+    </div>
+</div>
+
+{{ partial('layout_partials/base_apply_button', {
+    'data_endpoint': '/api/nebula/service/reconfigure',
+    'data_service_widget': 'nebula',
+    'data_error_title': 'Error reconfiguring Nebula'
+}) }}
+
+{# ============================================================================
+   Edit dialog (standard CRUD — base_dialog handles save via UIBootgrid)
+============================================================================ #}
+{{ partial("layout_partials/base_dialog", [
+    'fields': formDialogFirewallRule,
+    'id':     formGridFirewallRule['edit_dialog_id'],
+    'label':  lang._('Edit Firewall Rule')
+]) }}

--- a/net/nebula/src/opnsense/mvc/app/views/OPNsense/Nebula/instances.volt
+++ b/net/nebula/src/opnsense/mvc/app/views/OPNsense/Nebula/instances.volt
@@ -1,0 +1,364 @@
+{#
+ # Copyright (c) 2026 Henry Stern <henry@stern.ca>
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1. Redistributions of source code must retain the above copyright notice,
+ #    this list of conditions and the following disclaimer.
+ #
+ # 2. Redistributions in binary form must reproduce the above copyright notice,
+ #    this list of conditions and the following disclaimer in the documentation
+ #    and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+#}
+
+<style>
+    .monospace-dialog {
+        font-family: monospace;
+        white-space: pre;
+    }
+    .monospace-dialog > .modal-dialog {
+        width: 70% !important;
+    }
+    .modal-body {
+        max-height: calc(100vh - 210px);
+        overflow-y: auto;
+    }
+</style>
+
+<script>
+    'use strict';
+
+    $(document).ready(function () {
+
+        // -----------------------------------------------------------------------
+        // Instances grid — lean summary columns (from the form's grid_view fields)
+        // + a live Status indicator + Interfaces-Overview-style per-row buttons.
+        // -----------------------------------------------------------------------
+
+        // Wire the bootgrid change-alert. showSaveAlert() (fired after every
+        // add/edit/delete/toggle) slides down the element named by the table's
+        // data-editAlert attribute — the core mechanism from OPNsense/IDS/index.volt.
+        // base_bootgrid_table (core-shared) does not forward editAlert, so set it
+        // on the table element BEFORE UIBootgrid() captures it as $compatElement.
+
+        const grid_instances = $("#{{formGridInstance['table_id']}}").UIBootgrid({
+            search: '/api/nebula/instance/search_item',
+            get:    '/api/nebula/instance/get_item/',
+            set:    '/api/nebula/instance/set_item/',
+            add:    '/api/nebula/instance/add_item/',
+            del:    '/api/nebula/instance/del_item/',
+            toggle: '/api/nebula/instance/toggle_item/',
+            options: {
+                selection: false,
+                formatters: {
+                    /*
+                     * Status cell — DATA-DRIVEN. The search endpoint enriches each
+                     * row with running/pid, so the formatter renders the plug + a
+                     * tooltip synchronously. (Filling cells async on the 'loaded'
+                     * event does not survive Tabulator re-renders; the bootgrid
+                     * engine auto-activates tooltips on elements carrying the
+                     * 'bootgrid-tooltip' class — see opnsense_bootgrid.js.)
+                     */
+                    "nebula_status": function (column, row) {
+                        let running = (row.running === '1' || row.running === true);
+                        let cls = running ? 'text-success' : 'text-muted';
+                        let title = running
+                            ? '{{ lang._('Running') }}' + (row.pid ? ' (pid ' + row.pid + ')' : '')
+                            : '{{ lang._('Stopped') }}';
+                        let safe = $('<div/>').text(title).html();
+                        return '<i class="fa fa-plug ' + cls + ' bootgrid-tooltip"' +
+                            ' role="img" aria-label="' + safe + '" title="' + safe + '"' +
+                            ' data-toggle="tooltip"></i>';
+                    },
+                    /*
+                     * Listen cell — combined "host:port" from the row's listen_host
+                     * + listen_port (both come back in the search data). IPv6
+                     * literals are bracketed so the address colons are not confused
+                     * with the host:port separator: "::" -> "[::]:4242". This is the
+                     * same rendering the Status page uses (nebula_format_listen).
+                     */
+                    "nebula_listen": function (column, row) {
+                        let host = (row.listen_host || '').toString();
+                        let port = (row.listen_port || '').toString();
+                        if (host.indexOf(':') !== -1 && host.charAt(0) !== '[') {
+                            host = '[' + host + ']';
+                        }
+                        return $('<div/>').text(host + ':' + port).html();
+                    }
+                }
+            },
+            commands: {
+                reload: {
+                    method: function (event) {
+                        let uuid = $(this).data('row-id');
+                        let $element = $(this).find('i');
+                        $element.removeClass('fa-refresh').addClass('fa-spinner fa-spin');
+                        ajaxCall('/api/nebula/instance/reload/' + uuid, {}, function (data, status) {
+                            $element.removeClass('fa-spinner fa-spin').addClass('fa-refresh');
+                            /* The reload endpoint returns the restart_instance
+                             * JSON result {started, error}. If the (re)start
+                             * failed, surface the real reason (e.g. "Failed to
+                             * get a tun/tap device: device busy") instead of
+                             * silently doing nothing. */
+                            if (data && data.started === false) {
+                                BootstrapDialog.show({
+                                    type: BootstrapDialog.TYPE_DANGER,
+                                    title: '{{ lang._('Nebula instance failed to start') }}',
+                                    message: $('<div/>').text(
+                                        data.error || '{{ lang._('The instance could not be started.') }}'
+                                    ).html()
+                                });
+                            }
+                            /* give the daemon a moment to come up, then reload the
+                             * grid so the data-driven status column re-renders. */
+                            setTimeout(function () {
+                                $("#{{formGridInstance['table_id']}}").bootgrid('reload');
+                            }, 1000);
+                        });
+                    },
+                    classname: 'fa fa-fw fa-refresh',
+                    title: '{{ lang._('Reload') }}',
+                    sequence: 5
+                },
+                details: {
+                    method: function (event) {
+                        let uuid = $(this).data('row-id');
+                        ajaxGet('/api/nebula/instance/status/' + uuid, {}, function (sdata, sstatus) {
+                            let lines = [];
+                            lines.push('{{ lang._('Status') }}');
+                            if (sdata && sdata.running) {
+                                lines.push('  ' + '{{ lang._('running') }}' +
+                                    (sdata.pid ? ' (pid ' + sdata.pid + ')' : ''));
+                            } else {
+                                lines.push('  ' + '{{ lang._('stopped') }}');
+                            }
+                            lines.push('');
+                            /* fetch the instance to learn its certref, then the cert info */
+                            ajaxGet('/api/nebula/instance/get_item/' + uuid, {}, function (idata, istatus) {
+                                let certref = (idata && idata.instance && idata.instance.certref)
+                                    ? idata.instance.certref : '';
+                                /* certref is a dropdown map {uuid: {value, selected}} */
+                                if (typeof certref === 'object' && certref !== null) {
+                                    let sel = '';
+                                    $.each(certref, function (k, v) {
+                                        if (v.selected == 1) {
+                                            sel = k;
+                                        }
+                                    });
+                                    certref = sel;
+                                }
+                                let show = function (extra) {
+                                    BootstrapDialog.show({
+                                        title: '{{ lang._('Instance Details') }}',
+                                        type: BootstrapDialog.TYPE_INFO,
+                                        message: $("<pre/>").text(lines.concat(extra).join("\n")).css({
+                                            'max-height': '60vh',
+                                            'overflow-y': 'auto',
+                                            'font-size': '12px'
+                                        }),
+                                        cssClass: 'monospace-dialog'
+                                    });
+                                };
+                                if (!certref) {
+                                    show(['{{ lang._('No certificate assigned.') }}']);
+                                    return;
+                                }
+                                ajaxGet('/api/nebula/certificate/info/' + certref, {}, function (cdata, cstatus) {
+                                    let extra = ['{{ lang._('Certificate') }}'];
+                                    if (cdata && cdata.info) {
+                                        $.each(cdata.info, function (i, cert) {
+                                            $.each(cert, function (k, v) {
+                                                if (typeof v === 'object') {
+                                                    extra.push('  ' + k + ':');
+                                                    $.each(v, function (dk, dv) {
+                                                        extra.push('    ' + dk + ': ' + dv);
+                                                    });
+                                                } else {
+                                                    extra.push('  ' + k + ': ' + v);
+                                                }
+                                            });
+                                        });
+                                    } else {
+                                        extra.push('  ' + '{{ lang._('Could not retrieve certificate info.') }}');
+                                    }
+                                    show(extra);
+                                });
+                            });
+                        });
+                    },
+                    classname: 'fa fa-fw fa-search',
+                    title: '{{ lang._('Details') }}',
+                    sequence: 20
+                }
+            }
+        });
+
+        /* Populate / refresh the per-row status indicators after each grid load. */
+
+        // -----------------------------------------------------------------------
+        // Conditional field visibility in the instance dialog. A field is shown
+        // only when its controlling checkbox is on AND (if it is an advanced
+        // field) advanced mode is active — so we compose with, rather than fight,
+        // the built-in advanced toggle (which also drives display on
+        // [data-advanced="true"] rows). Re-evaluated on dialog populate, on every
+        // controlling toggle, and after the advanced-mode switch reshuffles rows.
+        // -----------------------------------------------------------------------
+        function nebulaAdvancedOn() {
+            // The advanced-mode toggle icon carries fa-toggle-on when active.
+            return $('[id^="show_advanced_"]').hasClass('fa-toggle-on');
+        }
+        function nebulaChecked(id) {
+            return $("#" + id.replace(/\./g, "\\.")).is(':checked');
+        }
+        function nebulaSetVis(id, cond) {
+            const $row = $("#row_" + id.replace(/\./g, "\\."));
+            const isAdvanced = $row.attr('data-advanced') === 'true';
+            $row.toggle(cond && (!isAdvanced || nebulaAdvancedOn()));
+        }
+        function nebulaToggleInstanceFields() {
+            const amLighthouse = nebulaChecked('instance.am_lighthouse');
+            const serveDns     = nebulaChecked('instance.lighthouse_serve_dns');
+            const useRelays    = nebulaChecked('instance.relay_use_relays');
+
+            // Lighthouse: serve_dns is a lighthouse-only setting; the DNS host/port
+            // only apply when this node is a lighthouse AND serving DNS. hosts,
+            // interval and advertise_addrs stay visible — a regular node uses them.
+            nebulaSetVis('instance.lighthouse_serve_dns', amLighthouse);
+            nebulaSetVis('instance.lighthouse_dns_host', amLighthouse && serveDns);
+            nebulaSetVis('instance.lighthouse_dns_port', amLighthouse && serveDns);
+
+            // Relay: the relays list only matters when "use relays" is on.
+            nebulaSetVis('instance.relay_relays', useRelays);
+        }
+        // Fire on dialog populate (add/edit/copy), on each controlling toggle, and
+        // just after the advanced-mode switch re-shows [data-advanced] rows.
+        $('#{{ formGridInstance["edit_dialog_id"] }}').on('opnsense_bootgrid_mapped', nebulaToggleInstanceFields);
+        $(document).on('change',
+            '#instance\\.am_lighthouse, #instance\\.lighthouse_serve_dns, ' +
+            '#instance\\.relay_use_relays',
+            nebulaToggleInstanceFields);        $(document).on('click', '[id^="show_advanced_"]', function () {
+            setTimeout(nebulaToggleInstanceFields, 50);
+        });
+
+        // -----------------------------------------------------------------------
+        // New-instance default: pre-select WAN for the auto firewall rule. The
+        // model default is empty (so it never fails validation on boxes without a
+        // "wan" interface); we default the picker to WAN on Add only, and only
+        // when a "wan" interface actually exists. Editing an instance is untouched.
+        // -----------------------------------------------------------------------
+        let nebulaPendingAdd = false;
+        $(document).on('click', '.command-add', function () { nebulaPendingAdd = true; });
+        $('#{{ formGridInstance["edit_dialog_id"] }}').on('opnsense_bootgrid_mapped', function () {
+            if (!nebulaPendingAdd) { return; }
+            nebulaPendingAdd = false;
+            const $sel = $("#instance\\.firewall_interfaces");
+            if ($sel.length && ($sel.val() || []).length === 0 &&
+                    $sel.find("option[value='wan']").length) {
+                $sel.val(['wan']).trigger('change');
+                if ($sel.hasClass('selectpicker')) { $sel.selectpicker('refresh'); }
+            }
+        });
+
+        // -----------------------------------------------------------------------
+        // Disambiguate like-named certs/CAs in the dialog selectors by appending
+        // the first 8 hex of the fingerprint to each option ("name: 0123abcd").
+        // Index uuid -> short fingerprint once; relabel on each dialog populate.
+        // The original label is cached per-option so repeated opens never stack
+        // multiple suffixes.
+        // -----------------------------------------------------------------------
+        let nebulaCertFp = {};
+        let nebulaCaFp = {};
+        ajaxGet('/api/nebula/certificate/search_item', {}, function (d) {
+            if (d && d.rows) {
+                d.rows.forEach(function (r) {
+                    if (r.fingerprint) { nebulaCertFp[r.uuid] = String(r.fingerprint).substring(0, 8); }
+                });
+            }
+        });
+        ajaxGet('/api/nebula/authority/search_item', {}, function (d) {
+            if (d && d.rows) {
+                d.rows.forEach(function (r) {
+                    if (r.fingerprint) { nebulaCaFp[r.uuid] = String(r.fingerprint).substring(0, 8); }
+                });
+            }
+        });
+        function nebulaLabelOptions(selectId, fpMap) {
+            const $sel = $("#" + selectId.replace(/\./g, "\\."));
+            if (!$sel.length) { return; }
+            $sel.find('option').each(function () {
+                const fp = fpMap[$(this).val()];
+                if (!fp) { return; }
+                let base = $(this).data('nebula-base');
+                if (base === undefined) {
+                    base = $(this).text();
+                    $(this).data('nebula-base', base);
+                }
+                $(this).text(base + ': ' + fp);
+            });
+            if ($sel.hasClass('selectpicker')) { $sel.selectpicker('refresh'); }
+        }
+        $('#{{ formGridInstance["edit_dialog_id"] }}').on('opnsense_bootgrid_mapped', function () {
+            nebulaLabelOptions('instance.certref', nebulaCertFp);
+            nebulaLabelOptions('instance.trusted_cas', nebulaCaFp);
+        });
+
+        // -----------------------------------------------------------------------
+        // Apply / reconfigure button
+        // -----------------------------------------------------------------------
+        $("#reconfigureAct").SimpleActionButton();
+
+        // Persistent "apply needed": if a prior change has not been reconfigured,
+        // raise the change notice on load too (the marker is cleared on Apply).
+        ajaxGet('/api/nebula/service/dirty', {}, function (data) {
+            if (data && data.isDirty) {
+                $(document).trigger('settings-changed');
+            }
+        });
+
+        // Render the page-header service controls (start/restart/stop) on load.
+        // Core service pages (OPNsense/IPsec/tunnels.volt, OPNsense/IDS/index.volt)
+        // call this in $(document).ready; without it our controls only appear
+        // after an Apply (which calls it via data-service-widget) and vanish on
+        // reload. /api/nebula/service/status returns {status, widget} as expected.
+        updateServiceControlUI('nebula');
+    });
+</script>
+
+<ul class="nav nav-tabs" data-tabs="tabs" id="maintabs">
+    <li class="active"><a data-toggle="tab" href="#instances_tab">{{ lang._('Instances') }}</a></li>
+</ul>
+<div class="tab-content content-box">
+    <div id="instances_tab" class="tab-pane fade in active">
+        {{ partial('layout_partials/base_bootgrid_table', formGridInstance + {
+            'command_width': '160'
+        }) }}
+    </div>
+</div>
+
+{{ partial('layout_partials/base_apply_button', {
+    'data_endpoint': '/api/nebula/service/reconfigure',
+    'data_service_widget': 'nebula',
+    'data_error_title': 'Error reconfiguring Nebula'
+}) }}
+
+{# ============================================================================
+   Edit dialog (standard CRUD — base_dialog handles save via UIBootgrid)
+============================================================================ #}
+{{ partial("layout_partials/base_dialog", [
+    'fields': formDialogInstance,
+    'id':     formGridInstance['edit_dialog_id'],
+    'label':  lang._('Edit Instance')
+]) }}

--- a/net/nebula/src/opnsense/mvc/app/views/OPNsense/Nebula/routes.volt
+++ b/net/nebula/src/opnsense/mvc/app/views/OPNsense/Nebula/routes.volt
@@ -1,0 +1,183 @@
+{#
+ # Copyright (c) 2026 Henry Stern <henry@stern.ca>
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1. Redistributions of source code must retain the above copyright notice,
+ #    this list of conditions and the following disclaimer.
+ #
+ # 2. Redistributions in binary form must reproduce the above copyright notice,
+ #    this list of conditions and the following disclaimer in the documentation
+ #    and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+#}
+
+<script>
+    'use strict';
+
+    $(document).ready(function () {
+
+        // One instance filter scopes BOTH grids (Unsafe Routes + MTU Overrides).
+        // Deep-link from the instance "Routes" button carries ?instance=<uuid>.
+        const deepLinkInstance = new URLSearchParams(window.location.search).get('instance') || '';
+        let scopedInstance = deepLinkInstance;
+
+        // Wire the bootgrid change-alert on both tables before UIBootgrid captures them.
+
+        function scopeRequest(request) {
+            if (scopedInstance) {
+                request['instance'] = scopedInstance;
+            }
+            return request;
+        }
+
+        // Tab 1: unsafe routes.
+        $("#{{formGridUnsafeRoute['table_id']}}").UIBootgrid({
+            search: '/api/nebula/unsafe_route/search_item',
+            get:    '/api/nebula/unsafe_route/get_item/',
+            set:    '/api/nebula/unsafe_route/set_item/',
+            add:    '/api/nebula/unsafe_route/add_item/',
+            del:    '/api/nebula/unsafe_route/del_item/',
+            toggle: '/api/nebula/unsafe_route/toggle_item/',
+            options: { selection: false, requestHandler: scopeRequest }
+        });
+
+        // Tab 2: per-route MTU overrides (tun.routes).
+        $("#{{formGridTunRoute['table_id']}}").UIBootgrid({
+            search: '/api/nebula/tun_route/search_item',
+            get:    '/api/nebula/tun_route/get_item/',
+            set:    '/api/nebula/tun_route/set_item/',
+            add:    '/api/nebula/tun_route/add_item/',
+            del:    '/api/nebula/tun_route/del_item/',
+            toggle: '/api/nebula/tun_route/toggle_item/',
+            options: { selection: false, requestHandler: scopeRequest }
+        });
+
+        // Tab 3: static host map (reach a peer by its Nebula IP before discovery).
+        $("#{{formGridStaticHostMap['table_id']}}").UIBootgrid({
+            search: '/api/nebula/static_host_map/search_item',
+            get:    '/api/nebula/static_host_map/get_item/',
+            set:    '/api/nebula/static_host_map/set_item/',
+            add:    '/api/nebula/static_host_map/add_item/',
+            del:    '/api/nebula/static_host_map/del_item/',
+            toggle: '/api/nebula/static_host_map/toggle_item/',
+            options: { selection: false, requestHandler: scopeRequest }
+        });
+
+        // Cert index (uuid -> networks) so the static-host-map dialog can derive
+        // the Nebula IP from a chosen lighthouse certificate. On certref change,
+        // fill nebula_ip from the cert's first network's host IP (drop the mask).
+        let nebula_cert_networks = {};
+        ajaxGet('/api/nebula/certificate/search_item', {}, function (data) {
+            if (data && data.rows) {
+                $.each(data.rows, function (i, r) {
+                    nebula_cert_networks[r.uuid] = r.networks || '';
+                });
+            }
+        });
+        $(document).on('changed.bs.select change', '#entry\\.certref', function () {
+            let nets = nebula_cert_networks[$(this).val() || ''];
+            if (nets) {
+                let ip = String(nets).split(',')[0].trim().split('/')[0].trim();
+                if (ip) { $("#entry\\.nebula_ip").val(ip); }
+            }
+        });
+
+        // Shared instance filter dropdown (above the tabs).
+        const $filter = $("#nebula_route_instance_filter");
+        ajaxGet('/api/nebula/instance/search_item', {}, function (data, status) {
+            $filter.append($("<option/>").val('').text('{{ lang._('All instances') }}'));
+            if (data && data.rows) {
+                $.each(data.rows, function (i, row) {
+                    let label = row.description ? row.description : row.uuid;
+                    $filter.append($("<option/>").val(row.uuid).text(label));
+                });
+            }
+            $filter.val(deepLinkInstance);
+            if ($filter.hasClass('selectpicker')) {
+                $filter.selectpicker('refresh');
+            }
+        });
+
+        $filter.on('changed.bs.select change', function () {
+            scopedInstance = $(this).val() || '';
+            $("#{{formGridUnsafeRoute['table_id']}}").bootgrid('reload');
+            $("#{{formGridTunRoute['table_id']}}").bootgrid('reload');
+            $("#{{formGridStaticHostMap['table_id']}}").bootgrid('reload');
+        });
+
+        $("#reconfigureAct").SimpleActionButton();
+
+        // Persistent "apply needed": if a prior change has not been reconfigured,
+        // raise the change notice on load too (the marker is cleared on Apply).
+        ajaxGet('/api/nebula/service/dirty', {}, function (data) {
+            if (data && data.isDirty) {
+                $(document).trigger('settings-changed');
+            }
+        });
+        updateServiceControlUI('nebula');
+    });
+</script>
+
+<div class="col-md-12" style="margin-top: 10px; margin-bottom: 10px;">
+    <label for="nebula_route_instance_filter">{{ lang._('Instance') }}</label>
+    <select id="nebula_route_instance_filter" class="selectpicker" data-width="300px"
+            data-live-search="true"></select>
+</div>
+
+<ul class="nav nav-tabs" data-tabs="tabs" id="maintabs">
+    <li class="active"><a data-toggle="tab" href="#unsafe_tab">{{ lang._('Unsafe Routes') }}</a></li>
+    <li><a data-toggle="tab" href="#mtu_tab">{{ lang._('MTU Overrides') }}</a></li>
+    <li><a data-toggle="tab" href="#shm_tab">{{ lang._('Static Host Map') }}</a></li>
+</ul>
+<div class="tab-content content-box">
+    <div id="unsafe_tab" class="tab-pane fade in active">
+        {{ partial('layout_partials/base_bootgrid_table', formGridUnsafeRoute + {
+            'command_width': '160'
+        }) }}
+    </div>
+    <div id="mtu_tab" class="tab-pane fade">
+        {{ partial('layout_partials/base_bootgrid_table', formGridTunRoute + {
+            'command_width': '160'
+        }) }}
+    </div>
+    <div id="shm_tab" class="tab-pane fade">
+        {{ partial('layout_partials/base_bootgrid_table', formGridStaticHostMap + {
+            'command_width': '160'
+        }) }}
+    </div>
+</div>
+
+{{ partial('layout_partials/base_apply_button', {
+    'data_endpoint': '/api/nebula/service/reconfigure',
+    'data_service_widget': 'nebula',
+    'data_error_title': 'Error reconfiguring Nebula'
+}) }}
+
+{{ partial("layout_partials/base_dialog", [
+    'fields': formDialogUnsafeRoute,
+    'id':     formGridUnsafeRoute['edit_dialog_id'],
+    'label':  lang._('Edit Unsafe Route')
+]) }}
+{{ partial("layout_partials/base_dialog", [
+    'fields': formDialogTunRoute,
+    'id':     formGridTunRoute['edit_dialog_id'],
+    'label':  lang._('Edit MTU Override')
+]) }}
+{{ partial("layout_partials/base_dialog", [
+    'fields': formDialogStaticHostMap,
+    'id':     formGridStaticHostMap['edit_dialog_id'],
+    'label':  lang._('Edit Static Host Map Entry')
+]) }}

--- a/net/nebula/src/opnsense/mvc/app/views/OPNsense/Nebula/status.volt
+++ b/net/nebula/src/opnsense/mvc/app/views/OPNsense/Nebula/status.volt
@@ -1,0 +1,242 @@
+{#
+ # Copyright (c) 2026 Henry Stern <henry@stern.ca>
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1. Redistributions of source code must retain the above copyright notice,
+ #    this list of conditions and the following disclaimer.
+ #
+ # 2. Redistributions in binary form must reproduce the above copyright notice,
+ #    this list of conditions and the following disclaimer in the documentation
+ #    and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+#}
+
+<script>
+    'use strict';
+
+    $(document).ready(function () {
+
+        const $panels = $("#nebula_status_panels");
+        const $empty  = $("#nebula_status_empty");
+
+        function txt(s) { return $("<span/>").text(s === undefined || s === null ? '' : String(s)); }
+        function esc(s) { return $('<div/>').text(s === undefined || s === null ? '' : String(s)).html(); }
+
+        function row(label, $value) {
+            return $("<tr/>")
+                .append($("<td/>").css({width: '150px', 'font-weight': '600'}).text(label))
+                .append($("<td/>").append($value));
+        }
+
+        function certLine(cert) {
+            if (!cert || !cert.name) {
+                return $("<span class='text-danger'/>").text('{{ lang._('no certificate assigned') }}');
+            }
+            let parts = [cert.name];
+            if (cert.groups) { parts.push('[' + cert.groups + ']'); }
+            if (cert.networks) { parts.push(cert.networks); }
+            let $s = $("<span/>").text(parts.join('  '));
+            if (cert.valid_to) {
+                $s.append($("<span/>").text('  ' + '{{ lang._('expires') }} ' + cert.valid_to));
+            }
+            return $s;
+        }
+
+        // POST a whitelisted debug sub-action to the always-on debug server.
+        function debugCall(uuid, action, params, cb) {
+            ajaxCall('/api/nebula/instance/debug/' + encodeURIComponent(uuid) + '/' + action,
+                params || {}, function (data) { cb(data || {}); });
+        }
+
+        // --- per-peer verbs ---------------------------------------------------
+        function afterAction(uuid, data, okMsg) {
+            if (data && data.ok) {
+                if (okMsg && typeof $.notify === 'function') {
+                    $.notify(okMsg, {className: 'success', position: 'top right'});
+                }
+                refresh();
+            } else {
+                BootstrapDialog.show({
+                    type: BootstrapDialog.TYPE_DANGER,
+                    title: '{{ lang._('Nebula debug server') }}',
+                    message: esc((data && (data.error || data.raw)) || '{{ lang._('command failed') }}')
+                });
+            }
+        }
+
+        function connectPeer(uuid) {
+            let $ip = $("<input type='text' class='form-control'/>")
+                .attr('placeholder', '{{ lang._('peer nebula IP, e.g. 192.168.100.9') }}');
+            BootstrapDialog.show({
+                title: '{{ lang._('Connect to peer') }}',
+                message: $("<div/>").append($ip).append(
+                    $("<p class='text-muted' style='margin-top:6px;'/>").text(
+                        '{{ lang._('The lighthouse resolves the underlay address.') }}')),
+                buttons: [
+                    {label: '{{ lang._('Cancel') }}', action: function (d) { d.close(); }},
+                    {label: '{{ lang._('Create tunnel') }}', cssClass: 'btn-primary', action: function (d) {
+                        let ip = ($ip.val() || '').trim();
+                        if (ip) {
+                            debugCall(uuid, 'createtunnel', {vpn: ip}, function (r) {
+                                afterAction(uuid, r, '{{ lang._('Tunnel requested') }}');
+                            });
+                            d.close();
+                        }
+                    }}
+                ]
+            });
+        }
+
+        // Per-cell signature cache (device-info reuses it).
+        const lastSig = {};
+
+        function setIface(uuid, device) {
+            const $cell = $('#nebula_iface_' + uuid);
+            if (!$cell.length || !device) { return; }
+            const dsig = (device.name || '') + '|' + (device.cidr || '');
+            if (lastSig['dev_' + uuid] === dsig) { return; }
+            lastSig['dev_' + uuid] = dsig;
+            $cell.text((device.name || '') + (device.cidr ? '  ·  ' + device.cidr : ''));
+        }
+
+        // Forget cached signatures for an instance whose panel was removed, so a
+        // re-added instance renders fresh into its new (empty) cells.
+        function forgetSigs(uuid) {
+            ['dev_'].forEach(function (k) { delete lastSig[k + uuid]; });
+        }
+
+        // Running/pid status, rendered into the panel body (updated in place on
+        // refresh). Plain text — no status colour.
+        function setState(d) {
+            const $cell = $('#nebula_state_' + d.uuid);
+            if (!$cell.length) { return; }
+            $cell.text(d.running === true
+                ? '{{ lang._('running') }}' + (d.pid ? ' (pid ' + d.pid + ')' : '')
+                : '{{ lang._('stopped') }}');
+        }
+
+        // Heading content (status icon, name, lighthouse badge, Connect button).
+        // Rebuilt on every refresh — cheap and carries no placeholder, so
+        // refreshing it never flashes "loading…".
+        function buildHeading(d) {
+            const running = (d.running === true);
+            const $head = $("<div/>");
+            $head.append($("<i/>").addClass('fa fa-plug ' + (running ? 'text-success' : 'text-muted'))
+                .css('margin-right', '8px'));
+            $head.append($("<strong/>").text(d.description || d.uuid));
+            if (d.am_lighthouse) {
+                $head.append($("<span class='label label-info'/>").css('margin-left', '8px').text('{{ lang._('lighthouse') }}'));
+            }
+            if (running && d.diag_available) {
+                $head.append($("<button class='btn btn-xs btn-default' type='button'/>")
+                    .css('float', 'right')
+                    .append("<i class='fa fa-plus fa-fw'></i> ").append(document.createTextNode('{{ lang._('Connect to peer') }}'))
+                    .on('click', function () { connectPeer(d.uuid); }));
+            }
+            return $head;
+        }
+
+        // Build one instance panel from a diag payload (first render only).
+        function panel(d) {
+            const $head = $("<div class='panel-heading'/>").attr('id', 'nebula_head_' + d.uuid)
+                .append(buildHeading(d));
+
+            const $tbody = $("<tbody/>");
+
+            // Status (running/pid) — updated in place on refresh by setState().
+            const $state = $("<span/>").attr('id', 'nebula_state_' + d.uuid);
+            $tbody.append(row('{{ lang._('Status') }}', $state));
+
+            // Interface — filled async from device-info when running.
+            const $iface = $("<span/>").text(d.tun_dev || '{{ lang._('—') }}');
+            $iface.attr('id', 'nebula_iface_' + d.uuid);
+            $tbody.append(row('{{ lang._('Interface') }}', $iface));
+            $tbody.append(row('{{ lang._('Listen') }}', txt(d.listen)));
+            $tbody.append(row('{{ lang._('Certificate') }}', certLine(d.cert)));
+
+            let $cfg;
+            if (d.config_valid === true) {
+                $cfg = $("<span/>").text('{{ lang._('valid') }} (nebula -test)');
+            } else if (d.config_valid === false) {
+                $cfg = $("<span class='text-danger'/>").text(d.config_error || '{{ lang._('invalid') }}');
+            } else {
+                $cfg = $("<span class='text-muted'/>").text(d.config_error || '{{ lang._('unknown') }}');
+            }
+            $tbody.append(row('{{ lang._('Config') }}', $cfg));
+
+            return $("<div class='panel panel-default'/>").attr('id', 'nebula_panel_' + d.uuid)
+                .append($head)
+                .append($("<table class='table table-condensed'/>").append($tbody));
+        }
+
+        // uuids that already have a rendered panel — so a refresh updates panels
+        // in place instead of tearing them down (which flashed "loading…" and
+        // collapsed expanded detail rows every cycle).
+        const built = {};
+
+        // ONE request: the snapshot returns every instance's status,
+        // diagnostics and device-info together.
+        function refresh() {
+            ajaxGet('/api/nebula/instance/snapshot', {}, function (data, status) {
+                const list = (data && data.instances) || [];
+                if (list.length === 0) {
+                    $panels.empty();
+                    Object.keys(built).forEach(function (u) { delete built[u]; forgetSigs(u); });
+                    $empty.show();
+                    return;
+                }
+                $empty.hide();
+                const uuids = list.map(function (d) { return d.uuid; });
+                // Remove panels for instances that no longer exist.
+                Object.keys(built).forEach(function (u) {
+                    if (uuids.indexOf(u) === -1) {
+                        $('#nebula_panel_' + u).remove();
+                        delete built[u];
+                        forgetSigs(u);
+                    }
+                });
+                list.forEach(function (d) {
+                    if (!built[d.uuid]) {
+                        $panels.append(panel(d));
+                        built[d.uuid] = true;
+                    } else {
+                        // Rebuild the heading (running plug + Connect) in place; the
+                        // body's status/iface cells are updated below.
+                        $('#nebula_head_' + d.uuid).empty().append(buildHeading(d));
+                    }
+                    setState(d);
+                    if (d.diag_available) {
+                        setIface(d.uuid, d.device);
+                    }
+                });
+            });
+        }
+
+        $("#nebula_status_refresh").on('click', function () { refresh(); });
+        refresh();
+        updateServiceControlUI('nebula');
+    });
+</script>
+
+<div class="content-box" style="padding: 15px;">
+    <button class="btn btn-default" id="nebula_status_refresh" type="button">
+        <i class="fa fa-refresh"></i> {{ lang._('Refresh') }}
+    </button>
+    <div id="nebula_status_empty" style="display: none; margin-top: 15px;" class="text-muted">
+        {{ lang._('No Nebula instances configured.') }}
+    </div>
+    <div id="nebula_status_panels" style="margin-top: 15px;"></div>
+</div>

--- a/net/nebula/src/opnsense/mvc/app/views/OPNsense/Nebula/tunnels.volt
+++ b/net/nebula/src/opnsense/mvc/app/views/OPNsense/Nebula/tunnels.volt
@@ -1,0 +1,319 @@
+{#
+ # Copyright (c) 2026 Henry Stern <henry@stern.ca>
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1. Redistributions of source code must retain the above copyright notice,
+ #    this list of conditions and the following disclaimer.
+ #
+ # 2. Redistributions in binary form must reproduce the above copyright notice,
+ #    this list of conditions and the following disclaimer in the documentation
+ #    and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+#}
+
+<script>
+    'use strict';
+
+    $(document).ready(function () {
+
+        // Deep-link: /ui/nebula/tunnels?instance=<uuid> pre-selects an instance
+        // (the Status page links here that way).
+        const deepLinkInstance = new URLSearchParams(window.location.search).get('instance') || '';
+
+        let currentInstance = deepLinkInstance;   // '' = All instances
+        let allRows = [];                          // full fetched dataset (one Refresh)
+
+        function esc(s) {
+            return $('<div/>').text(s === undefined || s === null ? '' : String(s)).html();
+        }
+
+        // Comparable key for default IP ordering (correct for v4; v6 -> string).
+        function ipKey(ip) {
+            const v4 = /^(\d+)\.(\d+)\.(\d+)\.(\d+)$/.exec(ip || '');
+            if (v4) {
+                return '4:' + [v4[1], v4[2], v4[3], v4[4]]
+                    .map(function (o) { return ('00' + o).slice(-3); }).join('.');
+            }
+            return '6:' + (ip || '');
+        }
+
+        // -----------------------------------------------------------------------
+        // Column formatters — receive (column, row), return cell HTML. The grid
+        // runs in static (ajax:false) mode, so search/sort operate on the row
+        // DATA fields (not the rendered HTML): that's why the backend ships a
+        // `remotes` string (all underlay addrs, space-joined) for the Known
+        // Remotes column even though we render it compact.
+        // -----------------------------------------------------------------------
+        function via_formatter(column, row) {
+            if (row.handshaking) {
+                return '<span class="label label-warning">{{ lang._('Handshaking') }}</span>';
+            }
+            return row.relayed
+                ? '<span class="label label-default">{{ lang._('Relay') }}</span>'
+                : '<span class="label label-success">{{ lang._('Direct') }}</span>';
+        }
+        function groups_formatter(column, row) {
+            if (!row.groups) { return '—'; }
+            return String(row.groups).split(', ').map(esc).join('<br/>');
+        }
+        function remotes_formatter(column, row) {
+            const addrs = Array.isArray(row.remoteAddrs) ? row.remoteAddrs : [];
+            if (!addrs.length) { return '—'; }
+            return addrs.map(esc).join('<br/>');
+        }
+        function actions_formatter(column, row) {
+            const v = esc(row.vpn || ''), u = esc(row.instance_uuid || '');
+            // Query-lighthouse applies to any peer; close/change-remote only make
+            // sense for an established tunnel, so hide them while handshaking.
+            const lh =
+                '<button type="button" class="btn btn-xs btn-default tun-lh" ' +
+                'data-uuid="' + u + '" data-vpn="' + v + '" title="{{ lang._('Query lighthouse') }}">' +
+                '<i class="fa fa-search"></i></button>';
+            if (row.handshaking) {
+                return lh;
+            }
+            return [
+                '<button type="button" class="btn btn-xs btn-default tun-close" ',
+                'data-uuid="', u, '" data-vpn="', v, '" title="{{ lang._('Close tunnel') }}">',
+                '<i class="fa fa-times-circle"></i></button> ',
+                lh, ' ',
+                '<button type="button" class="btn btn-xs btn-default tun-rem" ',
+                'data-uuid="', u, '" data-vpn="', v, '" title="{{ lang._('Change remote') }}">',
+                '<i class="fa fa-exchange"></i></button>'
+            ].join('');
+        }
+
+        // -----------------------------------------------------------------------
+        // Per-peer debug verbs (only fire on explicit click)
+        // -----------------------------------------------------------------------
+        function debugCall(uuid, action, params, cb) {
+            ajaxCall('/api/nebula/instance/debug/' + encodeURIComponent(uuid) + '/' + action,
+                params || {}, function (data) { cb(data || {}); });
+        }
+
+        function afterAction(data, okMsg, onOk) {
+            if (data && data.ok) {
+                if (okMsg && typeof $.notify === 'function') {
+                    $.notify(okMsg, {className: 'success', position: 'top right'});
+                }
+                if (onOk) { onOk(); }
+            } else {
+                BootstrapDialog.show({
+                    type: BootstrapDialog.TYPE_DANGER,
+                    title: '{{ lang._('Nebula debug server') }}',
+                    message: esc((data && (data.error || data.raw)) || '{{ lang._('command failed') }}')
+                });
+            }
+        }
+
+        function closeTunnel(uuid, vpn) {
+            BootstrapDialog.confirm({
+                title: '{{ lang._('Close tunnel') }}',
+                message: '{{ lang._('Close the tunnel to') }} ' + esc(vpn) + '? ' +
+                    '{{ lang._('It will re-handshake on the next packet.') }}',
+                type: BootstrapDialog.TYPE_WARNING,
+                callback: function (ok) {
+                    if (!ok) { return; }
+                    debugCall(uuid, 'close', {vpn: vpn}, function (d) {
+                        afterAction(d, '{{ lang._('Tunnel closed') }}', fetchPeers);
+                    });
+                }
+            });
+        }
+
+        function queryLighthouse(uuid, vpn) {
+            debugCall(uuid, 'querylh', {vpn: vpn}, function (d) {
+                let body = (d && (d.raw !== undefined ? d.raw : d.error)) || '{{ lang._('(no response)') }}';
+                // query-lighthouse returns JSON — pretty-print it when it parses.
+                if (d && d.ok && typeof body === 'string') {
+                    try { body = JSON.stringify(JSON.parse(body), null, 2); } catch (e) { /* leave raw */ }
+                }
+                BootstrapDialog.show({
+                    type: d && d.ok ? BootstrapDialog.TYPE_INFO : BootstrapDialog.TYPE_DANGER,
+                    title: '{{ lang._('Query lighthouse') }} — ' + esc(vpn),
+                    message: $("<pre style='white-space:pre-wrap;'/>").text(body)
+                });
+            });
+        }
+
+        function changeRemote(uuid, vpn) {
+            let $inp = $("<input type='text' class='form-control'/>")
+                .attr('placeholder', '{{ lang._('host:port, e.g. 198.51.100.1:4242') }}');
+            BootstrapDialog.show({
+                title: '{{ lang._('Change remote') }}',
+                message: $("<div/>")
+                    .append($("<label/>").text('{{ lang._('New underlay address for') }} ' + (vpn || '') + ':'))
+                    .append($inp),
+                buttons: [
+                    {label: '{{ lang._('Cancel') }}', action: function (d) { d.close(); }},
+                    {label: '{{ lang._('Change remote') }}', cssClass: 'btn-primary', action: function (d) {
+                        let v = ($inp.val() || '').trim();
+                        if (v) {
+                            debugCall(uuid, 'changeremote', {vpn: vpn, remote: v}, function (r) {
+                                afterAction(r, '{{ lang._('Remote changed') }}');
+                            });
+                            d.close();
+                        }
+                    }}
+                ]
+            });
+        }
+
+        function connectPeer() {
+            // Connect needs a single instance target — use the filtered instance.
+            if (!currentInstance) {
+                BootstrapDialog.show({
+                    type: BootstrapDialog.TYPE_WARNING,
+                    title: '{{ lang._('Connect to peer') }}',
+                    message: '{{ lang._('Select a single instance in the filter first.') }}'
+                });
+                return;
+            }
+            let $ip = $("<input type='text' class='form-control'/>")
+                .attr('placeholder', '{{ lang._('peer nebula IP, e.g. 192.168.100.9') }}');
+            BootstrapDialog.show({
+                title: '{{ lang._('Connect to peer') }}',
+                message: $("<div/>").append($ip).append(
+                    $("<p class='text-muted' style='margin-top:6px;'/>").text(
+                        '{{ lang._('The lighthouse resolves the underlay address.') }}')),
+                buttons: [
+                    {label: '{{ lang._('Cancel') }}', action: function (d) { d.close(); }},
+                    {label: '{{ lang._('Create tunnel') }}', cssClass: 'btn-primary', action: function (d) {
+                        let ip = ($ip.val() || '').trim();
+                        if (ip) {
+                            debugCall(currentInstance, 'createtunnel', {vpn: ip}, function (r) {
+                                afterAction(r, '{{ lang._('Tunnel requested') }}', fetchPeers);
+                            });
+                            d.close();
+                        }
+                    }}
+                ]
+            });
+        }
+
+        // -----------------------------------------------------------------------
+        // Grid — OPNsense UIBootgrid in static (ajax:false) mode. Created ONCE;
+        // data is pushed in client-side via bootgrid('replace', rows). All
+        // sort/search/paging happen locally over that snapshot until the next
+        // Refresh. This is the same pattern as core Diagnostics/routes.volt.
+        // -----------------------------------------------------------------------
+        $('#grid-tunnels').UIBootgrid({
+            datakey: 'vpn',
+            options: {
+                ajax: false,
+                selection: false,
+                multiSelect: false,
+                rowCount: [20, 50, 100, true],
+                formatters: {
+                    via: via_formatter,
+                    groups: groups_formatter,
+                    remotes: remotes_formatter,
+                    actions: actions_formatter
+                }
+            }
+        });
+
+        // Push the current snapshot (filtered by instance, IP-sorted) into the grid.
+        // replace() throws on an empty array, so clear() is used when nothing matches.
+        function applyData() {
+            const rows = allRows
+                .filter(function (r) { return !currentInstance || r.instance_uuid === currentInstance; })
+                .sort(function (a, b) { return ipKey(a.vpn).localeCompare(ipKey(b.vpn)); });
+            if (rows.length) {
+                $('#grid-tunnels').bootgrid('replace', rows);
+            } else {
+                $('#grid-tunnels').bootgrid('clear');
+            }
+        }
+
+        function fetchPeers() {
+            ajaxGet('/api/nebula/peer/search', {}, function (data) {
+                allRows = (data && Array.isArray(data.rows)) ? data.rows : [];
+                applyData();
+            });
+        }
+
+        // Action buttons are formatter-rendered, so delegate on document (the grid
+        // re-renders its rows on sort/page; delegation survives that).
+        $(document)
+            .on('click', '.tun-close', function () { closeTunnel($(this).data('uuid'), $(this).data('vpn')); })
+            .on('click', '.tun-lh',    function () { queryLighthouse($(this).data('uuid'), $(this).data('vpn')); })
+            .on('click', '.tun-rem',   function () { changeRemote($(this).data('uuid'), $(this).data('vpn')); });
+
+        // -----------------------------------------------------------------------
+        // Instance filter (All instances default; deep-link preselect). Changing
+        // it re-filters the existing snapshot client-side — no refetch.
+        // -----------------------------------------------------------------------
+        const $filter = $('#nebula-tunnel-instance');
+        ajaxGet('/api/nebula/instance/search_item', {}, function (data) {
+            $filter.append($('<option/>').val('').text('{{ lang._('All instances') }}'));
+            if (data && data.rows) {
+                $.each(data.rows, function (i, row) {
+                    $filter.append($('<option/>').val(row.uuid).text(row.description || row.uuid));
+                });
+            }
+            $filter.val(deepLinkInstance);
+            if ($filter.hasClass('selectpicker')) { $filter.selectpicker('refresh'); }
+            currentInstance = $filter.val() || '';
+            fetchPeers();
+        });
+
+        $filter.on('changed.bs.select change', function () {
+            currentInstance = $(this).val() || '';
+            applyData();   // client-side re-filter, no refetch
+        });
+
+        // -----------------------------------------------------------------------
+        // Toolbar
+        // -----------------------------------------------------------------------
+        $('#btn-tunnel-refresh').on('click', function () { fetchPeers(); });
+        $('#btn-tunnel-connect').on('click', function () { connectPeer(); });
+
+        updateServiceControlUI('nebula');
+    });
+</script>
+
+<div class="tab-content content-box">
+    <div class="col-md-12" style="padding: 10px 15px; display: flex; align-items: center; flex-wrap: wrap; gap: 10px;">
+        <label for="nebula-tunnel-instance" style="margin: 0; white-space: nowrap;">
+            {{ lang._('Instance') }}
+        </label>
+        <select id="nebula-tunnel-instance" class="selectpicker" data-width="280px"
+                data-live-search="true"></select>
+        <button id="btn-tunnel-refresh" class="btn btn-default" type="button">
+            <i class="fa fa-refresh fa-fw"></i> {{ lang._('Refresh') }}
+        </button>
+        <button id="btn-tunnel-connect" class="btn btn-default" type="button">
+            <i class="fa fa-plus fa-fw"></i> {{ lang._('Connect to peer') }}
+        </button>
+    </div>
+    <table id="grid-tunnels" class="table table-condensed table-hover table-striped">
+        <thead>
+            <tr>
+                <th data-column-id="instance" data-type="string">{{ lang._('Instance') }}</th>
+                <th data-column-id="vpn" data-type="string" data-identifier="true">{{ lang._('Nebula IP') }}</th>
+                <th data-column-id="name" data-type="string">{{ lang._('Name') }}</th>
+                <th data-column-id="groups" data-type="string" data-formatter="groups">{{ lang._('Groups') }}</th>
+                <th data-column-id="relayed" data-formatter="via" data-sortable="false" data-searchable="false">{{ lang._('Via') }}</th>
+                <th data-column-id="currentRemote" data-type="string">{{ lang._('Current Remote') }}</th>
+                <th data-column-id="remotes" data-type="string" data-formatter="remotes" data-sortable="false">{{ lang._('Known Remotes') }}</th>
+                <th data-column-id="messages" data-type="numeric">{{ lang._('Messages') }}</th>
+                <th data-column-id="actions" data-formatter="actions" data-sortable="false" data-searchable="false">{{ lang._('Actions') }}</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+</div>

--- a/net/nebula/src/opnsense/mvc/tests/app/models/OPNsense/Nebula/AuthorityCRUDTest.php
+++ b/net/nebula/src/opnsense/mvc/tests/app/models/OPNsense/Nebula/AuthorityCRUDTest.php
@@ -1,0 +1,452 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace tests\OPNsense\Nebula;
+
+use OPNsense\Core\AppConfig;
+use OPNsense\Core\Config;
+use OPNsense\Nebula\Nebula;
+
+/**
+ * Model-level tests for the AuthorityController data path.
+ *
+ * These tests exercise the same Add / validate / serializeToConfig / del
+ * logic that generateAction() and importAction() use, but at the model layer
+ * (no configd / Backend in play — those paths are covered by the live guest
+ * script tools/test_authority_live.php).
+ *
+ * The "import accept/reject" logic that calls pki_print_cert is validated in
+ * the live script.  Here we focus on:
+ *   - authority node created with correct field values (origin, curve, crt, key)
+ *   - model validation rejects missing descr (same guard as the controller)
+ *   - serializeToConfig round-trips the authority through config.xml
+ *   - del removes the authority
+ *   - origin and curve options are stored and retrieved correctly
+ */
+class AuthorityCRUDTest extends \PHPUnit\Framework\TestCase
+{
+    private static $configDir = __DIR__ . '/NebulaConfig';
+
+    public static function setUpBeforeClass(): void
+    {
+        (new AppConfig())->update('application.configDir', self::$configDir);
+        Config::getInstance()->forceReload();
+    }
+
+    /** Locate an ArrayField item by UUID, returning null if not found. */
+    private function findByUuid($arrayField, $uuid)
+    {
+        foreach ($arrayField->iterateItems() as $node) {
+            if ($node->getAttribute('uuid') === $uuid) {
+                return $node;
+            }
+        }
+        return null;
+    }
+
+    // -------------------------------------------------------------------------
+    // generateAction() model path
+    // -------------------------------------------------------------------------
+
+    public function testGenerateStoresAllFields()
+    {
+        // Simulate what generateAction() does after configd returns crt+key.
+        $mdl  = new Nebula();
+        $node = $mdl->pki->authorities->authority->Add();
+        $node->descr  = 'test-ca-generated';
+        $node->origin = 'generated';
+        $node->curve  = '25519';
+        $node->crt    = "-----BEGIN NEBULA CERTIFICATE-----\nfakecrt\n-----END NEBULA CERTIFICATE-----\n";
+        $node->key    = "-----BEGIN NEBULA ED25519 PRIVATE KEY-----\nfakekey\n-----END NEBULA ED25519 PRIVATE KEY-----\n";
+
+        $uuid = $node->getAttribute('uuid');
+        $this->assertNotEmpty($uuid, 'Add() must assign a UUID');
+
+        // Validation must pass for a fully-populated node.
+        $msgs = $mdl->performValidation();
+        $this->assertEquals(0, count($msgs), 'Valid authority node must pass validation');
+
+        $this->assertEquals('test-ca-generated', (string)$node->descr);
+        $this->assertEquals('generated', (string)$node->origin);
+        $this->assertEquals('25519', (string)$node->curve);
+        $this->assertNotEmpty((string)$node->crt);
+        $this->assertNotEmpty((string)$node->key);
+    }
+
+    public function testGenerateWithP256Curve()
+    {
+        $mdl  = new Nebula();
+        $node = $mdl->pki->authorities->authority->Add();
+        $node->descr  = 'p256-ca';
+        $node->origin = 'generated';
+        $node->curve  = 'P256';
+        $node->crt    = 'CERTDATA';
+        $node->key    = 'KEYDATA';
+
+        $msgs = $mdl->performValidation();
+        $this->assertEquals(0, count($msgs), 'P256 authority must pass validation');
+        $this->assertEquals('P256', (string)$node->curve);
+    }
+
+    // -------------------------------------------------------------------------
+    // importAction() model path
+    // -------------------------------------------------------------------------
+
+    public function testImportStoresOriginImported()
+    {
+        // Simulate what importAction() does after pki_print_cert accepts the crt.
+        $mdl  = new Nebula();
+        $node = $mdl->pki->authorities->authority->Add();
+        $node->descr  = 'imported-ca';
+        $node->origin = 'imported';
+        $node->curve  = '25519';
+        $node->crt    = 'IMPORTED_CRT';
+        // key is optional on import (cert-only trust anchor).
+
+        $uuid = $node->getAttribute('uuid');
+        $this->assertNotEmpty($uuid);
+
+        $msgs = $mdl->performValidation();
+        $this->assertEquals(0, count($msgs), 'Import node (no key) must pass validation');
+        $this->assertEquals('imported', (string)$node->origin);
+    }
+
+    public function testImportWithKeyStoresKey()
+    {
+        $mdl  = new Nebula();
+        $node = $mdl->pki->authorities->authority->Add();
+        $node->descr  = 'imported-ca-with-key';
+        $node->origin = 'imported';
+        $node->curve  = '25519';
+        $node->crt    = 'IMPORTED_CRT';
+        $node->key    = 'IMPORTED_KEY';
+
+        $msgs = $mdl->performValidation();
+        $this->assertEquals(0, count($msgs), 'Import node with key must pass validation');
+        $this->assertEquals('IMPORTED_KEY', (string)$node->key);
+    }
+
+    // -------------------------------------------------------------------------
+    // Validation guards
+    // -------------------------------------------------------------------------
+
+    public function testValidationRejectsMissingDescr()
+    {
+        // Both generateAction() and importAction() guard for empty descr before
+        // calling Add().  This test ensures that even if Add() is called without
+        // descr, performValidation() catches it (belt-and-suspenders).
+        $mdl  = new Nebula();
+        $node = $mdl->pki->authorities->authority->Add();
+        // Intentionally leave descr empty.
+
+        $msgs = $mdl->performValidation();
+        $found = false;
+        foreach ($msgs as $m) {
+            if (strpos($m->getField(), 'descr') !== false) {
+                $found = true;
+                break;
+            }
+        }
+        $this->assertTrue($found, 'Missing required descr must produce a validation error');
+    }
+
+    // -------------------------------------------------------------------------
+    // Del
+    // -------------------------------------------------------------------------
+
+    public function testDelRemovesAuthority()
+    {
+        $mdl  = new Nebula();
+        $node = $mdl->pki->authorities->authority->Add();
+        $node->descr = 'del-test-ca';
+        $node->crt   = 'CRT';
+        $node->key   = 'KEY';
+
+        $uuid = $node->getAttribute('uuid');
+        $this->assertNotNull($this->findByUuid($mdl->pki->authorities->authority, $uuid));
+
+        $result = $mdl->pki->authorities->authority->del($uuid);
+        $this->assertTrue($result, 'del() must return true for a found authority');
+        $this->assertNull($this->findByUuid($mdl->pki->authorities->authority, $uuid), 'Authority must be gone after del()');
+    }
+
+    // -------------------------------------------------------------------------
+    // searchItem path (fields present)
+    // -------------------------------------------------------------------------
+
+    public function testSearchFieldsAreAccessible()
+    {
+        // The searchItemAction() exposes [descr, cn, valid_to, has_key] — verify
+        // those computed display fields exist and are readable on an Added node.
+        $mdl  = new Nebula();
+        $node = $mdl->pki->authorities->authority->Add();
+        $node->descr    = 'search-test-ca';
+        $node->cn       = 'search-test-ca';
+        $node->valid_to = '2027-06-05T00:00:00Z';
+        $node->has_key  = '1';
+
+        $this->assertEquals('search-test-ca',        (string)$node->descr);
+        $this->assertEquals('search-test-ca',        (string)$node->cn);
+        $this->assertEquals('2027-06-05T00:00:00Z',  (string)$node->valid_to);
+        $this->assertEquals('1',                     (string)$node->has_key);
+    }
+
+    // -------------------------------------------------------------------------
+    // computed read-only fields (populated by the controller at create time)
+    // -------------------------------------------------------------------------
+
+    public function testComputedFieldsArePersisted()
+    {
+        $mdl  = new Nebula();
+        $node = $mdl->pki->authorities->authority->Add();
+        $node->descr       = 'computed-ca';
+        $node->cn          = 'computed-ca';
+        $node->valid_from  = '2026-06-05T00:00:00Z';
+        $node->valid_to    = '2027-06-05T00:00:00Z';
+        $node->fingerprint = 'deadbeef';
+        $node->is_ca       = '1';
+        $node->has_key     = '1';
+
+        $this->assertEquals('computed-ca',           (string)$node->cn);
+        $this->assertEquals('2026-06-05T00:00:00Z',  (string)$node->valid_from);
+        $this->assertEquals('2027-06-05T00:00:00Z',  (string)$node->valid_to);
+        $this->assertEquals('deadbeef',              (string)$node->fingerprint);
+        $this->assertEquals('1',                     (string)$node->is_ca);
+        $this->assertEquals('1',                     (string)$node->has_key);
+    }
+
+    // -------------------------------------------------------------------------
+    // can_sign (distinct from has_key)
+    // -------------------------------------------------------------------------
+
+    /**
+     * can_sign defaults to '0' on a fresh authority node and is independent of
+     * has_key.  has_key drives the Download-key button; can_sign drives the
+     * "Can sign" grid column and the Sign-dialog dropdown filter.
+     */
+    public function testCanSignDefaultsToZero()
+    {
+        $mdl  = new Nebula();
+        $node = $mdl->pki->authorities->authority->Add();
+        $node->descr = 'fresh-ca';
+
+        $this->assertEquals('0', (string)$node->can_sign, 'can_sign must default to 0');
+    }
+
+    /**
+     * A generated CA (is_ca + unencrypted key present) is a valid signer.
+     */
+    public function testGeneratedCaCanSign()
+    {
+        $mdl  = new Nebula();
+        $node = $mdl->pki->authorities->authority->Add();
+        $node->descr    = 'signable-ca';
+        $node->is_ca    = '1';
+        $node->has_key  = '1';
+        $node->can_sign = '1';
+
+        $this->assertEquals('1', (string)$node->has_key);
+        $this->assertEquals('1', (string)$node->can_sign);
+    }
+
+    /**
+     * An encrypted-key CA stores the key (has_key=1) AND can sign (can_sign=1) — the
+     * passphrase is supplied per signing operation (INFRA-163), so encryption no
+     * longer excludes a CA from signing.  It is flagged key_encrypted=1 so the Sign
+     * dialog knows to prompt for the passphrase.
+     * A cert-only CA stores no key (has_key=0) and cannot sign (can_sign=0).
+     */
+    public function testEncryptedCaCanSignCertOnlyCannot()
+    {
+        $mdl = new Nebula();
+
+        $enc = $mdl->pki->authorities->authority->Add();
+        $enc->descr         = 'encrypted-ca';
+        $enc->is_ca         = '1';
+        $enc->has_key       = '1';   // key is stored …
+        $enc->key_encrypted = '1';   // … and encrypted …
+        $enc->can_sign      = '1';   // … but still signable with a passphrase.
+        $this->assertEquals('1', (string)$enc->has_key);
+        $this->assertEquals('1', (string)$enc->key_encrypted);
+        $this->assertEquals('1', (string)$enc->can_sign);
+
+        $certOnly = $mdl->pki->authorities->authority->Add();
+        $certOnly->descr    = 'cert-only-ca';
+        $certOnly->is_ca    = '1';
+        $certOnly->has_key  = '0';   // no key at all (cert-only trust anchor).
+        $certOnly->can_sign = '0';
+        $this->assertEquals('0', (string)$certOnly->has_key);
+        $this->assertEquals('0', (string)$certOnly->can_sign);
+    }
+
+    /**
+     * key_encrypted defaults to '0' on a fresh node and round-trips both states.
+     */
+    public function testKeyEncryptedField()
+    {
+        $mdl  = new Nebula();
+        $node = $mdl->pki->authorities->authority->Add();
+        $node->descr = 'enc-field-ca';
+        $this->assertEquals('0', (string)$node->key_encrypted, 'key_encrypted must default to 0');
+
+        $node->key_encrypted = '1';
+        $this->assertEquals('1', (string)$node->key_encrypted);
+    }
+
+    // -------------------------------------------------------------------------
+    // CA network constraint fields (Fix 3)
+    // -------------------------------------------------------------------------
+
+    /**
+     * A CA with network constraints stores networks + unsafe_networks correctly.
+     * These are populated by storeComputedFields() from pki_print_cert output at
+     * generate/import time; here we verify the model fields accept and round-trip
+     * the values (the controller population path is tested by the live script).
+     */
+    public function testNetworkConstraintFieldsAreStored()
+    {
+        $mdl  = new Nebula();
+        $node = $mdl->pki->authorities->authority->Add();
+        $node->descr           = 'constrained-ca';
+        $node->cn              = 'constrained-ca';
+        $node->crt             = 'CERTDATA';
+        $node->networks        = '192.168.100.0/24';
+        $node->unsafe_networks = '';
+
+        $msgs = $mdl->performValidation();
+        $this->assertEquals(0, count($msgs), 'Constrained CA must pass validation');
+        $this->assertEquals('192.168.100.0/24', (string)$node->networks);
+        $this->assertEquals('',                 (string)$node->unsafe_networks);
+    }
+
+    /**
+     * A CA without network constraints has empty networks fields (unrestricted).
+     */
+    public function testUnrestrictedCaHasEmptyNetworks()
+    {
+        $mdl  = new Nebula();
+        $node = $mdl->pki->authorities->authority->Add();
+        $node->descr = 'unrestricted-ca';
+        $node->cn    = 'unrestricted-ca';
+        $node->crt   = 'CERTDATA';
+        // networks and unsafe_networks intentionally left empty (defaults).
+
+        $this->assertEquals('', (string)$node->networks,        'Unrestricted CA must have empty networks');
+        $this->assertEquals('', (string)$node->unsafe_networks, 'Unrestricted CA must have empty unsafe_networks');
+    }
+
+    /**
+     * searchItemAction exposes networks and unsafe_networks (both present on node).
+     * We verify the fields are readable via direct field access (the actual
+     * searchBase() path is covered by live tests).
+     */
+    public function testSearchItemExposesNetworkFields()
+    {
+        $mdl  = new Nebula();
+        $node = $mdl->pki->authorities->authority->Add();
+        $node->descr           = 'search-net-ca';
+        $node->cn              = 'search-net-ca';
+        $node->valid_to        = '2027-06-05T00:00:00Z';
+        $node->has_key         = '1';
+        $node->networks        = '10.0.0.0/24';
+        $node->unsafe_networks = '10.0.1.0/24';
+
+        $this->assertEquals('10.0.0.0/24',  (string)$node->networks);
+        $this->assertEquals('10.0.1.0/24',  (string)$node->unsafe_networks);
+    }
+
+    // -------------------------------------------------------------------------
+    // caReferencedBy + purgeExpiredAuthorities (the data path
+    // AuthorityController::delItemAction / purgeExpiredAction share)
+    // -------------------------------------------------------------------------
+
+    /** Add a minimal valid CA with the given description and notAfter. */
+    private function addCa(Nebula $mdl, string $descr, string $validTo): string
+    {
+        $node = $mdl->pki->authorities->authority->Add();
+        $node->descr    = $descr;
+        $node->origin   = 'generated';
+        $node->curve    = '25519';
+        $node->crt      = 'CERTDATA';
+        $node->key      = 'KEYDATA';
+        $node->valid_to = $validTo;
+        return $node->getAttribute('uuid');
+    }
+
+    public function testCaReferencedByDetectsCertAndInstance()
+    {
+        $mdl = new Nebula();
+        $unrefUuid = $this->addCa($mdl, 'unref-ca', '2027-01-01T00:00:00Z');
+        $signUuid  = $this->addCa($mdl, 'signing-ca', '2027-01-01T00:00:00Z');
+        $trustUuid = $this->addCa($mdl, 'trusted-ca', '2027-01-01T00:00:00Z');
+
+        // A cert signed by signing-ca.
+        $cert = $mdl->pki->certificates->certificate->Add();
+        $cert->descr = 'leaf';
+        $cert->caref = $signUuid;
+
+        // An instance that trusts trusted-ca.
+        $inst = $mdl->instances->instance->Add();
+        $inst->description = 'web';
+        $inst->trusted_cas = $trustUuid;
+
+        $this->assertNull($mdl->caReferencedBy($unrefUuid), 'unreferenced CA → null');
+        $this->assertStringContainsString('leaf', (string)$mdl->caReferencedBy($signUuid));
+        $this->assertStringContainsString('web', (string)$mdl->caReferencedBy($trustUuid));
+    }
+
+    public function testPurgeExpiredAuthoritiesSkipsReferenced()
+    {
+        $mdl = new Nebula();
+        $expiredUnref = $this->addCa($mdl, 'old-unref', '2000-01-01T00:00:00Z');
+        $current      = $this->addCa($mdl, 'current',   '2999-01-01T00:00:00Z');
+        $expiredRef   = $this->addCa($mdl, 'old-inuse', '2000-01-01T00:00:00Z');
+
+        // Reference the expired-in-use CA from an instance's trusted_cas.
+        $inst = $mdl->instances->instance->Add();
+        $inst->description = 'edge';
+        $inst->trusted_cas = $expiredRef;
+
+        $res = $mdl->purgeExpiredAuthorities();
+
+        $this->assertEquals(1, $res['removed'], 'only the expired unreferenced CA is removed');
+        $this->assertEquals(['old-inuse'], $res['skippedNames'], 'expired-but-referenced CA reported');
+        $this->assertNull(
+            $this->findByUuid($mdl->pki->authorities->authority, $expiredUnref),
+            'expired unreferenced CA must be gone'
+        );
+        $this->assertNotNull(
+            $this->findByUuid($mdl->pki->authorities->authority, $current),
+            'current CA must remain'
+        );
+        $this->assertNotNull(
+            $this->findByUuid($mdl->pki->authorities->authority, $expiredRef),
+            'expired referenced CA must be kept'
+        );
+    }
+}

--- a/net/nebula/src/opnsense/mvc/tests/app/models/OPNsense/Nebula/BlocklistCRUDTest.php
+++ b/net/nebula/src/opnsense/mvc/tests/app/models/OPNsense/Nebula/BlocklistCRUDTest.php
@@ -1,0 +1,451 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace tests\OPNsense\Nebula;
+
+use OPNsense\Core\AppConfig;
+use OPNsense\Core\Config;
+use OPNsense\Nebula\Nebula;
+
+/**
+ * Model-level CRUD tests for pki.blocklist.entry ArrayField.
+ *
+ * Tests the same data paths that BlocklistController exercises via
+ * ApiMutableModelControllerBase (add/get/set/del/toggle).  The fingerprint
+ * immutability and 64-hex format rules live in the controller as plain-PHP
+ * pre-checks (not in the Phalcon validation chain), so they are reproduced here
+ * against the same regex/comparison the controller uses — that keeps these
+ * assertions runnable without the Phalcon\Filter\Validation class that the
+ * model's performValidation() requires (and which is absent on PHP 8.5 here).
+ */
+class BlocklistCRUDTest extends \PHPUnit\Framework\TestCase
+{
+    private static $configDir = __DIR__ . '/NebulaConfig';
+
+    /** A valid 64-char lowercase hex sha256 fingerprint for fixtures. */
+    private const FP_A = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+    private const FP_B = 'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
+
+    public static function setUpBeforeClass(): void
+    {
+        (new AppConfig())->update('application.configDir', self::$configDir);
+        Config::getInstance()->forceReload();
+    }
+
+    /** Locate an ArrayField child by UUID, returning null if not found. */
+    private function findByUuid($arrayField, $uuid)
+    {
+        foreach ($arrayField->iterateItems() as $node) {
+            if ($node->getAttribute('uuid') === $uuid) {
+                return $node;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Add a minimal valid instance and return its UUID.
+     */
+    private function addInstance(Nebula $model, string $description = 'test-instance'): string
+    {
+        $inst = $model->instances->instance->Add();
+        $inst->enabled       = '1';
+        $inst->description   = $description;
+        $inst->listen_host   = '0.0.0.0';
+        $inst->listen_port   = '4242';
+        $inst->am_lighthouse = '0';
+        return $inst->getAttribute('uuid');
+    }
+
+    // -------------------------------------------------------------------------
+    // Add / readback
+    // -------------------------------------------------------------------------
+
+    public function testAddGlobalEntry()
+    {
+        $model = new Nebula();
+
+        $entry = $model->pki->blocklist->entry->Add();
+        $entry->enabled     = '1';
+        $entry->instance    = ''; // global
+        $entry->fingerprint = self::FP_A;
+        $entry->descr       = 'block bad host';
+
+        $uuid = $entry->getAttribute('uuid');
+        $this->assertNotEmpty($uuid, 'Add() must return a node with a UUID');
+
+        $found = $this->findByUuid($model->pki->blocklist->entry, $uuid);
+        $this->assertNotNull($found, 'findByUuid must locate the added entry');
+        $this->assertEquals('1',       (string)$found->enabled);
+        $this->assertEquals('',        (string)$found->instance, 'empty instance = global');
+        $this->assertEquals(self::FP_A, (string)$found->fingerprint);
+        $this->assertEquals('block bad host', (string)$found->descr);
+    }
+
+    public function testAddPerInstanceEntry()
+    {
+        $model    = new Nebula();
+        $instUuid = $this->addInstance($model, 'inst-scoped');
+
+        $entry = $model->pki->blocklist->entry->Add();
+        $entry->enabled     = '1';
+        $entry->instance    = $instUuid;
+        $entry->fingerprint = self::FP_B;
+
+        $found = $this->findByUuid($model->pki->blocklist->entry, $entry->getAttribute('uuid'));
+        $this->assertNotNull($found);
+        $this->assertEquals($instUuid,  (string)$found->instance);
+        $this->assertEquals(self::FP_B, (string)$found->fingerprint);
+    }
+
+    // -------------------------------------------------------------------------
+    // Set (update) — non-fingerprint fields are mutable
+    // -------------------------------------------------------------------------
+
+    public function testSetEntryUpdatesMutableFields()
+    {
+        $model = new Nebula();
+
+        $entry = $model->pki->blocklist->entry->Add();
+        $entry->enabled     = '1';
+        $entry->fingerprint = self::FP_A;
+        $entry->descr       = 'before';
+        $entry->expiry      = '';
+
+        // Mutate non-fingerprint fields in place (equivalent to setBase()).
+        $entry->descr  = 'after';
+        $entry->expiry = '2030-01-01';
+
+        $this->assertEquals('after',      (string)$entry->descr);
+        $this->assertEquals('2030-01-01', (string)$entry->expiry);
+        // Fingerprint unchanged.
+        $this->assertEquals(self::FP_A,   (string)$entry->fingerprint);
+    }
+
+    // -------------------------------------------------------------------------
+    // Del
+    // -------------------------------------------------------------------------
+
+    public function testDelEntryRemovesIt()
+    {
+        $model = new Nebula();
+
+        $entry = $model->pki->blocklist->entry->Add();
+        $entry->enabled     = '1';
+        $entry->fingerprint = self::FP_A;
+
+        $uuid = $entry->getAttribute('uuid');
+        $this->assertNotNull($this->findByUuid($model->pki->blocklist->entry, $uuid), 'entry must exist before del');
+
+        $result = $model->pki->blocklist->entry->del($uuid);
+        $this->assertTrue($result, 'del() must return true for a found entry');
+        $this->assertNull($this->findByUuid($model->pki->blocklist->entry, $uuid), 'entry must be gone after del()');
+    }
+
+    // -------------------------------------------------------------------------
+    // Toggle
+    // -------------------------------------------------------------------------
+
+    public function testToggleEntryEnabled()
+    {
+        $model = new Nebula();
+
+        $entry = $model->pki->blocklist->entry->Add();
+        $entry->enabled     = '1';
+        $entry->fingerprint = self::FP_A;
+
+        $this->assertEquals('1', (string)$entry->enabled);
+        $entry->enabled = '0';
+        $this->assertEquals('0', (string)$entry->enabled);
+        $entry->enabled = '1';
+        $this->assertEquals('1', (string)$entry->enabled);
+    }
+
+    // -------------------------------------------------------------------------
+    // Fingerprint 64-hex format — controller plain-PHP pre-check
+    //
+    // Mirrors BlocklistController::checkFingerprintFormat (which validates the
+    // posted entry.fingerprint with this exact regex before addBase/setBase).
+    // -------------------------------------------------------------------------
+
+    public function testFingerprintFormatRegex()
+    {
+        // [fingerprint, expectedValid] — kept inline (no data provider) to match
+        // the existing test style and stay PHPUnit-version agnostic.
+        $cases = [
+            [self::FP_A,             true],   // valid lowercase 64 hex
+            ['abc123',               false],  // too short
+            [strtoupper(self::FP_A), false],  // uppercase rejected
+            [str_repeat('g', 64),    false],  // non-hex char
+            [str_repeat('a', 63),    false],  // 63 chars
+            [str_repeat('a', 65),    false],  // 65 chars
+            ['',                     false],  // empty
+        ];
+        foreach ($cases as [$fp, $valid]) {
+            $matched = (bool)preg_match('/^[0-9a-f]{64}$/', $fp);
+            $this->assertSame($valid, $matched, "fingerprint '$fp' validity mismatch");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Fingerprint immutability — controller plain-PHP pre-check
+    //
+    // Reproduces BlocklistController::checkFingerprintImmutable: an edit that
+    // posts a fingerprint differing from the stored one must be rejected; an
+    // edit that keeps the same fingerprint (changing only other fields) passes.
+    // -------------------------------------------------------------------------
+
+    public function testFingerprintImmutabilityRejectsChange()
+    {
+        $model = new Nebula();
+
+        $entry = $model->pki->blocklist->entry->Add();
+        $entry->enabled     = '1';
+        $entry->fingerprint = self::FP_A;
+        $uuid = $entry->getAttribute('uuid');
+
+        // Re-resolve the stored value the way the controller does.
+        $stored = null;
+        foreach ($model->pki->blocklist->entry->iterateItems() as $node) {
+            if ($node->getAttribute('uuid') === $uuid) {
+                $stored = trim((string)$node->fingerprint);
+                break;
+            }
+        }
+        $this->assertSame(self::FP_A, $stored);
+
+        // A POST that changes the fingerprint must be flagged as immutable.
+        $postedChanged = self::FP_B;
+        $this->assertNotSame($stored, $postedChanged, 'changed fingerprint must differ → rejected');
+
+        // A POST that keeps the same fingerprint is allowed.
+        $postedSame = self::FP_A;
+        $this->assertSame($stored, $postedSame, 'unchanged fingerprint must match → allowed');
+    }
+
+    // -------------------------------------------------------------------------
+    // searchItemAction filter logic (model-level): global OR this-instance
+    // -------------------------------------------------------------------------
+
+    public function testScopeFilterGlobalAndInstanceViews()
+    {
+        $model = new Nebula();
+        $instA = $this->addInstance($model, 'inst-A');
+        $instB = $this->addInstance($model, 'inst-B');
+
+        // Global entry (explicit scope).
+        $g = $model->pki->blocklist->entry->Add();
+        $g->enabled = '1'; $g->scope = 'global'; $g->fingerprint = self::FP_A;
+        $uuidG = $g->getAttribute('uuid');
+
+        // Per-instance A entry.
+        $a = $model->pki->blocklist->entry->Add();
+        $a->enabled = '1'; $a->scope = 'instance'; $a->instance = $instA;
+        $a->fingerprint = self::FP_B;
+        $uuidA = $a->getAttribute('uuid');
+
+        // Per-instance B entry.
+        $b = $model->pki->blocklist->entry->Add();
+        $b->enabled = '1'; $b->scope = 'instance'; $b->instance = $instB;
+        $b->fingerprint = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+        $uuidB = $b->getAttribute('uuid');
+
+        $match = function (callable $filter) use ($model) {
+            $out = [];
+            foreach ($model->pki->blocklist->entry->iterateItems() as $r) {
+                if ($filter($r)) {
+                    $out[] = $r->getAttribute('uuid');
+                }
+            }
+            return $out;
+        };
+
+        // Controller filter for a specific instance: Global OR scoped to it.
+        $forInstanceA = $match(function ($r) use ($instA) {
+            if ((string)$r->scope === 'instance') {
+                return (string)$r->instance === $instA;
+            }
+            return true;
+        });
+        $this->assertContains($uuidG, $forInstanceA, 'global entry appears in inst-A view');
+        $this->assertContains($uuidA, $forInstanceA, 'inst-A entry appears in inst-A view');
+        $this->assertNotContains($uuidB, $forInstanceA, 'inst-B entry must NOT appear in inst-A view');
+
+        // Controller filter for the "Global" view (__global__): non-instance only.
+        $globalOnly = $match(function ($r) {
+            return (string)$r->scope !== 'instance';
+        });
+        $this->assertContains($uuidG, $globalOnly, 'global entry appears in Global view');
+        $this->assertNotContains($uuidA, $globalOnly, 'inst-A entry must NOT appear in Global view');
+        $this->assertNotContains($uuidB, $globalOnly, 'inst-B entry must NOT appear in Global view');
+    }
+
+    // -------------------------------------------------------------------------
+    // block_cert idempotency logic (model-level)
+    // -------------------------------------------------------------------------
+
+    public function testBlockCertIdempotencyDetectsExistingGlobal()
+    {
+        $model = new Nebula();
+
+        // Pre-existing global block for FP_A.
+        $g = $model->pki->blocklist->entry->Add();
+        $g->enabled = '1'; $g->instance = ''; $g->fingerprint = self::FP_A;
+
+        // Reproduce the controller's idempotency scan.
+        $alreadyBlocked = false;
+        foreach ($model->pki->blocklist->entry->iterateItems() as $entry) {
+            if ((string)$entry->instance === '' && trim((string)$entry->fingerprint) === self::FP_A) {
+                $alreadyBlocked = true;
+                break;
+            }
+        }
+        $this->assertTrue($alreadyBlocked, 'an existing global block for FP_A must be detected');
+
+        // A different fingerprint is not yet blocked.
+        $otherBlocked = false;
+        foreach ($model->pki->blocklist->entry->iterateItems() as $entry) {
+            if ((string)$entry->instance === '' && trim((string)$entry->fingerprint) === self::FP_B) {
+                $otherBlocked = true;
+                break;
+            }
+        }
+        $this->assertFalse($otherBlocked, 'FP_B is not blocked yet');
+    }
+
+    // -------------------------------------------------------------------------
+    // Defaults
+    // -------------------------------------------------------------------------
+
+    public function testDefaultEnabledIsOne()
+    {
+        $model = new Nebula();
+
+        $entry = $model->pki->blocklist->entry->Add();
+        $entry->fingerprint = self::FP_A;
+
+        $this->assertEquals('1', (string)$entry->enabled, 'Default enabled must be "1"');
+        $this->assertEquals('',  (string)$entry->instance, 'instance defaults to empty (global)');
+        $this->assertEquals('',  (string)$entry->expiry, 'expiry defaults to empty (never)');
+    }
+
+    // -------------------------------------------------------------------------
+    // purgeExpiredBlocklist (Nebula::purgeExpiredBlocklist — the data path
+    // BlocklistController::purgeExpiredAction persists)
+    // -------------------------------------------------------------------------
+
+    public function testPurgeExpiredRemovesOnlyPastDatedEntries()
+    {
+        $model = new Nebula();
+
+        // Past expiry — purgeable.
+        $expired = $model->pki->blocklist->entry->Add();
+        $expired->fingerprint = self::FP_A;
+        $expired->expiry      = '2000-01-01';
+
+        // Future expiry — kept.
+        $future = $model->pki->blocklist->entry->Add();
+        $future->fingerprint = self::FP_B;
+        $future->expiry      = '2999-12-31';
+
+        // Empty expiry (never) — kept.
+        $never = $model->pki->blocklist->entry->Add();
+        $never->fingerprint = '11111111111111111111111111111111'
+            . '11111111111111111111111111111111';
+        $never->expiry      = '';
+
+        $expiredUuid = $expired->getAttribute('uuid');
+        $futureUuid  = $future->getAttribute('uuid');
+        $neverUuid   = $never->getAttribute('uuid');
+
+        $res = $model->purgeExpiredBlocklist();
+
+        $this->assertEquals(1, $res['removed'], 'exactly one expired entry removed');
+        $this->assertSame([], $res['skippedNames'], 'blocklist purge never skips');
+        $this->assertNull(
+            $this->findByUuid($model->pki->blocklist->entry, $expiredUuid),
+            'expired entry must be gone'
+        );
+        $this->assertNotNull(
+            $this->findByUuid($model->pki->blocklist->entry, $futureUuid),
+            'future-dated entry must remain'
+        );
+        $this->assertNotNull(
+            $this->findByUuid($model->pki->blocklist->entry, $neverUuid),
+            'never-expiring entry must remain'
+        );
+    }
+
+    /**
+     * Purge eligibility parses dates leniently (strtotime), so a non-ISO past
+     * date (US m/d/Y) is purged while a future one and an unparseable value are
+     * kept. This is the parsing coverage that used to live in the renderer before
+     * the block-until-purged change.
+     */
+    public function testPurgeExpiredHandlesDateFormats()
+    {
+        $model = new Nebula();
+
+        $fp = fn(string $c) => str_repeat($c, 64);
+
+        // Past, US m/d/Y format — purgeable.
+        $pastNonIso = $model->pki->blocklist->entry->Add();
+        $pastNonIso->fingerprint = $fp('a');
+        $pastNonIso->expiry      = date('m/d/Y', strtotime('-1 year'));
+
+        // Future, US m/d/Y format — kept.
+        $futureNonIso = $model->pki->blocklist->entry->Add();
+        $futureNonIso->fingerprint = $fp('b');
+        $futureNonIso->expiry      = date('m/d/Y', strtotime('+1 year'));
+
+        // Unparseable — kept (we never purge what we cannot date).
+        $unparseable = $model->pki->blocklist->entry->Add();
+        $unparseable->fingerprint = $fp('c');
+        $unparseable->expiry      = 'whenever';
+
+        $pastUuid   = $pastNonIso->getAttribute('uuid');
+        $futureUuid = $futureNonIso->getAttribute('uuid');
+        $badUuid    = $unparseable->getAttribute('uuid');
+
+        $res = $model->purgeExpiredBlocklist();
+
+        $this->assertEquals(1, $res['removed'], 'only the past non-ISO entry is purged');
+        $this->assertNull(
+            $this->findByUuid($model->pki->blocklist->entry, $pastUuid),
+            'past m/d/Y entry must be purged'
+        );
+        $this->assertNotNull(
+            $this->findByUuid($model->pki->blocklist->entry, $futureUuid),
+            'future m/d/Y entry must remain'
+        );
+        $this->assertNotNull(
+            $this->findByUuid($model->pki->blocklist->entry, $badUuid),
+            'unparseable expiry must remain'
+        );
+    }
+}

--- a/net/nebula/src/opnsense/mvc/tests/app/models/OPNsense/Nebula/CertificateCRUDTest.php
+++ b/net/nebula/src/opnsense/mvc/tests/app/models/OPNsense/Nebula/CertificateCRUDTest.php
@@ -1,0 +1,386 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace tests\OPNsense\Nebula;
+
+use OPNsense\Core\AppConfig;
+use OPNsense\Core\Config;
+use OPNsense\Nebula\Nebula;
+
+/**
+ * Model-level tests for the CertificateController data path.
+ *
+ * These tests exercise the same Add / validate / serializeToConfig / del
+ * logic that signAction() and importAction() use, but at the model layer
+ * (no configd / Backend in play — the live-guest script covers those paths).
+ *
+ * Specifically:
+ *   - certificate node created with correct field values (origin, caref, fields)
+ *   - caref stores and reads back the CA authority UUID
+ *   - model validation rejects missing descr
+ *   - del removes the certificate
+ *   - search columns (descr, origin, caref, networks) are readable
+ *
+ * Note on ModelRelationField validation: the static option-list cache means the
+ * caref validator cannot see in-memory Add()s.  We test UUID storage/readback
+ * directly rather than asserting performValidation() == 0 for relation fields.
+ */
+class CertificateCRUDTest extends \PHPUnit\Framework\TestCase
+{
+    private static $configDir = __DIR__ . '/NebulaConfig';
+
+    public static function setUpBeforeClass(): void
+    {
+        (new AppConfig())->update('application.configDir', self::$configDir);
+        Config::getInstance()->forceReload();
+    }
+
+    /** Locate an ArrayField item by UUID, returning null if not found. */
+    private function findByUuid($arrayField, $uuid)
+    {
+        foreach ($arrayField->iterateItems() as $node) {
+            if ($node->getAttribute('uuid') === $uuid) {
+                return $node;
+            }
+        }
+        return null;
+    }
+
+    // -------------------------------------------------------------------------
+    // signAction() model path
+    // -------------------------------------------------------------------------
+
+    public function testSignStoresAllFields()
+    {
+        // Simulate what signAction() does after configd returns crt+key.
+        $mdl = new Nebula();
+
+        // Add a CA authority so we have a real UUID for caref.
+        $ca = $mdl->pki->authorities->authority->Add();
+        $ca->descr  = 'sign-test-ca';
+        $ca->crt    = 'CA_CRT';
+        $ca->key    = 'CA_KEY';
+        $caUuid = $ca->getAttribute('uuid');
+        $this->assertNotEmpty($caUuid);
+
+        // Now simulate what signAction() does.
+        $cert = $mdl->pki->certificates->certificate->Add();
+        $cert->descr           = 'sign-test-cert';
+        $cert->origin          = 'signed';
+        $cert->caref           = $caUuid;
+        $cert->crt             = "-----BEGIN NEBULA CERTIFICATE-----\nfakecrt\n-----END NEBULA CERTIFICATE-----\n";
+        $cert->key             = "-----BEGIN NEBULA ED25519 PRIVATE KEY-----\nfakekey\n-----END NEBULA ED25519 PRIVATE KEY-----\n";
+        $cert->networks        = '10.10.0.1/24';
+        $cert->groups          = 'lighthouse';
+        $cert->unsafe_networks = '';
+
+        $certUuid = $cert->getAttribute('uuid');
+        $this->assertNotEmpty($certUuid, 'Add() must assign a UUID');
+
+        // Verify field storage.
+        $this->assertEquals('sign-test-cert', (string)$cert->descr);
+        $this->assertEquals('signed', (string)$cert->origin);
+        $this->assertEquals($caUuid, (string)$cert->caref, 'caref must store the CA UUID');
+        $this->assertNotEmpty((string)$cert->crt);
+        $this->assertNotEmpty((string)$cert->key);
+        $this->assertEquals('10.10.0.1/24', (string)$cert->networks);
+        $this->assertEquals('lighthouse', (string)$cert->groups);
+    }
+
+    public function testSignDefaultOriginIsSigned()
+    {
+        $mdl  = new Nebula();
+        $cert = $mdl->pki->certificates->certificate->Add();
+        $cert->descr = 'origin-check';
+
+        $this->assertEquals('signed', (string)$cert->origin, 'Default origin must be signed');
+    }
+
+    // -------------------------------------------------------------------------
+    // importAction() model path
+    // -------------------------------------------------------------------------
+
+    public function testImportStoresOriginImported()
+    {
+        // Simulate what importAction() does after pki_print_cert accepts the crt.
+        $mdl  = new Nebula();
+        $cert = $mdl->pki->certificates->certificate->Add();
+        $cert->descr    = 'imported-cert';
+        $cert->origin   = 'imported';
+        $cert->crt      = 'IMPORTED_HOST_CRT';
+        $cert->networks = '10.10.0.5/24';
+        $cert->groups   = 'servers';
+        // key intentionally omitted.
+
+        $uuid = $cert->getAttribute('uuid');
+        $this->assertNotEmpty($uuid);
+        $this->assertEquals('imported', (string)$cert->origin);
+        $this->assertEquals('IMPORTED_HOST_CRT', (string)$cert->crt);
+        $this->assertEquals('10.10.0.5/24', (string)$cert->networks);
+        $this->assertEquals('servers', (string)$cert->groups);
+    }
+
+    public function testImportWithKeyAndCaref()
+    {
+        $mdl = new Nebula();
+
+        // CA authority for the caref.
+        $ca = $mdl->pki->authorities->authority->Add();
+        $ca->descr  = 'import-ca';
+        $ca->crt    = 'CA_CRT';
+        $caUuid = $ca->getAttribute('uuid');
+
+        $cert = $mdl->pki->certificates->certificate->Add();
+        $cert->descr  = 'imported-with-key';
+        $cert->origin = 'imported';
+        $cert->caref  = $caUuid;
+        $cert->crt    = 'HOST_CRT';
+        $cert->key    = 'HOST_KEY';
+
+        $this->assertEquals($caUuid, (string)$cert->caref, 'caref must store the CA UUID');
+        $this->assertEquals('HOST_KEY', (string)$cert->key);
+    }
+
+    // -------------------------------------------------------------------------
+    // Validation guards
+    // -------------------------------------------------------------------------
+
+    public function testValidationRejectsMissingDescr()
+    {
+        // signAction() and importAction() both guard for empty descr before calling
+        // Add().  Belt-and-suspenders: verify performValidation() also catches it.
+        $mdl  = new Nebula();
+        $cert = $mdl->pki->certificates->certificate->Add();
+        // descr intentionally left empty.
+
+        $msgs  = $mdl->performValidation();
+        $found = false;
+        foreach ($msgs as $m) {
+            if (strpos($m->getField(), 'descr') !== false) {
+                $found = true;
+                break;
+            }
+        }
+        $this->assertTrue($found, 'Missing required descr must produce a validation error');
+    }
+
+    // -------------------------------------------------------------------------
+    // Del
+    // -------------------------------------------------------------------------
+
+    public function testDelRemovesCertificate()
+    {
+        $mdl  = new Nebula();
+        $cert = $mdl->pki->certificates->certificate->Add();
+        $cert->descr = 'del-cert-test';
+        $cert->crt   = 'CRT';
+        $cert->key   = 'KEY';
+
+        $uuid = $cert->getAttribute('uuid');
+        $this->assertNotNull($this->findByUuid($mdl->pki->certificates->certificate, $uuid));
+
+        $result = $mdl->pki->certificates->certificate->del($uuid);
+        $this->assertTrue($result, 'del() must return true for a found certificate');
+        $this->assertNull(
+            $this->findByUuid($mdl->pki->certificates->certificate, $uuid),
+            'Certificate must be gone after del()'
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // searchItem columns (descr, origin, caref, networks)
+    // -------------------------------------------------------------------------
+
+    public function testSearchColumnsAreReadable()
+    {
+        // searchItemAction() exposes [descr, ca_name, networks, valid_to].
+        // Verify these computed display fields exist and are readable.
+        $mdl  = new Nebula();
+        $cert = $mdl->pki->certificates->certificate->Add();
+        $cert->descr    = 'search-test-cert';
+        $cert->ca_name  = 'demo-ca';
+        $cert->networks = '10.0.0.2/24';
+        $cert->valid_to = '2027-06-05T00:00:00Z';
+
+        $this->assertEquals('search-test-cert',     (string)$cert->descr);
+        $this->assertEquals('demo-ca',              (string)$cert->ca_name);
+        $this->assertEquals('10.0.0.2/24',          (string)$cert->networks);
+        $this->assertEquals('2027-06-05T00:00:00Z', (string)$cert->valid_to);
+        // caref defaults to empty when not set.
+        $this->assertEquals('', (string)$cert->caref);
+    }
+
+    public function testComputedFieldsArePersisted()
+    {
+        $mdl  = new Nebula();
+        $cert = $mdl->pki->certificates->certificate->Add();
+        $cert->descr       = 'computed-cert';
+        $cert->cn          = 'host1';
+        $cert->ca_name     = 'demo-ca';
+        $cert->valid_from  = '2026-06-05T00:00:00Z';
+        $cert->valid_to    = '2027-06-05T00:00:00Z';
+        $cert->fingerprint = 'cafebabe';
+        $cert->is_ca       = '0';
+        $cert->has_key     = '1';
+
+        $this->assertEquals('host1',                 (string)$cert->cn);
+        $this->assertEquals('demo-ca',               (string)$cert->ca_name);
+        $this->assertEquals('cafebabe',              (string)$cert->fingerprint);
+        $this->assertEquals('0',                     (string)$cert->is_ca);
+        $this->assertEquals('1',                     (string)$cert->has_key);
+    }
+
+    // -------------------------------------------------------------------------
+    // issuer (signing CA fingerprint) + curve + cert-only has_key
+    // -------------------------------------------------------------------------
+
+    /**
+     * The cert stores the signing CA's fingerprint in `issuer` (set by
+     * storeComputedFields from details.issuer).  searchItemAction resolves the
+     * CA's display name dynamically from this, so we never rely on a stored
+     * ca_name.  Here we verify the field round-trips.
+     */
+    public function testIssuerFingerprintIsStored()
+    {
+        $mdl  = new Nebula();
+        $cert = $mdl->pki->certificates->certificate->Add();
+        $cert->descr  = 'issuer-cert';
+        $cert->issuer = '06a5719971755f60540408916f37af0c165fe4d5a31cc8a2a4848a461889ed06';
+
+        $this->assertEquals(
+            '06a5719971755f60540408916f37af0c165fe4d5a31cc8a2a4848a461889ed06',
+            (string)$cert->issuer
+        );
+    }
+
+    /**
+     * The cert model carries a curve field (populated from info[0].curve at
+     * sign/import) so the Host Certificates grid can show a Curve column.
+     */
+    public function testCurveFieldIsStored()
+    {
+        $mdl  = new Nebula();
+        $cert = $mdl->pki->certificates->certificate->Add();
+        $cert->descr = 'curve-cert';
+        $cert->curve = 'P256';
+
+        $this->assertEquals('P256', (string)$cert->curve);
+
+        $cert2 = $mdl->pki->certificates->certificate->Add();
+        $cert2->descr = 'default-curve-cert';
+        $this->assertEquals('25519', (string)$cert2->curve, 'curve defaults to 25519');
+    }
+
+    /**
+     * A cert-only import (no private key) must have has_key='0' so no
+     * Download-key button is shown for it.
+     */
+    public function testCertOnlyImportHasNoKey()
+    {
+        $mdl  = new Nebula();
+        $cert = $mdl->pki->certificates->certificate->Add();
+        $cert->descr   = 'cert-only';
+        $cert->origin  = 'imported';
+        $cert->crt     = 'HOST_CRT';
+        $cert->has_key = '0';
+
+        $this->assertEquals('0', (string)$cert->has_key, 'cert-only import must have has_key=0');
+    }
+
+    public function testCertRetrievableByUuid()
+    {
+        $mdl  = new Nebula();
+        $cert = $mdl->pki->certificates->certificate->Add();
+        $cert->descr    = 'lookup-cert';
+        $cert->networks = '192.168.50.10/24';
+
+        $uuid  = $cert->getAttribute('uuid');
+        $found = $this->findByUuid($mdl->pki->certificates->certificate, $uuid);
+        $this->assertNotNull($found, 'Certificate must be retrievable by UUID');
+        $this->assertEquals('lookup-cert',       (string)$found->descr);
+        $this->assertEquals('192.168.50.10/24',  (string)$found->networks);
+    }
+
+    // -------------------------------------------------------------------------
+    // certReferencedBy + purgeExpiredCertificates (the data path
+    // CertificateController::delItemAction / purgeExpiredAction share)
+    // -------------------------------------------------------------------------
+
+    /** Add a certificate with the given description and notAfter. */
+    private function addCert(Nebula $mdl, string $descr, string $validTo): string
+    {
+        $cert = $mdl->pki->certificates->certificate->Add();
+        $cert->descr    = $descr;
+        $cert->valid_to = $validTo;
+        return $cert->getAttribute('uuid');
+    }
+
+    public function testCertReferencedByDetectsInstance()
+    {
+        $mdl = new Nebula();
+        $unrefUuid = $this->addCert($mdl, 'unref-cert', '2027-01-01T00:00:00Z');
+        $usedUuid  = $this->addCert($mdl, 'used-cert',  '2027-01-01T00:00:00Z');
+
+        $inst = $mdl->instances->instance->Add();
+        $inst->description = 'gw';
+        $inst->certref     = $usedUuid;
+
+        $this->assertNull($mdl->certReferencedBy($unrefUuid), 'unreferenced cert → null');
+        $this->assertStringContainsString('gw', (string)$mdl->certReferencedBy($usedUuid));
+    }
+
+    public function testPurgeExpiredCertificatesSkipsReferenced()
+    {
+        $mdl = new Nebula();
+        $expiredUnref = $this->addCert($mdl, 'old-unref', '2000-01-01T00:00:00Z');
+        $current      = $this->addCert($mdl, 'current',   '2999-01-01T00:00:00Z');
+        $expiredRef   = $this->addCert($mdl, 'old-inuse', '2000-01-01T00:00:00Z');
+
+        // An instance references the expired-in-use cert.
+        $inst = $mdl->instances->instance->Add();
+        $inst->description = 'router';
+        $inst->certref     = $expiredRef;
+
+        $res = $mdl->purgeExpiredCertificates();
+
+        $this->assertEquals(1, $res['removed'], 'only the expired unreferenced cert is removed');
+        $this->assertEquals(['old-inuse'], $res['skippedNames'], 'expired-but-referenced cert reported');
+        $this->assertNull(
+            $this->findByUuid($mdl->pki->certificates->certificate, $expiredUnref),
+            'expired unreferenced cert must be gone'
+        );
+        $this->assertNotNull(
+            $this->findByUuid($mdl->pki->certificates->certificate, $current),
+            'current cert must remain'
+        );
+        $this->assertNotNull(
+            $this->findByUuid($mdl->pki->certificates->certificate, $expiredRef),
+            'expired referenced cert must be kept'
+        );
+    }
+}

--- a/net/nebula/src/opnsense/mvc/tests/app/models/OPNsense/Nebula/FirewallRuleCRUDTest.php
+++ b/net/nebula/src/opnsense/mvc/tests/app/models/OPNsense/Nebula/FirewallRuleCRUDTest.php
@@ -1,0 +1,359 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace tests\OPNsense\Nebula;
+
+use OPNsense\Core\AppConfig;
+use OPNsense\Core\Config;
+use OPNsense\Nebula\Nebula;
+
+/**
+ * Model-level CRUD tests for fwrules.rule ArrayField.
+ *
+ * Tests the same data paths that FirewallRuleController exercises via
+ * ApiMutableModelControllerBase (add/get/set/del/toggle).  The at-least-one
+ * matcher validation and the instance-scoped filter are tested here at the
+ * model/query layer; the route-resolution path is covered by live tests.
+ */
+class FirewallRuleCRUDTest extends \PHPUnit\Framework\TestCase
+{
+    private static $configDir = __DIR__ . '/NebulaConfig';
+
+    public static function setUpBeforeClass(): void
+    {
+        (new AppConfig())->update('application.configDir', self::$configDir);
+        Config::getInstance()->forceReload();
+    }
+
+    /** Locate an ArrayField child by UUID, returning null if not found. */
+    private function findByUuid($arrayField, $uuid)
+    {
+        foreach ($arrayField->iterateItems() as $node) {
+            if ($node->getAttribute('uuid') === $uuid) {
+                return $node;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Add a minimal valid instance and return its UUID.
+     */
+    private function addInstance(Nebula $model, string $description = 'test-instance'): string
+    {
+        $inst = $model->instances->instance->Add();
+        $inst->enabled      = '1';
+        $inst->description  = $description;
+        $inst->listen_host  = '0.0.0.0';
+        $inst->listen_port  = '4242';
+        $inst->am_lighthouse = '0';
+        return $inst->getAttribute('uuid');
+    }
+
+    // -------------------------------------------------------------------------
+    // Add / readback
+    // -------------------------------------------------------------------------
+
+    public function testAddRuleWithGroups()
+    {
+        $model     = new Nebula();
+        $instUuid  = $this->addInstance($model, 'inst-for-rule');
+
+        $rule = $model->fwrules->rule->Add();
+        $rule->enabled     = '1';
+        $rule->instance    = $instUuid;
+        $rule->direction   = 'inbound';
+        $rule->protocol    = 'tcp';
+        $rule->port        = '443';
+        $rule->groups      = 'vpn-clients';
+        $rule->description = 'Allow HTTPS from vpn-clients';
+
+        $uuid = $rule->getAttribute('uuid');
+        $this->assertNotEmpty($uuid, 'Add() must return a node with a UUID');
+
+        // NOTE: ModelRelationField uses a static option-list cache that is
+        // populated from the persisted config.xml, not from in-memory Add()s.
+        // Therefore performValidation() will report an error for the `instance`
+        // field even when the UUID is valid in-memory (same constraint as
+        // CertificateCRUDTest with caref/certref).  We test field storage and
+        // readback directly instead of asserting validation count == 0 here.
+        $this->assertEquals($instUuid,      (string)$rule->instance);
+        $this->assertEquals('vpn-clients',  (string)$rule->groups);
+        $this->assertEquals('inbound',      (string)$rule->direction);
+        $this->assertEquals('tcp',          (string)$rule->protocol);
+        $this->assertEquals('443',          (string)$rule->port);
+    }
+
+    public function testRuleFieldsReadBack()
+    {
+        $model    = new Nebula();
+        $instUuid = $this->addInstance($model, 'inst-readback');
+
+        $rule = $model->fwrules->rule->Add();
+        $rule->enabled     = '1';
+        $rule->instance    = $instUuid;
+        $rule->direction   = 'outbound';
+        $rule->protocol    = 'udp';
+        $rule->port        = '53';
+        $rule->cidr        = '10.0.0.0/8';
+        $rule->description = 'DNS outbound';
+
+        $uuid  = $rule->getAttribute('uuid');
+        $found = $this->findByUuid($model->fwrules->rule, $uuid);
+
+        $this->assertNotNull($found, 'findByUuid must locate the added rule');
+        $this->assertEquals('outbound',    (string)$found->direction);
+        $this->assertEquals('udp',         (string)$found->protocol);
+        $this->assertEquals('53',          (string)$found->port);
+        $this->assertEquals('10.0.0.0/8',  (string)$found->cidr);
+        $this->assertEquals($instUuid,     (string)$found->instance);
+        $this->assertEquals('DNS outbound',(string)$found->description);
+    }
+
+    // -------------------------------------------------------------------------
+    // Set (update)
+    // -------------------------------------------------------------------------
+
+    public function testSetRuleUpdatesFields()
+    {
+        $model    = new Nebula();
+        $instUuid = $this->addInstance($model, 'inst-set');
+
+        $rule = $model->fwrules->rule->Add();
+        $rule->enabled   = '1';
+        $rule->instance  = $instUuid;
+        $rule->direction = 'inbound';
+        $rule->protocol  = 'any';
+        $rule->host      = '192.168.1.1';
+
+        // Mutate in-place (equivalent to setBase() field update).
+        $rule->protocol  = 'icmp';
+        $rule->port      = 'any';
+        $rule->host      = '10.0.0.5';
+
+        // NOTE: ModelRelationField option-list is seeded from persisted config,
+        // not from in-memory Add()s, so we verify field values directly instead of
+        // asserting performValidation() == 0 (same design note as CertificateCRUDTest).
+        $this->assertEquals('icmp',     (string)$rule->protocol);
+        $this->assertEquals('any',      (string)$rule->port);
+        $this->assertEquals('10.0.0.5', (string)$rule->host);
+        $this->assertEquals($instUuid,  (string)$rule->instance);
+    }
+
+    // -------------------------------------------------------------------------
+    // Del
+    // -------------------------------------------------------------------------
+
+    public function testDelRuleRemovesIt()
+    {
+        $model    = new Nebula();
+        $instUuid = $this->addInstance($model, 'inst-del');
+
+        $rule = $model->fwrules->rule->Add();
+        $rule->instance  = $instUuid;
+        $rule->direction = 'inbound';
+        $rule->ca_name   = 'my-ca';
+
+        $uuid = $rule->getAttribute('uuid');
+        $this->assertNotNull($this->findByUuid($model->fwrules->rule, $uuid), 'Rule must exist before del');
+
+        $result = $model->fwrules->rule->del($uuid);
+        $this->assertTrue($result, 'del() must return true for a found rule');
+        $this->assertNull($this->findByUuid($model->fwrules->rule, $uuid), 'Rule must be gone after del()');
+    }
+
+    // -------------------------------------------------------------------------
+    // Toggle
+    // -------------------------------------------------------------------------
+
+    public function testToggleRuleEnabled()
+    {
+        $model    = new Nebula();
+        $instUuid = $this->addInstance($model, 'inst-toggle');
+
+        $rule = $model->fwrules->rule->Add();
+        $rule->enabled   = '1';
+        $rule->instance  = $instUuid;
+        $rule->direction = 'inbound';
+        $rule->groups    = 'admins';
+
+        $this->assertEquals('1', (string)$rule->enabled);
+
+        $rule->enabled = '0';
+        $this->assertEquals('0', (string)$rule->enabled);
+
+        $rule->enabled = '1';
+        $this->assertEquals('1', (string)$rule->enabled);
+    }
+
+    // -------------------------------------------------------------------------
+    // Matcher-field validation: at least one required
+    // -------------------------------------------------------------------------
+
+    /**
+     * A rule with NO matcher fields set must fail model-level validation.
+     *
+     * The controller's checkMatcherPresent() returns an error before addBase()
+     * is called, so the model never receives such a request — but the model
+     * validation must also catch it (belt-and-suspenders) if e.g. the rule is
+     * built programmatically.
+     *
+     * NOTE: the model uses free-form TextField for all matchers (no Required
+     * constraint at the schema level — the constraint is applied at the
+     * controller layer via checkMatcherPresent).  So this test verifies that
+     * a rule WITH a matcher passes, and that the matcher fields are accessible
+     * as empty strings when unset (the *controller* is responsible for the
+     * rejection, not the model schema itself).
+     *
+     * This documents the design: model is permissive; controller enforces the
+     * at-least-one-matcher invariant.  If a model-level constraint is added
+     * later, this test should be updated to assert 0 messages for the valid
+     * case and >0 for the no-matcher case.
+     */
+    public function testRuleWithMatcherPassesValidation()
+    {
+        $model    = new Nebula();
+        $instUuid = $this->addInstance($model, 'inst-matcher');
+
+        $rule = $model->fwrules->rule->Add();
+        $rule->enabled   = '1';
+        $rule->instance  = $instUuid;
+        $rule->direction = 'inbound';
+        $rule->host      = '192.168.50.1';
+
+        // The `instance` ModelRelationField option-list is seeded from the
+        // persisted config, not from in-memory Add()s, so performValidation()
+        // reports an error for it even when the UUID is valid in-memory.  This
+        // is the same design constraint documented in CertificateCRUDTest (caref).
+        // We verify that the matcher field is stored and readable.
+        $this->assertEquals('192.168.50.1', (string)$rule->host);
+        $this->assertEquals($instUuid,      (string)$rule->instance);
+        $this->assertEquals('inbound',      (string)$rule->direction);
+
+        // The validation error count will be exactly 1 (the instance relfield).
+        // All other fields are valid.
+        $msgs = $model->performValidation();
+        $instanceErrors = 0;
+        $otherErrors    = 0;
+        foreach ($msgs as $m) {
+            if (strpos($m->getField(), '.instance') !== false) {
+                $instanceErrors++;
+            } else {
+                $otherErrors++;
+            }
+        }
+        $this->assertEquals(0, $otherErrors, 'No validation errors other than the in-memory instance UUID');
+    }
+
+    public function testRuleWithNoMatcherHasEmptyMatcherFields()
+    {
+        $model    = new Nebula();
+        $instUuid = $this->addInstance($model, 'inst-no-matcher');
+
+        $rule = $model->fwrules->rule->Add();
+        $rule->enabled   = '1';
+        $rule->instance  = $instUuid;
+        $rule->direction = 'inbound';
+        // Intentionally leave all matcher fields empty.
+
+        // At the model level (no controller) no Required constraint fires on
+        // matcher fields — validation still passes.  The controller's
+        // checkMatcherPresent() would have rejected the request before reaching
+        // the model, so this represents the belt-and-suspenders design note.
+        $this->assertEquals('', (string)$rule->host,    'host must default to empty');
+        $this->assertEquals('', (string)$rule->groups,  'groups must default to empty');
+        $this->assertEquals('', (string)$rule->cidr,    'cidr must default to empty');
+        $this->assertEquals('', (string)$rule->ca_name, 'ca_name must default to empty');
+        $this->assertEquals('', (string)$rule->ca_sha,  'ca_sha must default to empty');
+    }
+
+    // -------------------------------------------------------------------------
+    // Instance-scoped filter logic (model-level)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verify that two rules referencing different instances can be
+     * distinguished by the instance UUID — the same logic the controller's
+     * filter_funct uses when ?instance=<uuid> is passed to searchItemAction.
+     */
+    public function testInstanceScopedFilterDistinguishesRules()
+    {
+        $model     = new Nebula();
+        $instA     = $this->addInstance($model, 'inst-A');
+        $instB     = $this->addInstance($model, 'inst-B');
+
+        $ruleA = $model->fwrules->rule->Add();
+        $ruleA->enabled   = '1';
+        $ruleA->instance  = $instA;
+        $ruleA->direction = 'inbound';
+        $ruleA->groups    = 'group-a';
+        $uuidA = $ruleA->getAttribute('uuid');
+
+        $ruleB = $model->fwrules->rule->Add();
+        $ruleB->enabled   = '1';
+        $ruleB->instance  = $instB;
+        $ruleB->direction = 'outbound';
+        $ruleB->cidr      = '10.10.0.0/16';
+        $uuidB = $ruleB->getAttribute('uuid');
+
+        // Simulate the controller's filter_funct for inst-A.
+        $filterA = function ($record) use ($instA) {
+            return (string)$record->instance === $instA;
+        };
+
+        $matchesA = [];
+        foreach ($model->fwrules->rule->iterateItems() as $record) {
+            if ($filterA($record)) {
+                $matchesA[] = $record->getAttribute('uuid');
+            }
+        }
+
+        $this->assertContains($uuidA, $matchesA, 'Rule for inst-A must appear in inst-A filter');
+        $this->assertNotContains($uuidB, $matchesA, 'Rule for inst-B must NOT appear in inst-A filter');
+    }
+
+    // -------------------------------------------------------------------------
+    // Default field values
+    // -------------------------------------------------------------------------
+
+    public function testDefaultProtocolIsAny()
+    {
+        $model    = new Nebula();
+        $instUuid = $this->addInstance($model, 'inst-defaults');
+
+        $rule = $model->fwrules->rule->Add();
+        $rule->instance  = $instUuid;
+        $rule->direction = 'inbound';
+        $rule->host      = '10.0.0.1';
+
+        $this->assertEquals('any',      (string)$rule->protocol, 'Default protocol must be "any"');
+        $this->assertEquals('any',      (string)$rule->port,     'Default port must be "any"');
+        $this->assertEquals('1',        (string)$rule->enabled,  'Default enabled must be "1"');
+        $this->assertEquals('inbound',  (string)$rule->direction,'Direction must round-trip');
+    }
+}

--- a/net/nebula/src/opnsense/mvc/tests/app/models/OPNsense/Nebula/GenerateConfigTest.php
+++ b/net/nebula/src/opnsense/mvc/tests/app/models/OPNsense/Nebula/GenerateConfigTest.php
@@ -1,0 +1,1086 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace tests\OPNsense\Nebula;
+
+use OPNsense\Core\AppConfig;
+use OPNsense\Core\Config;
+use OPNsense\Nebula\Nebula;
+
+class GenerateConfigTest extends \PHPUnit\Framework\TestCase
+{
+    private static $configDir = __DIR__ . '/NebulaConfig';
+
+    public static function setUpBeforeClass(): void
+    {
+        (new AppConfig())->update('application.configDir', self::$configDir);
+        Config::getInstance()->forceReload();
+    }
+
+    /**
+     * Add a minimal valid instance and return [model, node, uuid].
+     */
+    private function makeInstance(string $description = 'test'): array
+    {
+        $model = new Nebula();
+        $node  = $model->instances->instance->Add();
+        $node->enabled       = '1';
+        $node->description   = $description;
+        $node->listen_host   = '0.0.0.0';
+        $node->listen_port   = '4242';
+        $node->am_lighthouse = '0';
+        return [$model, $node, $node->getAttribute('uuid')];
+    }
+
+    /**
+     * Add an fwrule to $model and return the rule node.
+     */
+    private function addRule(Nebula $model, string $instUuid, string $direction, array $fields = [])
+    {
+        $rule = $model->fwrules->rule->Add();
+        $rule->enabled   = '1';
+        $rule->instance  = $instUuid;
+        $rule->direction = $direction;
+        foreach ($fields as $k => $v) {
+            $rule->$k = $v;
+        }
+        return $rule;
+    }
+
+    // -------------------------------------------------------------------------
+    // Firewall rule rendering tests (Task 2)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Two inbound rules + one outbound rule → rendered correctly per direction.
+     */
+    public function testFwrulesRenderPerDirection()
+    {
+        [$model, $node, $uuid] = $this->makeInstance('fw-per-dir');
+
+        // Inbound rule 1: groups (single) + port + proto
+        $this->addRule($model, $uuid, 'inbound', [
+            'groups'   => 'db',
+            'port'     => '5432',
+            'protocol' => 'tcp',
+        ]);
+        // Inbound rule 2: host=any, port=any, proto=icmp
+        $this->addRule($model, $uuid, 'inbound', [
+            'host'     => 'any',
+            'port'     => 'any',
+            'protocol' => 'icmp',
+        ]);
+        // Outbound rule 1: a distinct real rule (groups=web, port 8080, udp).
+        $this->addRule($model, $uuid, 'outbound', [
+            'groups'   => 'web',
+            'port'     => '8080',
+            'protocol' => 'udp',
+        ]);
+
+        $yaml = $model->generateConfig($node);
+
+        // Both inbound rules must appear.
+        // groups renders as a YAML list even for a single entry.
+        $this->assertStringContainsString('- "db"', $yaml);
+        $this->assertStringContainsString('port: "5432"', $yaml);
+        $this->assertStringContainsString('proto: "tcp"', $yaml);
+        $this->assertStringContainsString('proto: "icmp"', $yaml);
+
+        // The distinct outbound rule must appear (proves the permissive
+        // fallback did NOT stomp real rules in the outbound direction).
+        $this->assertStringContainsString('outbound:', $yaml);
+        $this->assertStringContainsString('- "web"', $yaml);
+        $this->assertStringContainsString('port: "8080"', $yaml);
+        $this->assertStringContainsString('proto: "udp"', $yaml);
+    }
+
+    /**
+     * An instance with NO enabled rules gets the permissive fallback on both directions.
+     */
+    public function testNoRulesFallbackToPermissive()
+    {
+        [$model, $node, $uuid] = $this->makeInstance('fw-no-rules');
+
+        $yaml = $model->generateConfig($node);
+
+        $this->assertStringContainsString('firewall:', $yaml);
+        $this->assertStringContainsString('inbound:', $yaml);
+        $this->assertStringContainsString('outbound:', $yaml);
+        $this->assertStringContainsString('port: "any"', $yaml);
+        $this->assertStringContainsString('proto: "any"', $yaml);
+        $this->assertStringContainsString('host: "any"', $yaml);
+    }
+
+    /**
+     * An instance with only inbound rules gets the permissive fallback for outbound.
+     */
+    public function testOnlyInboundRulesGivesPermissiveFallbackForOutbound()
+    {
+        [$model, $node, $uuid] = $this->makeInstance('fw-inbound-only');
+
+        $this->addRule($model, $uuid, 'inbound', [
+            'host'     => '10.0.0.1',
+            'port'     => '22',
+            'protocol' => 'tcp',
+        ]);
+
+        $yaml = $model->generateConfig($node);
+
+        // Inbound rule rendered.
+        $this->assertStringContainsString('host: "10.0.0.1"', $yaml);
+        // Outbound gets permissive fallback — check that 'proto: "any"' appears
+        // (from the fallback, since the inbound rule has proto tcp, not any).
+        $this->assertStringContainsString('proto: "any"', $yaml);
+    }
+
+    /**
+     * A multi-value `groups` matcher is rendered as a YAML list.
+     */
+    public function testGroupsMatcherRendersAsList()
+    {
+        [$model, $node, $uuid] = $this->makeInstance('fw-groups-list');
+
+        $this->addRule($model, $uuid, 'inbound', [
+            'groups'   => 'admins,ops,dev',
+            'port'     => '443',
+            'protocol' => 'tcp',
+        ]);
+
+        $yaml = $model->generateConfig($node);
+
+        $this->assertStringContainsString('groups:', $yaml);
+        $this->assertStringContainsString('- "admins"', $yaml);
+        $this->assertStringContainsString('- "ops"', $yaml);
+        $this->assertStringContainsString('- "dev"', $yaml);
+    }
+
+    /**
+     * A single-entry `groups` value renders as a one-element YAML list.
+     * (group/groups collapse: a single group is now groups:["a"].)
+     */
+    public function testSingleGroupRendersAsOneElementList()
+    {
+        [$model, $node, $uuid] = $this->makeInstance('fw-single-group');
+
+        $this->addRule($model, $uuid, 'inbound', [
+            'groups'   => 'mygroup',
+            'port'     => '22',
+            'protocol' => 'tcp',
+        ]);
+
+        $yaml = $model->generateConfig($node);
+
+        $this->assertStringContainsString('groups:', $yaml);
+        $this->assertStringContainsString('- "mygroup"', $yaml);
+        // Verify there is no bare scalar `group:` key emitted.
+        $this->assertStringNotContainsString('group: "mygroup"', $yaml);
+    }
+
+    /**
+     * Disabled rules are skipped; if all rules for an instance are disabled the
+     * permissive fallback is returned for that direction.
+     */
+    public function testDisabledRulesAreSkipped()
+    {
+        [$model, $node, $uuid] = $this->makeInstance('fw-disabled');
+
+        // Add a disabled inbound rule.
+        $rule = $model->fwrules->rule->Add();
+        $rule->enabled   = '0';
+        $rule->instance  = $uuid;
+        $rule->direction = 'inbound';
+        $rule->host      = '10.99.0.1';
+
+        // Add an enabled outbound rule.
+        $this->addRule($model, $uuid, 'outbound', ['host' => '10.1.2.3']);
+
+        $yaml = $model->generateConfig($node);
+
+        // The disabled rule's host must not appear.
+        $this->assertStringNotContainsString('10.99.0.1', $yaml);
+        // Inbound falls back to permissive (the only inbound rule was disabled).
+        $this->assertStringContainsString('proto: "any"', $yaml);
+        // Outbound has the real rule.
+        $this->assertStringContainsString('host: "10.1.2.3"', $yaml);
+    }
+
+    /**
+     * Rules for a DIFFERENT instance must not appear in this instance's config.
+     */
+    public function testRulesFromOtherInstanceAreIgnored()
+    {
+        $model = new Nebula();
+
+        $nodeA = $model->instances->instance->Add();
+        $nodeA->enabled = '1'; $nodeA->description = 'inst-A';
+        $nodeA->listen_host = '0.0.0.0'; $nodeA->listen_port = '4242';
+        $nodeA->am_lighthouse = '0';
+        $uuidA = $nodeA->getAttribute('uuid');
+
+        $nodeB = $model->instances->instance->Add();
+        $nodeB->enabled = '1'; $nodeB->description = 'inst-B';
+        $nodeB->listen_host = '0.0.0.0'; $nodeB->listen_port = '4243';
+        $nodeB->am_lighthouse = '0';
+        $uuidB = $nodeB->getAttribute('uuid');
+
+        // Rule for B only.
+        $this->addRule($model, $uuidB, 'inbound', ['host' => '192.168.50.50']);
+
+        $yaml = $model->generateConfig($nodeA);
+
+        // Instance A has no rules → permissive fallback; B's host must not appear.
+        $this->assertStringNotContainsString('192.168.50.50', $yaml);
+        $this->assertStringContainsString('proto: "any"', $yaml);
+    }
+
+    public function testEnabledInstanceRendersMinimalYaml()
+    {
+        $model = new Nebula();
+        $node = $model->instances->instance->Add();
+        $node->enabled = '1';
+        $node->description = 'lh';
+        $node->listen_host = '0.0.0.0';
+        $node->listen_port = '4242';
+        $node->am_lighthouse = '1';
+
+        $uuid = $node->getAttribute('uuid');
+        $yaml = $model->generateConfig($node);
+
+        $this->assertStringContainsString('listen:', $yaml);
+        // strings are double-quoted; the listen host/port live under listen:
+        $this->assertStringContainsString('host: "0.0.0.0"', $yaml);
+        $this->assertStringContainsString('port: 4242', $yaml);
+        $this->assertStringContainsString('am_lighthouse: true', $yaml);
+        $this->assertNotEmpty($uuid);
+
+        // pki: section must reference the per-instance cert dir (keyed by uuid).
+        // pki paths are string scalars, hence double-quoted.
+        $this->assertStringContainsString('pki:', $yaml);
+        $this->assertStringContainsString('ca: "/usr/local/etc/nebula/' . $uuid . '/ca.crt"', $yaml);
+        $this->assertStringContainsString('cert: "/usr/local/etc/nebula/' . $uuid . '/host.crt"', $yaml);
+        $this->assertStringContainsString('key: "/usr/local/etc/nebula/' . $uuid . '/host.key"', $yaml);
+
+        // firewall: must be present (nebula is deny-by-default) and permissive
+        $this->assertStringContainsString('firewall:', $yaml);
+        $this->assertStringContainsString('outbound:', $yaml);
+        $this->assertStringContainsString('inbound:', $yaml);
+        $this->assertStringContainsString('port: "any"', $yaml);
+        $this->assertStringContainsString('proto: "any"', $yaml);
+        $this->assertStringContainsString('host: "any"', $yaml);
+    }
+
+    public function testAdvancedBlockIsAppendedToOutput()
+    {
+        $model = new Nebula();
+        $node = $model->instances->instance->Add();
+        $node->enabled = '1';
+        $node->description = 'adv-test';
+        $node->listen_host = '0.0.0.0';
+        $node->listen_port = '4242';
+        $node->am_lighthouse = '1';
+        $node->advanced = "stats:\n  type: prometheus\n  listen: \"127.0.0.1:8080\"\n  path: \"/metrics\"";
+
+        $yaml = $model->generateConfig($node);
+
+        // The advanced block must appear in the output, after the generated section.
+        $this->assertStringContainsString('stats:', $yaml);
+        $this->assertStringContainsString('type: prometheus', $yaml);
+        $this->assertStringContainsString('listen: "127.0.0.1:8080"', $yaml);
+        $this->assertStringContainsString('path: "/metrics"', $yaml);
+
+        // The advanced block must come AFTER the generated pki: section.
+        $pkiPos = strpos($yaml, 'pki:');
+        $statsPos = strpos($yaml, 'stats:');
+        $this->assertNotFalse($pkiPos, 'pki: must be present');
+        $this->assertNotFalse($statsPos, 'stats: must be present');
+        $this->assertGreaterThan($pkiPos, $statsPos, 'advanced block must follow generated YAML');
+
+        // Output must end with a newline.
+        $this->assertStringEndsWith("\n", $yaml);
+    }
+
+    public function testEmptyAdvancedLeavesOutputUnchanged()
+    {
+        $model = new Nebula();
+
+        $nodeWithout = $model->instances->instance->Add();
+        $nodeWithout->enabled = '1';
+        $nodeWithout->description = 'no-adv';
+        $nodeWithout->listen_host = '0.0.0.0';
+        $nodeWithout->listen_port = '4242';
+        $nodeWithout->am_lighthouse = '1';
+
+        $nodeWith = $model->instances->instance->Add();
+        $nodeWith->enabled = '1';
+        $nodeWith->description = 'no-adv';
+        $nodeWith->listen_host = '0.0.0.0';
+        $nodeWith->listen_port = '4242';
+        $nodeWith->am_lighthouse = '1';
+        $nodeWith->advanced = '';
+
+        $yamlWithout = $model->generateConfig($nodeWithout);
+        $yamlWith = $model->generateConfig($nodeWith);
+
+        // Empty advanced must not alter the output (no extra trailing junk).
+        // We compare after normalising the per-instance bits (uuid cert paths and
+        // the uuid-derived sshd debug port), which legitimately differ between the
+        // two instances.
+        $normalise = function (string $y): string {
+            $y = preg_replace('#/usr/local/etc/nebula/[0-9a-f\-]+/#', '/UUID/', $y);
+            $y = preg_replace('#127\.0\.0\.1:\d+#', '127.0.0.1:PORT', $y);
+            return $y;
+        };
+        $this->assertSame($normalise($yamlWithout), $normalise($yamlWith));
+
+        // No spurious blank line or separator at end of output.
+        $this->assertStringNotContainsString("\n\n\n", $yaml = $yamlWith, 'no triple-newlines from empty advanced');
+    }
+
+    public function testListKnobNewlineSeparated()
+    {
+        $model = new Nebula();
+        $node = $model->instances->instance->Add();
+        $node->enabled = '1';
+        $node->description = 'list-test';
+        $node->listen_host = '0.0.0.0';
+        $node->listen_port = '4242';
+        $node->am_lighthouse = '0';
+        $node->lighthouse_hosts = "192.168.100.1\n192.168.100.2";
+        $node->relay_relays = '192.168.100.5';
+
+        $yaml = $model->generateConfig($node);
+
+        // lighthouse.hosts must render as a YAML sequence
+        $this->assertStringContainsString("lighthouse:\n", $yaml);
+        $this->assertStringContainsString("  hosts:\n", $yaml);
+        $this->assertStringContainsString('    - "192.168.100.1"', $yaml);
+        $this->assertStringContainsString('    - "192.168.100.2"', $yaml);
+
+        // relay.relays must render as a YAML sequence
+        $this->assertStringContainsString("relay:\n", $yaml);
+        $this->assertStringContainsString("  relays:\n", $yaml);
+        $this->assertStringContainsString('    - "192.168.100.5"', $yaml);
+    }
+
+    public function testListKnobCommaSeparated()
+    {
+        $model = new Nebula();
+        $node = $model->instances->instance->Add();
+        $node->enabled = '1';
+        $node->description = 'list-comma';
+        $node->listen_host = '0.0.0.0';
+        $node->listen_port = '4242';
+        $node->preferred_ranges = 'a, b, c';
+
+        $yaml = $model->generateConfig($node);
+
+        $this->assertStringContainsString("preferred_ranges:\n", $yaml);
+        $this->assertStringContainsString('  - "a"', $yaml);
+        $this->assertStringContainsString('  - "b"', $yaml);
+        $this->assertStringContainsString('  - "c"', $yaml);
+    }
+
+    public function testListKnobEmptyIsOmitted()
+    {
+        $model = new Nebula();
+        $node = $model->instances->instance->Add();
+        $node->enabled = '1';
+        $node->description = 'list-empty';
+        $node->listen_host = '0.0.0.0';
+        $node->listen_port = '4242';
+        // lighthouse_advertise_addrs left empty (default)
+
+        $yaml = $model->generateConfig($node);
+
+        $this->assertStringNotContainsString('advertise_addrs', $yaml);
+    }
+
+    // -------------------------------------------------------------------------
+    // static_hostmap grid rendering (+ legacy textarea union)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Grid entries render into static_host_map (map-of-lists) for their own
+     * instance; addresses split on comma/newline.
+     */
+    public function testStaticHostMapGridRenders()
+    {
+        [$model, $node, $uuid] = $this->makeInstance('shm-grid');
+        $node->lighthouse_hosts = '192.168.100.1';
+        $e = $model->static_hostmap->entry->Add();
+        $e->enabled   = '1';
+        $e->instance  = $uuid;
+        $e->nebula_ip = '192.168.100.1';
+        $e->addresses = "198.51.100.1:4242, 203.0.113.5:4242";
+
+        $yaml = $model->generateConfig($node);
+
+        $this->assertStringContainsString('static_host_map:', $yaml);
+        $this->assertStringContainsString('192.168.100.1:', $yaml);
+        $this->assertStringContainsString('- "198.51.100.1:4242"', $yaml);
+        $this->assertStringContainsString('- "203.0.113.5:4242"', $yaml);
+
+        // The static_host_map key must precede its list items.
+        $shmPos = strpos($yaml, 'static_host_map:');
+        $firstAddrPos = strpos($yaml, '"198.51.100.1:4242"');
+        $this->assertNotFalse($shmPos);
+        $this->assertNotFalse($firstAddrPos);
+        $this->assertLessThan($firstAddrPos, $shmPos, 'static_host_map: must precede its list items');
+    }
+
+    /**
+     * Grid entries for a different instance, and disabled ones, do not render.
+     */
+    public function testStaticHostMapGridScopedAndEnabled()
+    {
+        $model = new Nebula();
+        $a = $model->instances->instance->Add();
+        $a->enabled = '1'; $a->description = 'shm-A';
+        $a->listen_host = '0.0.0.0'; $a->listen_port = '4242'; $a->am_lighthouse = '0';
+        $uuidA = $a->getAttribute('uuid');
+        $b = $model->instances->instance->Add();
+        $b->enabled = '1'; $b->description = 'shm-B';
+        $b->listen_host = '0.0.0.0'; $b->listen_port = '4243'; $b->am_lighthouse = '0';
+        $uuidB = $b->getAttribute('uuid');
+
+        $e = $model->static_hostmap->entry->Add();
+        $e->enabled = '1'; $e->instance = $uuidB;
+        $e->nebula_ip = '192.168.100.9'; $e->addresses = '198.51.100.9:4242';
+        $d = $model->static_hostmap->entry->Add();
+        $d->enabled = '0'; $d->instance = $uuidA;
+        $d->nebula_ip = '192.168.100.8'; $d->addresses = '198.51.100.8:4242';
+
+        $yamlA = $model->generateConfig($a);
+
+        $this->assertStringNotContainsString('192.168.100.9', $yamlA, 'other-instance entry must not render');
+        $this->assertStringNotContainsString('192.168.100.8', $yamlA, 'disabled entry must not render');
+        $this->assertStringNotContainsString('static_host_map:', $yamlA);
+    }
+
+    /**
+     * Addresses repeated across rows for the same overlay IP are de-duplicated.
+     */
+    public function testStaticHostMapDeduplicatesAddresses()
+    {
+        [$model, $node, $uuid] = $this->makeInstance('shm-dedup');
+        $e1 = $model->static_hostmap->entry->Add();
+        $e1->enabled = '1'; $e1->instance = $uuid;
+        $e1->nebula_ip = '192.168.100.1';
+        $e1->addresses = "198.51.100.1:4242, 203.0.113.5:4242";
+        $e2 = $model->static_hostmap->entry->Add();
+        $e2->enabled = '1'; $e2->instance = $uuid;
+        $e2->nebula_ip = '192.168.100.1';
+        $e2->addresses = "198.51.100.1:4242";
+
+        $yaml = $model->generateConfig($node);
+
+        $this->assertStringContainsString('- "198.51.100.1:4242"', $yaml);
+        $this->assertStringContainsString('- "203.0.113.5:4242"', $yaml);
+        $this->assertSame(
+            1,
+            substr_count($yaml, '- "198.51.100.1:4242"'),
+            'a repeated address must be de-duplicated'
+        );
+    }
+
+    public function testDataDrivenRenderFromConfigMap()
+    {
+        $model = new Nebula();
+        $node = $model->instances->instance->Add();
+        $node->enabled = '1';
+        $node->description = 'data-driven';
+        $node->listen_host = '::';
+        $node->cipher = 'aes';
+        $node->punchy_punch = '0';
+        $node->listen_port = '0';
+        $node->logging_level = 'debug';
+        $node->tun_mtu = '1300';
+        // leave listen_read_buffer empty (unset optional) -> must be omitted
+
+        $uuid = $node->getAttribute('uuid');
+        $yaml = $model->generateConfig($node);
+
+        // header
+        $this->assertStringContainsString('# Generated by os-nebula. Do not edit by hand.', $yaml);
+
+        // enum/string scalars -> double quoted
+        $this->assertStringContainsString('cipher: "aes"', $yaml);
+        $this->assertStringContainsString('level: "debug"', $yaml);
+        // the listen host "::" MUST be quoted, else YAML mis-parses the bare ::
+        $this->assertStringContainsString('host: "::"', $yaml);
+
+        // bool -> bare false (punch under punchy:)
+        $this->assertStringContainsString('punch: false', $yaml);
+        // bool -> bare true (sshd enabled)
+        $this->assertStringContainsString('enabled: true', $yaml);
+
+        // int -> bare, including port 0 (must emit 0, not omit)
+        $this->assertStringContainsString('port: 0', $yaml);
+        $this->assertStringContainsString('mtu: 1300', $yaml);
+
+        // logging: is a real section header (level lives under it)
+        $this->assertStringContainsString('logging:', $yaml);
+        $this->assertStringContainsString('punchy:', $yaml);
+
+        // pki: block with the uuid-derived paths
+        $this->assertStringContainsString('pki:', $yaml);
+        $this->assertStringContainsString('ca: "/usr/local/etc/nebula/' . $uuid . '/ca.crt"', $yaml);
+
+        // firewall: block must carry BOTH the scalar actions AND the rule lists
+        $this->assertStringContainsString('firewall:', $yaml);
+        $this->assertStringContainsString('outbound_action: "drop"', $yaml);
+        $this->assertStringContainsString('inbound_action: "drop"', $yaml);
+        $this->assertStringContainsString('outbound:', $yaml);
+        $this->assertStringContainsString('inbound:', $yaml);
+        $this->assertStringContainsString('proto: "any"', $yaml);
+
+        // omitted optional must NOT appear
+        $this->assertStringNotContainsString('read_buffer', $yaml);
+
+        // bools render bare (no quotes), ints bare, strings quoted
+        $this->assertStringNotContainsString('punch: "false"', $yaml);
+        $this->assertStringNotContainsString('mtu: "1300"', $yaml);
+        $this->assertStringNotContainsString('cipher: aes', $yaml);
+    }
+
+    // -------------------------------------------------------------------------
+    // pki.blocklist rendering
+    // -------------------------------------------------------------------------
+
+    /** A pair of valid 64-char lowercase hex sha256 fingerprints. */
+    private const BL_FP_A = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+    private const BL_FP_B = 'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
+
+    /** Add a blocklist entry to $model and return the entry node. */
+    private function addBlock(Nebula $model, string $fingerprint, array $fields = [])
+    {
+        $entry = $model->pki->blocklist->entry->Add();
+        $entry->enabled     = '1';
+        $entry->scope       = 'global'; // default; override via $fields for per-instance
+        $entry->instance    = '';
+        $entry->fingerprint = $fingerprint;
+        foreach ($fields as $k => $v) {
+            $entry->$k = $v;
+        }
+        return $entry;
+    }
+
+    /**
+     * A global blocklist entry (empty instance) renders for every instance.
+     */
+    public function testGlobalBlocklistEntryAppearsForEveryInstance()
+    {
+        $model = new Nebula();
+
+        $nodeA = $model->instances->instance->Add();
+        $nodeA->enabled = '1'; $nodeA->description = 'bl-A';
+        $nodeA->listen_host = '0.0.0.0'; $nodeA->listen_port = '4242';
+        $nodeA->am_lighthouse = '0';
+
+        $nodeB = $model->instances->instance->Add();
+        $nodeB->enabled = '1'; $nodeB->description = 'bl-B';
+        $nodeB->listen_host = '0.0.0.0'; $nodeB->listen_port = '4243';
+        $nodeB->am_lighthouse = '0';
+
+        // One global block.
+        $this->addBlock($model, self::BL_FP_A);
+
+        $yamlA = $model->generateConfig($nodeA);
+        $yamlB = $model->generateConfig($nodeB);
+
+        // blocklist: is nested under pki: with the fingerprint as a quoted list item.
+        $this->assertStringContainsString('blocklist:', $yamlA);
+        $this->assertStringContainsString('- "' . self::BL_FP_A . '"', $yamlA);
+        $this->assertStringContainsString('- "' . self::BL_FP_A . '"', $yamlB);
+    }
+
+    /**
+     * A per-instance blocklist entry renders only for its own instance.
+     */
+    public function testPerInstanceBlocklistEntryScopedToItsInstance()
+    {
+        $model = new Nebula();
+
+        $nodeA = $model->instances->instance->Add();
+        $nodeA->enabled = '1'; $nodeA->description = 'bl-scope-A';
+        $nodeA->listen_host = '0.0.0.0'; $nodeA->listen_port = '4242';
+        $nodeA->am_lighthouse = '0';
+        $uuidA = $nodeA->getAttribute('uuid');
+
+        $nodeB = $model->instances->instance->Add();
+        $nodeB->enabled = '1'; $nodeB->description = 'bl-scope-B';
+        $nodeB->listen_host = '0.0.0.0'; $nodeB->listen_port = '4243';
+        $nodeB->am_lighthouse = '0';
+
+        // Block scoped to instance A only (explicit instance scope).
+        $this->addBlock($model, self::BL_FP_A, ['scope' => 'instance', 'instance' => $uuidA]);
+
+        $yamlA = $model->generateConfig($nodeA);
+        $yamlB = $model->generateConfig($nodeB);
+
+        // A sees the block; B does not (and B has no blocklist key at all).
+        $this->assertStringContainsString('- "' . self::BL_FP_A . '"', $yamlA);
+        $this->assertStringNotContainsString(self::BL_FP_A, $yamlB);
+        $this->assertStringNotContainsString('blocklist:', $yamlB);
+    }
+
+    /**
+     * Disabled blocklist entries are skipped.
+     */
+    public function testDisabledBlocklistEntryIsSkipped()
+    {
+        [$model, $node, $uuid] = $this->makeInstance('bl-disabled');
+
+        $this->addBlock($model, self::BL_FP_A, ['enabled' => '0']);
+
+        $yaml = $model->generateConfig($node);
+
+        $this->assertStringNotContainsString(self::BL_FP_A, $yaml);
+        // No enabled entries → the blocklist key is omitted entirely.
+        $this->assertStringNotContainsString('blocklist:', $yaml);
+    }
+
+    /**
+     * Block-until-purged: the renderer ignores Expiry entirely. An enabled entry
+     * renders whether its Expiry date is in the past or the future — Expiry is now
+     * only a purge-eligibility marker, not an effective end date. (The expired one
+     * is removed only when the admin runs Purge expired, covered in
+     * BlocklistCRUDTest::testPurgeExpiredRemovesOnlyPastDatedEntries.)
+     */
+    public function testExpiredBlocklistEntryStillRenders()
+    {
+        [$model, $node, $uuid] = $this->makeInstance('bl-expiry');
+
+        // Expired yesterday — still blocks until purged.
+        $this->addBlock($model, self::BL_FP_A, ['expiry' => date('Y-m-d', strtotime('-1 day'))]);
+        // Future-dated — also blocks.
+        $this->addBlock($model, self::BL_FP_B, ['expiry' => date('Y-m-d', strtotime('+1 year'))]);
+
+        $yaml = $model->generateConfig($node);
+
+        $this->assertStringContainsString('- "' . self::BL_FP_A . '"', $yaml, 'expired entry still blocks until purged');
+        $this->assertStringContainsString('- "' . self::BL_FP_B . '"', $yaml, 'future-dated entry blocks');
+    }
+
+    /**
+     * An empty / no-entry blocklist omits the pki.blocklist key entirely.
+     */
+    public function testEmptyBlocklistOmitsKey()
+    {
+        [$model, $node, $uuid] = $this->makeInstance('bl-empty');
+
+        $yaml = $model->generateConfig($node);
+
+        $this->assertStringNotContainsString('blocklist:', $yaml);
+        // The fixed pki: block must still be present.
+        $this->assertStringContainsString('pki:', $yaml);
+    }
+
+    // Note: the renderer no longer consults Expiry at all (block-until-purged),
+    // so empty / non-ISO / unparseable expiry values all render the same way —
+    // see testExpiredBlocklistEntryStillRenders above. The date-format parsing
+    // that decides *purge* eligibility is covered by
+    // BlocklistCRUDTest::testPurgeExpiredHandlesDateFormats.
+
+    // -------------------------------------------------------------------------
+    // tun.unsafe_routes rendering
+    // -------------------------------------------------------------------------
+
+    /** Add an unsafe route to $model and return the node. */
+    private function addRoute(Nebula $model, string $instUuid, array $fields = [])
+    {
+        $r = $model->unsafe_routes->route->Add();
+        $r->enabled  = '1';
+        $r->instance = $instUuid;
+        $r->route    = '172.16.1.0/24';
+        $r->via      = '192.168.100.99';
+        $r->install  = '1';
+        foreach ($fields as $k => $v) {
+            $r->$k = $v;
+        }
+        return $r;
+    }
+
+    public function testUnsafeRouteRendersForItsInstanceOnly()
+    {
+        $model = new Nebula();
+        $a = $model->instances->instance->Add();
+        $a->enabled = '1'; $a->description = 'ur-A';
+        $a->listen_host = '0.0.0.0'; $a->listen_port = '4242'; $a->am_lighthouse = '0';
+        $uuidA = $a->getAttribute('uuid');
+
+        $b = $model->instances->instance->Add();
+        $b->enabled = '1'; $b->description = 'ur-B';
+        $b->listen_host = '0.0.0.0'; $b->listen_port = '4243'; $b->am_lighthouse = '0';
+
+        $this->addRoute($model, $uuidA, ['route' => '10.9.0.0/16', 'via' => '192.168.100.5']);
+
+        $yamlA = $model->generateConfig($a);
+        $yamlB = $model->generateConfig($b);
+
+        $this->assertStringContainsString('unsafe_routes:', $yamlA);
+        $this->assertStringContainsString('route: "10.9.0.0/16"', $yamlA);
+        $this->assertStringContainsString('via: "192.168.100.5"', $yamlA);
+        $this->assertStringContainsString('install: true', $yamlA);
+        $this->assertStringNotContainsString('unsafe_routes:', $yamlB);
+    }
+
+    public function testUnsafeRouteOptionalFieldsOmittedWhenEmpty()
+    {
+        [$model, $node, $uuid] = $this->makeInstance('ur-opt');
+        $this->addRoute($model, $uuid); // no mtu/metric
+
+        $yaml = $model->generateConfig($node);
+
+        // metric: is only emitted by unsafe routes (tun.mtu's default makes a bare
+        // "mtu:" check ambiguous, so we assert on metric for the omitted case).
+        $this->assertStringContainsString('route: "172.16.1.0/24"', $yaml);
+        $this->assertStringNotContainsString('metric:', $yaml);
+    }
+
+    public function testUnsafeRouteMtuMetricRenderedWhenSet()
+    {
+        [$model, $node, $uuid] = $this->makeInstance('ur-mtu');
+        // 8800 is distinct from the tun.mtu default (1300) so it uniquely
+        // identifies the route-level mtu.
+        $this->addRoute($model, $uuid, ['mtu' => '8800', 'metric' => '100']);
+
+        $yaml = $model->generateConfig($node);
+
+        $this->assertStringContainsString('mtu: 8800', $yaml);
+        $this->assertStringContainsString('metric: 100', $yaml);
+    }
+
+    public function testDisabledUnsafeRouteSkipped()
+    {
+        [$model, $node, $uuid] = $this->makeInstance('ur-off');
+        $this->addRoute($model, $uuid, ['enabled' => '0']);
+
+        $yaml = $model->generateConfig($node);
+
+        $this->assertStringNotContainsString('unsafe_routes:', $yaml);
+    }
+
+    // -------------------------------------------------------------------------
+    // tun.routes (per-route MTU override) rendering
+    // -------------------------------------------------------------------------
+
+    /** Add a tun.routes MTU override and return the node. */
+    private function addTunRoute(Nebula $model, string $instUuid, array $fields = [])
+    {
+        $r = $model->tun_routes->route->Add();
+        $r->enabled  = '1';
+        $r->instance = $instUuid;
+        $r->route    = '10.0.0.0/16';
+        $r->mtu      = '8800';
+        foreach ($fields as $k => $v) {
+            $r->$k = $v;
+        }
+        return $r;
+    }
+
+    public function testTunRouteRendersForItsInstanceOnly()
+    {
+        $model = new Nebula();
+        $a = $model->instances->instance->Add();
+        $a->enabled = '1'; $a->description = 'tr-A';
+        $a->listen_host = '0.0.0.0'; $a->listen_port = '4242'; $a->am_lighthouse = '0';
+        $uuidA = $a->getAttribute('uuid');
+
+        $b = $model->instances->instance->Add();
+        $b->enabled = '1'; $b->description = 'tr-B';
+        $b->listen_host = '0.0.0.0'; $b->listen_port = '4243'; $b->am_lighthouse = '0';
+
+        $this->addTunRoute($model, $uuidA, ['route' => '10.7.0.0/16', 'mtu' => '8000']);
+
+        $yamlA = $model->generateConfig($a);
+        $yamlB = $model->generateConfig($b);
+
+        // Rendered under tun.routes as {route, mtu}.
+        $this->assertStringContainsString('routes:', $yamlA);
+        $this->assertStringContainsString('route: "10.7.0.0/16"', $yamlA);
+        $this->assertStringContainsString('mtu: 8000', $yamlA);
+        $this->assertStringNotContainsString('10.7.0.0/16', $yamlB);
+    }
+
+    public function testDisabledTunRouteSkipped()
+    {
+        [$model, $node, $uuid] = $this->makeInstance('tr-off');
+        $this->addTunRoute($model, $uuid, ['enabled' => '0', 'route' => '10.8.0.0/16']);
+
+        $yaml = $model->generateConfig($node);
+
+        $this->assertStringNotContainsString('10.8.0.0/16', $yaml);
+    }
+
+    // -------------------------------------------------------------------------
+    // sshd debug server — always on, internal management channel only
+    // -------------------------------------------------------------------------
+
+    /**
+     * The sshd block is ALWAYS emitted: enabled, bound to 127.0.0.1 on the
+     * per-instance derived port, with a per-instance host key. When a diag
+     * pubkey is supplied, only the _opnsense_diag user is authorized.
+     */
+    public function testSshdAlwaysOnWithDiagKeyOnly()
+    {
+        [$model, $node, $uuid] = $this->makeInstance('sshd-always');
+
+        $yaml = $model->generateConfig($node, 'ssh-ed25519 AAAADIAGKEY diag');
+
+        $this->assertStringContainsString('sshd:', $yaml);
+        $this->assertStringContainsString('enabled: true', $yaml);
+        // Bound to localhost on the derived port (and nothing else).
+        $port = $model->sshdPortFor($uuid);
+        $this->assertStringContainsString('listen: "127.0.0.1:' . $port . '"', $yaml);
+        $this->assertStringContainsString('host_key: "/usr/local/etc/nebula/' . $uuid . '/sshd_host_key"', $yaml);
+        // Only the plugin diagnostics user is authorized; no user lists.
+        $this->assertStringContainsString('user: "_opnsense_diag"', $yaml);
+        $this->assertStringContainsString('- "ssh-ed25519 AAAADIAGKEY diag"', $yaml);
+        $this->assertStringNotContainsString('trusted_cas:', $yaml);
+    }
+
+    /**
+     * The derived sshd port is stable for a given instance and distinct across
+     * instances (each daemon needs its own 127.0.0.1 port).
+     */
+    public function testSshdPortDistinctPerInstance()
+    {
+        $model = new Nebula();
+        $a = $model->instances->instance->Add();
+        $a->enabled = '1'; $a->description = 'a';
+        $a->listen_host = '0.0.0.0'; $a->listen_port = '4242'; $a->am_lighthouse = '0';
+        $b = $model->instances->instance->Add();
+        $b->enabled = '1'; $b->description = 'b';
+        $b->listen_host = '0.0.0.0'; $b->listen_port = '4243'; $b->am_lighthouse = '0';
+
+        $pa = $model->sshdPortFor($a->getAttribute('uuid'));
+        $pb = $model->sshdPortFor($b->getAttribute('uuid'));
+
+        $this->assertNotSame($pa, $pb, 'two instances must get distinct sshd ports');
+        $this->assertSame($pa, $model->sshdPortFor($a->getAttribute('uuid')), 'port must be stable');
+        $this->assertGreaterThanOrEqual(22000, $pa);
+        $this->assertLessThan(26000, $pa);
+    }
+
+    /**
+     * Without a diag pubkey (a bare render, e.g. nebula -test), the sshd block is
+     * still present (enabled/listen/host_key) but carries no authorized_users.
+     */
+    public function testSshdBareRenderHasNoAuthorizedUsers()
+    {
+        [$model, $node, $uuid] = $this->makeInstance('sshd-bare');
+
+        $yaml = $model->generateConfig($node);
+
+        $this->assertStringContainsString('sshd:', $yaml);
+        $this->assertStringContainsString('enabled: true', $yaml);
+        $this->assertStringNotContainsString('authorized_users:', $yaml);
+    }
+
+    // -------------------------------------------------------------------------
+    // stats (graphite/prometheus telemetry) rendering
+    // -------------------------------------------------------------------------
+
+    /**
+     * Blank stats_type (the default) emits no stats: block at all.
+     */
+    public function testStatsOmittedWhenTypeBlank()
+    {
+        [$model, $node, $uuid] = $this->makeInstance('stats-off');
+
+        $yaml = $model->generateConfig($node);
+
+        $this->assertStringNotContainsString('stats:', $yaml);
+    }
+
+    /**
+     * graphite type emits the graphite keys (prefix/protocol/host) + interval and
+     * does NOT leak prometheus-only keys.
+     */
+    public function testStatsGraphiteRendersGraphiteKeysOnly()
+    {
+        [$model, $node, $uuid] = $this->makeInstance('stats-graphite');
+        $node->stats_type     = 'graphite';
+        $node->stats_interval = '15s';
+        $node->stats_prefix   = 'nebula';
+        $node->stats_protocol = 'tcp';
+        $node->stats_host     = '127.0.0.1:9999';
+
+        $yaml = $model->generateConfig($node);
+
+        $this->assertStringContainsString('stats:', $yaml);
+        $this->assertStringContainsString('type: "graphite"', $yaml);
+        $this->assertStringContainsString('interval: "15s"', $yaml);
+        $this->assertStringContainsString('prefix: "nebula"', $yaml);
+        $this->assertStringContainsString('protocol: "tcp"', $yaml);
+        $this->assertStringContainsString('host: "127.0.0.1:9999"', $yaml);
+
+        // prometheus-only keys must be absent.
+        $this->assertStringNotContainsString('namespace:', $yaml);
+        $this->assertStringNotContainsString('subsystem:', $yaml);
+    }
+
+    /**
+     * prometheus type emits the prometheus keys (listen/path/namespace/subsystem)
+     * + interval and does NOT leak graphite-only keys.
+     */
+    public function testStatsPrometheusRendersPrometheusKeysOnly()
+    {
+        [$model, $node, $uuid] = $this->makeInstance('stats-prometheus');
+        $node->stats_type      = 'prometheus';
+        $node->stats_interval  = '10s';
+        $node->stats_listen    = '127.0.0.1:8080';
+        $node->stats_path      = '/metrics';
+        $node->stats_namespace = 'nebulans';
+        $node->stats_subsystem = 'nebula';
+
+        $yaml = $model->generateConfig($node);
+
+        $this->assertStringContainsString('stats:', $yaml);
+        $this->assertStringContainsString('type: "prometheus"', $yaml);
+        $this->assertStringContainsString('listen: "127.0.0.1:8080"', $yaml);
+        $this->assertStringContainsString('path: "/metrics"', $yaml);
+        $this->assertStringContainsString('namespace: "nebulans"', $yaml);
+        $this->assertStringContainsString('subsystem: "nebula"', $yaml);
+
+        // graphite-only keys must be absent.
+        $this->assertStringNotContainsString('prefix:', $yaml);
+        $this->assertStringNotContainsString('protocol:', $yaml);
+    }
+
+    /**
+     * The two metric toggles render as bare booleans only when enabled.
+     */
+    public function testStatsMetricTogglesEmittedOnlyWhenEnabled()
+    {
+        [$model, $node, $uuid] = $this->makeInstance('stats-toggles');
+        $node->stats_type               = 'prometheus';
+        $node->stats_listen             = '127.0.0.1:8080';
+        $node->stats_message_metrics    = '1';
+        $node->stats_lighthouse_metrics = '0';
+
+        $yaml = $model->generateConfig($node);
+
+        $this->assertStringContainsString('message_metrics: true', $yaml);
+        // The disabled toggle is omitted entirely (not emitted as false).
+        $this->assertStringNotContainsString('lighthouse_metrics:', $yaml);
+    }
+
+    // -------------------------------------------------------------------------
+    // lighthouse allow-lists rendering
+    // -------------------------------------------------------------------------
+
+    /**
+     * remote_allow_list: "CIDR = bool" lines render as a map under lighthouse.
+     * An IPv6 CIDR key (leading colon) must be quoted so it stays a valid key.
+     */
+    public function testLighthouseRemoteAllowListRendersMap()
+    {
+        [$model, $node, $uuid] = $this->makeInstance('lh-remote-allow');
+        $node->lighthouse_remote_allow_list = "10.0.0.0/8 = false\n10.42.42.0/24 = true\n::1/128 = false";
+
+        $yaml = $model->generateConfig($node);
+
+        $this->assertStringContainsString('lighthouse:', $yaml);
+        $this->assertStringContainsString('remote_allow_list:', $yaml);
+        $this->assertStringContainsString('10.0.0.0/8: false', $yaml);
+        $this->assertStringContainsString('10.42.42.0/24: true', $yaml);
+        // IPv6 CIDR key must be quoted (bare ::1/128 as a key mis-parses).
+        $this->assertStringContainsString('"::1/128": false', $yaml);
+    }
+
+    /**
+     * local_allow_list: plain CIDR lines plus the "interface <regex>" form,
+     * which lands under a nested interfaces: map (the regex key gets quoted).
+     */
+    public function testLighthouseLocalAllowListWithInterfaces()
+    {
+        [$model, $node, $uuid] = $this->makeInstance('lh-local-allow');
+        $node->lighthouse_local_allow_list = "10.0.0.0/8 = true\ninterface docker.* = false";
+
+        $yaml = $model->generateConfig($node);
+
+        $this->assertStringContainsString('local_allow_list:', $yaml);
+        $this->assertStringContainsString('10.0.0.0/8: true', $yaml);
+        $this->assertStringContainsString('interfaces:', $yaml);
+        // The interface regex key is quoted because it contains '*'.
+        $this->assertStringContainsString('"docker.*": false', $yaml);
+    }
+
+    /**
+     * remote_allow_ranges (experimental): "<vpn> <remote> = bool" renders a
+     * map<vpn, map<remote, bool>>.
+     */
+    public function testLighthouseRemoteAllowRangesRendersNestedMap()
+    {
+        [$model, $node, $uuid] = $this->makeInstance('lh-ranges');
+        $node->lighthouse_remote_allow_ranges = "10.42.42.0/24 192.168.0.0/16 = true";
+
+        $yaml = $model->generateConfig($node);
+
+        $this->assertStringContainsString('remote_allow_ranges:', $yaml);
+        $this->assertStringContainsString('10.42.42.0/24:', $yaml);
+        $this->assertStringContainsString('192.168.0.0/16: true', $yaml);
+    }
+
+    /**
+     * calculated_remotes (experimental): "<vpn> <mask> <port>" renders a
+     * map<vpn, list<{mask, port}>>; repeated vpn-cidr appends to the list.
+     */
+    public function testLighthouseCalculatedRemotesRendersListOfStructs()
+    {
+        [$model, $node, $uuid] = $this->makeInstance('lh-calc');
+        $node->lighthouse_calculated_remotes = "192.168.1.0/24 192.168.1.0/24 4242\n"
+            . "192.168.1.0/24 192.168.1.0/24 4243";
+
+        $yaml = $model->generateConfig($node);
+
+        $this->assertStringContainsString('calculated_remotes:', $yaml);
+        $this->assertStringContainsString('192.168.1.0/24:', $yaml);
+        $this->assertStringContainsString('mask: "192.168.1.0/24"', $yaml);
+        // port is an int -> bare; both repeated entries present.
+        $this->assertStringContainsString('port: 4242', $yaml);
+        $this->assertStringContainsString('port: 4243', $yaml);
+    }
+
+    /**
+     * Malformed allow-list lines (no '=', unrecognized bool) are skipped, and an
+     * all-empty set adds no lighthouse allow-list keys.
+     */
+    public function testLighthouseAllowListMalformedAndEmptySkipped()
+    {
+        [$model, $node, $uuid] = $this->makeInstance('lh-malformed');
+        $node->lighthouse_remote_allow_list = "this has no equals\n10.0.0.0/8 = maybe";
+
+        $yaml = $model->generateConfig($node);
+
+        $this->assertStringNotContainsString('remote_allow_list:', $yaml);
+        $this->assertStringNotContainsString('this has no equals', $yaml);
+    }
+}

--- a/net/nebula/src/opnsense/mvc/tests/app/models/OPNsense/Nebula/InstanceCRUDTest.php
+++ b/net/nebula/src/opnsense/mvc/tests/app/models/OPNsense/Nebula/InstanceCRUDTest.php
@@ -1,0 +1,246 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace tests\OPNsense\Nebula;
+
+use OPNsense\Core\AppConfig;
+use OPNsense\Core\Config;
+use OPNsense\Nebula\Nebula;
+
+/**
+ * Model-level CRUD tests for instances.instance ArrayField.
+ * These exercise the same data paths the API controllers exercise via
+ * ApiMutableModelControllerBase (add/get/set/del/toggle).
+ */
+class InstanceCRUDTest extends \PHPUnit\Framework\TestCase
+{
+    private static $configDir = __DIR__ . '/NebulaConfig';
+
+    public static function setUpBeforeClass(): void
+    {
+        (new AppConfig())->update('application.configDir', self::$configDir);
+        Config::getInstance()->forceReload();
+    }
+
+    /** Locate an ArrayField child by UUID, returning null if not found. */
+    private function findByUuid($arrayField, $uuid)
+    {
+        foreach ($arrayField->iterateItems() as $node) {
+            if ($node->getAttribute('uuid') === $uuid) {
+                return $node;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * The trusted_cas multi-relation round-trips a set of CA uuids (the
+     * per-instance trusted-CA allow-list). Storage only — no validation — so it
+     * runs without the Phalcon validation extension.
+     */
+    public function testTrustedCasStoresMultiple()
+    {
+        $model = new Nebula();
+        $ca1 = $model->pki->authorities->authority->Add();
+        $ca1->descr = 'ca-one';
+        $ca2 = $model->pki->authorities->authority->Add();
+        $ca2->descr = 'ca-two';
+        $u1 = $ca1->getAttribute('uuid');
+        $u2 = $ca2->getAttribute('uuid');
+
+        $node = $model->instances->instance->Add();
+        $node->description = 'multi-ca';
+        $node->trusted_cas = $u1 . ',' . $u2;
+
+        $parts = array_values(array_filter(explode(',', (string)$node->trusted_cas)));
+        sort($parts);
+        $expect = [$u1, $u2];
+        sort($expect);
+        $this->assertEquals($expect, $parts, 'trusted_cas must round-trip both CA uuids');
+    }
+
+    public function testAddInstance()
+    {
+        $model = new Nebula();
+        $node = $model->instances->instance->Add();
+        $node->enabled = '1';
+        $node->description = 'test-lh';
+        $node->listen_host = '0.0.0.0';
+        $node->listen_port = '4242';
+        $node->am_lighthouse = '1';
+
+        $uuid = $node->getAttribute('uuid');
+        $this->assertNotEmpty($uuid, 'Add() must return a node with a UUID');
+
+        $msgs = $model->performValidation();
+        $this->assertEquals(0, count($msgs), 'New valid instance should pass validation');
+    }
+
+    public function testGetInstance()
+    {
+        $model = new Nebula();
+        $node = $model->instances->instance->Add();
+        $node->enabled = '1';
+        $node->description = 'get-test';
+        $node->listen_host = '10.0.0.1';
+        $node->listen_port = '4242';
+        $node->am_lighthouse = '0';
+
+        $uuid = $node->getAttribute('uuid');
+
+        // Retrieve by iterating items (equivalent to getBase() lookup)
+        $found = $this->findByUuid($model->instances->instance, $uuid);
+        $this->assertNotNull($found, 'Should retrieve the added node by UUID');
+        $this->assertEquals('get-test', (string)$found->description);
+        $this->assertEquals('10.0.0.1', (string)$found->listen_host);
+    }
+
+    public function testSetInstance()
+    {
+        $model = new Nebula();
+        $node = $model->instances->instance->Add();
+        $node->enabled = '1';
+        $node->description = 'before-set';
+        $node->listen_host = '0.0.0.0';
+        $node->listen_port = '4242';
+        $node->am_lighthouse = '0';
+
+        // Mutate the node in-place (equivalent to setBase() field update)
+        $node->description = 'after-set';
+        $node->listen_port = '7777';
+
+        $msgs = $model->performValidation();
+        $this->assertEquals(0, count($msgs), 'Mutated instance should still pass validation');
+        $this->assertEquals('after-set', (string)$node->description);
+        $this->assertEquals('7777', (string)$node->listen_port);
+    }
+
+    public function testDelInstance()
+    {
+        $model = new Nebula();
+        $node = $model->instances->instance->Add();
+        $node->enabled = '1';
+        $node->description = 'to-delete';
+        $node->listen_host = '0.0.0.0';
+        $node->listen_port = '4242';
+        $node->am_lighthouse = '0';
+
+        $uuid = $node->getAttribute('uuid');
+        $this->assertNotNull($this->findByUuid($model->instances->instance, $uuid), 'Node should exist before del');
+
+        // del() takes the UUID as the array key
+        $result = $model->instances->instance->del($uuid);
+        $this->assertTrue($result, 'del() should return true for a found item');
+        $this->assertNull($this->findByUuid($model->instances->instance, $uuid), 'Node should be gone after del()');
+    }
+
+    public function testToggleInstance()
+    {
+        $model = new Nebula();
+        $node = $model->instances->instance->Add();
+        $node->enabled = '1';
+        $node->description = 'toggle-test';
+        $node->listen_host = '0.0.0.0';
+        $node->listen_port = '4242';
+        $node->am_lighthouse = '0';
+
+        $this->assertEquals('1', (string)$node->enabled);
+
+        $node->enabled = '0';
+        $this->assertEquals('0', (string)$node->enabled);
+
+        $node->enabled = '1';
+        $this->assertEquals('1', (string)$node->enabled);
+    }
+
+    public function testValidationRejectsInvalidPort()
+    {
+        $model = new Nebula();
+        $node = $model->instances->instance->Add();
+        $node->enabled = '1';
+        $node->description = 'bad-port';
+        $node->listen_host = '0.0.0.0';
+        $node->listen_port = 'notaport';
+        $node->am_lighthouse = '0';
+
+        $msgs = $model->performValidation();
+        $this->assertGreaterThan(0, count($msgs), 'Invalid port should fail validation');
+    }
+
+    // -------------------------------------------------------------------------
+    // assignDeviceNames() — stable, never-reused tun device naming (#35)
+    // -------------------------------------------------------------------------
+
+    private function addInst($model, string $descr): string
+    {
+        $node = $model->instances->instance->Add();
+        $node->enabled = '1';
+        $node->description = $descr;
+        $node->listen_host = '::';
+        return $node->getAttribute('uuid');
+    }
+
+    public function testAssignDeviceNamesDerivesFromUuid()
+    {
+        $model = new Nebula();
+        $ua = $this->addInst($model, 'alpha');
+        $model->assignDeviceNames();
+        $node = $this->findByUuid($model->instances->instance, $ua);
+        $this->assertEquals('nebula' . substr(md5($ua), 0, 6), (string)$node->tun_name);
+    }
+
+    public function testAssignDeviceNamesKeepsExplicitName()
+    {
+        $model = new Nebula();
+        $node = $model->instances->instance->Add();
+        $node->enabled = '1';
+        $node->description = 'custom';
+        $node->listen_host = '::';
+        $node->tun_name = 'mydev';
+        $model->assignDeviceNames();
+        $this->assertEquals('mydev', (string)$node->tun_name, 'an explicit name is never overwritten');
+    }
+
+    public function testAssignDeviceNamesStableAcrossDelete()
+    {
+        $model = new Nebula();
+        $ua = $this->addInst($model, 'alpha');
+        $ub = $this->addInst($model, 'beta');
+        $model->assignDeviceNames();
+        $nameA = (string)$this->findByUuid($model->instances->instance, $ua)->tun_name;
+
+        // Deleting beta must NOT renumber alpha's device name.
+        $model->instances->instance->del($ub);
+        $model->assignDeviceNames();
+        $this->assertEquals(
+            $nameA,
+            (string)$this->findByUuid($model->instances->instance, $ua)->tun_name,
+            'deleting another instance must not change a stable device name'
+        );
+    }
+}

--- a/net/nebula/src/opnsense/mvc/tests/app/models/OPNsense/Nebula/InstanceUniqueListenerTest.php
+++ b/net/nebula/src/opnsense/mvc/tests/app/models/OPNsense/Nebula/InstanceUniqueListenerTest.php
@@ -1,0 +1,142 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace tests\OPNsense\Nebula;
+
+use OPNsense\Core\AppConfig;
+use OPNsense\Core\Config;
+use OPNsense\Nebula\Nebula;
+
+/**
+ * Locks the duplicate listen_port / tun_name detection used by
+ * InstanceController::checkUniqueListener.  The controller reads the posted
+ * values from $_POST['instance'] and scans the model excluding the edited
+ * uuid; this test reproduces that scan against real model instances so the
+ * rules (port 0 exempt, empty exempt, edit excludes self) are regression-safe.
+ */
+class InstanceUniqueListenerTest extends \PHPUnit\Framework\TestCase
+{
+    private static $configDir = __DIR__ . '/NebulaConfig';
+
+    public static function setUpBeforeClass(): void
+    {
+        (new AppConfig())->update('application.configDir', self::$configDir);
+        Config::getInstance()->forceReload();
+    }
+
+    /**
+     * Mirror of InstanceController::checkUniqueListener's model scan.
+     * Returns the colliding field key ('instance.listen_port' /
+     * 'instance.tun_name') or null when the posted values are unique.
+     */
+    private function scan($model, ?string $editUuid, string $listenPort, string $tunName): ?string
+    {
+        $checkPort = ($listenPort !== '' && (int)$listenPort !== 0);
+        $checkTun  = ($tunName !== '');
+        if (!$checkPort && !$checkTun) {
+            return null;
+        }
+        foreach ($model->instances->instance->iterateItems() as $node) {
+            if ($node->getAttribute('uuid') === $editUuid) {
+                continue;
+            }
+            if ($checkPort && trim((string)$node->listen_port) === $listenPort) {
+                return 'instance.listen_port';
+            }
+            if ($checkTun && trim((string)$node->tun_name) === $tunName) {
+                return 'instance.tun_name';
+            }
+        }
+        return null;
+    }
+
+    private function makeInstance($model, string $port, string $tun)
+    {
+        $node = $model->instances->instance->Add();
+        $node->enabled = '1';
+        $node->listen_host = '0.0.0.0';
+        $node->listen_port = $port;
+        $node->tun_name = $tun;
+        return $node;
+    }
+
+    public function testDuplicatePortRejected()
+    {
+        $model = new Nebula();
+        $this->makeInstance($model, '4242', 'nebula0');
+        $this->assertEquals('instance.listen_port', $this->scan($model, null, '4242', 'nebulaX'));
+    }
+
+    public function testDuplicateTunRejected()
+    {
+        $model = new Nebula();
+        $this->makeInstance($model, '4242', 'nebula0');
+        $this->assertEquals('instance.tun_name', $this->scan($model, null, '5555', 'nebula0'));
+    }
+
+    public function testUniquePortAndTunAccepted()
+    {
+        $model = new Nebula();
+        $this->makeInstance($model, '4242', 'nebula0');
+        $this->assertNull($this->scan($model, null, '4243', 'nebula1'));
+    }
+
+    public function testPortZeroMayRepeat()
+    {
+        $model = new Nebula();
+        $this->makeInstance($model, '0', '');
+        // a second random-port (0) instance is allowed
+        $this->assertNull($this->scan($model, null, '0', ''));
+    }
+
+    public function testEmptyPortAndTunSkipsChecks()
+    {
+        $model = new Nebula();
+        $this->makeInstance($model, '4242', 'nebula0');
+        $this->assertNull($this->scan($model, null, '', ''));
+    }
+
+    public function testEditExcludesSelf()
+    {
+        $model = new Nebula();
+        $node = $this->makeInstance($model, '4242', 'nebula0');
+        $uuid = $node->getAttribute('uuid');
+        // editing the same instance, keeping its own port/tun, must not collide
+        $this->assertNull($this->scan($model, $uuid, '4242', 'nebula0'));
+    }
+
+    public function testEditDetectsCollisionWithOther()
+    {
+        $model = new Nebula();
+        $a = $this->makeInstance($model, '4242', 'nebula0');
+        $b = $this->makeInstance($model, '4243', 'nebula1');
+        $bUuid = $b->getAttribute('uuid');
+        // editing B to take A's port must collide
+        $this->assertEquals('instance.listen_port', $this->scan($model, $bUuid, '4242', 'nebula1'));
+    }
+}

--- a/net/nebula/src/opnsense/mvc/tests/app/models/OPNsense/Nebula/NebulaConfig/backup/config.xml
+++ b/net/nebula/src/opnsense/mvc/tests/app/models/OPNsense/Nebula/NebulaConfig/backup/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<opnsense>
+  <revision>
+    <username>tests\OPNsense\Nebula\GenerateConfigTest</username>
+    <description>N/A</description>
+    <time>0</time>
+  </revision>
+</opnsense>

--- a/net/nebula/src/opnsense/mvc/tests/app/models/OPNsense/Nebula/NebulaConfig/config.xml
+++ b/net/nebula/src/opnsense/mvc/tests/app/models/OPNsense/Nebula/NebulaConfig/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<opnsense>
+  <revision>
+    <username>tests\OPNsense\Nebula\GenerateConfigTest</username>
+    <description>N/A</description>
+    <time>0</time>
+  </revision>
+</opnsense>

--- a/net/nebula/src/opnsense/mvc/tests/app/models/OPNsense/Nebula/PkiCRUDTest.php
+++ b/net/nebula/src/opnsense/mvc/tests/app/models/OPNsense/Nebula/PkiCRUDTest.php
@@ -1,0 +1,316 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace tests\OPNsense\Nebula;
+
+use OPNsense\Core\AppConfig;
+use OPNsense\Core\Config;
+use OPNsense\Nebula\Nebula;
+
+/**
+ * Model-level CRUD tests for the shared PKI pool (authorities + certificates)
+ * and the instance certref ModelRelationField.
+ *
+ * Note on ModelRelationField validation: OPNsense's ModelRelationField uses a
+ * PHP static option-list cache keyed by md5(serialized model structure).  In
+ * unit tests every test method gets a fresh in-memory Nebula() instance, but
+ * the static cache persists across methods in the same process.  The validator
+ * therefore cannot reliably see items Added() only in memory; it validates only
+ * what was written to the config store.  We therefore test UUID storage and
+ * readback directly rather than asserting performValidation() == 0 for the
+ * relation fields — that path is covered by integration tests that go through
+ * serializeToConfig().  Validation IS tested for non-relation fields (descr
+ * Required, int ranges, enum values) where no static-cache issue exists.
+ */
+class PkiCRUDTest extends \PHPUnit\Framework\TestCase
+{
+    private static $configDir = __DIR__ . '/NebulaConfig';
+
+    public static function setUpBeforeClass(): void
+    {
+        (new AppConfig())->update('application.configDir', self::$configDir);
+        Config::getInstance()->forceReload();
+    }
+
+    /** Find an ArrayField item by UUID, or return null. */
+    private function findByUuid($arrayField, $uuid)
+    {
+        foreach ($arrayField->iterateItems() as $node) {
+            if ($node->getAttribute('uuid') === $uuid) {
+                return $node;
+            }
+        }
+        return null;
+    }
+
+    public function testAddAuthority()
+    {
+        $model = new Nebula();
+        $auth = $model->pki->authorities->authority->Add();
+        $auth->descr = 'test-ca';
+        $auth->crt = 'CERT_DATA';
+        $auth->key = 'KEY_DATA';
+
+        $uuid = $auth->getAttribute('uuid');
+        $this->assertNotEmpty($uuid, 'Add() must assign a UUID to the authority');
+
+        // Validate only the non-relation fields; descr is Required → should pass.
+        // We do not assert performValidation() == 0 because the certref/caref
+        // relation validator is subject to the static-cache issue described above.
+        $this->assertEquals('test-ca', (string)$auth->descr);
+        $this->assertEquals('generated', (string)$auth->origin);
+        $this->assertEquals('25519', (string)$auth->curve);
+    }
+
+    public function testAuthorityDefaultValues()
+    {
+        $model = new Nebula();
+        $auth = $model->pki->authorities->authority->Add();
+        $auth->descr = 'defaults-test';
+
+        $this->assertEquals('generated', (string)$auth->origin, 'Default origin must be generated');
+        $this->assertEquals('25519', (string)$auth->curve, 'Default curve must be 25519');
+    }
+
+    public function testAuthorityValidationRequiresDescr()
+    {
+        $model = new Nebula();
+        $auth = $model->pki->authorities->authority->Add();
+        // descr intentionally left blank — Required field
+
+        $msgs = $model->performValidation();
+        $found = false;
+        foreach ($msgs as $m) {
+            if (strpos($m->getField(), 'descr') !== false) {
+                $found = true;
+                break;
+            }
+        }
+        $this->assertTrue($found, 'Missing required descr must produce a validation message');
+    }
+
+    public function testAddCertificateUuidAndFields()
+    {
+        $model = new Nebula();
+
+        // Add authority — we need its UUID for the caref
+        $auth = $model->pki->authorities->authority->Add();
+        $auth->descr = 'ca-for-cert';
+        $authUuid = $auth->getAttribute('uuid');
+        $this->assertNotEmpty($authUuid);
+
+        // Add certificate referencing the authority
+        $cert = $model->pki->certificates->certificate->Add();
+        $cert->descr = 'test-cert';
+        $cert->caref = $authUuid;
+        $cert->crt = 'HOST_CRT';
+        $cert->key = 'HOST_KEY';
+        $cert->networks = '192.168.100.1/24';
+        $cert->groups = 'lighthouse';
+
+        $certUuid = $cert->getAttribute('uuid');
+        $this->assertNotEmpty($certUuid, 'Certificate must get a UUID');
+
+        // Read back fields directly without going through the static-cache validator
+        $this->assertEquals('test-cert', (string)$cert->descr);
+        $this->assertEquals($authUuid, (string)$cert->caref, 'caref must store the authority UUID');
+        $this->assertEquals('signed', (string)$cert->origin, 'Default origin must be signed');
+        $this->assertEquals('HOST_CRT', (string)$cert->crt);
+        $this->assertEquals('HOST_KEY', (string)$cert->key);
+        $this->assertEquals('192.168.100.1/24', (string)$cert->networks);
+        $this->assertEquals('lighthouse', (string)$cert->groups);
+    }
+
+    public function testCertificateUnsafeNetworksFieldIsDistinctFromNetworks()
+    {
+        // unsafe_networks must be a separate field — distinct from networks —
+        // and must round-trip independently without conflating the two.
+        $model = new Nebula();
+
+        $auth = $model->pki->authorities->authority->Add();
+        $auth->descr = 'ca-unsafe-test';
+        $authUuid = $auth->getAttribute('uuid');
+
+        $cert = $model->pki->certificates->certificate->Add();
+        $cert->descr           = 'cert-with-unsafe';
+        $cert->caref           = $authUuid;
+        $cert->networks        = '192.168.100.1/24';
+        $cert->unsafe_networks = '10.0.0.0/8,172.16.0.0/12';
+
+        // The two fields must store independently.
+        $this->assertEquals('192.168.100.1/24', (string)$cert->networks, 'networks must be stored separately');
+        $this->assertEquals('10.0.0.0/8,172.16.0.0/12', (string)$cert->unsafe_networks, 'unsafe_networks must be stored separately');
+        $this->assertNotEquals((string)$cert->networks, (string)$cert->unsafe_networks, 'networks and unsafe_networks must not be conflated');
+    }
+
+    public function testCertificateUnsafeNetworksEmptyByDefault()
+    {
+        // When a cert is created without unsafe_networks the field must be empty,
+        // not populated with the networks value.
+        $model = new Nebula();
+        $cert  = $model->pki->certificates->certificate->Add();
+        $cert->descr    = 'cert-no-unsafe';
+        $cert->networks = '10.20.30.1/24';
+
+        $this->assertEquals('10.20.30.1/24', (string)$cert->networks);
+        $this->assertEquals('', (string)$cert->unsafe_networks, 'unsafe_networks must be empty when not set');
+    }
+
+    public function testAuthorityUnsafeNetworksFieldIsDistinctFromNetworks()
+    {
+        // Same distinctness guarantee for the authority model.
+        $model = new Nebula();
+        $auth  = $model->pki->authorities->authority->Add();
+        $auth->descr           = 'ca-with-unsafe';
+        $auth->networks        = '192.168.100.0/24';
+        $auth->unsafe_networks = '203.0.113.0/24';
+
+        $this->assertEquals('192.168.100.0/24', (string)$auth->networks, 'authority networks must be stored separately');
+        $this->assertEquals('203.0.113.0/24', (string)$auth->unsafe_networks, 'authority unsafe_networks must be stored separately');
+        $this->assertNotEquals((string)$auth->networks, (string)$auth->unsafe_networks, 'authority networks and unsafe_networks must not be conflated');
+    }
+
+    public function testAuthorityUnsafeNetworksEmptyByDefault()
+    {
+        $model = new Nebula();
+        $auth  = $model->pki->authorities->authority->Add();
+        $auth->descr    = 'ca-no-unsafe';
+        $auth->networks = '10.0.0.0/8';
+
+        $this->assertEquals('10.0.0.0/8', (string)$auth->networks);
+        $this->assertEquals('', (string)$auth->unsafe_networks, 'authority unsafe_networks must be empty when not set');
+    }
+
+    public function testCertificateDefaultOriginIsSigned()
+    {
+        $model = new Nebula();
+        $cert = $model->pki->certificates->certificate->Add();
+        $cert->descr = 'cert-origin-test';
+
+        $this->assertEquals('signed', (string)$cert->origin, 'Default origin must be signed');
+    }
+
+    public function testCertificateCaRefStoredAsUuid()
+    {
+        $model = new Nebula();
+
+        $auth = $model->pki->authorities->authority->Add();
+        $auth->descr = 'my-ca';
+        $authUuid = $auth->getAttribute('uuid');
+
+        $cert = $model->pki->certificates->certificate->Add();
+        $cert->descr = 'my-cert';
+        $cert->caref = $authUuid;
+
+        // Read back through the array field lookup
+        $certUuid = $cert->getAttribute('uuid');
+        $found = $this->findByUuid($model->pki->certificates->certificate, $certUuid);
+        $this->assertNotNull($found, 'Certificate retrievable by UUID');
+        $this->assertEquals($authUuid, (string)$found->caref, 'caref resolves to the authority UUID');
+    }
+
+    public function testInstanceCertrefStoredAsUuid()
+    {
+        $model = new Nebula();
+
+        // Build the chain: authority → certificate → instance.certref
+        $auth = $model->pki->authorities->authority->Add();
+        $auth->descr = 'instance-ca';
+        $authUuid = $auth->getAttribute('uuid');
+
+        $cert = $model->pki->certificates->certificate->Add();
+        $cert->descr = 'instance-cert';
+        $cert->caref = $authUuid;
+        $certUuid = $cert->getAttribute('uuid');
+
+        $inst = $model->instances->instance->Add();
+        $inst->enabled = '1';
+        $inst->description = 'inst-with-cert';
+        $inst->listen_host = '0.0.0.0';
+        $inst->listen_port = '4242';
+        $inst->am_lighthouse = '1';
+        $inst->certref = $certUuid;
+
+        // Verify the UUID is stored correctly
+        $this->assertEquals($certUuid, (string)$inst->certref, 'certref must store the certificate UUID');
+
+        // Verify retrievable via ArrayField iteration
+        $instUuid = $inst->getAttribute('uuid');
+        $found = $this->findByUuid($model->instances->instance, $instUuid);
+        $this->assertNotNull($found, 'Instance must be retrievable by UUID');
+        $this->assertEquals($certUuid, (string)$found->certref, 'certref survives ArrayField lookup');
+    }
+
+    public function testInstanceWithoutCertrefPassesValidation()
+    {
+        // certref is optional — an instance with no cert must still validate OK.
+        $model = new Nebula();
+        $inst = $model->instances->instance->Add();
+        $inst->enabled = '1';
+        $inst->description = 'no-cert';
+        $inst->listen_host = '0.0.0.0';
+        $inst->listen_port = '4242';
+        $inst->am_lighthouse = '1';
+
+        $msgs = $model->performValidation();
+        // Filter to only messages from our instance (ignore any from other fields)
+        $instMsgs = [];
+        foreach ($msgs as $m) {
+            $instMsgs[] = $m->getField() . ': ' . $m->getMessage();
+        }
+        $this->assertEquals(0, count($msgs), 'Instance without certref should pass validation: ' . implode(', ', $instMsgs));
+    }
+
+    public function testDelAuthority()
+    {
+        $model = new Nebula();
+        $auth = $model->pki->authorities->authority->Add();
+        $auth->descr = 'to-delete';
+
+        $uuid = $auth->getAttribute('uuid');
+        $this->assertNotNull($this->findByUuid($model->pki->authorities->authority, $uuid), 'Must exist before del');
+
+        $result = $model->pki->authorities->authority->del($uuid);
+        $this->assertTrue($result, 'del() returns true for a found authority');
+        $this->assertNull($this->findByUuid($model->pki->authorities->authority, $uuid), 'Gone after del()');
+    }
+
+    public function testDelCertificate()
+    {
+        $model = new Nebula();
+        $cert = $model->pki->certificates->certificate->Add();
+        $cert->descr = 'cert-to-delete';
+
+        $uuid = $cert->getAttribute('uuid');
+        $this->assertNotNull($this->findByUuid($model->pki->certificates->certificate, $uuid));
+
+        $result = $model->pki->certificates->certificate->del($uuid);
+        $this->assertTrue($result, 'del() returns true for a found certificate');
+        $this->assertNull($this->findByUuid($model->pki->certificates->certificate, $uuid), 'Gone after del()');
+    }
+}

--- a/net/nebula/src/opnsense/scripts/OPNsense/Nebula/pki.php
+++ b/net/nebula/src/opnsense/scripts/OPNsense/Nebula/pki.php
@@ -1,0 +1,374 @@
+#!/usr/local/bin/php
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * nebula-cert wrapper — model-free, pure JSON I/O.
+ *
+ * Usage: pki.php <subcommand> <base64-json-params>
+ *
+ * Subcommands:
+ *   generate-ca  params: {name, curve, duration_hours, groups?, networks?, unsafe_networks?, passphrase?}
+ *   sign-cert    params: {name, networks, groups?, unsafe_networks?, duration_hours?, ca_crt, ca_key, in_pub?, passphrase?}
+ *   print-cert   params: {crt}
+ *
+ * passphrase (generate-ca/sign-cert) is passed to nebula-cert ONLY via the
+ * NEBULA_CA_PASSPHRASE environment variable — never on the command line — so it
+ * is not exposed in the process argument list.  On generate-ca a non-empty
+ * passphrase adds -encrypt (the CA key is stored encrypted).  On sign-cert a
+ * non-empty passphrase decrypts an encrypted CA key.
+ *
+ * Prints a JSON result to stdout; exits 0 on success, 1 on error.
+ * On error: {"error": "<message>"}
+ */
+
+const NEBULA_CERT_BIN = '/usr/local/bin/nebula-cert';
+
+/**
+ * Emit a JSON error to stdout, then exit with code 0.
+ *
+ * Exit 0 is required so that configd's script_output action type does not
+ * suppress stdout.  The caller (controller) inspects the JSON 'error' key.
+ */
+function fail(string $msg): never
+{
+    echo json_encode(['error' => $msg]) . "\n";
+    exit(0);
+}
+
+/**
+ * Run a shell command capturing stdout + stderr separately.
+ *
+ * $extraEnv lets the caller inject environment variables for the child WITHOUT
+ * exposing them on the process argument list (which is world-readable via ps).
+ * It is used to pass NEBULA_CA_PASSPHRASE to nebula-cert for encrypted CA keys:
+ * the passphrase never appears in $cmd, only in the child's environment.  When
+ * $extraEnv is empty we pass null so proc_open inherits the current environment
+ * (preserving PATH etc.) exactly as before.
+ *
+ * Returns ['out' => string, 'err' => string, 'rc' => int].
+ */
+function run_cmd(string $cmd, array $extraEnv = []): array
+{
+    $descriptors = [
+        0 => ['pipe', 'r'],
+        1 => ['pipe', 'w'],
+        2 => ['pipe', 'w'],
+    ];
+    $env = null;
+    if (!empty($extraEnv)) {
+        // Merge onto the inherited environment so PATH and friends survive.
+        $env = array_merge($_ENV, getenv(), $extraEnv);
+    }
+    $proc = proc_open($cmd, $descriptors, $pipes, null, $env);
+    if (!is_resource($proc)) {
+        return ['out' => '', 'err' => 'proc_open failed', 'rc' => -1];
+    }
+    fclose($pipes[0]);
+    $out = stream_get_contents($pipes[1]);
+    $err = stream_get_contents($pipes[2]);
+    fclose($pipes[1]);
+    fclose($pipes[2]);
+    $rc = proc_close($proc);
+    return ['out' => $out, 'err' => $err, 'rc' => $rc];
+}
+
+/**
+ * Create a secure temp directory; register a shutdown cleanup so it is
+ * always removed even on fatal PHP errors.  Returns the dir path.
+ */
+function make_tempdir(): string
+{
+    $dir = rtrim(shell_exec('mktemp -d'), "\n");
+    if (empty($dir) || !is_dir($dir)) {
+        fail('mktemp -d failed');
+    }
+    /* register cleanup; harmless if already removed */
+    register_shutdown_function(function () use ($dir) {
+        if (is_dir($dir)) {
+            shell_exec('rm -rf ' . escapeshellarg($dir));
+        }
+    });
+    return $dir;
+}
+
+/**
+ * Forcibly remove a temp dir immediately (on the success path so we don't wait
+ * for shutdown).
+ */
+function cleanup_tempdir(string $dir): void
+{
+    if (is_dir($dir)) {
+        shell_exec('rm -rf ' . escapeshellarg($dir));
+    }
+}
+
+/* -------------------------------------------------------------------------
+ * Subcommand: generate-ca
+ * ------------------------------------------------------------------------- */
+function cmd_generate_ca(array $params): void
+{
+    $name            = $params['name']            ?? '';
+    $curve           = $params['curve']           ?? '25519';
+    $duration_hours  = $params['duration_hours']  ?? null;
+    $groups          = $params['groups']          ?? '';
+    $networks        = $params['networks']        ?? '';
+    $unsafe_networks = $params['unsafe_networks'] ?? '';
+    $passphrase      = $params['passphrase']      ?? '';
+
+    if ($name === '') {
+        fail('generate-ca: name is required');
+    }
+
+    $tmpdir  = make_tempdir();
+    $crt_out = $tmpdir . '/ca.crt';
+    $key_out = $tmpdir . '/ca.key';
+
+    $cmd  = NEBULA_CERT_BIN . ' ca';
+    $cmd .= ' -name '    . escapeshellarg($name);
+    $cmd .= ' -curve '   . escapeshellarg($curve);
+    $cmd .= ' -out-crt ' . escapeshellarg($crt_out);
+    $cmd .= ' -out-key ' . escapeshellarg($key_out);
+
+    if (!empty($duration_hours)) {
+        $cmd .= ' -duration ' . escapeshellarg((string)(int)$duration_hours . 'h');
+    }
+    if (!empty($groups)) {
+        $cmd .= ' -groups ' . escapeshellarg($groups);
+    }
+    if (!empty($networks)) {
+        $cmd .= ' -networks ' . escapeshellarg($networks);
+    }
+    if (!empty($unsafe_networks)) {
+        $cmd .= ' -unsafe-networks ' . escapeshellarg($unsafe_networks);
+    }
+
+    // Encrypted CA key: add -encrypt and pass the passphrase ONLY via the
+    // environment (NEBULA_CA_PASSPHRASE), never on the argv (ps-visible).  The
+    // resulting ca.key carries an "ENCRYPTED" PEM header.
+    $extraEnv = [];
+    if ($passphrase !== '') {
+        $cmd .= ' -encrypt';
+        $extraEnv['NEBULA_CA_PASSPHRASE'] = $passphrase;
+    }
+
+    $res = run_cmd($cmd, $extraEnv);
+    if ($res['rc'] !== 0) {
+        cleanup_tempdir($tmpdir);
+        fail(trim($res['err']) ?: 'nebula-cert ca failed');
+    }
+
+    $crt = @file_get_contents($crt_out);
+    $key = @file_get_contents($key_out);
+
+    cleanup_tempdir($tmpdir);
+
+    if ($crt === false || $key === false) {
+        fail('generate-ca: output files missing after nebula-cert ca');
+    }
+
+    echo json_encode(['crt' => $crt, 'key' => $key]) . "\n";
+}
+
+/* -------------------------------------------------------------------------
+ * Subcommand: sign-cert
+ * ------------------------------------------------------------------------- */
+function cmd_sign_cert(array $params): void
+{
+    $name            = $params['name']            ?? '';
+    $networks        = $params['networks']        ?? '';
+    $groups          = $params['groups']          ?? '';
+    $unsafe_networks = $params['unsafe_networks'] ?? '';
+    $duration_hours  = $params['duration_hours']  ?? null;
+    $ca_crt          = $params['ca_crt']          ?? '';
+    $ca_key          = $params['ca_key']          ?? '';
+    $in_pub          = $params['in_pub']          ?? '';
+    $passphrase      = $params['passphrase']      ?? '';
+
+    if ($name === '') {
+        fail('sign-cert: name is required');
+    }
+    if ($networks === '') {
+        fail('sign-cert: networks is required');
+    }
+    if ($ca_crt === '' || $ca_key === '') {
+        fail('sign-cert: ca_crt and ca_key are required');
+    }
+
+    $tmpdir      = make_tempdir();
+    $ca_crt_file = $tmpdir . '/ca.crt';
+    $ca_key_file = $tmpdir . '/ca.key';
+    $crt_out     = $tmpdir . '/host.crt';
+
+    if (file_put_contents($ca_crt_file, $ca_crt) === false) {
+        cleanup_tempdir($tmpdir);
+        fail('sign-cert: failed to write ca_crt to temp file');
+    }
+    if (file_put_contents($ca_key_file, $ca_key) === false) {
+        cleanup_tempdir($tmpdir);
+        fail('sign-cert: failed to write ca_key to temp file');
+    }
+
+    $cmd  = NEBULA_CERT_BIN . ' sign';
+    $cmd .= ' -ca-crt '  . escapeshellarg($ca_crt_file);
+    $cmd .= ' -ca-key '  . escapeshellarg($ca_key_file);
+    $cmd .= ' -name '    . escapeshellarg($name);
+    $cmd .= ' -networks ' . escapeshellarg($networks);
+    $cmd .= ' -out-crt ' . escapeshellarg($crt_out);
+
+    // CSR mode: sign a node-supplied public key; no -out-key (node keeps its key).
+    if ($in_pub !== '') {
+        $pub_file = $tmpdir . '/host.pub';
+        if (file_put_contents($pub_file, $in_pub) === false) {
+            cleanup_tempdir($tmpdir);
+            fail('sign-cert: failed to write in_pub to temp file');
+        }
+        $cmd .= ' -in-pub ' . escapeshellarg($pub_file);
+    } else {
+        // Generate-here mode: nebula-cert writes a fresh keypair.
+        $key_out  = $tmpdir . '/host.key';
+        $cmd     .= ' -out-key ' . escapeshellarg($key_out);
+    }
+
+    if (!empty($duration_hours)) {
+        $cmd .= ' -duration ' . escapeshellarg((string)(int)$duration_hours . 'h');
+    }
+    if (!empty($groups)) {
+        $cmd .= ' -groups ' . escapeshellarg($groups);
+    }
+    if (!empty($unsafe_networks)) {
+        $cmd .= ' -unsafe-networks ' . escapeshellarg($unsafe_networks);
+    }
+
+    // When the CA key is encrypted, nebula-cert decrypts it with the passphrase
+    // read from NEBULA_CA_PASSPHRASE.  We pass it ONLY via the environment (never
+    // argv) so it is not exposed in the process list.  A wrong/missing passphrase
+    // for an encrypted key surfaces as a non-zero rc with a stderr message like
+    // "invalid passphrase or corrupt private key", which we propagate to the
+    // caller via fail() below.
+    $extraEnv = [];
+    if ($passphrase !== '') {
+        $extraEnv['NEBULA_CA_PASSPHRASE'] = $passphrase;
+    }
+
+    $res = run_cmd($cmd, $extraEnv);
+    if ($res['rc'] !== 0) {
+        cleanup_tempdir($tmpdir);
+        fail(trim($res['err']) ?: 'nebula-cert sign failed');
+    }
+
+    $crt = @file_get_contents($crt_out);
+    if ($crt === false) {
+        cleanup_tempdir($tmpdir);
+        fail('sign-cert: crt output file missing after nebula-cert sign');
+    }
+
+    if ($in_pub !== '') {
+        // CSR mode: no private key is produced or stored.
+        cleanup_tempdir($tmpdir);
+        echo json_encode(['crt' => $crt, 'key' => '']) . "\n";
+    } else {
+        $key = @file_get_contents($key_out);
+        cleanup_tempdir($tmpdir);
+        if ($key === false) {
+            fail('sign-cert: key output file missing after nebula-cert sign');
+        }
+        echo json_encode(['crt' => $crt, 'key' => $key]) . "\n";
+    }
+}
+
+/* -------------------------------------------------------------------------
+ * Subcommand: print-cert
+ * ------------------------------------------------------------------------- */
+function cmd_print_cert(array $params): void
+{
+    $crt = $params['crt'] ?? '';
+
+    if ($crt === '') {
+        fail('print-cert: crt is required');
+    }
+
+    $tmpdir   = make_tempdir();
+    $crt_file = $tmpdir . '/cert.crt';
+
+    if (file_put_contents($crt_file, $crt) === false) {
+        cleanup_tempdir($tmpdir);
+        fail('print-cert: failed to write crt to temp file');
+    }
+
+    $cmd = NEBULA_CERT_BIN . ' print -path ' . escapeshellarg($crt_file) . ' -json';
+    $res = run_cmd($cmd);
+
+    cleanup_tempdir($tmpdir);
+
+    if ($res['rc'] !== 0) {
+        fail(trim($res['err']) ?: 'nebula-cert print failed');
+    }
+
+    $decoded = json_decode(trim($res['out']), true);
+    if ($decoded === null) {
+        fail('print-cert: nebula-cert print returned non-JSON: ' . trim($res['out']));
+    }
+
+    echo json_encode(['info' => $decoded]) . "\n";
+}
+
+/* -------------------------------------------------------------------------
+ * Entry point
+ * ------------------------------------------------------------------------- */
+
+if ($argc < 3) {
+    fail('Usage: pki.php <subcommand> <base64-json-params>');
+}
+
+$subcommand  = $argv[1];
+$params_b64  = $argv[2];
+$params_json = base64_decode($params_b64, true);
+
+if ($params_json === false) {
+    fail('params: base64 decode failed');
+}
+
+$params = json_decode($params_json, true);
+if ($params === null) {
+    fail('params: JSON decode failed: ' . json_last_error_msg());
+}
+
+switch ($subcommand) {
+    case 'generate-ca':
+        cmd_generate_ca($params);
+        break;
+    case 'sign-cert':
+        cmd_sign_cert($params);
+        break;
+    case 'print-cert':
+        cmd_print_cert($params);
+        break;
+    default:
+        fail("unknown subcommand: {$subcommand}");
+}

--- a/net/nebula/src/opnsense/scripts/OPNsense/Nebula/setup.php
+++ b/net/nebula/src/opnsense/scripts/OPNsense/Nebula/setup.php
@@ -1,0 +1,1430 @@
+#!/usr/local/bin/php
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+require_once('script/load_phalcon.php');
+
+use OPNsense\Core\Config;
+use OPNsense\Nebula\Nebula;
+
+const NEBULA_ETC = '/usr/local/etc/nebula';
+const NEBULA_RUN = '/var/run/nebula';
+const NEBULA_BIN = '/usr/local/bin/nebula';
+const DAEMON_BIN = '/usr/sbin/daemon';
+/* Plugin diagnostics SSH identity: private key used by the `peers` query, public
+ * key injected (user _opnsense_diag) into an instance's sshd authorized_users
+ * when diag_access is on. */
+const NEBULA_DIAG_DIR = NEBULA_ETC . '/.diag';
+const NEBULA_DIAG_USER = '_opnsense_diag';
+
+/**
+ * Path of the rendered config for an instance.
+ */
+function nebula_config_file($uuid)
+{
+    return NEBULA_ETC . '/' . $uuid . '.yml';
+}
+
+/**
+ * Path of the pidfile for an instance daemon.
+ */
+function nebula_pid_file($uuid)
+{
+    return NEBULA_RUN . '/' . $uuid . '.pid';
+}
+
+/**
+ * Return the pid of a running instance, or null when not running.
+ */
+function nebula_running_pid($uuid)
+{
+    $pidfile = nebula_pid_file($uuid);
+    if (!is_file($pidfile)) {
+        return null;
+    }
+    $pid = (int)trim(@file_get_contents($pidfile));
+    /* CLI php has no posix extension here; probe liveness with `kill -0`. */
+    if ($pid > 0) {
+        $rc = 0;
+        $out = [];
+        exec(sprintf('/bin/kill -0 %d 2>/dev/null', $pid), $out, $rc);
+        if ($rc === 0) {
+            return $pid;
+        }
+    }
+    /* stale pidfile */
+    @unlink($pidfile);
+    return null;
+}
+
+/**
+ * Write the three PKI files for one instance from the model's cert pool.
+ *
+ * Resolves instance->certref to a pki.certificates.certificate node, then
+ * resolves that cert's caref to its signing authority, and writes:
+ *   <certDir>/ca.crt   (trusted-CA bundle: signing CA + instance->trusted_cas, 0600)
+ *   <certDir>/host.crt (certificate crt, 0600)
+ *   <certDir>/host.key (certificate key, 0600)
+ *
+ * Returns true on success.  On any skip condition (missing certref, unresolved
+ * cert/CA, empty PEM field) logs the reason and returns false so the caller
+ * can skip starting this instance.
+ */
+function nebula_write_certs($model, $node, $uuid)
+{
+    $descr = (string)$node->description;
+    $label = "instance {$uuid}" . ($descr !== '' ? " ({$descr})" : '');
+
+    /* 1. certref must be set */
+    $certref = (string)$node->certref;
+    if ($certref === '') {
+        syslog(LOG_WARNING, "nebula: {$label} has no certificate; skipping");
+        return false;
+    }
+
+    /* 2. resolve the certificate node */
+    $cert = null;
+    foreach ($model->pki->certificates->certificate->iterateItems() as $cUuid => $cNode) {
+        if ($cUuid === $certref) {
+            $cert = $cNode;
+            break;
+        }
+    }
+    if ($cert === null) {
+        syslog(LOG_WARNING, "nebula: {$label} certificate {$certref} not found in pool; skipping");
+        return false;
+    }
+
+    /* 3. resolve the signing authority via cert->caref, indexing every authority
+          by uuid so we can also pull the instance's additional trusted CAs. */
+    $caref = (string)$cert->caref;
+    if ($caref === '') {
+        syslog(LOG_WARNING, "nebula: {$label} certificate {$certref} has no CA reference; skipping");
+        return false;
+    }
+    $authority = null;
+    $authByUuid = [];
+    foreach ($model->pki->authorities->authority->iterateItems() as $aUuid => $aNode) {
+        $authByUuid[$aUuid] = $aNode;
+        if ($aUuid === $caref) {
+            $authority = $aNode;
+        }
+    }
+    if ($authority === null) {
+        syslog(LOG_WARNING, "nebula: {$label} CA {$caref} not found in pool; skipping");
+        return false;
+    }
+
+    /* 4. validate the host cert/key + signing CA PEM fields are non-empty */
+    $signingCrt = (string)$authority->crt;
+    $hostCrt    = (string)$cert->crt;
+    $hostKey    = (string)$cert->key;
+    if ($signingCrt === '' || $hostCrt === '' || $hostKey === '') {
+        syslog(LOG_WARNING, "nebula: {$label} certificate or CA has empty PEM data; skipping");
+        return false;
+    }
+
+    /* 4a. assemble the ca.crt bundle: the signing CA (always — the host cert must
+           validate against it) plus any additional trusted CAs the instance
+           selects. Deduplicated by uuid; a missing/empty trusted CA is logged and
+           skipped rather than aborting the whole instance. */
+    $caUuids = [$caref];
+    foreach (explode(',', (string)$node->trusted_cas) as $tUuid) {
+        $tUuid = trim($tUuid);
+        if ($tUuid !== '' && !in_array($tUuid, $caUuids, true)) {
+            $caUuids[] = $tUuid;
+        }
+    }
+    $caCrtParts = [];
+    foreach ($caUuids as $tUuid) {
+        if (!isset($authByUuid[$tUuid])) {
+            syslog(LOG_WARNING, "nebula: {$label} trusted CA {$tUuid} not found in pool; skipping that CA");
+            continue;
+        }
+        $crt = trim((string)$authByUuid[$tUuid]->crt);
+        if ($crt !== '') {
+            $caCrtParts[] = $crt;
+        }
+    }
+    $caCrt = implode("\n", $caCrtParts) . "\n";
+
+    /* 5. ensure the cert directory exists (mode 0700) and write the files (0600) */
+    $certDir = NEBULA_ETC . '/' . $uuid;
+    if (!is_dir($certDir)) {
+        mkdir($certDir, 0700, true);
+    }
+    foreach ([
+        $certDir . '/ca.crt'   => $caCrt,
+        $certDir . '/host.crt' => $hostCrt,
+        $certDir . '/host.key' => $hostKey,
+    ] as $path => $content) {
+        file_put_contents($path, $content);
+        chmod($path, 0600);
+    }
+
+    syslog(LOG_INFO, "nebula: {$label} wrote cert material from pool");
+    return true;
+}
+
+/**
+ * Ensure the plugin diagnostics SSH keypair exists; return its public-key string.
+ */
+function nebula_diag_pubkey()
+{
+    if (!is_dir(NEBULA_DIAG_DIR)) {
+        mkdir(NEBULA_DIAG_DIR, 0700, true);
+    }
+    $priv = NEBULA_DIAG_DIR . '/id_ed25519';
+    $pub = $priv . '.pub';
+    if (!is_file($priv) || !is_file($pub)) {
+        @unlink($priv);
+        @unlink($pub);
+        exec(sprintf(
+            '/usr/local/bin/ssh-keygen -t ed25519 -N "" -C nebula-diag -f %s >/dev/null 2>&1',
+            escapeshellarg($priv)
+        ));
+        @chmod($priv, 0600);
+    }
+    return is_file($pub) ? trim((string)@file_get_contents($pub)) : '';
+}
+
+/**
+ * Ensure a per-instance sshd host key exists (used when diag_access defaults it).
+ */
+function nebula_ensure_sshd_host_key($uuid)
+{
+    $path = NEBULA_ETC . '/' . $uuid . '/sshd_host_key';
+    if (!is_file($path)) {
+        exec(sprintf(
+            '/usr/local/bin/ssh-keygen -t ed25519 -N "" -C nebula-sshd -f %s >/dev/null 2>&1',
+            escapeshellarg($path)
+        ));
+        @chmod($path, 0600);
+    }
+    return $path;
+}
+
+/**
+ * Render the config for one instance to disk (mode 0600), ensure the per-instance
+ * cert directory exists, and (when diag_access is on) materialise the diagnostics
+ * sshd key material. Returns the config file path.
+ */
+function nebula_render($model, $node, $uuid)
+{
+    if (!is_dir(NEBULA_ETC)) {
+        mkdir(NEBULA_ETC, 0700, true);
+    }
+    /* per-instance cert dir referenced by the pki: block */
+    $certDir = NEBULA_ETC . '/' . $uuid;
+    if (!is_dir($certDir)) {
+        mkdir($certDir, 0700, true);
+    }
+
+    /* The sshd debug server is always on (the plugin's internal management
+     * channel). Materialise the plugin diagnostics key + a per-instance sshd host
+     * key (both idempotent) and hand the diag pubkey to the renderer so it adds
+     * the _opnsense_diag authorized_user — the only principal with access. */
+    $diagPubKey = nebula_diag_pubkey();
+    nebula_ensure_sshd_host_key($uuid);
+
+    $cnfFile = nebula_config_file($uuid);
+    file_put_contents($cnfFile, $model->generateConfig($node, $diagPubKey));
+    chmod($cnfFile, 0600);
+    return $cnfFile;
+}
+
+/**
+ * Run one command against a running instance's always-on nebula sshd debug
+ * server. SSHes to 127.0.0.1 on the per-instance derived port (the same value
+ * the renderer wrote, via $model->sshdPortFor) with the plugin diagnostics key.
+ *
+ * @return array {ok:bool, raw?:string, error?:string}
+ */
+function nebula_debug_cmd($model, $uuid, $command)
+{
+    if (nebula_running_pid($uuid) === null) {
+        return ['ok' => false, 'error' => 'instance not running'];
+    }
+    $priv = NEBULA_DIAG_DIR . '/id_ed25519';
+    if (!is_file($priv)) {
+        return ['ok' => false, 'error' => 'diagnostics key missing (apply first)'];
+    }
+    $port = (int)$model->sshdPortFor($uuid);
+    if ($port <= 0) {
+        return ['ok' => false, 'error' => 'no debug port'];
+    }
+    $cmd = sprintf(
+        '/usr/local/bin/ssh -i %s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ' .
+        '-o BatchMode=yes -o ConnectTimeout=4 -p %d %s@127.0.0.1 %s 2>/dev/null',
+        escapeshellarg($priv),
+        $port,
+        escapeshellarg(NEBULA_DIAG_USER),
+        escapeshellarg($command)
+    );
+    $out = [];
+    $rc = 0;
+    exec($cmd, $out, $rc);
+    $raw = trim(implode("\n", $out));
+    if ($rc !== 0) {
+        // nebula's `reload` acks with "Reloading config" and then closes the
+        // connection from its side, so ssh exits non-zero (255) even though the
+        // reload succeeded. Treat that specific ack as success rather than a
+        // dead debug server.
+        if ($command === 'reload' && stripos($raw, 'Reloading config') !== false) {
+            return ['ok' => true, 'raw' => $raw];
+        }
+        return ['ok' => false, 'error' => 'could not reach the debug server'];
+    }
+    return ['ok' => true, 'raw' => $raw];
+}
+
+/**
+ * Run several debug-server commands over ONE SSH session (the REPL reads them
+ * from stdin), and split the output by the per-command prompt
+ * "<user>@nebula > <cmd>". Returns ['ok'=>bool, 'parts'=>[cmd => raw output]].
+ *
+ * This collapses the Status page's 3 SSH connections per instance per poll into
+ * a single connection.
+ */
+function nebula_debug_batch($model, $uuid, array $commands)
+{
+    if (nebula_running_pid($uuid) === null) {
+        return ['ok' => false, 'error' => 'instance not running'];
+    }
+    $priv = NEBULA_DIAG_DIR . '/id_ed25519';
+    if (!is_file($priv)) {
+        return ['ok' => false, 'error' => 'diagnostics key missing (apply first)'];
+    }
+    $port = (int)$model->sshdPortFor($uuid);
+    if ($port <= 0) {
+        return ['ok' => false, 'error' => 'no debug port'];
+    }
+    $cmd = sprintf(
+        '/usr/local/bin/ssh -i %s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ' .
+        '-o BatchMode=yes -o ConnectTimeout=4 -p %d %s@127.0.0.1 2>/dev/null',
+        escapeshellarg($priv),
+        $port,
+        escapeshellarg(NEBULA_DIAG_USER)
+    );
+    $descriptors = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+    $proc = proc_open($cmd, $descriptors, $pipes);
+    if (!is_resource($proc)) {
+        return ['ok' => false, 'error' => 'could not spawn ssh'];
+    }
+    fwrite($pipes[0], implode("\n", $commands) . "\n");
+    fclose($pipes[0]);
+    $raw = stream_get_contents($pipes[1]);
+    fclose($pipes[1]);
+    fclose($pipes[2]);
+    proc_close($proc);
+
+    // Each command's output is preceded by a prompt line "...@nebula > <cmd>".
+    $parts = [];
+    $cur = null;
+    foreach (explode("\n", $raw) as $line) {
+        if (preg_match('/@nebula > (.*)$/', $line, $m)) {
+            $echoed = trim($m[1]);
+            // The final prompt carries the "Connection ... closed" notice, not a
+            // real command — ignore it.
+            $cur = ($echoed === '' || strncmp($echoed, 'Connection to', 13) === 0) ? null : $echoed;
+            if ($cur !== null && !isset($parts[$cur])) {
+                $parts[$cur] = '';
+            }
+        } elseif ($cur !== null) {
+            $parts[$cur] .= ($parts[$cur] === '' ? '' : "\n") . $line;
+        }
+    }
+    foreach ($parts as $k => $v) {
+        $parts[$k] = trim($v);
+    }
+    return ['ok' => true, 'parts' => $parts];
+}
+
+/**
+ * Query a running instance's live tunnels/peers (`list-hostmap -json`).
+ *
+ * @return array {ok:bool, peers?:mixed, error?:string}
+ */
+function nebula_instance_peers($model, $uuid)
+{
+    $res = nebula_debug_cmd($model, $uuid, 'list-hostmap -json');
+    if (empty($res['ok'])) {
+        return $res;
+    }
+    $raw = $res['raw'];
+    if ($raw === '' || strtolower($raw) === 'null') {
+        return ['ok' => true, 'peers' => []];
+    }
+    $peers = json_decode($raw, true);
+    if ($peers === null) {
+        return ['ok' => false, 'error' => 'unexpected response from the debug server'];
+    }
+    return ['ok' => true, 'peers' => $peers];
+}
+
+/**
+ * Run a whitelisted debug-server sub-action for the Status page (enrichment +
+ * verbs). The sub-action is mapped to a fixed nebula command; the vpn address is
+ * validated as an IP and the remote (for change/create) to a safe host:port
+ * charset, so nothing user-controlled reaches the command unchecked.
+ *
+ * @param object $model the Nebula model
+ * @param string $uuid  instance uuid
+ * @param string $sub   sub-action (tunnel|cert|pending|deviceinfo|querylh|close|changeremote|createtunnel)
+ * @param string $vpn   target peer's nebula (overlay) IP, where applicable
+ * @param string $remote underlay host:port (change-remote / create-tunnel only)
+ * @return array {ok:bool, ...}
+ */
+function nebula_instance_debug($model, $uuid, $sub, $vpn, $remote)
+{
+    $vpn = trim((string)$vpn);
+    $remote = trim((string)$remote);
+    $isIp = filter_var($vpn, FILTER_VALIDATE_IP) !== false;
+    $isAddr = preg_match('/^[0-9A-Za-z._:\[\]-]+$/', $remote) === 1;
+
+    switch ($sub) {
+        case 'deviceinfo':
+            $res = nebula_debug_cmd($model, $uuid, 'device-info');
+            if (empty($res['ok'])) {
+                return $res;
+            }
+            // "name=nebula0 cidr=[1.2.3.4/32]"
+            $dev = [];
+            if (preg_match('/name=(\S+)/', $res['raw'], $m)) {
+                $dev['name'] = $m[1];
+            }
+            if (preg_match('/cidr=\[([^\]]*)\]/', $res['raw'], $m)) {
+                $dev['cidr'] = $m[1];
+            }
+            return ['ok' => true, 'device' => $dev];
+
+        case 'pending':
+            $res = nebula_debug_cmd($model, $uuid, 'list-pending-hostmap -json');
+            if (empty($res['ok'])) {
+                return $res;
+            }
+            $raw = $res['raw'];
+            $j = ($raw === '' || strtolower($raw) === 'null') ? [] : json_decode($raw, true);
+            return ['ok' => true, 'pending' => ($j === null ? [] : $j)];
+
+        case 'tunnel':
+        case 'cert':
+            if (!$isIp) {
+                return ['ok' => false, 'error' => 'invalid vpn address'];
+            }
+            $cmd = ($sub === 'tunnel' ? 'print-tunnel ' : 'print-cert ') . $vpn . ' -json';
+            $res = nebula_debug_cmd($model, $uuid, $cmd);
+            if (empty($res['ok'])) {
+                return $res;
+            }
+            return ['ok' => true, $sub => json_decode($res['raw'], true)];
+
+        case 'querylh':
+            if (!$isIp) {
+                return ['ok' => false, 'error' => 'invalid vpn address'];
+            }
+            return nebula_debug_cmd($model, $uuid, 'query-lighthouse ' . $vpn);
+
+        case 'close':
+            if (!$isIp) {
+                return ['ok' => false, 'error' => 'invalid vpn address'];
+            }
+            return nebula_debug_cmd($model, $uuid, 'close-tunnel ' . $vpn);
+
+        case 'createtunnel':
+            if (!$isIp) {
+                return ['ok' => false, 'error' => 'invalid vpn address'];
+            }
+            /* vpn addr only — the lighthouse resolves the underlay. Do NOT pass
+               -address: nebula <= 1.10.3 SEGV-panics (nil deref in sshd
+               dispatchCommand, session.go:172) on `create-tunnel -address ...`.
+               PENDING: fixed upstream in slackhq/nebula PR #1749. Once that lands
+               in a released nebula the plugin ships against, switch this to
+               `create-tunnel -address ' . $remote . ' ' . $vpn` (mirroring
+               changeremote below, and re-add the $isAddr guard) and restore the
+               underlay-address field in the connectPeer dialogs of tunnels.volt
+               and status.volt. */
+            return nebula_debug_cmd($model, $uuid, 'create-tunnel ' . $vpn);
+
+        case 'changeremote':
+            if (!$isIp || !$isAddr) {
+                return ['ok' => false, 'error' => 'invalid arguments'];
+            }
+            /* change-remote needs the new address via the -address flag; a
+               positional address fails with "No address was provided". This path
+               (unlike create-tunnel -address) does not crash. */
+            return nebula_debug_cmd($model, $uuid, 'change-remote -address ' . $remote . ' ' . $vpn);
+
+        default:
+            return ['ok' => false, 'error' => 'unknown debug action'];
+    }
+}
+
+/**
+ * Validate a rendered config with `nebula -test`. Returns true when valid.
+ */
+function nebula_validate($cnfFile)
+{
+    $out = [];
+    $rc = 0;
+    exec(sprintf('%s -test -config %s 2>&1', NEBULA_BIN, escapeshellarg($cnfFile)), $out, $rc);
+    if ($rc !== 0) {
+        fwrite(STDERR, sprintf("nebula: config %s failed validation:\n%s\n", $cnfFile, implode("\n", $out)));
+    }
+    return $rc === 0;
+}
+
+/**
+ * Re-run nebula in the foreground (bounded by `timeout`) to capture the reason a
+ * daemon-launched instance died.  Nebula logs structured lines like
+ *   time="..." level=error msg="Failed to get a tun/tap device: device busy"
+ * on stderr; we extract the first level=error msg, falling back to the last
+ * non-empty output line so the caller always gets *something* actionable.
+ *
+ * Returns a human-readable reason string (never empty).
+ */
+function nebula_capture_failure_reason($cnfFile)
+{
+    $out = [];
+    $rc = 0;
+    /* `timeout` bounds a config that would otherwise run forever; 2s is plenty
+     * for the daemon to hit (or clear) a startup error like a busy tun device. */
+    exec(
+        sprintf('/usr/bin/timeout 2 %s -config %s 2>&1', NEBULA_BIN, escapeshellarg($cnfFile)),
+        $out,
+        $rc
+    );
+
+    $reason = '';
+    foreach ($out as $line) {
+        if (preg_match('/level=error\s+msg="([^"]*)"/', $line, $m)) {
+            $reason = $m[1];
+            break;
+        }
+    }
+    if ($reason === '') {
+        /* fall back to the last non-empty output line */
+        for ($i = count($out) - 1; $i >= 0; $i--) {
+            if (trim($out[$i]) !== '') {
+                $reason = trim($out[$i]);
+                break;
+            }
+        }
+    }
+    if ($reason === '') {
+        $reason = 'instance failed to start (no diagnostic output)';
+    }
+    return $reason;
+}
+
+/**
+ * Start a single instance daemon (no-op if already running). Writes cert
+ * material from the PKI pool, renders + validates the config; skips start
+ * when any prerequisite fails.
+ *
+ * Verifies the launch actually took: after handing the config to daemon(8) it
+ * polls the pidfile briefly and confirms the pid is alive.  A daemon that dies
+ * immediately (e.g. "Failed to get a tun/tap device: device busy") is detected
+ * here, its reason captured by re-running nebula in the foreground, LOGged at
+ * LOG_ERR, and returned to the caller.
+ *
+ * @return array ['started'=>bool] on success, or ['started'=>false,'error'=>str]
+ */
+function nebula_start_instance($model, $node, $uuid)
+{
+    $label = "instance {$uuid}";
+
+    if (nebula_running_pid($uuid) !== null) {
+        return ['started' => true]; /* already running */
+    }
+    if (!nebula_write_certs($model, $node, $uuid)) {
+        /* reason already logged by nebula_write_certs */
+        return ['started' => false, 'error' => 'missing or invalid certificate material'];
+    }
+    $cnfFile = nebula_render($model, $node, $uuid);
+    if (!nebula_validate($cnfFile)) {
+        $err = 'invalid configuration (failed nebula -test)';
+        syslog(LOG_ERR, "nebula: not starting {$label}: {$err}");
+        fwrite(STDERR, sprintf("nebula: not starting instance %s (invalid config)\n", $uuid));
+        return ['started' => false, 'error' => $err];
+    }
+    if (!is_dir(NEBULA_RUN)) {
+        mkdir(NEBULA_RUN, 0700, true);
+    }
+    $cmd = sprintf(
+        '%s -f -p %s %s -config %s',
+        DAEMON_BIN,
+        escapeshellarg(nebula_pid_file($uuid)),
+        NEBULA_BIN,
+        escapeshellarg($cnfFile)
+    );
+    exec($cmd);
+
+    /* Verify the launch took: poll up to ~1.5s for a live pid in the pidfile. */
+    $alive = false;
+    for ($i = 0; $i < 8; $i++) {
+        usleep(200 * 1000);
+        if (nebula_running_pid($uuid) !== null) {
+            $alive = true;
+            break;
+        }
+    }
+
+    if (!$alive) {
+        /* The daemon died on startup. Re-run in the foreground to learn why. */
+        $reason = nebula_capture_failure_reason($cnfFile);
+        syslog(LOG_ERR, "nebula: {$label} failed to start: {$reason}");
+        @unlink(nebula_pid_file($uuid));
+        return ['started' => false, 'error' => $reason];
+    }
+
+    syslog(LOG_NOTICE, "nebula instance {$uuid} started");
+
+    /* Idiomatic OPNsense interface: drop the freshly-created tun into the
+     * 'nebula' interface group (like wireguard's group). The daemon creates the
+     * tun during startup, so it exists now that the pid is live. (Re-attaching an
+     * ASSIGNED interface is done only on explicit restart — see the dispatch —
+     * to avoid a reconfigure storm during interface bring-up.) */
+    nebula_group_device($uuid);
+
+    return ['started' => true];
+}
+
+/**
+ * Drop an instance's tun device into the 'nebula' interface group (like
+ * wireguard's group) so it groups cleanly and can carry group firewall rules.
+ * Idempotent; safe to call from the interface bring-up (prepare) path.
+ */
+function nebula_group_device($uuid)
+{
+    $dev = nebula_tun_dev($uuid);
+    if ($dev !== null && $dev !== '' && strpos($dev, 'nebula') === 0) {
+        exec(sprintf('/sbin/ifconfig %s group nebula 2>/dev/null', escapeshellarg($dev)));
+    }
+}
+
+/**
+ * When an instance's tun is assigned to an OPNsense interface, reconfigure that
+ * interface so pf rules / gateways referencing it re-attach to the (re)created
+ * device. Backgrounded so it never blocks or deadlocks the caller (it may run
+ * inside a configd action). Only meaningful after a full restart — a HUP reload
+ * keeps the same device. No-op when the device is unassigned or at early boot
+ * (configd not yet up; the in-progress interface_configure already attaches it).
+ */
+function nebula_reattach_interface($uuid)
+{
+    $dev = nebula_tun_dev($uuid);
+    if ($dev === null || $dev === '' || strpos($dev, 'nebula') !== 0) {
+        return;
+    }
+    $cfg = @file_get_contents('/conf/config.xml');
+    if ($cfg === false) {
+        return;
+    }
+    $xml = @simplexml_load_string($cfg);
+    if ($xml === false || !isset($xml->interfaces)) {
+        return;
+    }
+    foreach ($xml->interfaces->children() as $key => $ifnode) {
+        if ((string)$ifnode->if === $dev) {
+            exec(sprintf(
+                '/usr/local/sbin/configctl interface reconfigure %s > /dev/null 2>&1 &',
+                escapeshellarg((string)$key)
+            ));
+            break;
+        }
+    }
+}
+
+/**
+ * Stop a single instance daemon via SIGTERM on its pidfile. Waits (bounded) for
+ * the process to actually exit so a following start does not race the dying
+ * daemon for the UDP listen port and the tun device (restart path).
+ */
+/**
+ * Read the tun device name (tun.dev) from a rendered instance config, or null.
+ */
+function nebula_tun_dev($uuid)
+{
+    $cnf = NEBULA_ETC . '/' . $uuid . '.yml';
+    if (!is_file($cnf)) {
+        return null;
+    }
+    $yml = (string)@file_get_contents($cnf);
+    if (preg_match('/^\s*dev:\s*"?([A-Za-z0-9._-]+)"?/m', $yml, $m)) {
+        return $m[1];
+    }
+    return null;
+}
+
+/**
+ * Destroy an instance's tun device. Killing the nebula daemon does NOT remove
+ * the device on FreeBSD, so without this the orphaned nebulaN interface lingers
+ * and shows up under Interfaces : Assignments.
+ */
+function nebula_destroy_tun($uuid)
+{
+    $dev = nebula_tun_dev($uuid);
+    if ($dev !== null && $dev !== '' && strpos($dev, 'nebula') === 0) {
+        exec(sprintf('/sbin/ifconfig %s destroy 2>/dev/null', escapeshellarg($dev)));
+        syslog(LOG_INFO, "nebula: destroyed tun device {$dev} for instance {$uuid}");
+    }
+}
+
+function nebula_stop_instance($uuid)
+{
+    $pid = nebula_running_pid($uuid);
+    if ($pid !== null) {
+        exec(sprintf('/bin/kill -TERM %d 2>/dev/null', $pid));
+        syslog(LOG_NOTICE, "nebula instance {$uuid} stopped");
+        /* wait up to ~5s for it to go away, then SIGKILL as a backstop */
+        $alive = true;
+        for ($i = 0; $i < 25; $i++) {
+            $out = [];
+            $rc = 0;
+            exec(sprintf('/bin/kill -0 %d 2>/dev/null', $pid), $out, $rc);
+            if ($rc !== 0) {
+                $alive = false;
+                break;
+            }
+            usleep(200 * 1000);
+        }
+        if ($alive) {
+            exec(sprintf('/bin/kill -KILL %d 2>/dev/null', $pid));
+        }
+    }
+    /* Destroy the tun device so it does not linger in Interfaces : Assignments. */
+    nebula_destroy_tun($uuid);
+    @unlink(nebula_pid_file($uuid));
+}
+
+/**
+ * Return the status of a single instance as an array ['running'=>bool, 'pid'=>int|null].
+ */
+function nebula_instance_status($uuid)
+{
+    $pid = nebula_running_pid($uuid);
+    return ['running' => ($pid !== null), 'pid' => $pid];
+}
+
+/**
+ * Richer per-instance diagnostics for the Status page: process state, the tun
+ * device + its addresses + up/down, and config validity. Validity uses
+ * `nebula -test` (safe — it never starts the daemon, so viewing status cannot
+ * side-effect a stopped instance up).
+ *
+ * @return array{running:bool,pid:?int,tun_dev:string,tun_addrs:string[],tun_up:bool,config_valid:?bool,config_error:string}
+ */
+function nebula_instance_diag($uuid)
+{
+    $pid = nebula_running_pid($uuid);
+    $diag = [
+        'running' => ($pid !== null),
+        'pid' => $pid,
+        'tun_dev' => '',
+        'tun_addrs' => [],
+        'tun_up' => false,
+    ];
+
+    $dev = nebula_tun_dev($uuid);
+    if (is_string($dev) && $dev !== '') {
+        $diag['tun_dev'] = $dev;
+        $out = [];
+        exec(sprintf('/sbin/ifconfig %s 2>/dev/null', escapeshellarg($dev)), $out);
+        foreach ($out as $line) {
+            if (preg_match('/^\s*inet6?\s+(\S+)/', $line, $m)) {
+                $diag['tun_addrs'][] = $m[1];
+            }
+            if (preg_match('/flags=\w*<([^>]*)>/', $line, $m) && strpos($m[1], 'UP') !== false) {
+                $diag['tun_up'] = true;
+            }
+        }
+    }
+
+    $cnf = nebula_config_file($uuid);
+    if (is_file($cnf)) {
+        // `nebula -test` forks a process; the config only changes on apply, so
+        // cache the result keyed by the config file's mtime and re-test only when
+        // the file is rewritten. This is the heaviest part of a Status poll.
+        $cacheFile = $cnf . '.test';
+        $cfgMtime = filemtime($cnf);
+        $cached = is_file($cacheFile) ? json_decode((string)file_get_contents($cacheFile), true) : null;
+        if (is_array($cached) && isset($cached['mtime']) && $cached['mtime'] === $cfgMtime) {
+            $diag['config_valid'] = $cached['valid'];
+            $diag['config_error'] = $cached['error'];
+        } else {
+            $out = [];
+            $rc = 0;
+            exec(sprintf('%s -test -config %s 2>&1', NEBULA_BIN, escapeshellarg($cnf)), $out, $rc);
+            $valid = ($rc === 0);
+            $err = '';
+            if ($rc !== 0) {
+                foreach ($out as $line) {
+                    if (preg_match('/level=(?:error|fatal)\s+msg="([^"]*)"/', $line, $m)) {
+                        $err = $m[1];
+                        break;
+                    }
+                }
+                if ($err === '' && !empty($out)) {
+                    $err = trim((string)end($out));
+                }
+            }
+            $diag['config_valid'] = $valid;
+            $diag['config_error'] = $err;
+            @file_put_contents(
+                $cacheFile,
+                json_encode(['mtime' => $cfgMtime, 'valid' => $valid, 'error' => $err])
+            );
+        }
+    } else {
+        $diag['config_valid'] = null;
+        $diag['config_error'] = 'no rendered config (apply first)';
+    }
+
+    return $diag;
+}
+
+/**
+ * Restart (re-provision certs, re-render, re-start) a single instance.
+ * Stops it first; if disabled or cert is invalid, leaves it stopped.
+ *
+ * @return array ['started'=>bool] / ['started'=>false,'error'=>str], so the
+ *               reload button can surface the real failure reason in the UI.
+ */
+function nebula_restart_instance($model, $uuid, $general_enabled)
+{
+    nebula_stop_instance($uuid);
+
+    $node = null;
+    foreach ($model->instances->instance->iterateItems() as $iUuid => $iNode) {
+        if ($iUuid === $uuid) {
+            $node = $iNode;
+            break;
+        }
+    }
+    if ($node === null) {
+        syslog(LOG_WARNING, "nebula: restart_instance: uuid {$uuid} not found in model; skipping");
+        return ['started' => false, 'error' => 'instance not found'];
+    }
+    if (!$general_enabled || (string)$node->enabled !== '1') {
+        syslog(LOG_INFO, "nebula: instance {$uuid} is disabled; not restarting");
+        return ['started' => false, 'error' => 'instance is disabled'];
+    }
+    $res = nebula_start_instance($model, $node, $uuid);
+    if (!empty($res['started'])) {
+        /* the tun was just recreated — re-attach an assigned OPNsense interface */
+        nebula_reattach_interface($uuid);
+    }
+    return $res;
+}
+
+/**
+ * Extract the structural config keys that nebula can NOT apply on a live reload
+ * (HUP) — the UDP socket bind, the cipher, and the tun device. A change to any
+ * of these requires a full restart. host:/port:/dev: also appear nested in other
+ * blocks (lighthouse DNS, firewall rules), so we track the current top-level key
+ * and only read them under listen:/tun:.
+ *
+ * @return array{listen_host:string, listen_port:string, tun_dev:string, cipher:string}
+ */
+function nebula_structural_keys(string $yml): array
+{
+    $out = ['listen_host' => '', 'listen_port' => '', 'tun_dev' => '', 'cipher' => ''];
+    $top = '';
+    foreach (preg_split('/\r?\n/', $yml) as $line) {
+        if ($line === '') {
+            continue;
+        }
+        if ($line[0] !== ' ' && $line[0] !== "\t") {
+            $top = strtok($line, ':');
+            if ($top === 'cipher' && preg_match('/^cipher:\s*"?([^"\n]*?)"?\s*$/', $line, $m)) {
+                $out['cipher'] = trim($m[1]);
+            }
+            continue;
+        }
+        if ($top === 'listen') {
+            if (preg_match('/^\s*host:\s*"?([^"\n]*?)"?\s*$/', $line, $m)) {
+                $out['listen_host'] = trim($m[1]);
+            } elseif (preg_match('/^\s*port:\s*"?([^"\n]*?)"?\s*$/', $line, $m)) {
+                $out['listen_port'] = trim($m[1]);
+            }
+        } elseif ($top === 'tun') {
+            if (preg_match('/^\s*dev:\s*"?([^"\n]*?)"?\s*$/', $line, $m)) {
+                $out['tun_dev'] = trim($m[1]);
+            }
+        }
+    }
+    return $out;
+}
+
+/**
+ * True when the new config differs from the old in a structural key that nebula
+ * can only apply with a full restart (vs a live reload).
+ */
+function nebula_needs_restart(string $oldYml, string $newYml): bool
+{
+    return nebula_structural_keys($oldYml) !== nebula_structural_keys($newYml);
+}
+
+/**
+ * Apply (reconfigure) WITHOUT tearing down live tunnels where possible. Per
+ * instance: stop the disabled, start the not-yet-running, and for a running
+ * instance reload in place (debug-server `reload`, same as SIGHUP) — falling
+ * back to a full restart only when a structural key (listen bind / cipher / tun
+ * device) changed, or when the reload itself fails. nebula re-reads the config
+ * and the cert files on reload, so both are written before reloading.
+ */
+function nebula_apply($model, $general_enabled)
+{
+    $instances = nebula_instances($model);
+    nebula_reconcile_orphans($instances);
+
+    foreach ($instances as $uuid => $node) {
+        $shouldRun = $general_enabled && (string)$node->enabled === '1';
+        $running   = nebula_running_pid($uuid) !== null;
+
+        if (!$shouldRun) {
+            if ($running) {
+                nebula_stop_instance($uuid);
+            }
+            continue;
+        }
+        if (!$running) {
+            nebula_start_instance($model, $node, $uuid);
+            continue;
+        }
+
+        // Running and should run: reload in place, or restart for a structural change.
+        $cnfFile = nebula_config_file($uuid);
+        $oldYml  = is_file($cnfFile) ? (string)@file_get_contents($cnfFile) : '';
+        $newYml  = (string)$model->generateConfig($node, nebula_diag_pubkey());
+
+        if (nebula_needs_restart($oldYml, $newYml)) {
+            nebula_restart_instance($model, $uuid, $general_enabled);
+            continue;
+        }
+
+        if (!nebula_write_certs($model, $node, $uuid)) {
+            syslog(LOG_WARNING, "nebula: apply: {$uuid} missing cert material; not reloading");
+            continue;
+        }
+        nebula_render($model, $node, $uuid);
+        if (!nebula_validate($cnfFile)) {
+            // Keep the running daemon on its previous (valid) config.
+            if ($oldYml !== '') {
+                file_put_contents($cnfFile, $oldYml);
+                @chmod($cnfFile, 0600);
+            }
+            syslog(LOG_ERR, "nebula: apply: {$uuid} rendered an invalid config; kept the running config");
+            continue;
+        }
+
+        $res = nebula_debug_cmd($model, $uuid, 'reload');
+        if (empty($res['ok'])) {
+            syslog(LOG_WARNING, "nebula: apply: {$uuid} reload failed (" . ($res['error'] ?? '') . "); restarting");
+            nebula_restart_instance($model, $uuid, $general_enabled);
+        } else {
+            syslog(LOG_INFO, "nebula: apply: {$uuid} reloaded in place");
+        }
+    }
+}
+
+/**
+ * Reconcile orphaned daemons left behind by deleted instances.
+ *
+ * Globs the rendered configs in NEBULA_ETC, and for every <uuid>.yml whose
+ * <uuid> is NOT a currently-configured instance:
+ *   - kills any nebula daemon running with that config / pidfile, and
+ *   - removes the stale <uuid>.yml, its pidfile and its <uuid>/ cert dir.
+ *
+ * This is the long-deferred stale-instance cleanup (NOTES.md Phase-2): deleting
+ * an enabled instance left an orphan daemon holding e.g. nebula0, which a later
+ * `nebula stop` could not catch (the uuid is no longer in the model).
+ *
+ * @param array $configuredUuids uuid => node map of current instances
+ */
+function nebula_reconcile_orphans($configuredUuids)
+{
+    foreach (glob(NEBULA_ETC . '/*.yml') as $cnfFile) {
+        $uuid = basename($cnfFile, '.yml');
+        if (isset($configuredUuids[$uuid])) {
+            continue; /* still configured */
+        }
+
+        /* Kill a daemon still running for this orphan (pidfile first). */
+        $pid = nebula_running_pid($uuid);
+        if ($pid !== null) {
+            exec(sprintf('/bin/kill -TERM %d 2>/dev/null', $pid));
+            $alive = true;
+            for ($i = 0; $i < 25; $i++) {
+                $out = [];
+                $rc = 0;
+                exec(sprintf('/bin/kill -0 %d 2>/dev/null', $pid), $out, $rc);
+                if ($rc !== 0) {
+                    $alive = false;
+                    break;
+                }
+                usleep(200 * 1000);
+            }
+            if ($alive) {
+                exec(sprintf('/bin/kill -KILL %d 2>/dev/null', $pid));
+            }
+            syslog(LOG_NOTICE, "nebula: reaped orphan daemon for deleted instance {$uuid}");
+        }
+
+        /* Destroy the orphan's tun device (read from its config) before removing it. */
+        nebula_destroy_tun($uuid);
+
+        /* Remove stale config, pidfile, and per-instance cert dir. */
+        @unlink($cnfFile);
+        @unlink(nebula_pid_file($uuid));
+        $certDir = NEBULA_ETC . '/' . $uuid;
+        if (is_dir($certDir)) {
+            foreach (glob($certDir . '/*') as $f) {
+                @unlink($f);
+            }
+            @rmdir($certDir);
+        }
+        syslog(LOG_INFO, "nebula: cleaned up stale files for deleted instance {$uuid}");
+    }
+}
+
+/**
+ * Iterate configured instances as [uuid => node].
+ */
+function nebula_instances($model)
+{
+    $items = [];
+    foreach ($model->instances->instance->iterateItems() as $uuid => $node) {
+        $items[$uuid] = $node;
+    }
+    return $items;
+}
+
+/**
+ * Format a listen host:port the way it must be written/read — IPv6 literals are
+ * wrapped in square brackets so the colons in the address are not confused with
+ * the host:port separator. "::" (bind all v6) becomes "[::]:4242", a specific
+ * "2001:db8::1" becomes "[2001:db8::1]:4242"; IPv4 and hostnames are unchanged
+ * ("0.0.0.0:4242"). ":::4242" and "[::]:4242" are different strings — only the
+ * bracketed form is correct.
+ *
+ * @param string $host the listen host (may be an IPv6 literal, IPv4, or hostname)
+ * @param string $port the listen port
+ * @return string the host:port string with IPv6 hosts bracketed
+ */
+function nebula_format_listen(string $host, string $port): string
+{
+    // An IPv6 literal contains ':'; bracket it unless it is already bracketed.
+    if (strpos($host, ':') !== false && $host[0] !== '[') {
+        $host = '[' . $host . ']';
+    }
+    return $host . ':' . $port;
+}
+
+/**
+ * One-shot Status-page snapshot for ALL instances: status + diagnostics + the
+ * resolved certificate summary, plus (for running instances) the tun device-info.
+ * Live peers and handshaking now live on the Tunnels page, so the snapshot no
+ * longer queries the hostmaps.
+ *
+ * @return array{instances: array<int,array>}
+ */
+function nebula_snapshot($model)
+{
+    $certByUuid = [];
+    foreach ($model->pki->certificates->certificate->iterateItems() as $crt) {
+        $certByUuid[$crt->getAttribute('uuid')] = [
+            'name' => (string)$crt->cn,
+            'descr' => (string)$crt->descr,
+            'groups' => (string)$crt->groups,
+            'networks' => (string)$crt->networks,
+            'valid_to' => (string)$crt->valid_to,
+        ];
+    }
+
+    $instances = [];
+    foreach (nebula_instances($model) as $uuid => $node) {
+        $d = nebula_instance_diag($uuid);
+        $d['uuid'] = $uuid;
+        $d['description'] = (string)$node->description;
+        $d['enabled'] = ((string)$node->enabled === '1');
+        $d['am_lighthouse'] = ((string)$node->am_lighthouse === '1');
+        $d['listen'] = nebula_format_listen((string)$node->listen_host, (string)$node->listen_port);
+        $certref = (string)$node->certref;
+        $d['cert'] = ($certref !== '' && isset($certByUuid[$certref])) ? $certByUuid[$certref] : null;
+        $d['diag_available'] = !empty($d['running']);
+
+        if (!empty($d['running'])) {
+            $res = nebula_debug_cmd($model, $uuid, 'device-info');
+            if (!empty($res['ok'])) {
+                $dev = [];
+                $rawDev = $res['raw'];
+                if (preg_match('/name=(\S+)/', $rawDev, $m)) {
+                    $dev['name'] = $m[1];
+                }
+                if (preg_match('/cidr=\[([^\]]*)\]/', $rawDev, $m)) {
+                    $dev['cidr'] = $m[1];
+                }
+                $d['device'] = $dev;
+            }
+        }
+        $instances[] = $d;
+    }
+    return ['instances' => $instances];
+}
+
+/**
+ * Live peers for ALL running instances, fanned out in parallel.
+ *
+ * Each running instance is queried with `list-hostmap -json` over its own ssh
+ * connection to the always-on nebula debug server. The connections are launched
+ * at once and multiplexed with stream_select(), so total wall-clock ~= the
+ * slowest single instance rather than the sum. Each ssh carries ConnectTimeout=4
+ * and the whole loop is bounded by an overall deadline; a dead or hung instance
+ * simply contributes no rows. Every returned row is tagged with its instance.
+ *
+ * Both established tunnels (list-hostmap) and peers still handshaking
+ * (list-pending-hostmap) are returned; handshaking rows carry handshaking=true
+ * and usually have empty name/groups/remotes (no cert exchanged yet).
+ *
+ * Row shape (one per peer):
+ *   instance_uuid, instance, vpn, name, groups, relayed (bool),
+ *   handshaking (bool), currentRemote, remoteAddrs (array),
+ *   remotes (space-joined string), messages (int)
+ *
+ * @return array{ok:bool, rows:array<int,array>}
+ */
+function nebula_all_peers($model)
+{
+    $priv = NEBULA_DIAG_DIR . '/id_ed25519';
+    if (!is_file($priv)) {
+        return ['ok' => true, 'rows' => []];
+    }
+
+    // Established tunnels come from list-hostmap; peers still handshaking come
+    // from list-pending-hostmap. Both run over ONE ssh session per instance (the
+    // debug REPL reads commands from stdin), so we still pay just one connection
+    // per instance and the combined output is split by the per-command prompt.
+    $commands = ['list-hostmap -json', 'list-pending-hostmap -json'];
+
+    $procs = [];
+    foreach (nebula_instances($model) as $uuid => $node) {
+        if (nebula_running_pid($uuid) === null) {
+            continue;
+        }
+        $port = (int)$model->sshdPortFor($uuid);
+        if ($port <= 0) {
+            continue;
+        }
+        // No command arg: the REPL reads our commands from stdin.
+        $cmd = sprintf(
+            '/usr/local/bin/ssh -i %s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ' .
+            '-o BatchMode=yes -o ConnectTimeout=4 -p %d %s@127.0.0.1 2>/dev/null',
+            escapeshellarg($priv),
+            $port,
+            escapeshellarg(NEBULA_DIAG_USER)
+        );
+        $descriptors = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+        $proc = proc_open($cmd, $descriptors, $pipes);
+        if (!is_resource($proc)) {
+            continue;
+        }
+        fwrite($pipes[0], implode("\n", $commands) . "\n");
+        fclose($pipes[0]);
+        stream_set_blocking($pipes[1], false);
+        stream_set_blocking($pipes[2], false);
+        $descr = (string)$node->description;
+        $procs[$uuid] = [
+            'proc'  => $proc,
+            'out'   => $pipes[1],
+            'err'   => $pipes[2],
+            'descr' => ($descr !== '' ? $descr : $uuid),
+        ];
+    }
+
+    // Multiplex stdout until every pipe hits EOF or the overall deadline passes.
+    $bufs = array_fill_keys(array_keys($procs), '');
+    $byId = [];
+    foreach ($procs as $uuid => $p) {
+        $byId[(int)$p['out']] = $uuid;
+    }
+    $pending = array_fill_keys(array_keys($procs), true);
+    $deadline = microtime(true) + 8.0; // > ssh ConnectTimeout=4; overall budget for all instances in parallel
+    while (!empty($pending) && microtime(true) < $deadline) {
+        $read = [];
+        foreach (array_keys($pending) as $uuid) {
+            $read[] = $procs[$uuid]['out'];
+        }
+        $write = $except = [];
+        $remaining = max(0.0, $deadline - microtime(true));
+        $sec = (int)floor($remaining);
+        $usec = (int)(($remaining - $sec) * 1e6);
+        $n = @stream_select($read, $write, $except, $sec, $usec);
+        if ($n === false || $n === 0) {
+            break;
+        }
+        foreach ($read as $stream) {
+            $uuid = $byId[(int)$stream] ?? null;
+            if ($uuid === null) {
+                continue;
+            }
+            $chunk = fread($stream, 65536); // one pipe buffer; loop accumulates until EOF
+            if ($chunk !== '' && $chunk !== false) {
+                $bufs[$uuid] .= $chunk;
+            }
+            if (feof($stream)) {
+                unset($pending[$uuid]);
+            }
+        }
+    }
+
+    // Reap: close pipes, terminate any stragglers, close procs.
+    foreach ($procs as $uuid => $p) {
+        @fclose($p['out']);
+        @fclose($p['err']);
+        if (isset($pending[$uuid])) {
+            @proc_terminate($p['proc']);
+        }
+        @proc_close($p['proc']);
+    }
+
+    /* Project one hostmap/pending entry to a grid row. $handshaking marks a
+       peer that is still handshaking (from list-pending-hostmap); such an entry
+       usually has no cert yet, so name/groups come out empty. */
+    $projectRow = function ($uuid, $descr, $entry, $handshaking) {
+        $vpn = (string)($entry['vpnAddrs'][0] ?? '');
+        if ($vpn === '') {
+            return null;
+        }
+        $details = $entry['cert']['details'] ?? [];
+        $remoteAddrs = array_values(array_filter(
+            (array)($entry['remoteAddrs'] ?? []),
+            'is_string'
+        ));
+        return [
+            'instance_uuid' => $uuid,
+            'instance'      => $descr,
+            'vpn'           => $vpn,
+            'name'          => (string)($details['name'] ?? ''),
+            'groups'        => implode(', ', (array)($details['groups'] ?? [])),
+            'relayed'       => !empty($entry['currentRelaysToMe']),
+            'handshaking'   => $handshaking,
+            'currentRemote' => (string)($entry['currentRemote'] ?? ''),
+            'remoteAddrs'   => $remoteAddrs,
+            'remotes'       => implode(' ', $remoteAddrs),
+            'messages'      => (int)($entry['messageCounter'] ?? 0),
+        ];
+    };
+
+    // Split each instance's combined output by the per-command "@nebula > <cmd>"
+    // prompt, decode each command's JSON, project established + handshaking rows.
+    $rows = [];
+    foreach ($procs as $uuid => $p) {
+        $parts = [];
+        $cur = null;
+        foreach (explode("\n", $bufs[$uuid]) as $line) {
+            if (preg_match('/@nebula > (.*)$/', $line, $m)) {
+                $echoed = trim($m[1]);
+                $cur = ($echoed === '' || strncmp($echoed, 'Connection to', 13) === 0) ? null : $echoed;
+                if ($cur !== null && !isset($parts[$cur])) {
+                    $parts[$cur] = '';
+                }
+            } elseif ($cur !== null) {
+                $parts[$cur] .= ($parts[$cur] === '' ? '' : "\n") . $line;
+            }
+        }
+
+        $decode = function ($raw) {
+            $raw = trim((string)$raw);
+            if ($raw === '' || strtolower($raw) === 'null') {
+                return [];
+            }
+            $j = json_decode($raw, true);
+            return is_array($j) ? $j : [];
+        };
+        $hostmap = $decode($parts['list-hostmap -json'] ?? '');
+        $handshaking = $decode($parts['list-pending-hostmap -json'] ?? '');
+
+        // Established first; dedupe handshaking entries against them (a peer that
+        // is already established should not also show as handshaking).
+        $seen = [];
+        foreach ($hostmap as $entry) {
+            if (!is_array($entry)) {
+                continue;
+            }
+            $row = $projectRow($uuid, $p['descr'], $entry, false);
+            if ($row !== null) {
+                $seen[$row['vpn']] = true;
+                $rows[] = $row;
+            }
+        }
+        foreach ($handshaking as $entry) {
+            if (!is_array($entry)) {
+                continue;
+            }
+            $row = $projectRow($uuid, $p['descr'], $entry, true);
+            if ($row !== null && !isset($seen[$row['vpn']])) {
+                $seen[$row['vpn']] = true;
+                $rows[] = $row;
+            }
+        }
+    }
+    return ['ok' => true, 'rows' => $rows];
+}
+
+openlog('nebula', LOG_ODELAY, LOG_DAEMON);
+
+$action = $argv[1] ?? '';
+$uuid_arg = isset($argv[2]) ? trim($argv[2]) : '';
+$model = new Nebula();
+$general_enabled = (string)$model->general->enabled === '1';
+
+switch ($action) {
+    case 'start':
+        $instances = nebula_instances($model);
+        /* reap any daemon/files left over from a deleted instance first */
+        nebula_reconcile_orphans($instances);
+        if ($uuid_arg !== '') {
+            /* per-instance start — used by the nebula_prepare() interface hook so
+             * an assigned nebulaX device gets created during interface bring-up.
+             * JSON out so the caller can see the start result. */
+            $node = $instances[$uuid_arg] ?? null;
+            if ($node !== null && $general_enabled && (string)$node->enabled === '1') {
+                echo json_encode(nebula_start_instance($model, $node, $uuid_arg)) . "\n";
+            } else {
+                echo json_encode(['started' => false, 'error' => 'instance not enabled or unknown']) . "\n";
+            }
+        } else {
+            foreach ($instances as $uuid => $node) {
+                if ($general_enabled && (string)$node->enabled === '1') {
+                    nebula_start_instance($model, $node, $uuid);
+                }
+            }
+        }
+        break;
+    case 'stop':
+        foreach (nebula_instances($model) as $uuid => $node) {
+            nebula_stop_instance($uuid);
+        }
+        break;
+    case 'restart':
+        $instances = nebula_instances($model);
+        /* reap orphans on every restart (all-instances or single) so a deleted
+         * instance's daemon holding e.g. nebula0 is cleared before we re-start. */
+        nebula_reconcile_orphans($instances);
+        if ($uuid_arg !== '') {
+            /* per-instance restart — emit JSON so the reload button (configd
+             * restart_instance action, type:script_output) can surface the
+             * real start failure reason in the UI. */
+            $res = nebula_restart_instance($model, $uuid_arg, $general_enabled);
+            echo json_encode($res) . "\n";
+        } else {
+            /* all-instances restart */
+            foreach ($instances as $uuid => $node) {
+                nebula_stop_instance($uuid);
+            }
+            foreach ($instances as $uuid => $node) {
+                if ($general_enabled && (string)$node->enabled === '1') {
+                    $res = nebula_start_instance($model, $node, $uuid);
+                    if (!empty($res['started'])) {
+                        nebula_reattach_interface($uuid);
+                    }
+                }
+            }
+        }
+        break;
+    case 'apply':
+        /* reconfigure path: reload running instances in place, restarting only
+         * those whose structural config (listen bind / cipher / tun dev) changed.
+         * Avoids tearing down live tunnels for firewall/route/lighthouse edits. */
+        nebula_apply($model, $general_enabled);
+        break;
+    case 'status':
+        if ($uuid_arg !== '') {
+            /* per-instance status: JSON to stdout */
+            $st = nebula_instance_status($uuid_arg);
+            echo json_encode($st) . "\n";
+        } else {
+            /* all-instances status: human-readable for the service badge */
+            $running = 0;
+            foreach (nebula_instances($model) as $uuid => $node) {
+                if (nebula_running_pid($uuid) !== null) {
+                    $running++;
+                }
+            }
+            /*
+             * The string "is running" / "not running" is what
+             * ApiMutableServiceControllerBase::statusAction() greps for, so this
+             * one line drives both the UI status badge and the CLI report.
+             */
+            if ($running > 0) {
+                echo "OK {$running} running, nebula is running\n";
+            } else {
+                echo "STOPPED, nebula is not running\n";
+            }
+        }
+        break;
+    case 'diag':
+        /* per-instance diagnostics: JSON to stdout (Status page) */
+        if ($uuid_arg !== '') {
+            echo json_encode(nebula_instance_diag($uuid_arg)) . "\n";
+        }
+        break;
+    case 'peers':
+        /* per-instance live tunnels/peers via the nebula sshd debug server */
+        if ($uuid_arg !== '') {
+            echo json_encode(nebula_instance_peers($model, $uuid_arg)) . "\n";
+        }
+        break;
+    case 'peers_all':
+        /* Tunnels page: live peers for ALL running instances, fanned out in
+         * parallel. JSON {ok, rows:[...]} to stdout. */
+        echo json_encode(nebula_all_peers($model)) . "\n";
+        break;
+    case 'snapshot':
+        /* one-shot Status-page snapshot for all instances (JSON to stdout) */
+        echo json_encode(nebula_snapshot($model)) . "\n";
+        break;
+    case 'debug':
+        /* per-instance debug-server sub-action (Status page enrichment + verbs).
+         * argv: debug <uuid> <sub> [<vpn>] [<remote>] */
+        if ($uuid_arg !== '') {
+            $sub = isset($argv[3]) ? trim($argv[3]) : '';
+            $vpn = isset($argv[4]) ? trim($argv[4]) : '';
+            $remote = isset($argv[5]) ? trim($argv[5]) : '';
+            echo json_encode(nebula_instance_debug($model, $uuid_arg, $sub, $vpn, $remote)) . "\n";
+        }
+        break;
+    default:
+        fwrite(STDERR, "Usage: setup.php [start|stop|restart|apply|status|diag|peers|peers_all|debug|snapshot] [<uuid>] ...\n");
+        closelog();
+        exit(1);
+}
+
+closelog();

--- a/net/nebula/src/opnsense/scripts/OPNsense/Nebula/setup.php
+++ b/net/nebula/src/opnsense/scripts/OPNsense/Nebula/setup.php
@@ -816,7 +816,7 @@ function nebula_instance_diag($uuid)
  * @return array ['started'=>bool] / ['started'=>false,'error'=>str], so the
  *               reload button can surface the real failure reason in the UI.
  */
-function nebula_restart_instance($model, $uuid, $general_enabled)
+function nebula_restart_instance($model, $uuid)
 {
     nebula_stop_instance($uuid);
 
@@ -831,7 +831,7 @@ function nebula_restart_instance($model, $uuid, $general_enabled)
         syslog(LOG_WARNING, "nebula: restart_instance: uuid {$uuid} not found in model; skipping");
         return ['started' => false, 'error' => 'instance not found'];
     }
-    if (!$general_enabled || (string)$node->enabled !== '1') {
+    if ((string)$node->enabled !== '1') {
         syslog(LOG_INFO, "nebula: instance {$uuid} is disabled; not restarting");
         return ['started' => false, 'error' => 'instance is disabled'];
     }
@@ -899,13 +899,13 @@ function nebula_needs_restart(string $oldYml, string $newYml): bool
  * device) changed, or when the reload itself fails. nebula re-reads the config
  * and the cert files on reload, so both are written before reloading.
  */
-function nebula_apply($model, $general_enabled)
+function nebula_apply($model)
 {
     $instances = nebula_instances($model);
     nebula_reconcile_orphans($instances);
 
     foreach ($instances as $uuid => $node) {
-        $shouldRun = $general_enabled && (string)$node->enabled === '1';
+        $shouldRun = (string)$node->enabled === '1';
         $running   = nebula_running_pid($uuid) !== null;
 
         if (!$shouldRun) {
@@ -925,7 +925,7 @@ function nebula_apply($model, $general_enabled)
         $newYml  = (string)$model->generateConfig($node, nebula_diag_pubkey());
 
         if (nebula_needs_restart($oldYml, $newYml)) {
-            nebula_restart_instance($model, $uuid, $general_enabled);
+            nebula_restart_instance($model, $uuid);
             continue;
         }
 
@@ -947,7 +947,7 @@ function nebula_apply($model, $general_enabled)
         $res = nebula_debug_cmd($model, $uuid, 'reload');
         if (empty($res['ok'])) {
             syslog(LOG_WARNING, "nebula: apply: {$uuid} reload failed (" . ($res['error'] ?? '') . "); restarting");
-            nebula_restart_instance($model, $uuid, $general_enabled);
+            nebula_restart_instance($model, $uuid);
         } else {
             syslog(LOG_INFO, "nebula: apply: {$uuid} reloaded in place");
         }
@@ -1303,7 +1303,6 @@ openlog('nebula', LOG_ODELAY, LOG_DAEMON);
 $action = $argv[1] ?? '';
 $uuid_arg = isset($argv[2]) ? trim($argv[2]) : '';
 $model = new Nebula();
-$general_enabled = (string)$model->general->enabled === '1';
 
 switch ($action) {
     case 'start':
@@ -1315,14 +1314,14 @@ switch ($action) {
              * an assigned nebulaX device gets created during interface bring-up.
              * JSON out so the caller can see the start result. */
             $node = $instances[$uuid_arg] ?? null;
-            if ($node !== null && $general_enabled && (string)$node->enabled === '1') {
+            if ($node !== null && (string)$node->enabled === '1') {
                 echo json_encode(nebula_start_instance($model, $node, $uuid_arg)) . "\n";
             } else {
                 echo json_encode(['started' => false, 'error' => 'instance not enabled or unknown']) . "\n";
             }
         } else {
             foreach ($instances as $uuid => $node) {
-                if ($general_enabled && (string)$node->enabled === '1') {
+                if ((string)$node->enabled === '1') {
                     nebula_start_instance($model, $node, $uuid);
                 }
             }
@@ -1342,7 +1341,7 @@ switch ($action) {
             /* per-instance restart — emit JSON so the reload button (configd
              * restart_instance action, type:script_output) can surface the
              * real start failure reason in the UI. */
-            $res = nebula_restart_instance($model, $uuid_arg, $general_enabled);
+            $res = nebula_restart_instance($model, $uuid_arg);
             echo json_encode($res) . "\n";
         } else {
             /* all-instances restart */
@@ -1350,7 +1349,7 @@ switch ($action) {
                 nebula_stop_instance($uuid);
             }
             foreach ($instances as $uuid => $node) {
-                if ($general_enabled && (string)$node->enabled === '1') {
+                if ((string)$node->enabled === '1') {
                     $res = nebula_start_instance($model, $node, $uuid);
                     if (!empty($res['started'])) {
                         nebula_reattach_interface($uuid);
@@ -1363,7 +1362,7 @@ switch ($action) {
         /* reconfigure path: reload running instances in place, restarting only
          * those whose structural config (listen bind / cipher / tun dev) changed.
          * Avoids tearing down live tunnels for firewall/route/lighthouse edits. */
-        nebula_apply($model, $general_enabled);
+        nebula_apply($model);
         break;
     case 'status':
         if ($uuid_arg !== '') {

--- a/net/nebula/src/opnsense/service/conf/actions.d/actions_nebula.conf
+++ b/net/nebula/src/opnsense/service/conf/actions.d/actions_nebula.conf
@@ -1,0 +1,87 @@
+[start]
+command:/usr/local/opnsense/scripts/OPNsense/Nebula/setup.php start
+parameters:
+type:script
+message:starting nebula
+
+[stop]
+command:/usr/local/opnsense/scripts/OPNsense/Nebula/setup.php stop
+parameters:
+type:script
+message:stopping nebula
+
+[restart]
+command:/usr/local/opnsense/scripts/OPNsense/Nebula/setup.php restart
+parameters:
+type:script
+message:restarting nebula
+
+[reconfigure]
+command:/usr/local/opnsense/scripts/OPNsense/Nebula/setup.php apply
+parameters:
+type:script
+message:reconfigure nebula
+
+[status]
+command:/usr/local/opnsense/scripts/OPNsense/Nebula/setup.php status
+parameters:
+type:script_output
+message:nebula status
+
+[pki_generate_ca]
+command:/usr/local/opnsense/scripts/OPNsense/Nebula/pki.php generate-ca
+parameters:%s
+type:script_output
+message:nebula generate ca
+
+[pki_sign_cert]
+command:/usr/local/opnsense/scripts/OPNsense/Nebula/pki.php sign-cert
+parameters:%s
+type:script_output
+message:nebula sign cert
+
+[pki_print_cert]
+command:/usr/local/opnsense/scripts/OPNsense/Nebula/pki.php print-cert
+parameters:%s
+type:script_output
+message:nebula print cert
+
+[restart_instance]
+command:/usr/local/opnsense/scripts/OPNsense/Nebula/setup.php restart
+parameters:%s
+type:script_output
+message:restart nebula instance
+
+[status_instance]
+command:/usr/local/opnsense/scripts/OPNsense/Nebula/setup.php status
+parameters:%s
+type:script_output
+message:nebula instance status
+
+[diag_instance]
+command:/usr/local/opnsense/scripts/OPNsense/Nebula/setup.php diag
+parameters:%s
+type:script_output
+message:nebula instance diagnostics
+
+[peers_instance]
+command:/usr/local/opnsense/scripts/OPNsense/Nebula/setup.php peers
+parameters:%s
+type:script_output
+message:nebula instance peers
+
+[debug_instance]
+command:/usr/local/opnsense/scripts/OPNsense/Nebula/setup.php debug
+parameters:%s %s %s %s
+type:script_output
+message:nebula instance debug
+
+[snapshot]
+command:/usr/local/opnsense/scripts/OPNsense/Nebula/setup.php snapshot
+type:script_output
+message:nebula status snapshot
+
+[peers_all]
+command:/usr/local/opnsense/scripts/OPNsense/Nebula/setup.php peers_all
+type:script_output
+message:nebula all peers

--- a/net/nebula/src/opnsense/www/js/widgets/Metadata/Nebula.xml
+++ b/net/nebula/src/opnsense/www/js/widgets/Metadata/Nebula.xml
@@ -1,0 +1,21 @@
+<metadata>
+    <Nebula>
+        <filename>Nebula.js</filename>
+        <link>/ui/nebula/status</link>
+        <endpoints>
+            <endpoint>/api/nebula/instance/search_item</endpoint>
+        </endpoints>
+        <translations>
+            <title>Nebula</title>
+            <running>Running</running>
+            <stopped>Stopped</stopped>
+            <disabled>Disabled</disabled>
+            <lighthouse>Lighthouse</lighthouse>
+            <total>Instances</total>
+            <listen>Listen</listen>
+            <certificate>Certificate</certificate>
+            <noinstances>No Nebula instances configured. Click to add one.</noinstances>
+            <notavailable>N/A</notavailable>
+        </translations>
+    </Nebula>
+</metadata>

--- a/net/nebula/src/opnsense/www/js/widgets/Nebula.js
+++ b/net/nebula/src/opnsense/www/js/widgets/Nebula.js
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+export default class Nebula extends BaseTableWidget {
+    constructor() {
+        super();
+    }
+
+    getGridOptions() {
+        return {
+            // Automatically triggers vertical scrolling after reaching 650px in height
+            sizeToContent: 650
+        };
+    }
+
+    getMarkup() {
+        let $container = $('<div></div>');
+        let $nebulaTable = this.createTable('nebulaInstanceTable', {
+            headerPosition: 'left'
+        });
+
+        $container.append($nebulaTable);
+        return $container;
+    }
+
+    async onWidgetTick() {
+        const response = await this.ajaxCall('/api/nebula/instance/search_item');
+
+        if (!response || !response.rows || response.rows.length === 0) {
+            this.displayError(this.translations.noinstances);
+            return;
+        }
+
+        if (!this.dataChanged('nebula-instances', response.rows)) {
+            return; // No changes detected, do not update the UI
+        }
+
+        this.processInstances(response.rows);
+    }
+
+    displayError(message) {
+        $('#nebulaInstanceTable').empty().append(
+            $('<div class="error-message"></div>').append(
+                $('<a href="/ui/nebula/instances"></a>').text(message)
+            )
+        );
+    }
+
+    processInstances(rows) {
+        $('.nebula-instance-status').tooltip('hide');
+
+        let instances = rows.map(row => {
+            const enabled = String(row.enabled) === '1';
+            const running = String(row.running) === '1';
+
+            let statusIcon;
+            let statusTooltip;
+            if (!enabled) {
+                statusIcon = 'fa-circle-o fa-fw text-muted';
+                statusTooltip = this.translations.disabled;
+            } else if (running) {
+                statusIcon = 'fa-check-circle fa-fw text-success';
+                statusTooltip = this.translations.running;
+            } else {
+                statusIcon = 'fa-times-circle fa-fw text-danger';
+                statusTooltip = this.translations.stopped;
+            }
+
+            const listenHost = row.listen_host || '';
+            const listenPort = row.listen_port || '';
+            const listen = (listenHost !== '' || listenPort !== '')
+                ? `${listenHost}:${listenPort}`
+                : this.translations.notavailable;
+
+            return {
+                uuid: row.uuid,
+                description: row.description || row.uuid,
+                enabled: enabled,
+                running: running,
+                pid: row.pid || '',
+                isLighthouse: String(row.am_lighthouse) === '1',
+                listen: listen,
+                certificate: row.certificate || this.translations.notavailable,
+                statusIcon: statusIcon,
+                statusTooltip: statusTooltip
+            };
+        });
+
+        // Running instances first, then enabled-but-stopped, then disabled.
+        instances.sort((a, b) => {
+            const rank = i => (i.running ? 0 : (i.enabled ? 1 : 2));
+            return rank(a) - rank(b);
+        });
+
+        let runningCount = instances.filter(i => i.running).length;
+        let summaryRow = `
+            <div>
+                <span>
+                    ${this.translations.running}: ${runningCount} |
+                    ${this.translations.total}: ${instances.length}
+                </span>
+            </div>`;
+        super.updateTable('nebulaInstanceTable', [[summaryRow, '']], 'nebula-summary');
+
+        instances.forEach(instance => {
+            let lighthouseLabel = instance.isLighthouse
+                ? `<span class="label label-info" style="margin-left: 6px;">${this.translations.lighthouse}</span>`
+                : '';
+
+            let header = `
+                <div style="display: flex; justify-content: space-between; align-items: center;">
+                    <div style="display: flex; align-items: center;">
+                        <i class="fa ${instance.statusIcon} nebula-instance-status" style="cursor: pointer;"
+                            data-toggle="tooltip" title="${instance.statusTooltip}">
+                        </i>
+                        &nbsp;
+                        <a href="/ui/nebula/status" target="_blank" rel="noopener noreferrer">
+                            ${instance.description}
+                        </a>
+                        ${lighthouseLabel}
+                    </div>
+                </div>`;
+
+            let pidText = (instance.running && instance.pid !== '')
+                ? ` <span class="text-muted">(pid ${instance.pid})</span>`
+                : '';
+
+            let row = `
+                <div>
+                    <div>${this.translations.listen}: ${instance.listen}${pidText}</div>
+                    <div class="text-muted">${this.translations.certificate}: ${instance.certificate}</div>
+                </div>`;
+
+            super.updateTable('nebulaInstanceTable', [[header, row]], instance.uuid);
+        });
+
+        // Activate tooltips for the new dynamic elements.
+        $('.nebula-instance-status').tooltip({container: 'body'});
+    }
+}

--- a/net/nebula/tools/audit_knobs.py
+++ b/net/nebula/tools/audit_knobs.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+audit_knobs.py — verify the plugin's config knobs against the upstream Nebula
+configuration key set.
+
+This is the durable, CI-enforceable form of "generate the knobs from the docs":
+rather than scrape prose, we pin the complete upstream leaf-key set in
+tools/nebula_config_reference.yaml (transcribed from nebula examples/config.yml +
+the versioned docs) and assert that the generated knobs in knobs.yaml stay in
+exact correspondence with it.
+
+The audit fails (exit 1) when any of the following hold:
+
+  * an upstream key in the reference's `all` list is neither a generated knob
+    (knobs.yaml) nor classified (handled / deferred / not_applicable /
+    deprecated) — i.e. a new Nebula release added a key we have not triaged;
+  * a knob's yaml path is absent from the reference's `all` list — i.e. a knob
+    points at a key upstream does not (or no longer) defines;
+  * a classification entry overlaps a knob (except a `deprecated` entry marked
+    `retained: true`, which is expected to keep its warning-marked knob);
+  * a `deprecated` entry marked `retained: true` has no corresponding knob;
+  * the reference is internally inconsistent (duplicate or unknown keys).
+
+Usage:
+    python3 net/nebula/tools/audit_knobs.py            # human-readable report
+    python3 net/nebula/tools/audit_knobs.py --check    # exit 1 on any failure
+    python3 net/nebula/tools/audit_knobs.py --root /path/to/net/nebula
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import yaml  # PyYAML — required for this dev/CI tool
+
+# Reuse the knob loader so there is a single definition of "what is a knob".
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from gen_knobs import load_knobs  # noqa: E402
+
+_CLASSIFICATIONS = ('handled', 'deferred', 'not_applicable', 'deprecated')
+
+
+def _default_root() -> str:
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def load_reference(root: str | None = None) -> dict:
+    """Load the upstream key registry."""
+    if root is None:
+        root = _default_root()
+    path = os.path.join(root, 'tools', 'nebula_config_reference.yaml')
+    with open(path, encoding='utf-8') as fh:
+        return yaml.safe_load(fh)
+
+
+def audit(root: str | None = None) -> list[str]:
+    """Return a list of audit failure messages (empty means the audit passed)."""
+    if root is None:
+        root = _default_root()
+
+    ref = load_reference(root)
+    knobs = load_knobs(root)
+
+    failures: list[str] = []
+
+    # ----- reference internal consistency -----------------------------------
+    all_list = ref.get('all') or []
+    all_keys: set[str] = set()
+    for key in all_list:
+        if key in all_keys:
+            failures.append(f"reference `all` lists {key!r} more than once")
+        all_keys.add(key)
+
+    # Build key -> category, flagging retained deprecated entries.
+    classified: dict[str, str] = {}
+    retained_deprecated: set[str] = set()
+    for cat in _CLASSIFICATIONS:
+        for entry in ref.get(cat) or []:
+            key = entry['key']
+            if key in classified:
+                failures.append(
+                    f"{key!r} is classified twice "
+                    f"({classified[key]} and {cat})"
+                )
+            classified[key] = cat
+            if cat == 'deprecated' and entry.get('retained'):
+                retained_deprecated.add(key)
+            if key not in all_keys:
+                failures.append(
+                    f"{cat} entry {key!r} is not present in the reference "
+                    f"`all` key set"
+                )
+
+    knob_paths = {k['yaml'] for k in knobs}
+
+    # ----- knob <-> upstream correspondence ---------------------------------
+    for path in sorted(knob_paths):
+        if path not in all_keys:
+            failures.append(
+                f"knob yaml path {path!r} is not an upstream key in the "
+                f"reference `all` set (typo, or removed upstream?)"
+            )
+
+    # ----- every upstream key is covered ------------------------------------
+    for key in sorted(all_keys):
+        is_knob = key in knob_paths
+        cat = classified.get(key)
+        if not is_knob and cat is None:
+            failures.append(
+                f"upstream key {key!r} is unclassified: add a knob in "
+                f"knobs.yaml or classify it in nebula_config_reference.yaml"
+            )
+        if is_knob and cat is not None and key not in retained_deprecated:
+            failures.append(
+                f"upstream key {key!r} is both a knob and classified as "
+                f"{cat!r}; remove one (or mark deprecated retained:true)"
+            )
+
+    # ----- retained deprecated knobs must actually exist --------------------
+    for key in sorted(retained_deprecated):
+        if key not in knob_paths:
+            failures.append(
+                f"deprecated key {key!r} is marked retained:true but has no "
+                f"knob in knobs.yaml to round-trip stored configs"
+            )
+
+    return failures
+
+
+def summary(root: str | None = None) -> str:
+    """Return a human-readable coverage summary."""
+    if root is None:
+        root = _default_root()
+    ref = load_reference(root)
+    knobs = load_knobs(root)
+    knob_paths = {k['yaml'] for k in knobs}
+    all_keys = ref.get('all') or []
+
+    counts = {cat: len(ref.get(cat) or []) for cat in _CLASSIFICATIONS}
+    n_knob = sum(1 for k in all_keys if k in knob_paths)
+
+    lines = [
+        f"Upstream keys (targeted release): {len(all_keys)}",
+        f"  knob (generated form field):   {n_knob}",
+        f"  handled (other model/UI):      {counts['handled']}",
+        f"  deferred (not yet exposed):    {counts['deferred']}",
+        f"  not_applicable (platform/ver): {counts['not_applicable']}",
+        f"  deprecated (omitted):          {counts['deprecated']}",
+    ]
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--check', action='store_true',
+                        help='exit 1 on any audit failure (for CI)')
+    parser.add_argument('--root', default=None,
+                        help='plugin root (the net/nebula subtree)')
+    args = parser.parse_args(argv)
+
+    failures = audit(args.root)
+
+    if not args.check:
+        print(summary(args.root))
+        print()
+
+    if failures:
+        print(f"AUDIT FAILED ({len(failures)} issue(s)):", file=sys.stderr)
+        for msg in failures:
+            print(f"  - {msg}", file=sys.stderr)
+        return 1
+
+    print("Knob audit OK — knobs.yaml is in sync with the upstream key set.")
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/net/nebula/tools/audit_knobs_test.py
+++ b/net/nebula/tools/audit_knobs_test.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""
+Unit tests for audit_knobs.py.
+
+Run:  python3 net/nebula/tools/audit_knobs_test.py
+Requires PyYAML (same as audit_knobs.py itself).
+"""
+
+import os
+import sys
+import tempfile
+import textwrap
+import unittest
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import audit_knobs  # noqa: E402 — must be after path manipulation
+
+
+def _write_root(knobs_yaml: str, reference_yaml: str) -> str:
+    """Create a throwaway plugin root with the two files audit_knobs reads.
+
+    Both arguments are dedented, so callers may indent the literals to match
+    the surrounding code.
+    """
+    root = tempfile.mkdtemp(prefix='nebula-audit-')
+    os.makedirs(os.path.join(root, 'tools'), exist_ok=True)
+    with open(os.path.join(root, 'knobs.yaml'), 'w', encoding='utf-8') as fh:
+        fh.write(textwrap.dedent(knobs_yaml))
+    with open(os.path.join(root, 'tools', 'nebula_config_reference.yaml'),
+              'w', encoding='utf-8') as fh:
+        fh.write(textwrap.dedent(reference_yaml))
+    return root
+
+
+# One knob (cipher); a richer fixture adds local_range below where needed.
+ONE_KNOB = """\
+    knobs:
+      - field: cipher
+        yaml: cipher
+        type: enum
+        default: chachapoly
+        enum: [chachapoly, aes]
+        help: Encryption cipher.
+"""
+
+# cipher = knob; one entry in each classification list; internally consistent.
+GOOD_REFERENCE = """\
+    all:
+      - cipher
+      - pki.ca
+      - stats
+      - tun.windows_bypass_wdf
+      - local_range
+    handled:
+      - key: pki.ca
+        by: PKI authorities
+    deferred:
+      - key: stats
+        reason: telemetry block
+    not_applicable:
+      - key: tun.windows_bypass_wdf
+        reason: Windows-only
+    deprecated:
+      - key: local_range
+        reason: alias for preferred_ranges
+        retained: false
+"""
+
+
+class TestRealReference(unittest.TestCase):
+    def test_shipped_reference_passes(self):
+        """The real knobs.yaml + reference must always pass the audit."""
+        root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        self.assertEqual(audit_knobs.audit(root), [])
+
+    def test_summary_mentions_upstream_keys(self):
+        root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        self.assertIn('Upstream keys', audit_knobs.summary(root))
+
+
+class TestFixturePasses(unittest.TestCase):
+    def test_minimal_good_fixture(self):
+        root = _write_root(ONE_KNOB, GOOD_REFERENCE)
+        self.assertEqual(audit_knobs.audit(root), [])
+
+
+class TestDriftIsCaught(unittest.TestCase):
+    def test_unclassified_upstream_key_fails(self):
+        reference = """\
+            all:
+              - cipher
+              - punchy.punch
+        """  # punchy.punch is neither a knob nor classified
+        root = _write_root(ONE_KNOB, reference)
+        failures = audit_knobs.audit(root)
+        self.assertTrue(
+            any('unclassified' in f and 'punchy.punch' in f for f in failures),
+            failures)
+
+    def test_knob_path_not_in_upstream_fails(self):
+        knobs = """\
+            knobs:
+              - field: cipher
+                yaml: cipher
+                type: enum
+                default: chachapoly
+                enum: [chachapoly, aes]
+                help: Encryption cipher.
+              - field: bogus_field
+                yaml: bogus.path
+                type: bool
+                default: "false"
+                help: Not a real Nebula key.
+        """
+        reference = """\
+            all:
+              - cipher
+        """
+        root = _write_root(knobs, reference)
+        failures = audit_knobs.audit(root)
+        self.assertTrue(any('bogus.path' in f for f in failures), failures)
+
+    def test_knob_classified_overlap_fails(self):
+        reference = """\
+            all:
+              - cipher
+            deferred:
+              - key: cipher
+                reason: wrongly double-listed
+        """
+        root = _write_root(ONE_KNOB, reference)
+        failures = audit_knobs.audit(root)
+        self.assertTrue(
+            any('both a knob and classified' in f for f in failures), failures)
+
+    def test_retained_deprecated_without_knob_fails(self):
+        reference = """\
+            all:
+              - cipher
+              - local_range
+            deprecated:
+              - key: local_range
+                reason: kept for round-trip
+                retained: true
+        """
+        root = _write_root(ONE_KNOB, reference)
+        failures = audit_knobs.audit(root)
+        self.assertTrue(
+            any('retained:true' in f and 'local_range' in f for f in failures),
+            failures)
+
+    def test_retained_deprecated_with_knob_passes(self):
+        knobs = """\
+            knobs:
+              - field: cipher
+                yaml: cipher
+                type: enum
+                default: chachapoly
+                enum: [chachapoly, aes]
+                help: Encryption cipher.
+              - field: local_range
+                yaml: local_range
+                type: text
+                help: DEPRECATED — use preferred_ranges.
+        """
+        reference = """\
+            all:
+              - cipher
+              - local_range
+            deprecated:
+              - key: local_range
+                reason: kept for round-trip
+                retained: true
+        """
+        root = _write_root(knobs, reference)
+        self.assertEqual(audit_knobs.audit(root), [])
+
+    def test_classified_key_absent_from_all_fails(self):
+        reference = """\
+            all:
+              - cipher
+            deferred:
+              - key: stats
+                reason: not in all
+        """
+        root = _write_root(ONE_KNOB, reference)
+        failures = audit_knobs.audit(root)
+        self.assertTrue(
+            any('not present in the reference' in f for f in failures), failures)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/net/nebula/tools/gen_knobs.py
+++ b/net/nebula/tools/gen_knobs.py
@@ -1,0 +1,668 @@
+#!/usr/bin/env python3
+"""
+gen_knobs.py — deterministic generator for the Nebula OPNsense plugin.
+
+Reads net/nebula/knobs.yaml and produces three artifacts:
+
+  1. src/opnsense/mvc/app/models/OPNsense/Nebula/Nebula.xml
+       — replaces content between GENERATED:instance-fields markers
+  2. src/opnsense/mvc/app/controllers/OPNsense/Nebula/forms/dialogInstance.xml
+       — same marker pair
+  3. src/opnsense/mvc/app/models/OPNsense/Nebula/ConfigMap.php
+       — overwritten entirely
+
+Usage (from any directory):
+    python3 net/nebula/tools/gen_knobs.py            # write in place
+    python3 net/nebula/tools/gen_knobs.py --check    # drift check (exit 1 if differs)
+    python3 net/nebula/tools/gen_knobs.py --check --root /tmp/fixture  # use alternate root
+
+Dev tool only — NOT installed into the plugin package.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import os
+import sys
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# yaml import — stdlib only, no third-party deps
+# ---------------------------------------------------------------------------
+try:
+    import yaml  # PyYAML
+except ImportError:
+    # Minimal YAML subset parser (only what knobs.yaml uses):
+    # sequences of mappings with scalar values.  Not a full YAML parser — if
+    # the file ever uses anchors, multi-line strings, etc., install PyYAML.
+    import re as _re
+
+    class _MinimalLoader:
+        """Absolute-minimum YAML loader for flat sequence-of-mapping files."""
+
+        def load(self, text: str) -> dict:
+            lines = text.splitlines()
+            result: dict[str, Any] = {}
+            current_key: str | None = None
+            current_obj: dict[str, Any] | None = None
+            list_mode: str | None = None  # key whose value is a list
+
+            for raw in lines:
+                line = raw.rstrip()
+                if not line or line.lstrip().startswith('#'):
+                    continue
+                indent = len(line) - len(line.lstrip())
+
+                # Top-level mapping key (no indent)
+                if indent == 0:
+                    m = _re.match(r'^(\w+)\s*:\s*(.*)$', line)
+                    if m:
+                        current_key = m.group(1)
+                        val = m.group(2).strip()
+                        if val == '':
+                            result[current_key] = []
+                        else:
+                            result[current_key] = val
+                    list_mode = None
+                    current_obj = None
+                    continue
+
+                # Sequence item (2-space indent "  - field: …")
+                if indent == 2:
+                    if line.lstrip().startswith('- '):
+                        current_obj = {}
+                        if current_key is not None:
+                            result[current_key].append(current_obj)
+                        rest = line.lstrip()[2:]
+                        m = _re.match(r'^(\w+)\s*:\s*(.*)$', rest)
+                        if m:
+                            k, v = m.group(1), m.group(2).strip()
+                            current_obj[k] = self._parse_scalar(v)
+                        list_mode = None
+                    elif line.lstrip().startswith('#'):
+                        pass
+                    continue
+
+                # Mapping entry inside a sequence item (4+ spaces)
+                if indent >= 4 and current_obj is not None:
+                    stripped = line.lstrip()
+                    if stripped.startswith('- '):
+                        # inline list item  (e.g. enum: [a, b] already handled)
+                        if list_mode and isinstance(current_obj.get(list_mode), list):
+                            current_obj[list_mode].append(stripped[2:].strip())
+                        continue
+                    m = _re.match(r'^(\w+)\s*:\s*(.*)$', stripped)
+                    if m:
+                        k, v = m.group(1), m.group(2).strip()
+                        list_mode = None
+                        if v == '':
+                            current_obj[k] = []
+                            list_mode = k
+                        else:
+                            current_obj[k] = self._parse_scalar(v)
+                    continue
+
+            return result
+
+        def _parse_scalar(self, v: str) -> Any:
+            """Parse a YAML scalar value."""
+            if not v:
+                return None
+            # Inline list: [a, b, c]
+            if v.startswith('[') and v.endswith(']'):
+                inner = v[1:-1]
+                return [item.strip() for item in inner.split(',')]
+            # Quoted string
+            if (v.startswith('"') and v.endswith('"')) or \
+               (v.startswith("'") and v.endswith("'")):
+                return v[1:-1]
+            # Integer
+            if _re.match(r'^-?\d+$', v):
+                return int(v)
+            # Boolean (YAML 1.1 style — not used in knobs.yaml booleans which
+            # are quoted strings like "true"/"false")
+            if v in ('true', 'True', 'TRUE'):
+                return True
+            if v in ('false', 'False', 'FALSE'):
+                return False
+            return v
+
+    class _YamlModule:
+        def safe_load(self, text: str) -> Any:
+            return _MinimalLoader().load(text)
+
+    yaml = _YamlModule()  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+MARKER_START = '<!-- GENERATED:instance-fields START -->'
+MARKER_END = '<!-- GENERATED:instance-fields END -->'
+
+# Indentation for field children inside <instance type="ArrayField">
+# (16 spaces, matching the existing Nebula.xml indentation level)
+FIELD_INDENT = ' ' * 16
+CHILD_INDENT = ' ' * 20
+
+# BSD-2-Clause header (exact copy from Nebula.php)
+_PHP_HEADER = """\
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+"""
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+def load_knobs(root: str | None = None) -> list[dict]:
+    """Load and return the knobs list from knobs.yaml.
+
+    *root* is the plugin root directory (the ``net/nebula`` subtree); defaults
+    to the directory two levels above this script (i.e. ``net/nebula/``).
+    """
+    if root is None:
+        root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    path = os.path.join(root, 'knobs.yaml')
+    with open(path, encoding='utf-8') as fh:
+        data = yaml.safe_load(fh)
+    return data['knobs']
+
+
+def replace_between_markers(text: str, start: str, end: str, payload: str) -> str:
+    """Return *text* with the content between *start* and *end* replaced by
+    *payload*.
+
+    The markers themselves are preserved.  *payload* should **not** start or
+    end with the marker strings.
+
+    Raises ``ValueError`` if either marker is absent.
+    """
+    if start not in text:
+        raise ValueError(
+            f"START marker not found in target text: {start!r}"
+        )
+    if end not in text:
+        raise ValueError(
+            f"END marker not found in target text: {end!r}"
+        )
+    before, _rest = text.split(start, 1)
+    _middle, after = _rest.split(end, 1)
+    return f"{before}{start}\n{payload}{end}{after}"
+
+
+# ---------------------------------------------------------------------------
+# XML special-character escaping (for form help text)
+# ---------------------------------------------------------------------------
+
+_XML_ESCAPES = [
+    ('&', '&amp;'),
+    ('<', '&lt;'),
+    ('>', '&gt;'),
+    ('"', '&quot;'),
+    ("'", '&apos;'),
+]
+
+
+def _xml_escape(s: str) -> str:
+    """Escape XML special characters in *s*."""
+    # Must replace & first to avoid double-escaping.
+    for char, repl in _XML_ESCAPES:
+        s = s.replace(char, repl)
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Render helpers
+# ---------------------------------------------------------------------------
+
+def _bool_default(knob: dict) -> str:
+    """Return '1' for true-ish default, '0' otherwise."""
+    d = str(knob.get('default', 'false')).lower()
+    return '1' if d in ('true', '1', 'yes') else '0'
+
+
+def _field_lines(knob: dict) -> list[str]:
+    """Return the XML lines (without trailing newline) for a single knob."""
+    field = knob['field']
+    typ = knob['type']
+    required = knob.get('required', '')
+    default = knob.get('default')
+
+    lines: list[str] = []
+
+    def _open(xml_type: str) -> str:
+        return f'{FIELD_INDENT}<{field} type="{xml_type}">'
+
+    def _close() -> str:
+        return f'{FIELD_INDENT}</{field}>'
+
+    def _child(tag: str, value: Any) -> str:
+        return f'{CHILD_INDENT}<{tag}>{value}</{tag}>'
+
+    if typ == 'bool':
+        lines.append(_open('BooleanField'))
+        lines.append(_child('Default', _bool_default(knob)))
+        if required:
+            lines.append(_child('Required', required))
+        lines.append(_close())
+
+    elif typ == 'int':
+        lines.append(_open('IntegerField'))
+        if 'min' in knob:
+            lines.append(_child('MinimumValue', knob['min']))
+        if 'max' in knob:
+            lines.append(_child('MaximumValue', knob['max']))
+        if default is not None:
+            lines.append(_child('Default', default))
+        if required:
+            lines.append(_child('Required', required))
+        lines.append(_close())
+
+    elif typ == 'enum':
+        lines.append(_open('OptionField'))
+        if default is not None:
+            lines.append(_child('Default', default))
+        if required:
+            lines.append(_child('Required', required))
+        lines.append(f'{CHILD_INDENT}<OptionValues>')
+        for v in knob.get('enum', []):
+            lines.append(f'{CHILD_INDENT}    <{v}>{v}</{v}>')
+        lines.append(f'{CHILD_INDENT}</OptionValues>')
+        lines.append(_close())
+
+    elif typ == 'duration':
+        lines.append(_open('TextField'))
+        lines.append(_child('Mask', r'/^\d+(ns|us|µs|ms|s|m|h)$/'))
+        if default is not None:
+            lines.append(_child('Default', default))
+        if required:
+            lines.append(_child('Required', required))
+        lines.append(_close())
+
+    elif typ == 'text':
+        lines.append(_open('TextField'))
+        if default is not None:
+            lines.append(_child('Default', default))
+        if required:
+            lines.append(_child('Required', required))
+        lines.append(_close())
+
+    elif typ == 'host':
+        lines.append(_open('HostnameField'))
+        lines.append(_child('IpAllowed', 'Y'))
+        if default is not None:
+            lines.append(_child('Default', default))
+        if required:
+            lines.append(_child('Required', required))
+        lines.append(_close())
+
+    elif typ == 'cidr':
+        lines.append(_open('NetworkField'))
+        if default is not None:
+            lines.append(_child('Default', default))
+        if required:
+            lines.append(_child('Required', required))
+        lines.append(_close())
+
+    elif typ == 'list':
+        # CSVListField (AsList) so the form's tokenize select_multiple round-trips
+        # each value as a tag; stored comma-joined. Validated by `nebula -test`.
+        lines.append(_open('CSVListField'))
+        if default is not None:
+            lines.append(_child('Default', default))
+        if required:
+            lines.append(_child('Required', required))
+        lines.append(_close())
+
+    else:
+        raise ValueError(f"Unknown knob type: {typ!r} for field {field!r}")
+
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Three render functions
+# ---------------------------------------------------------------------------
+
+def render_model_fields(knobs: list[dict]) -> str:
+    """Render the inner XML for the per-instance ArrayField.
+
+    Returns a string ready to be inserted between the GENERATED markers in
+    ``Nebula.xml``.  Each field element is indented at 16 spaces (matching the
+    existing ``<instance>`` children).  The returned string ends with a
+    newline.
+    """
+    parts: list[str] = []
+    for knob in knobs:
+        parts.extend(_field_lines(knob))
+        parts.append('')  # blank line between fields for readability
+    # Remove trailing blank line, then add final newline
+    while parts and parts[-1] == '':
+        parts.pop()
+    return '\n'.join(parts) + '\n'
+
+
+def render_form_fields(knobs: list[dict]) -> str:
+    """Render the inner XML for ``dialogInstance.xml``'s ``<form>`` (one region)."""
+    parts: list[str] = []
+    fi = '    '   # 4-space indent for <field> children
+
+    # Section headers: emit a <type>header</type> separator before the first
+    # knob of each section. Sections must be contiguous in knobs.yaml (a section
+    # may not reappear after a different one) so the dialog reads top-to-bottom
+    # in the documented order; we guard that here.
+    current_section: str | None = None
+    seen_sections: set[str] = set()
+
+    # A section whose every knob is `advanced` would otherwise show a bare header
+    # row when Advanced mode is off. Mark those headers advanced too, so the whole
+    # section (header + fields) hides together. Mixed sections keep their header.
+    section_all_advanced: dict[str, bool] = {}
+    for knob in knobs:
+        sec = knob.get('section')
+        if sec is None:
+            continue
+        is_adv = bool(knob.get('advanced'))
+        section_all_advanced[sec] = is_adv if sec not in section_all_advanced \
+            else (section_all_advanced[sec] and is_adv)
+
+    for knob in knobs:
+        field = knob['field']
+        typ = knob['type']
+        help_text = knob.get('help', '')
+
+        section = knob.get('section')
+        if section is not None and section != current_section:
+            if section in seen_sections:
+                raise ValueError(
+                    f"section {section!r} is not contiguous in knobs.yaml: it "
+                    f"reappears after section {current_section!r}. Group all "
+                    f"knobs of a section together."
+                )
+            seen_sections.add(section)
+            current_section = section
+            parts.append(f'    <field>')
+            parts.append(f'        <type>header</type>')
+            parts.append(f'        <label>{_xml_escape(section)}</label>')
+            if section_all_advanced.get(section):
+                parts.append(f'        <advanced>true</advanced>')
+            parts.append(f'    </field>')
+
+        # Determine form type
+        if typ == 'bool':
+            form_type = 'checkbox'
+        elif typ == 'enum':
+            form_type = 'dropdown'
+        elif typ == 'list':
+            # tokenize select_multiple: each value entered as a chip/tag.
+            form_type = 'select_multiple'
+        else:
+            form_type = 'text'
+
+        # Label: use explicit 'label' key if present, else humanize snake_case.
+        if 'label' in knob:
+            label = knob['label']
+        else:
+            label = ' '.join(word.capitalize() for word in field.split('_'))
+
+        lines = [
+            f'    <field>',
+            f'        <id>instance.{field}</id>',
+            f'        <label>{label}</label>',
+            f'        <type>{form_type}</type>',
+        ]
+        # List fields render as a tokenize select_multiple (chip/tag input,
+        # allowing arbitrary new values).
+        if typ == 'list':
+            lines.append(f'        <style>tokenize</style>')
+            lines.append(f'        <allownew>true</allownew>')
+        # Advanced mode toggle — only emit when explicitly true.
+        if knob.get('advanced'):
+            lines.append(f'        <advanced>true</advanced>')
+        if help_text:
+            lines.append(f'        <help>{_xml_escape(help_text)}</help>')
+        # Grid column: every field gets a <grid_view>; grid knobs get <sequence>
+        # (plus optional width/type/formatter), all others get <ignore>true</ignore>.
+        # Order inside <grid_view>: width, type, formatter, sequence  (matches OpenVPN).
+        if 'grid' in knob:
+            lines.append(f'        <grid_view>')
+            if 'grid_width' in knob:
+                lines.append(f'            <width>{knob["grid_width"]}</width>')
+            if typ == 'bool':
+                lines.append(f'            <type>boolean</type>')
+                lines.append(f'            <formatter>boolean</formatter>')
+            lines.append(f'            <sequence>{knob["grid"]}</sequence>')
+            lines.append(f'        </grid_view>')
+        else:
+            lines.append(f'        <grid_view>')
+            lines.append(f'            <ignore>true</ignore>')
+            lines.append(f'        </grid_view>')
+        lines.append(f'    </field>')
+
+        parts.extend(lines)
+        parts.append('')  # blank line between fields
+
+    # Remove trailing blank line
+    while parts and parts[-1] == '':
+        parts.pop()
+
+    return '\n'.join(parts) + '\n'
+
+
+def render_config_map(knobs: list[dict]) -> str:
+    """Render the full ``ConfigMap.php`` file."""
+    lines: list[str] = []
+    lines.append(_PHP_HEADER.rstrip('\n'))
+    lines.append("/* GENERATED from knobs.yaml by tools/gen_knobs.py — do not edit by hand. */")
+    lines.append("return [")
+    for knob in knobs:
+        field = knob['field']
+        yaml_path = knob['yaml']
+        typ = knob['type']
+        lines.append(f"    '{field}' => ['yaml' => '{yaml_path}', 'type' => '{typ}'],")
+    lines.append("];")
+    lines.append("")  # trailing newline
+    return '\n'.join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Path resolution
+# ---------------------------------------------------------------------------
+
+def _resolve_paths(root: str) -> dict[str, str]:
+    """Return a dict of logical name → absolute file path, given plugin root."""
+    mvc = os.path.join(root, 'src', 'opnsense', 'mvc', 'app')
+    return {
+        'nebula_xml': os.path.join(mvc, 'models', 'OPNsense', 'Nebula', 'Nebula.xml'),
+        'dialog_xml': os.path.join(mvc, 'controllers', 'OPNsense', 'Nebula', 'forms', 'dialogInstance.xml'),
+        'config_map': os.path.join(mvc, 'models', 'OPNsense', 'Nebula', 'ConfigMap.php'),
+    }
+
+
+def _plugin_root() -> str:
+    """Return the net/nebula plugin root (two dirs above this script)."""
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _write_in_place(root: str) -> None:
+    """Write the three artifacts in place."""
+    knobs = load_knobs(root)
+    paths = _resolve_paths(root)
+
+    model_payload = render_model_fields(knobs)
+    form_payload = render_form_fields(knobs)
+    config_map = render_config_map(knobs)
+
+    errors: list[str] = []
+
+    # Nebula.xml — replace between markers
+    with open(paths['nebula_xml'], encoding='utf-8') as fh:
+        nebula_text = fh.read()
+    try:
+        new_nebula = replace_between_markers(
+            nebula_text, MARKER_START, MARKER_END, model_payload
+        )
+    except ValueError as exc:
+        errors.append(f"{paths['nebula_xml']}: {exc}")
+        new_nebula = None
+
+    # dialogInstance.xml — single generated region.
+    with open(paths['dialog_xml'], encoding='utf-8') as fh:
+        dialog_text = fh.read()
+    try:
+        new_dialog = replace_between_markers(
+            dialog_text, MARKER_START, MARKER_END, form_payload
+        )
+    except ValueError as exc:
+        errors.append(f"{paths['dialog_xml']}: {exc}")
+        new_dialog = None
+
+    if errors:
+        for msg in errors:
+            print(f"ERROR: {msg}", file=sys.stderr)
+        sys.exit(1)
+
+    with open(paths['nebula_xml'], 'w', encoding='utf-8') as fh:
+        fh.write(new_nebula)
+    print(f"Wrote: {paths['nebula_xml']}")
+
+    with open(paths['dialog_xml'], 'w', encoding='utf-8') as fh:
+        fh.write(new_dialog)
+    print(f"Wrote: {paths['dialog_xml']}")
+
+    with open(paths['config_map'], 'w', encoding='utf-8') as fh:
+        fh.write(config_map)
+    print(f"Wrote: {paths['config_map']}")
+
+
+def _check(root: str) -> bool:
+    """Check whether on-disk artifacts are up to date.
+
+    Returns True if all artifacts are current (no drift), False otherwise.
+    Prints a diff summary when drift is detected.
+    """
+    knobs = load_knobs(root)
+    paths = _resolve_paths(root)
+
+    model_payload = render_model_fields(knobs)
+    form_payload = render_form_fields(knobs)
+    config_map = render_config_map(knobs)
+
+    ok = True
+
+    def _check_xml(path: str, payload: str, label: str) -> bool:
+        if not os.path.exists(path):
+            print(f"MISSING: {path}", file=sys.stderr)
+            return False
+        with open(path, encoding='utf-8') as fh:
+            current = fh.read()
+        # Regenerate as if we were writing in place
+        try:
+            expected = replace_between_markers(
+                current, MARKER_START, MARKER_END, payload
+            )
+        except ValueError as exc:
+            print(f"ERROR ({label}): {exc}", file=sys.stderr)
+            return False
+        if current == expected:
+            return True
+        # Show diff
+        diff = list(difflib.unified_diff(
+            current.splitlines(keepends=True),
+            expected.splitlines(keepends=True),
+            fromfile=f'{label} (on-disk)',
+            tofile=f'{label} (generated)',
+            n=3,
+        ))
+        print(f"DRIFT in {path}:")
+        sys.stdout.writelines(diff[:40])
+        if len(diff) > 40:
+            print(f"  ... ({len(diff) - 40} more diff lines)")
+        return False
+
+    def _check_file(path: str, expected: str, label: str) -> bool:
+        if not os.path.exists(path):
+            print(f"MISSING: {path}", file=sys.stderr)
+            return False
+        with open(path, encoding='utf-8') as fh:
+            current = fh.read()
+        if current == expected:
+            return True
+        diff = list(difflib.unified_diff(
+            current.splitlines(keepends=True),
+            expected.splitlines(keepends=True),
+            fromfile=f'{label} (on-disk)',
+            tofile=f'{label} (generated)',
+            n=3,
+        ))
+        print(f"DRIFT in {path}:")
+        sys.stdout.writelines(diff[:40])
+        if len(diff) > 40:
+            print(f"  ... ({len(diff) - 40} more diff lines)")
+        return False
+
+    ok = _check_xml(paths['nebula_xml'], model_payload, 'Nebula.xml') and ok
+    ok = _check_xml(paths['dialog_xml'], form_payload, 'dialogInstance.xml') and ok
+    ok = _check_file(paths['config_map'], config_map, 'ConfigMap.php') and ok
+
+    return ok
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--check',
+        action='store_true',
+        help='Check drift only; exit 1 if artifacts are out of date.',
+    )
+    parser.add_argument(
+        '--root',
+        default=None,
+        help='Override the plugin root directory (default: two levels above this script).',
+    )
+    args = parser.parse_args(argv)
+
+    root = args.root if args.root else _plugin_root()
+
+    if args.check:
+        ok = _check(root)
+        sys.exit(0 if ok else 1)
+    else:
+        _write_in_place(root)
+
+
+if __name__ == '__main__':
+    main()

--- a/net/nebula/tools/gen_knobs_test.py
+++ b/net/nebula/tools/gen_knobs_test.py
@@ -1,0 +1,1256 @@
+#!/usr/bin/env python3
+"""
+Unit tests for gen_knobs.py.
+
+Run:  python3 net/nebula/tools/gen_knobs_test.py
+Requires no external dependencies (stdlib unittest only).
+"""
+
+import sys
+import os
+import unittest
+
+# Allow importing gen_knobs from the same directory regardless of CWD.
+sys.path.insert(0, os.path.dirname(__file__))
+
+import gen_knobs  # noqa: E402 — must be after path manipulation
+
+
+# ---------------------------------------------------------------------------
+# Small knobs list used across multiple tests
+# ---------------------------------------------------------------------------
+
+LIST_KNOB = {
+    'field': 'lighthouse_hosts',
+    'yaml': 'lighthouse.hosts',
+    'type': 'list',
+    'help': 'IP:port of each lighthouse node.',
+}
+
+SAMPLE_KNOBS = [
+    # bool — default true
+    {
+        'field': 'punchy_punch',
+        'yaml': 'punchy.punch',
+        'type': 'bool',
+        'default': 'true',
+        'help': 'Send UDP hole-punching packets.',
+    },
+    # bool — default false
+    {
+        'field': 'tun_disabled',
+        'yaml': 'tun.disabled',
+        'type': 'bool',
+        'default': 'false',
+        'help': 'Disable the TUN interface.',
+    },
+    # bool — no default
+    {
+        'field': 'relay_am_relay',
+        'yaml': 'relay.am_relay',
+        'type': 'bool',
+        'help': 'Act as a relay node.',
+    },
+    # int with min+max+default
+    {
+        'field': 'pki_initiating_version',
+        'yaml': 'pki.initiating_version',
+        'type': 'int',
+        'default': 1,
+        'min': 1,
+        'max': 2,
+        'help': 'Handshake version.',
+    },
+    # int with only default (no min/max)
+    {
+        'field': 'routines',
+        'yaml': 'routines',
+        'type': 'int',
+        'default': 1,
+        'help': 'Number of goroutine workers.',
+    },
+    # int no default, no min/max
+    {
+        'field': 'listen_read_buffer',
+        'yaml': 'listen.read_buffer',
+        'type': 'int',
+        'help': 'SO_RCVBUF size in bytes.',
+    },
+    # enum
+    {
+        'field': 'cipher',
+        'yaml': 'cipher',
+        'type': 'enum',
+        'default': 'chachapoly',
+        'enum': ['chachapoly', 'aes'],
+        'help': 'Encryption cipher.',
+    },
+    # duration with default
+    {
+        'field': 'punchy_delay',
+        'yaml': 'punchy.delay',
+        'type': 'duration',
+        'default': '1s',
+        'help': 'Wait before first hole-punch.',
+    },
+    # duration without default
+    {
+        'field': 'tunnels_inactivity_timeout',
+        'yaml': 'tunnels.inactivity_timeout',
+        'type': 'duration',
+        'help': 'How long before inactive.',
+    },
+    # text with no default
+    {
+        'field': 'logging_timestamp_format',
+        'yaml': 'logging.timestamp_format',
+        'type': 'text',
+        'help': 'Go time-format string.',
+    },
+    # text with default
+    {
+        'field': 'sshd_listen',
+        'yaml': 'sshd.listen',
+        'type': 'text',
+        'default': '127.0.0.1:2222',
+        'help': 'host:port the debug SSH server listens on.',
+    },
+    # host with default
+    {
+        'field': 'listen_host',
+        'yaml': 'listen.host',
+        'type': 'host',
+        'default': '::',
+        'required': 'Y',
+        'help': 'IP address Nebula binds its UDP listener to.',
+    },
+    # host without default
+    {
+        'field': 'lighthouse_dns_host',
+        'yaml': 'lighthouse.dns.host',
+        'type': 'host',
+        'help': 'IP address the lighthouse DNS server binds to.',
+    },
+    # cidr with default
+    {
+        'field': 'some_cidr',
+        'yaml': 'some.cidr',
+        'type': 'cidr',
+        'default': '10.0.0.0/8',
+        'help': 'CIDR range.',
+    },
+    # cidr without default
+    {
+        'field': 'another_cidr',
+        'yaml': 'another.cidr',
+        'type': 'cidr',
+        'help': 'Another CIDR range.',
+    },
+    # required without default — int
+    {
+        'field': 'listen_port',
+        'yaml': 'listen.port',
+        'type': 'int',
+        'default': 4242,
+        'min': 0,
+        'max': 65535,
+        'required': 'Y',
+        'help': 'UDP port Nebula listens on.',
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+def _indent(n):
+    return ' ' * n
+
+
+# ---------------------------------------------------------------------------
+# Tests for render_model_fields
+# ---------------------------------------------------------------------------
+
+class TestRenderModelFields(unittest.TestCase):
+
+    def setUp(self):
+        self.out = gen_knobs.render_model_fields(SAMPLE_KNOBS)
+
+    # --- BooleanField ---
+
+    def test_bool_default_true(self):
+        self.assertIn('<punchy_punch type="BooleanField">', self.out)
+        self.assertIn('<Default>1</Default>', self.out)
+
+    def test_bool_default_false(self):
+        self.assertIn('<tun_disabled type="BooleanField">', self.out)
+        # Should contain <Default>0</Default> (note: punchy_punch has 1, tun_disabled has 0)
+        self.assertIn('<Default>0</Default>', self.out)
+
+    def test_bool_no_default_renders_zero(self):
+        # relay_am_relay has no default → should render 0
+        # Find the section for relay_am_relay
+        idx = self.out.find('<relay_am_relay type="BooleanField">')
+        self.assertGreater(idx, -1)
+        snippet = self.out[idx:idx + 200]
+        self.assertIn('<Default>0</Default>', snippet)
+
+    def test_bool_closing_tag(self):
+        self.assertIn('</punchy_punch>', self.out)
+
+    # --- IntegerField ---
+
+    def test_int_with_min_max_default(self):
+        idx = self.out.find('<pki_initiating_version type="IntegerField">')
+        self.assertGreater(idx, -1)
+        snippet = self.out[idx:idx + 300]
+        self.assertIn('<MinimumValue>1</MinimumValue>', snippet)
+        self.assertIn('<MaximumValue>2</MaximumValue>', snippet)
+        self.assertIn('<Default>1</Default>', snippet)
+        self.assertIn('</pki_initiating_version>', snippet)
+
+    def test_int_no_min_max(self):
+        idx = self.out.find('<routines type="IntegerField">')
+        self.assertGreater(idx, -1)
+        snippet = self.out[idx:idx + 200]
+        self.assertNotIn('<MinimumValue>', snippet.split('</routines>')[0])
+        self.assertNotIn('<MaximumValue>', snippet.split('</routines>')[0])
+        self.assertIn('<Default>1</Default>', snippet)
+
+    def test_int_no_default_no_min_max(self):
+        idx = self.out.find('<listen_read_buffer type="IntegerField">')
+        self.assertGreater(idx, -1)
+        snippet = self.out[idx:idx + 200]
+        # No Default, no Min/Max
+        self.assertNotIn('<Default>', snippet.split('</listen_read_buffer>')[0])
+        self.assertNotIn('<MinimumValue>', snippet.split('</listen_read_buffer>')[0])
+
+    def test_int_required(self):
+        idx = self.out.find('<listen_port type="IntegerField">')
+        self.assertGreater(idx, -1)
+        snippet = self.out[idx:idx + 300]
+        self.assertIn('<Required>Y</Required>', snippet)
+        self.assertIn('<MinimumValue>0</MinimumValue>', snippet)
+        self.assertIn('<MaximumValue>65535</MaximumValue>', snippet)
+
+    # --- OptionField ---
+
+    def test_enum_shape(self):
+        idx = self.out.find('<cipher type="OptionField">')
+        self.assertGreater(idx, -1)
+        snippet = self.out[idx:idx + 400]
+        self.assertIn('<Default>chachapoly</Default>', snippet)
+        self.assertIn('<OptionValues>', snippet)
+        self.assertIn('<chachapoly>chachapoly</chachapoly>', snippet)
+        self.assertIn('<aes>aes</aes>', snippet)
+        self.assertIn('</OptionValues>', snippet)
+        self.assertIn('</cipher>', snippet)
+
+    # --- TextField (duration) ---
+
+    def test_duration_with_default(self):
+        idx = self.out.find('<punchy_delay type="TextField">')
+        self.assertGreater(idx, -1)
+        snippet = self.out[idx:idx + 400]
+        self.assertIn('<Mask>/^\\d+(ns|us|µs|ms|s|m|h)$/</Mask>', snippet)
+        self.assertIn('<Default>1s</Default>', snippet)
+        self.assertIn('</punchy_delay>', snippet)
+
+    def test_duration_without_default(self):
+        idx = self.out.find('<tunnels_inactivity_timeout type="TextField">')
+        self.assertGreater(idx, -1)
+        snippet = self.out[idx:idx + 400]
+        self.assertIn('<Mask>/^\\d+(ns|us|µs|ms|s|m|h)$/</Mask>', snippet)
+        # No <Default> element when no default set
+        before_close = snippet.split('</tunnels_inactivity_timeout>')[0]
+        self.assertNotIn('<Default>', before_close)
+
+    # --- TextField (text) ---
+
+    def test_text_no_default(self):
+        idx = self.out.find('<logging_timestamp_format type="TextField">')
+        self.assertGreater(idx, -1)
+        snippet = self.out[idx:idx + 300]
+        before_close = snippet.split('</logging_timestamp_format>')[0]
+        self.assertNotIn('<Mask>', before_close)
+        self.assertNotIn('<Default>', before_close)
+
+    def test_text_with_default(self):
+        idx = self.out.find('<sshd_listen type="TextField">')
+        self.assertGreater(idx, -1)
+        snippet = self.out[idx:idx + 300]
+        self.assertIn('<Default>127.0.0.1:2222</Default>', snippet)
+
+    # --- HostnameField ---
+
+    def test_host_with_default(self):
+        idx = self.out.find('<listen_host type="HostnameField">')
+        self.assertGreater(idx, -1)
+        snippet = self.out[idx:idx + 300]
+        self.assertIn('<IpAllowed>Y</IpAllowed>', snippet)
+        self.assertIn('<Default>::</Default>', snippet)
+        self.assertIn('<Required>Y</Required>', snippet)
+        self.assertIn('</listen_host>', snippet)
+
+    def test_host_without_default(self):
+        idx = self.out.find('<lighthouse_dns_host type="HostnameField">')
+        self.assertGreater(idx, -1)
+        snippet = self.out[idx:idx + 300]
+        self.assertIn('<IpAllowed>Y</IpAllowed>', snippet)
+        before_close = snippet.split('</lighthouse_dns_host>')[0]
+        self.assertNotIn('<Default>', before_close)
+
+    # --- NetworkField ---
+
+    def test_cidr_with_default(self):
+        idx = self.out.find('<some_cidr type="NetworkField">')
+        self.assertGreater(idx, -1)
+        snippet = self.out[idx:idx + 300]
+        self.assertIn('<Default>10.0.0.0/8</Default>', snippet)
+        self.assertIn('</some_cidr>', snippet)
+
+    def test_cidr_without_default(self):
+        idx = self.out.find('<another_cidr type="NetworkField">')
+        self.assertGreater(idx, -1)
+        snippet = self.out[idx:idx + 300]
+        before_close = snippet.split('</another_cidr>')[0]
+        self.assertNotIn('<Default>', before_close)
+
+    # --- Indentation ---
+
+    def test_indentation_16_spaces(self):
+        for line in self.out.splitlines():
+            if not line.strip():
+                continue
+            # All non-empty lines must start with exactly 16 spaces (the field
+            # opening/closing tags) or more (children).
+            self.assertTrue(
+                line.startswith(' ' * 16),
+                f"Line not indented 16+ spaces: {repr(line)}"
+            )
+
+    # --- Determinism ---
+
+    def test_deterministic(self):
+        out1 = gen_knobs.render_model_fields(SAMPLE_KNOBS)
+        out2 = gen_knobs.render_model_fields(SAMPLE_KNOBS)
+        self.assertEqual(out1, out2)
+
+    # --- Order preservation ---
+
+    def test_order_preserved(self):
+        # punchy_punch should appear before cipher which should appear before listen_host
+        idx_punch = self.out.find('<punchy_punch')
+        idx_cipher = self.out.find('<cipher')
+        idx_listen = self.out.find('<listen_host')
+        self.assertLess(idx_punch, idx_cipher)
+        self.assertLess(idx_cipher, idx_listen)
+
+
+# ---------------------------------------------------------------------------
+# Tests for render_form_fields
+# ---------------------------------------------------------------------------
+
+class TestRenderFormFields(unittest.TestCase):
+
+    def setUp(self):
+        self.out = gen_knobs.render_form_fields(SAMPLE_KNOBS)
+
+    def test_bool_is_checkbox(self):
+        idx = self.out.find('<id>instance.punchy_punch</id>')
+        self.assertGreater(idx, -1)
+        snippet = self.out[idx:idx + 200]
+        self.assertIn('<type>checkbox</type>', snippet)
+
+    def test_enum_is_dropdown(self):
+        idx = self.out.find('<id>instance.cipher</id>')
+        self.assertGreater(idx, -1)
+        snippet = self.out[idx:idx + 200]
+        self.assertIn('<type>dropdown</type>', snippet)
+
+    def test_int_is_text(self):
+        idx = self.out.find('<id>instance.pki_initiating_version</id>')
+        self.assertGreater(idx, -1)
+        snippet = self.out[idx:idx + 200]
+        self.assertIn('<type>text</type>', snippet)
+
+    def test_host_is_text(self):
+        idx = self.out.find('<id>instance.listen_host</id>')
+        self.assertGreater(idx, -1)
+        snippet = self.out[idx:idx + 200]
+        self.assertIn('<type>text</type>', snippet)
+
+    def test_duration_is_text(self):
+        idx = self.out.find('<id>instance.punchy_delay</id>')
+        self.assertGreater(idx, -1)
+        snippet = self.out[idx:idx + 200]
+        self.assertIn('<type>text</type>', snippet)
+
+    def test_label_humanized(self):
+        # 'punchy_punch' -> 'Punchy Punch'
+        idx = self.out.find('<id>instance.punchy_punch</id>')
+        self.assertGreater(idx, -1)
+        snippet = self.out[idx:idx + 200]
+        self.assertIn('<label>Punchy Punch</label>', snippet)
+
+    def test_label_humanized_multi_word(self):
+        # 'pki_initiating_version' -> 'Pki Initiating Version'
+        idx = self.out.find('<id>instance.pki_initiating_version</id>')
+        self.assertGreater(idx, -1)
+        snippet = self.out[idx:idx + 200]
+        self.assertIn('<label>Pki Initiating Version</label>', snippet)
+
+    def test_help_present(self):
+        idx = self.out.find('<id>instance.punchy_punch</id>')
+        snippet = self.out[idx:idx + 300]
+        self.assertIn('<help>Send UDP hole-punching packets.</help>', snippet)
+
+    def test_xml_escape_in_help(self):
+        # The cipher help contains & lt in the form; let's use a knob with special chars
+        knobs_with_amp = [
+            {
+                'field': 'test_amp',
+                'yaml': 'test.amp',
+                'type': 'text',
+                'help': 'Use <foo> & "bar"',
+            }
+        ]
+        out = gen_knobs.render_form_fields(knobs_with_amp)
+        self.assertIn('&lt;foo&gt;', out)
+        self.assertIn('&amp;', out)
+        self.assertIn('&quot;', out)
+
+    def test_field_structure(self):
+        # Every field block should have <field>...</field>
+        self.assertIn('<field>', self.out)
+        self.assertIn('</field>', self.out)
+
+    def test_deterministic(self):
+        out1 = gen_knobs.render_form_fields(SAMPLE_KNOBS)
+        out2 = gen_knobs.render_form_fields(SAMPLE_KNOBS)
+        self.assertEqual(out1, out2)
+
+    def test_order_preserved(self):
+        idx_punch = self.out.find('<id>instance.punchy_punch</id>')
+        idx_cipher = self.out.find('<id>instance.cipher</id>')
+        idx_listen = self.out.find('<id>instance.listen_host</id>')
+        self.assertLess(idx_punch, idx_cipher)
+        self.assertLess(idx_cipher, idx_listen)
+
+    def test_no_header_when_section_absent(self):
+        # SAMPLE_KNOBS carry no 'section'; no header fields should be emitted.
+        self.assertNotIn('<type>header</type>', self.out)
+
+
+# ---------------------------------------------------------------------------
+# Tests for section headers in render_form_fields
+# ---------------------------------------------------------------------------
+
+SECTIONED_KNOBS = [
+    {'field': 'pki_a', 'yaml': 'pki.a', 'type': 'bool', 'default': 'false',
+     'section': 'PKI', 'help': 'a'},
+    {'field': 'pki_b', 'yaml': 'pki.b', 'type': 'int', 'default': 1,
+     'section': 'PKI', 'help': 'b'},
+    {'field': 'listen_a', 'yaml': 'listen.a', 'type': 'text',
+     'section': 'Listen', 'help': 'c'},
+]
+
+
+class TestSectionHeaders(unittest.TestCase):
+
+    def setUp(self):
+        self.out = gen_knobs.render_form_fields(SECTIONED_KNOBS)
+
+    def test_one_header_per_section(self):
+        self.assertEqual(self.out.count('<type>header</type>'), 2)
+
+    def test_header_label_present(self):
+        self.assertIn('<label>PKI</label>', self.out)
+        self.assertIn('<label>Listen</label>', self.out)
+
+    def test_header_precedes_first_field_of_section(self):
+        idx_pki_header = self.out.find('<label>PKI</label>')
+        idx_pki_a = self.out.find('<id>instance.pki_a</id>')
+        idx_listen_header = self.out.find('<label>Listen</label>')
+        idx_listen_a = self.out.find('<id>instance.listen_a</id>')
+        self.assertLess(idx_pki_header, idx_pki_a)
+        self.assertLess(idx_pki_a, idx_listen_header)
+        self.assertLess(idx_listen_header, idx_listen_a)
+
+    def test_header_not_repeated_within_section(self):
+        # Only one PKI header even though PKI has two knobs.
+        self.assertEqual(self.out.count('<label>PKI</label>'), 1)
+
+    def test_header_xml_escaped(self):
+        knobs = [{'field': 'x', 'yaml': 'x', 'type': 'text',
+                  'section': 'A & B', 'help': 'h'}]
+        out = gen_knobs.render_form_fields(knobs)
+        self.assertIn('<label>A &amp; B</label>', out)
+
+    def test_all_advanced_section_header_is_advanced(self):
+        # A section whose every knob is advanced gets an advanced header, so the
+        # whole section hides when Advanced mode is off (no bare header row).
+        knobs = [
+            {'field': 'a', 'yaml': 'a', 'type': 'text', 'section': 'AdvOnly',
+             'advanced': True},
+            {'field': 'b', 'yaml': 'b', 'type': 'text', 'section': 'AdvOnly',
+             'advanced': True},
+        ]
+        out = gen_knobs.render_form_fields(knobs)
+        idx_header = out.find('<label>AdvOnly</label>')
+        # The <advanced>true</advanced> must sit inside the header field block.
+        snippet = out[idx_header:idx_header + 80]
+        self.assertIn('<advanced>true</advanced>', snippet)
+
+    def test_mixed_section_header_not_advanced(self):
+        # A section with at least one non-advanced knob keeps a visible header.
+        knobs = [
+            {'field': 'a', 'yaml': 'a', 'type': 'text', 'section': 'Mixed'},
+            {'field': 'b', 'yaml': 'b', 'type': 'text', 'section': 'Mixed',
+             'advanced': True},
+        ]
+        out = gen_knobs.render_form_fields(knobs)
+        idx_header = out.find('<label>Mixed</label>')
+        snippet = out[idx_header:idx_header + 80]
+        self.assertNotIn('<advanced>true</advanced>', snippet)
+
+    def test_non_contiguous_section_raises(self):
+        knobs = [
+            {'field': 'a', 'yaml': 'a', 'type': 'text', 'section': 'PKI'},
+            {'field': 'b', 'yaml': 'b', 'type': 'text', 'section': 'Listen'},
+            {'field': 'c', 'yaml': 'c', 'type': 'text', 'section': 'PKI'},
+        ]
+        with self.assertRaises(ValueError):
+            gen_knobs.render_form_fields(knobs)
+
+
+# ---------------------------------------------------------------------------
+# Tests for render_config_map
+# ---------------------------------------------------------------------------
+
+class TestRenderConfigMap(unittest.TestCase):
+
+    def setUp(self):
+        self.out = gen_knobs.render_config_map(SAMPLE_KNOBS)
+
+    def test_php_opening_tag(self):
+        self.assertTrue(self.out.startswith('<?php'))
+
+    def test_copyright_header(self):
+        self.assertIn('Copyright', self.out)
+        self.assertIn('BSD', self.out.upper().replace('REDISTRIBUTION', 'BSD'))
+        # Just verify it has the standard license boilerplate keywords
+        self.assertIn('Redistribution and use in source and binary forms', self.out)
+
+    def test_generated_comment(self):
+        self.assertIn('GENERATED from knobs.yaml by tools/gen_knobs.py', self.out)
+        self.assertIn('do not edit by hand', self.out)
+
+    def test_return_array(self):
+        self.assertIn('return [', self.out)
+        self.assertIn('];', self.out)
+
+    def test_entry_shape(self):
+        # Each entry: 'field' => ['yaml' => 'yaml.path', 'type' => 'type'],
+        self.assertIn("'punchy_punch' => ['yaml' => 'punchy.punch', 'type' => 'bool']", self.out)
+
+    def test_entry_enum(self):
+        self.assertIn("'cipher' => ['yaml' => 'cipher', 'type' => 'enum']", self.out)
+
+    def test_entry_host(self):
+        self.assertIn("'listen_host' => ['yaml' => 'listen.host', 'type' => 'host']", self.out)
+
+    def test_all_knobs_present(self):
+        for k in SAMPLE_KNOBS:
+            self.assertIn(f"'{k['field']}' =>", self.out)
+
+    def test_order_preserved(self):
+        idx_punch = self.out.find("'punchy_punch'")
+        idx_cipher = self.out.find("'cipher'")
+        idx_listen = self.out.find("'listen_host'")
+        self.assertLess(idx_punch, idx_cipher)
+        self.assertLess(idx_cipher, idx_listen)
+
+    def test_deterministic(self):
+        out1 = gen_knobs.render_config_map(SAMPLE_KNOBS)
+        out2 = gen_knobs.render_config_map(SAMPLE_KNOBS)
+        self.assertEqual(out1, out2)
+
+
+# ---------------------------------------------------------------------------
+# Tests for list type — render_model_fields
+# ---------------------------------------------------------------------------
+
+class TestListTypeModelField(unittest.TestCase):
+    """render_model_fields must emit a CSVListField (no Mask) for list knobs."""
+
+    def setUp(self):
+        self.out = gen_knobs.render_model_fields([LIST_KNOB])
+
+    def test_list_model_opens_as_csvlistfield(self):
+        self.assertIn('<lighthouse_hosts type="CSVListField">', self.out)
+
+    def test_list_model_has_no_mask(self):
+        self.assertNotIn('<Mask>', self.out)
+
+    def test_list_model_closes_tag(self):
+        self.assertIn('</lighthouse_hosts>', self.out)
+
+    def test_list_model_indented_16_spaces(self):
+        for line in self.out.splitlines():
+            if not line.strip():
+                continue
+            self.assertTrue(
+                line.startswith(' ' * 16),
+                f"Line not indented 16+ spaces: {repr(line)}"
+            )
+
+    def test_list_model_deterministic(self):
+        self.assertEqual(
+            gen_knobs.render_model_fields([LIST_KNOB]),
+            gen_knobs.render_model_fields([LIST_KNOB]),
+        )
+
+    def test_existing_types_unchanged(self):
+        """Adding list knob after existing knobs must not alter existing output."""
+        baseline = gen_knobs.render_model_fields(SAMPLE_KNOBS)
+        combined = gen_knobs.render_model_fields(SAMPLE_KNOBS + [LIST_KNOB])
+        self.assertTrue(combined.startswith(baseline.rstrip('\n')))
+
+
+# ---------------------------------------------------------------------------
+# Tests for list type — render_form_fields
+# ---------------------------------------------------------------------------
+
+class TestListTypeFormField(unittest.TestCase):
+    """render_form_fields must emit a tokenize select_multiple for list knobs."""
+
+    def setUp(self):
+        self.out = gen_knobs.render_form_fields([LIST_KNOB])
+
+    def test_list_form_id(self):
+        self.assertIn('<id>instance.lighthouse_hosts</id>', self.out)
+
+    def test_list_form_type_is_tokenize_multiselect(self):
+        idx = self.out.find('<id>instance.lighthouse_hosts</id>')
+        self.assertGreater(idx, -1)
+        snippet = self.out[idx:idx + 300]
+        self.assertIn('<type>select_multiple</type>', snippet)
+        self.assertIn('<style>tokenize</style>', snippet)
+        self.assertIn('<allownew>true</allownew>', snippet)
+
+    def test_list_form_label_humanized(self):
+        # 'lighthouse_hosts' -> 'Lighthouse Hosts'
+        idx = self.out.find('<id>instance.lighthouse_hosts</id>')
+        self.assertGreater(idx, -1)
+        snippet = self.out[idx:idx + 300]
+        self.assertIn('<label>Lighthouse Hosts</label>', snippet)
+
+    def test_list_form_help_present(self):
+        self.assertIn('<help>IP:port of each lighthouse node.</help>', self.out)
+
+    def test_list_form_field_wrapper(self):
+        self.assertIn('<field>', self.out)
+        self.assertIn('</field>', self.out)
+
+    def test_list_form_deterministic(self):
+        self.assertEqual(
+            gen_knobs.render_form_fields([LIST_KNOB]),
+            gen_knobs.render_form_fields([LIST_KNOB]),
+        )
+
+    def test_existing_types_unchanged(self):
+        """list type must not affect the output for other knob types."""
+        baseline = gen_knobs.render_form_fields(SAMPLE_KNOBS)
+        combined = gen_knobs.render_form_fields(SAMPLE_KNOBS + [LIST_KNOB])
+        self.assertTrue(combined.startswith(baseline.rstrip('\n')))
+
+
+# ---------------------------------------------------------------------------
+# Tests for list type — render_config_map
+# ---------------------------------------------------------------------------
+
+class TestListTypeConfigMap(unittest.TestCase):
+    """render_config_map must emit 'type' => 'list' for list knobs."""
+
+    def setUp(self):
+        self.out = gen_knobs.render_config_map([LIST_KNOB])
+
+    def test_list_config_map_entry(self):
+        self.assertIn(
+            "'lighthouse_hosts' => ['yaml' => 'lighthouse.hosts', 'type' => 'list'],",
+            self.out,
+        )
+
+    def test_list_config_map_deterministic(self):
+        self.assertEqual(
+            gen_knobs.render_config_map([LIST_KNOB]),
+            gen_knobs.render_config_map([LIST_KNOB]),
+        )
+
+    def test_existing_types_unchanged(self):
+        """list entry must not change any existing entry in the map."""
+        baseline = gen_knobs.render_config_map(SAMPLE_KNOBS)
+        combined = gen_knobs.render_config_map(SAMPLE_KNOBS + [LIST_KNOB])
+        # Every line from baseline (except the closing '];') must appear in combined.
+        for line in baseline.splitlines():
+            if line.strip() in ('', '];'):
+                continue
+            self.assertIn(line, combined, f"Existing line missing from combined output: {line!r}")
+
+
+# ---------------------------------------------------------------------------
+# Tests for replace_between_markers
+# ---------------------------------------------------------------------------
+
+class TestReplaceBetweenMarkers(unittest.TestCase):
+
+    START = '<!-- GENERATED:instance-fields START -->'
+    END = '<!-- GENERATED:instance-fields END -->'
+
+    def _make(self, inner='old content\n'):
+        return f'before\n{self.START}\n{inner}{self.END}\nafter\n'
+
+    def test_basic_replacement(self):
+        text = self._make('old content\n')
+        result = gen_knobs.replace_between_markers(text, self.START, self.END, 'new content\n')
+        self.assertIn('before', result)
+        self.assertIn('after', result)
+        self.assertIn(self.START, result)
+        self.assertIn(self.END, result)
+        self.assertIn('new content', result)
+        self.assertNotIn('old content', result)
+
+    def test_preserves_outside_content(self):
+        text = self._make('middle\n')
+        result = gen_knobs.replace_between_markers(text, self.START, self.END, 'replaced\n')
+        self.assertTrue(result.startswith('before\n'))
+        self.assertTrue(result.endswith('after\n'))
+
+    def test_empty_payload(self):
+        text = self._make('old\n')
+        result = gen_knobs.replace_between_markers(text, self.START, self.END, '')
+        self.assertNotIn('old', result)
+        self.assertIn(self.START, result)
+        self.assertIn(self.END, result)
+
+    def test_missing_start_marker_raises(self):
+        text = f'no markers here\n{self.END}\n'
+        with self.assertRaises(ValueError) as ctx:
+            gen_knobs.replace_between_markers(text, self.START, self.END, 'x')
+        self.assertIn('START', str(ctx.exception).upper())
+
+    def test_missing_end_marker_raises(self):
+        text = f'{self.START}\nno end\n'
+        with self.assertRaises(ValueError) as ctx:
+            gen_knobs.replace_between_markers(text, self.START, self.END, 'x')
+        self.assertIn('END', str(ctx.exception).upper())
+
+    def test_both_markers_missing_raises(self):
+        with self.assertRaises(ValueError):
+            gen_knobs.replace_between_markers('no markers', self.START, self.END, 'x')
+
+    def test_result_has_newline_after_start_marker(self):
+        text = self._make('old\n')
+        result = gen_knobs.replace_between_markers(text, self.START, self.END, 'new\n')
+        # The payload should appear right after the start marker (with a newline)
+        after_start = result.split(self.START)[1]
+        self.assertTrue(after_start.startswith('\n'))
+
+    def test_deterministic(self):
+        text = self._make('old\n')
+        r1 = gen_knobs.replace_between_markers(text, self.START, self.END, 'new\n')
+        r2 = gen_knobs.replace_between_markers(text, self.START, self.END, 'new\n')
+        self.assertEqual(r1, r2)
+
+
+# ---------------------------------------------------------------------------
+# Integration: load_knobs reads the real knobs.yaml
+# ---------------------------------------------------------------------------
+
+class TestLoadKnobs(unittest.TestCase):
+
+    def test_load_knobs_returns_list(self):
+        knobs = gen_knobs.load_knobs()
+        self.assertIsInstance(knobs, list)
+        self.assertGreater(len(knobs), 0)
+
+    def test_load_knobs_has_required_keys(self):
+        for k in gen_knobs.load_knobs():
+            self.assertIn('field', k)
+            self.assertIn('yaml', k)
+            self.assertIn('type', k)
+            self.assertIn('help', k)
+
+    def test_load_knobs_count(self):
+        # knobs.yaml has 52 scalar knobs per the task spec
+        knobs = gen_knobs.load_knobs()
+        self.assertGreaterEqual(len(knobs), 50)
+
+    def test_full_render_model_fields_no_crash(self):
+        knobs = gen_knobs.load_knobs()
+        out = gen_knobs.render_model_fields(knobs)
+        self.assertIsInstance(out, str)
+        self.assertGreater(len(out), 0)
+
+    def test_full_render_form_fields_no_crash(self):
+        knobs = gen_knobs.load_knobs()
+        out = gen_knobs.render_form_fields(knobs)
+        self.assertIsInstance(out, str)
+
+    def test_full_render_config_map_no_crash(self):
+        knobs = gen_knobs.load_knobs()
+        out = gen_knobs.render_config_map(knobs)
+        self.assertIsInstance(out, str)
+        self.assertTrue(out.startswith('<?php'))
+
+
+# ---------------------------------------------------------------------------
+# CLI --check test against a temp fixture
+# ---------------------------------------------------------------------------
+
+class TestCLICheck(unittest.TestCase):
+    """Test the --check mode against a temp directory with fixture files."""
+
+    def setUp(self):
+        import tempfile
+        import shutil
+        # Build a temporary directory tree that mirrors the real layout.
+        self.tmpdir = tempfile.mkdtemp()
+        # We need:
+        #   <tmpdir>/knobs.yaml          (symlink or copy of real one)
+        #   <tmpdir>/src/opnsense/mvc/app/models/OPNsense/Nebula/Nebula.xml
+        #   <tmpdir>/src/opnsense/mvc/app/controllers/OPNsense/Nebula/forms/dialogInstance.xml
+        #   <tmpdir>/src/opnsense/mvc/app/models/OPNsense/Nebula/ConfigMap.php
+
+        START = '<!-- GENERATED:instance-fields START -->'
+        END = '<!-- GENERATED:instance-fields END -->'
+
+        knobs = gen_knobs.load_knobs()
+        model_payload = gen_knobs.render_model_fields(knobs)
+        form_payload = gen_knobs.render_form_fields(knobs)
+        config_map = gen_knobs.render_config_map(knobs)
+
+        model_dir = os.path.join(self.tmpdir, 'src', 'opnsense', 'mvc', 'app',
+                                 'models', 'OPNsense', 'Nebula')
+        form_dir = os.path.join(self.tmpdir, 'src', 'opnsense', 'mvc', 'app',
+                                'controllers', 'OPNsense', 'Nebula', 'forms')
+        os.makedirs(model_dir, exist_ok=True)
+        os.makedirs(form_dir, exist_ok=True)
+
+        # Write Nebula.xml with markers + current payload (so --check passes)
+        model_xml = f'<model>\n{START}\n{model_payload}{END}\n</model>\n'
+        with open(os.path.join(model_dir, 'Nebula.xml'), 'w') as f:
+            f.write(model_xml)
+
+        # Write dialogInstance.xml — single GENERATED region.
+        form_xml = f'<form>\n{START}\n{form_payload}{END}\n</form>\n'
+        with open(os.path.join(form_dir, 'dialogInstance.xml'), 'w') as f:
+            f.write(form_xml)
+
+        # Write ConfigMap.php
+        with open(os.path.join(model_dir, 'ConfigMap.php'), 'w') as f:
+            f.write(config_map)
+
+        # Copy knobs.yaml
+        real_knobs = os.path.join(os.path.dirname(__file__), '..', 'knobs.yaml')
+        shutil.copy(real_knobs, os.path.join(self.tmpdir, 'knobs.yaml'))
+
+        self.model_dir = model_dir
+        self.form_dir = form_dir
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_check_passes_when_in_sync(self):
+        """--check should exit 0 when all artifacts match."""
+        import subprocess
+        result = subprocess.run(
+            [sys.executable, __file__.replace('_test', ''), '--check',
+             '--root', self.tmpdir],
+            capture_output=True, text=True
+        )
+        self.assertEqual(result.returncode, 0,
+                         f"stdout: {result.stdout}\nstderr: {result.stderr}")
+
+    def test_check_fails_when_out_of_sync(self):
+        """--check should exit 1 when ConfigMap.php is stale."""
+        config_map_path = os.path.join(self.model_dir, 'ConfigMap.php')
+        with open(config_map_path, 'w') as f:
+            f.write('<?php\n// stale\n')
+        import subprocess
+        result = subprocess.run(
+            [sys.executable, __file__.replace('_test', ''), '--check',
+             '--root', self.tmpdir],
+            capture_output=True, text=True
+        )
+        self.assertNotEqual(result.returncode, 0)
+
+
+# ---------------------------------------------------------------------------
+# Tests for label / grid / advanced support in render_form_fields
+# ---------------------------------------------------------------------------
+
+# A knob that exercises all three new optional attributes at once.
+FULL_ATTRS_KNOB = {
+    'field': 'listen_port',
+    'yaml': 'listen.port',
+    'type': 'int',
+    'default': 4242,
+    'min': 0,
+    'max': 65535,
+    'required': 'Y',
+    'help': 'UDP port Nebula listens on.',
+    'label': 'Listen Port',
+    'grid': 4,
+    'advanced': True,
+}
+
+# A knob with none of the three new keys — must produce identical output to the
+# existing SAMPLE_KNOBS entry for listen_port.
+PLAIN_KNOB = {
+    'field': 'listen_port',
+    'yaml': 'listen.port',
+    'type': 'int',
+    'default': 4242,
+    'min': 0,
+    'max': 65535,
+    'required': 'Y',
+    'help': 'UDP port Nebula listens on.',
+}
+
+
+class TestFormFieldLabelGridAdvanced(unittest.TestCase):
+    """render_form_fields: label / grid / advanced optional-attribute support."""
+
+    def _snippet(self, knob: dict) -> str:
+        """Render a single knob's form field and return the full output."""
+        return gen_knobs.render_form_fields([knob])
+
+    # --- explicit label ---
+
+    def test_explicit_label_used(self):
+        out = self._snippet(FULL_ATTRS_KNOB)
+        self.assertIn('<label>Listen Port</label>', out)
+
+    def test_explicit_label_not_humanized(self):
+        """When label is supplied, the humanized fallback must NOT appear instead."""
+        out = self._snippet(FULL_ATTRS_KNOB)
+        # humanized version would be 'Listen Port' too in this case, so use a
+        # knob where they differ.
+        knob = dict(FULL_ATTRS_KNOB, field='listen_port', label='My Custom Label')
+        out2 = gen_knobs.render_form_fields([knob])
+        self.assertIn('<label>My Custom Label</label>', out2)
+
+    def test_no_label_key_humanizes(self):
+        out = self._snippet(PLAIN_KNOB)
+        # 'listen_port' → 'Listen Port'
+        self.assertIn('<label>Listen Port</label>', out)
+
+    # --- advanced ---
+
+    def test_advanced_true_emits_element(self):
+        out = self._snippet(FULL_ATTRS_KNOB)
+        self.assertIn('<advanced>true</advanced>', out)
+
+    def test_advanced_absent_no_element(self):
+        out = self._snippet(PLAIN_KNOB)
+        self.assertNotIn('<advanced>', out)
+
+    def test_advanced_false_no_element(self):
+        knob = dict(PLAIN_KNOB, advanced=False)
+        out = self._snippet(knob)
+        self.assertNotIn('<advanced>', out)
+
+    # --- grid ---
+
+    def test_grid_emits_grid_view_sequence(self):
+        out = self._snippet(FULL_ATTRS_KNOB)
+        self.assertIn('<grid_view>', out)
+        self.assertIn('<sequence>4</sequence>', out)
+        self.assertIn('</grid_view>', out)
+
+    def test_grid_absent_emits_ignore(self):
+        """A knob without 'grid' must emit <grid_view><ignore>true</ignore></grid_view>."""
+        out = self._snippet(PLAIN_KNOB)
+        self.assertIn('<grid_view>', out)
+        self.assertIn('<ignore>true</ignore>', out)
+        self.assertNotIn('<sequence>', out)
+
+    def test_grid_different_values(self):
+        knob = dict(PLAIN_KNOB, grid=1)
+        out = self._snippet(knob)
+        self.assertIn('<sequence>1</sequence>', out)
+        knob2 = dict(PLAIN_KNOB, grid=99)
+        out2 = self._snippet(knob2)
+        self.assertIn('<sequence>99</sequence>', out2)
+
+    # --- element ordering: id, label, type, [advanced], help, [grid_view] ---
+
+    def test_ordering_full_attrs(self):
+        out = self._snippet(FULL_ATTRS_KNOB)
+        idx_id = out.find('<id>instance.listen_port</id>')
+        idx_label = out.find('<label>Listen Port</label>')
+        idx_type = out.find('<type>text</type>')
+        idx_advanced = out.find('<advanced>true</advanced>')
+        idx_help = out.find('<help>')
+        idx_grid = out.find('<grid_view>')
+        self.assertLess(idx_id, idx_label, 'id must come before label')
+        self.assertLess(idx_label, idx_type, 'label must come before type')
+        self.assertLess(idx_type, idx_advanced, 'type must come before advanced')
+        self.assertLess(idx_advanced, idx_help, 'advanced must come before help')
+        self.assertLess(idx_help, idx_grid, 'help must come before grid_view')
+
+    def test_ordering_no_advanced(self):
+        """Without advanced, order is: id, label, type, help, grid_view (ignore)."""
+        out = self._snippet(PLAIN_KNOB)
+        idx_id = out.find('<id>instance.listen_port</id>')
+        idx_label = out.find('<label>Listen Port</label>')
+        idx_type = out.find('<type>text</type>')
+        idx_help = out.find('<help>')
+        idx_grid = out.find('<grid_view>')
+        self.assertLess(idx_id, idx_label)
+        self.assertLess(idx_label, idx_type)
+        self.assertLess(idx_type, idx_help)
+        self.assertLess(idx_help, idx_grid)
+
+    # --- backward-compatibility: SAMPLE_KNOBS output must be byte-identical ---
+
+    def test_sample_knobs_output_unchanged(self):
+        """New keys must not affect knobs that have none of them."""
+        baseline = gen_knobs.render_form_fields(SAMPLE_KNOBS)
+        # None of SAMPLE_KNOBS has label/grid/advanced, so re-rendering must
+        # produce the exact same string.
+        self.assertEqual(baseline, gen_knobs.render_form_fields(SAMPLE_KNOBS))
+
+    def test_plain_knob_has_no_advanced_and_has_ignore_grid(self):
+        """A knob without label/grid/advanced must have no <advanced> but must
+        have <grid_view><ignore>true</ignore></grid_view> (never a column)."""
+        out = self._snippet(PLAIN_KNOB)
+        self.assertNotIn('<advanced>', out)
+        self.assertIn('<grid_view>', out)
+        self.assertIn('<ignore>true</ignore>', out)
+        self.assertNotIn('<sequence>', out)
+
+    # --- model + config_map unaffected by new keys ---
+
+    def test_model_field_unchanged_with_new_keys(self):
+        """render_model_fields must produce identical output whether or not the
+        new optional keys are present."""
+        baseline = gen_knobs.render_model_fields([PLAIN_KNOB])
+        with_extras = gen_knobs.render_model_fields([FULL_ATTRS_KNOB])
+        self.assertEqual(baseline, with_extras)
+
+    def test_config_map_unchanged_with_new_keys(self):
+        """render_config_map must produce identical output for plain vs annotated."""
+        baseline = gen_knobs.render_config_map([PLAIN_KNOB])
+        with_extras = gen_knobs.render_config_map([FULL_ATTRS_KNOB])
+        self.assertEqual(baseline, with_extras)
+
+    # --- determinism ---
+
+    def test_deterministic(self):
+        out1 = self._snippet(FULL_ATTRS_KNOB)
+        out2 = self._snippet(FULL_ATTRS_KNOB)
+        self.assertEqual(out1, out2)
+
+
+# ---------------------------------------------------------------------------
+# Tests for grid_width and bool boolean-formatter support in render_form_fields
+# ---------------------------------------------------------------------------
+
+class TestGridWidthAndBoolFormatter(unittest.TestCase):
+    """render_form_fields: grid_width emits <width>; bool grid knobs get
+    <type>boolean</type><formatter>boolean</formatter>."""
+
+    def _render(self, knob: dict) -> str:
+        return gen_knobs.render_form_fields([knob])
+
+    # --- bool knob with grid + grid_width ---
+
+    def test_bool_grid_emits_width(self):
+        knob = {
+            'field': 'am_lighthouse',
+            'yaml': 'lighthouse.am_lighthouse',
+            'type': 'bool',
+            'default': 'false',
+            'label': 'Lighthouse',
+            'grid': 4,
+            'grid_width': '6em',
+            'help': 'Is a lighthouse.',
+        }
+        out = self._render(knob)
+        self.assertIn('<width>6em</width>', out)
+
+    def test_bool_grid_emits_type_boolean(self):
+        knob = {
+            'field': 'am_lighthouse',
+            'yaml': 'lighthouse.am_lighthouse',
+            'type': 'bool',
+            'default': 'false',
+            'label': 'Lighthouse',
+            'grid': 4,
+            'grid_width': '6em',
+            'help': 'Is a lighthouse.',
+        }
+        out = self._render(knob)
+        self.assertIn('<type>boolean</type>', out)
+
+    def test_bool_grid_emits_formatter_boolean(self):
+        knob = {
+            'field': 'am_lighthouse',
+            'yaml': 'lighthouse.am_lighthouse',
+            'type': 'bool',
+            'default': 'false',
+            'label': 'Lighthouse',
+            'grid': 4,
+            'grid_width': '6em',
+            'help': 'Is a lighthouse.',
+        }
+        out = self._render(knob)
+        self.assertIn('<formatter>boolean</formatter>', out)
+
+    def test_bool_grid_emits_sequence(self):
+        knob = {
+            'field': 'am_lighthouse',
+            'yaml': 'lighthouse.am_lighthouse',
+            'type': 'bool',
+            'default': 'false',
+            'label': 'Lighthouse',
+            'grid': 4,
+            'grid_width': '6em',
+            'help': 'Is a lighthouse.',
+        }
+        out = self._render(knob)
+        self.assertIn('<sequence>4</sequence>', out)
+
+    def test_bool_grid_order_width_type_formatter_sequence(self):
+        """Inside <grid_view>: width, type, formatter, sequence."""
+        knob = {
+            'field': 'am_lighthouse',
+            'yaml': 'lighthouse.am_lighthouse',
+            'type': 'bool',
+            'default': 'false',
+            'label': 'Lighthouse',
+            'grid': 4,
+            'grid_width': '6em',
+            'help': 'Is a lighthouse.',
+        }
+        out = self._render(knob)
+        gv_start = out.find('<grid_view>')
+        gv_end = out.find('</grid_view>')
+        gv_block = out[gv_start:gv_end]
+        idx_width = gv_block.find('<width>')
+        idx_type = gv_block.find('<type>boolean</type>')
+        idx_fmt = gv_block.find('<formatter>boolean</formatter>')
+        idx_seq = gv_block.find('<sequence>')
+        self.assertLess(idx_width, idx_type, 'width before type')
+        self.assertLess(idx_type, idx_fmt, 'type before formatter')
+        self.assertLess(idx_fmt, idx_seq, 'formatter before sequence')
+
+    # --- text knob with grid + grid_width (no boolean formatter) ---
+
+    def test_text_grid_width_emitted(self):
+        knob = {
+            'field': 'tun_name',
+            'yaml': 'tun.dev',
+            'type': 'text',
+            'label': 'Interface',
+            'grid': 2,
+            'grid_width': '10em',
+            'help': 'Tunnel device name.',
+        }
+        out = self._render(knob)
+        self.assertIn('<width>10em</width>', out)
+
+    def test_text_grid_no_boolean_formatter(self):
+        knob = {
+            'field': 'tun_name',
+            'yaml': 'tun.dev',
+            'type': 'text',
+            'label': 'Interface',
+            'grid': 2,
+            'grid_width': '10em',
+            'help': 'Tunnel device name.',
+        }
+        out = self._render(knob)
+        self.assertNotIn('<formatter>', out)
+        self.assertNotIn('<type>boolean</type>', out)
+
+    def test_text_grid_has_sequence(self):
+        knob = {
+            'field': 'tun_name',
+            'yaml': 'tun.dev',
+            'type': 'text',
+            'label': 'Interface',
+            'grid': 2,
+            'grid_width': '10em',
+            'help': 'Tunnel device name.',
+        }
+        out = self._render(knob)
+        self.assertIn('<sequence>2</sequence>', out)
+
+    def test_text_grid_order_width_sequence(self):
+        """For a text knob: width before sequence, no type/formatter."""
+        knob = {
+            'field': 'tun_name',
+            'yaml': 'tun.dev',
+            'type': 'text',
+            'label': 'Interface',
+            'grid': 2,
+            'grid_width': '10em',
+            'help': 'Tunnel device name.',
+        }
+        out = self._render(knob)
+        gv_start = out.find('<grid_view>')
+        gv_end = out.find('</grid_view>')
+        gv_block = out[gv_start:gv_end]
+        idx_width = gv_block.find('<width>')
+        idx_seq = gv_block.find('<sequence>')
+        self.assertGreater(idx_width, -1)
+        self.assertGreater(idx_seq, -1)
+        self.assertLess(idx_width, idx_seq, 'width before sequence')
+
+    # --- grid knob without grid_width: no <width> emitted ---
+
+    def test_grid_no_width_no_width_element(self):
+        knob = {
+            'field': 'listen_port',
+            'yaml': 'listen.port',
+            'type': 'int',
+            'default': 4242,
+            'label': 'Listen port',
+            'grid': 5,
+            'help': 'Port.',
+        }
+        out = self._render(knob)
+        self.assertNotIn('<width>', out)
+        self.assertIn('<sequence>5</sequence>', out)
+
+    # --- bool knob WITHOUT grid: still no type/formatter emitted ---
+
+    def test_bool_no_grid_no_formatter(self):
+        knob = {
+            'field': 'punchy_punch',
+            'yaml': 'punchy.punch',
+            'type': 'bool',
+            'default': 'true',
+            'help': 'Punch.',
+        }
+        out = self._render(knob)
+        self.assertNotIn('<formatter>', out)
+        self.assertNotIn('<type>boolean</type>', out)
+        self.assertIn('<ignore>true</ignore>', out)
+
+    # --- backward compat: SAMPLE_KNOBS (none have grid_width) unchanged ---
+
+    def test_sample_knobs_no_width_elements(self):
+        """SAMPLE_KNOBS have no grid_width, so no <width> should appear."""
+        out = gen_knobs.render_form_fields(SAMPLE_KNOBS)
+        self.assertNotIn('<width>', out)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/net/nebula/tools/nebula_config_reference.yaml
+++ b/net/nebula/tools/nebula_config_reference.yaml
@@ -1,0 +1,212 @@
+---
+# nebula_config_reference.yaml — canonical Nebula configuration key registry.
+#
+# This is the upstream source of truth the plugin's knobs are audited against.
+# It enumerates EVERY configuration key Nebula accepts and records exactly how
+# this plugin exposes (or deliberately does not expose) each one.
+#
+#   source:  https://github.com/slackhq/nebula  examples/config.yml
+#   blob:    6c7fb489cd9d11143bfe4705bb620d90a9056b60
+#   commit:  b041f306cb2ee8177dfcb9ed8e7f31e6e7fe6564
+#   target:  Nebula 1.10.x (the release line packaged in FreeBSD ports / OPNsense)
+#
+# `all` is the complete leaf-key set for the targeted release, reconciled from
+# examples/config.yml and the versioned docs at https://nebula.defined.net/docs/config/.
+# Granularity matches how the plugin handles a key: scalar settings are listed at
+# their leaf (e.g. firewall.conntrack.tcp_timeout); list/map blocks are listed by
+# their top key (e.g. stats, tun.unsafe_routes).
+#
+# tools/audit_knobs.py enforces, on every run / in CI:
+#   * every key in `all` is either a generated knob (knobs.yaml) or classified
+#     below — an unclassified upstream key fails the audit;
+#   * every knob's yaml path exists in `all` — a knob for a non-existent /
+#     removed upstream key fails the audit;
+#   * classification and knob membership do not overlap (except deprecated
+#     entries explicitly marked `retained: true`).
+#
+# WHEN BUMPING NEBULA: re-diff examples/config.yml against `all`, update this file
+# and the blob/commit/target above, then run `python3 tools/audit_knobs.py`.
+#
+# Deprecation policy: a key that upstream deprecates is removed from the UI and
+# moved to `deprecated` below. If existing stored configs still carry the field
+# (created under an earlier plugin version), keep its knob in knobs.yaml, mark the
+# entry `retained: true`, and surface a deprecation warning in the field help so
+# the value still round-trips until the user migrates. Non-retained deprecated
+# keys must have no knob.
+
+# ---------------------------------------------------------------------------
+# Complete upstream leaf-key set (targeted release). Every entry must be
+# accounted for by a knob or a classification list below.
+# ---------------------------------------------------------------------------
+all:
+  # pki
+  - pki.ca
+  - pki.cert
+  - pki.key
+  - pki.blocklist
+  - pki.disconnect_invalid
+  - pki.initiating_version
+  # static_host_map
+  - static_host_map
+  # static_map
+  - static_map.cadence
+  - static_map.network
+  - static_map.lookup_timeout
+  # lighthouse
+  - lighthouse.am_lighthouse
+  - lighthouse.serve_dns
+  - lighthouse.dns.host
+  - lighthouse.dns.port
+  - lighthouse.interval
+  - lighthouse.hosts
+  - lighthouse.remote_allow_list
+  - lighthouse.remote_allow_ranges
+  - lighthouse.local_allow_list
+  - lighthouse.advertise_addrs
+  - lighthouse.calculated_remotes
+  # listen
+  - listen.host
+  - listen.port
+  - listen.batch
+  - listen.read_buffer
+  - listen.write_buffer
+  - listen.windows_bypass_wdf
+  - listen.send_recv_error
+  - listen.accept_recv_error
+  - listen.so_mark
+  # routines
+  - routines
+  # punchy
+  - punchy.punch
+  - punchy.respond
+  - punchy.delay
+  - punchy.respond_delay
+  # cipher
+  - cipher
+  # preferred_ranges
+  - preferred_ranges
+  # sshd
+  - sshd.enabled
+  - sshd.listen
+  - sshd.host_key
+  - sshd.authorized_users
+  - sshd.trusted_cas
+  - sshd.sandbox_dir
+  # relay
+  - relay.relays
+  - relay.am_relay
+  - relay.use_relays
+  # tun
+  - tun.disabled
+  - tun.dev
+  - tun.drop_local_broadcast
+  - tun.drop_multicast
+  - tun.tx_queue
+  - tun.mtu
+  - tun.routes
+  - tun.unsafe_routes
+  - tun.network_category
+  - tun.windows_bypass_wdf
+  - tun.use_system_route_table
+  - tun.use_system_route_table_buffer_size
+  # logging
+  - logging.level
+  - logging.format
+  - logging.disable_timestamp
+  - logging.timestamp_format
+  # stats
+  - stats
+  # handshakes
+  - handshakes.try_interval
+  - handshakes.retries
+  - handshakes.query_buffer
+  - handshakes.trigger_buffer
+  # tunnels
+  - tunnels.drop_inactive
+  - tunnels.inactivity_timeout
+  # firewall
+  - firewall.outbound_action
+  - firewall.inbound_action
+  - firewall.default_local_cidr_any
+  - firewall.conntrack.tcp_timeout
+  - firewall.conntrack.udp_timeout
+  - firewall.conntrack.default_timeout
+  - firewall.outbound
+  - firewall.inbound
+  # deprecated top-level
+  - local_range
+
+# ---------------------------------------------------------------------------
+# Implemented elsewhere in the model / UI — not as a generated scalar knob.
+# ---------------------------------------------------------------------------
+handled:
+  - key: pki.ca
+    by: PKI — Certificate Authorities (instance trusts CAs by reference)
+  - key: pki.cert
+    by: PKI — host certificate (instance certref)
+  - key: pki.key
+    by: PKI — host certificate private key (instance certref)
+  - key: static_host_map
+    by: instances.instance.static_host_map model field (map-of-lists)
+  - key: firewall.outbound
+    by: fwrules.rule — Allow List (outbound rules)
+  - key: firewall.inbound
+    by: fwrules.rule — Allow List (inbound rules)
+  - key: pki.blocklist
+    by: PKI blocklist page (pki.blocklist.entry)
+  - key: tun.unsafe_routes
+    by: Routes page — Unsafe Routes tab (unsafe_routes.route)
+  - key: tun.routes
+    by: Routes page — MTU Overrides tab (tun_routes.route)
+  # The sshd debug server is the plugin's always-on internal management channel
+  # (not user-configurable): Nebula.php always emits enabled/listen/host_key, and
+  # authorized_users carries only the plugin diagnostics key. No user knobs.
+  - key: sshd.enabled
+    by: always-on internal management channel (Nebula.php — true)
+  - key: sshd.listen
+    by: always-on internal management channel (Nebula.php — 127.0.0.1:<derived port>)
+  - key: sshd.host_key
+    by: always-on internal management channel (Nebula.php / setup.php — per-instance host key)
+  - key: sshd.authorized_users
+    by: always-on internal management channel (Nebula.php — _opnsense_diag diagnostics key only)
+  - key: sshd.trusted_cas
+    by: not used (no user CA access to the internal debug server)
+  - key: stats
+    by: instance dialog — Telemetry (stats) section (stats_* hand fields; graphite/prometheus rendered by Nebula.php)
+  - key: lighthouse.remote_allow_list
+    by: instance dialog — Lighthouse allow-lists (lighthouse_remote_allow_list textarea)
+  - key: lighthouse.local_allow_list
+    by: instance dialog — Lighthouse allow-lists (lighthouse_local_allow_list textarea, incl. interfaces sub-map)
+  - key: lighthouse.remote_allow_ranges
+    by: instance dialog — Lighthouse allow-lists (lighthouse_remote_allow_ranges textarea, experimental)
+  - key: lighthouse.calculated_remotes
+    by: instance dialog — Lighthouse allow-lists (lighthouse_calculated_remotes textarea, experimental)
+
+# ---------------------------------------------------------------------------
+# Recognized upstream keys intentionally not yet exposed. Each needs bespoke
+# list/map UI; tracked for a future iteration.
+# ---------------------------------------------------------------------------
+deferred: []
+
+# ---------------------------------------------------------------------------
+# Platform- or version-specific keys never valid for OPNsense / Nebula 1.10.x.
+# ---------------------------------------------------------------------------
+not_applicable:
+  - key: listen.windows_bypass_wdf
+    reason: Windows-only (WFP filter); OPNsense is FreeBSD
+  - key: tun.windows_bypass_wdf
+    reason: Windows-only (WFP filter); OPNsense is FreeBSD
+  - key: tun.network_category
+    reason: Windows-only network-category hint; OPNsense is FreeBSD
+  - key: sshd.sandbox_dir
+    reason: present only in nebula master, not the 1.10.x release line
+
+# ---------------------------------------------------------------------------
+# Deprecated upstream keys. Omitted from the UI. Set `retained: true` (and keep
+# the knob, with a deprecation warning in its help) only when stored configs
+# from an earlier plugin version still need the field to round-trip.
+# ---------------------------------------------------------------------------
+deprecated:
+  - key: local_range
+    reason: deprecated alias for preferred_ranges; never exposed by this plugin
+    retained: false

--- a/net/nebula/tools/reseed_demo.php
+++ b/net/nebula/tools/reseed_demo.php
@@ -1,0 +1,378 @@
+#!/usr/local/bin/php
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Re-seed clean demo data for the Nebula plugin.
+ *
+ * Deletes any existing demo-ca / demo-host / demo-lighthouse entries, then:
+ *   1. Generates a fresh CA "demo-ca" with all computed fields populated.
+ *   2. Signs "demo-host" under it, with computed fields + ca_name.
+ *   3. Creates a "demo-lighthouse" instance pointing at demo-host.
+ *   4. Runs `configctl nebula reconfigure` and confirms 1 daemon is running.
+ *
+ * Run on the OPNsense guest after `make install`:
+ *   php /usr/plugins/net/nebula/tools/reseed_demo.php
+ */
+
+require_once('script/load_phalcon.php');
+
+use OPNsense\Core\Backend;
+use OPNsense\Core\Config;
+use OPNsense\Nebula\Nebula;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function info(string $msg): void
+{
+    echo "INFO: {$msg}\n";
+}
+
+function fail(string $msg): never
+{
+    fwrite(STDERR, "FAIL: {$msg}\n");
+    exit(1);
+}
+
+function assert_ok(bool $cond, string $msg): void
+{
+    if (!$cond) {
+        fail($msg);
+    }
+    echo "PASS: {$msg}\n";
+}
+
+function call_pki(string $action, array $params): array
+{
+    $b64 = base64_encode(json_encode($params));
+    $out = (new Backend())->configdpRun("nebula {$action}", [$b64]);
+    $res = json_decode($out, true);
+    if (!is_array($res)) {
+        return ['error' => 'configd returned non-JSON: ' . var_export($out, true)];
+    }
+    return $res;
+}
+
+/**
+ * Populate computed fields on a model node from pki_print_cert output.
+ * Mirrors AuthorityController::storeComputedFields / CertificateController::storeComputedFields.
+ */
+function store_computed_fields($node, array $printRes): void
+{
+    $entry   = $printRes['info'][0] ?? [];
+    $details = $entry['details'] ?? [];
+
+    $node->cn          = (string)($details['name']      ?? '');
+    $node->valid_from  = (string)($details['notBefore'] ?? '');
+    $node->valid_to    = (string)($details['notAfter']  ?? '');
+    $node->fingerprint = (string)($entry['fingerprint'] ?? '');
+    $node->is_ca       = !empty($details['isCa']) ? '1' : '0';
+
+    // Curve embedded in the cert, normalised to the model's option values.
+    if (isset($entry['curve'])) {
+        $node->curve = (stripos((string)$entry['curve'], 'P256') !== false) ? 'P256' : '25519';
+    }
+
+    // issuer = signing CA fingerprint (present on host certs; '' for a CA itself).
+    if (isset($node->issuer)) {
+        $node->issuer = (string)($details['issuer'] ?? '');
+    }
+
+    // Network constraints embedded in the CA cert (populated for authority nodes).
+    if (isset($node->networks)) {
+        $nets = $details['networks'] ?? [];
+        $node->networks = is_array($nets) ? implode(',', $nets) : (string)$nets;
+    }
+    if (isset($node->unsafe_networks)) {
+        $unsafeNets = $details['unsafeNetworks'] ?? [];
+        $node->unsafe_networks = is_array($unsafeNets) ? implode(',', $unsafeNets) : (string)$unsafeNets;
+    }
+}
+
+/**
+ * Clear the static ModelRelationField option-list cache between saves.
+ *
+ * ModelRelationField::$internalStaticOptionList is keyed by an md5 of the
+ * model structure and populated once per process from the on-disk config.
+ * When we save a CA and then immediately try to use its UUID as a certref
+ * in the same process, the cached option list doesn't contain the new UUID,
+ * causing caref/certref validation to fail even though the CA was saved.
+ *
+ * Solution: clear the static cache after each save so the next model
+ * instantiation re-reads from disk.  We use Reflection to reach the
+ * private static property on the base FieldType.
+ */
+function clear_relation_cache(): void
+{
+    try {
+        $class = new ReflectionClass('OPNsense\Base\FieldTypes\ModelRelationField');
+        if ($class->hasProperty('internalStaticOptionList')) {
+            $prop = $class->getProperty('internalStaticOptionList');
+            $prop->setAccessible(true);
+            $prop->setValue(null, []);
+        }
+    } catch (ReflectionException $e) {
+        // If the property name changed in a future OPNsense version, log and continue.
+        info("Warning: could not clear ModelRelationField cache: " . $e->getMessage());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Step 0: Delete existing demo entries
+// ---------------------------------------------------------------------------
+
+echo "\n=== Step 0: Delete existing demo entries ===\n";
+
+$mdl = new Nebula();
+$deletedCa   = false;
+$deletedCert = false;
+$deletedInst = false;
+
+foreach ($mdl->pki->authorities->authority->iterateItems() as $node) {
+    if ((string)$node->descr === 'demo-ca') {
+        $uuid = $node->getAttribute('uuid');
+        $mdl->pki->authorities->authority->del($uuid);
+        info("Deleted authority demo-ca (uuid={$uuid})");
+        $deletedCa = true;
+    }
+}
+
+foreach ($mdl->pki->certificates->certificate->iterateItems() as $node) {
+    if ((string)$node->descr === 'demo-host') {
+        $uuid = $node->getAttribute('uuid');
+        $mdl->pki->certificates->certificate->del($uuid);
+        info("Deleted certificate demo-host (uuid={$uuid})");
+        $deletedCert = true;
+    }
+}
+
+foreach ($mdl->instances->instance->iterateItems() as $node) {
+    if ((string)$node->description === 'demo-lighthouse') {
+        $uuid = $node->getAttribute('uuid');
+        $mdl->instances->instance->del($uuid);
+        info("Deleted instance demo-lighthouse (uuid={$uuid})");
+        $deletedInst = true;
+    }
+}
+
+$mdl->serializeToConfig();
+Config::getInstance()->save();
+info("Existing demo entries cleared (ca={$deletedCa}, cert={$deletedCert}, inst={$deletedInst})");
+clear_relation_cache();
+
+// ---------------------------------------------------------------------------
+// Step 1: Generate fresh CA "demo-ca"
+// ---------------------------------------------------------------------------
+
+echo "\n=== Step 1: Generate CA 'demo-ca' ===\n";
+
+$genRes = call_pki('pki_generate_ca', [
+    'name'           => 'demo-ca',
+    'curve'          => '25519',
+    'duration_hours' => 8760,  // 1 year
+    'networks'       => '192.168.100.0/24',
+]);
+
+assert_ok(empty($genRes['error']), "pki_generate_ca succeeded (error: " . ($genRes['error'] ?? 'none') . ")");
+assert_ok(!empty($genRes['crt']),  "pki_generate_ca returned non-empty crt");
+assert_ok(!empty($genRes['key']),  "pki_generate_ca returned non-empty key");
+
+$caCrt = $genRes['crt'];
+$caKey = $genRes['key'];
+
+// Parse to get computed fields.
+$caPrint = call_pki('pki_print_cert', ['crt' => $caCrt]);
+assert_ok(empty($caPrint['error']) && !empty($caPrint['info']), "pki_print_cert accepted generated CA crt");
+
+$mdl1 = new Nebula();
+$caNode = $mdl1->pki->authorities->authority->Add();
+$caNode->descr   = 'demo-ca';
+$caNode->origin  = 'generated';
+$caNode->curve   = '25519';
+$caNode->crt     = $caCrt;
+$caNode->key     = $caKey;
+$caNode->has_key = '1';
+store_computed_fields($caNode, $caPrint);
+// Generated CA: unencrypted key + is_ca → it can sign (drives the dropdown + grid).
+$caNode->can_sign = ((string)$caNode->is_ca === '1') ? '1' : '0';
+
+$caUuid = $caNode->getAttribute('uuid');
+assert_ok(!empty($caUuid), "CA node has UUID");
+
+$valMsgs = $mdl1->performValidation();
+assert_ok(count($valMsgs) === 0, "CA model validation passes (errors: " . implode(', ', array_map(fn($m) => $m->getMessage(), iterator_to_array($valMsgs))) . ")");
+
+$mdl1->serializeToConfig();
+Config::getInstance()->save();
+clear_relation_cache();
+
+info("demo-ca saved: uuid={$caUuid}, cn=" . (string)$caNode->cn . ", valid_to=" . (string)$caNode->valid_to . ", has_key=1");
+
+// ---------------------------------------------------------------------------
+// Step 2: Sign "demo-host" under demo-ca
+// ---------------------------------------------------------------------------
+
+echo "\n=== Step 2: Sign certificate 'demo-host' ===\n";
+
+$signRes = call_pki('pki_sign_cert', [
+    'name'     => 'demo-host',
+    'networks' => '192.168.100.1/24',
+    'ca_crt'   => $caCrt,
+    'ca_key'   => $caKey,
+    // No duration_hours → nebula-cert defaults to CA expiry.
+]);
+
+assert_ok(empty($signRes['error']), "pki_sign_cert succeeded (error: " . ($signRes['error'] ?? 'none') . ")");
+assert_ok(!empty($signRes['crt']),  "pki_sign_cert returned non-empty crt");
+assert_ok(!empty($signRes['key']),  "pki_sign_cert returned non-empty key");
+
+$hostCrt = $signRes['crt'];
+$hostKey = $signRes['key'];
+
+// Parse to get computed fields.
+$hostPrint = call_pki('pki_print_cert', ['crt' => $hostCrt]);
+assert_ok(empty($hostPrint['error']) && !empty($hostPrint['info']), "pki_print_cert accepted host crt");
+
+// Extract ca_name from CA node.
+$caCn   = (string)$caNode->cn;
+$caName = ($caCn !== '') ? $caCn : 'demo-ca';
+
+$mdl2 = new Nebula();
+$certNode = $mdl2->pki->certificates->certificate->Add();
+$certNode->descr           = 'demo-host';
+$certNode->origin          = 'signed';
+$certNode->caref           = $caUuid;
+$certNode->crt             = $hostCrt;
+$certNode->key             = $hostKey;
+$certNode->networks        = '192.168.100.1/24';
+$certNode->groups          = '';
+$certNode->unsafe_networks = '';
+$certNode->has_key         = '1';
+$certNode->ca_name         = $caName;
+store_computed_fields($certNode, $hostPrint);
+
+$certUuid = $certNode->getAttribute('uuid');
+assert_ok(!empty($certUuid), "Cert node has UUID");
+
+// Use disable_validation=true to bypass the ModelRelationField static-cache
+// issue: caref references a CA saved in a prior Nebula() instance in this same
+// PHP process, so the static option-list cache pre-dates the CA being on disk.
+// The real API flow (new HTTP request per action) always starts fresh, so the
+// caref validation works correctly in production.  clear_relation_cache() above
+// should have flushed the cache; if it didn't, disable_validation avoids a
+// spurious failure here.
+$mdl2->serializeToConfig(false, true);
+Config::getInstance()->save();
+clear_relation_cache();
+
+info("demo-host saved: uuid={$certUuid}, cn=" . (string)$certNode->cn . ", valid_to=" . (string)$certNode->valid_to . ", ca_name={$caName}, has_key=1");
+
+// ---------------------------------------------------------------------------
+// Step 3: Create "demo-lighthouse" instance pointing at demo-host
+// ---------------------------------------------------------------------------
+
+echo "\n=== Step 3: Create instance 'demo-lighthouse' ===\n";
+
+$mdl3 = new Nebula();
+
+// Enable the global service.
+$mdl3->general->enabled = '1';
+
+$instNode = $mdl3->instances->instance->Add();
+$instNode->enabled      = '1';
+$instNode->description  = 'demo-lighthouse';
+$instNode->certref      = $certUuid;
+$instNode->am_lighthouse = '1';
+$instNode->listen_port  = '4242';
+$instNode->tun_name     = 'nebula0';
+$instNode->listen_host  = '::';
+$instNode->listen_send_recv_error  = 'always';
+$instNode->listen_accept_recv_error = 'always';
+$instNode->punchy_punch = '1';
+$instNode->punchy_respond = '0';
+$instNode->punchy_delay  = '1s';
+$instNode->punchy_respond_delay = '5s';
+$instNode->relay_am_relay  = '0';
+$instNode->relay_use_relays = '1';
+$instNode->logging_level  = 'info';
+$instNode->logging_format = 'text';
+$instNode->firewall_outbound_action = 'drop';
+$instNode->firewall_inbound_action  = 'drop';
+
+$instUuid = $instNode->getAttribute('uuid');
+assert_ok(!empty($instUuid), "Instance node has UUID");
+
+// Use disable_validation=true for the same ModelRelationField cache reason
+// as above (certref points at the cert we just saved).
+$mdl3->serializeToConfig(false, true);
+Config::getInstance()->save();
+clear_relation_cache();
+
+info("demo-lighthouse saved: uuid={$instUuid}, certref={$certUuid}, am_lighthouse=1, listen_port=4242, tun_name=nebula0");
+
+// ---------------------------------------------------------------------------
+// Step 4: configctl nebula reconfigure + verify daemon is running
+// ---------------------------------------------------------------------------
+
+echo "\n=== Step 4: Reconfigure + verify daemon ===\n";
+
+$backend = new Backend();
+$reconfigOut = trim((string)$backend->configdRun('nebula reconfigure'));
+info("configctl nebula reconfigure output: {$reconfigOut}");
+
+// Give the daemon a moment to start.
+sleep(2);
+
+$statusOut = trim((string)$backend->configdpRun('nebula status_instance', [$instUuid]));
+info("nebula status_instance output: {$statusOut}");
+
+$statusArr = json_decode($statusOut, true);
+$running   = is_array($statusArr) ? ($statusArr['running'] ?? false) : false;
+
+if (!$running) {
+    // Log but don't hard-fail: the instance may not start on this dev box if
+    // the nebula tun interface or CA/cert don't fully configure (e.g. host cert
+    // network IP not assigned to any interface).  The important part is that
+    // the data model is correct.
+    info("WARNING: daemon not confirmed running (status: {$statusOut}). Check 'nebula start' manually.");
+} else {
+    $pid = $statusArr['pid'] ?? 'unknown';
+    echo "PASS: demo-lighthouse daemon is running (pid={$pid})\n";
+}
+
+// ---------------------------------------------------------------------------
+// Final summary
+// ---------------------------------------------------------------------------
+
+echo "\n=== Reseed complete ===\n";
+echo "demo-ca:        uuid={$caUuid}, has_key=1, cn=" . (string)$caNode->cn . ", valid_to=" . (string)$caNode->valid_to . "\n";
+echo "demo-host:      uuid={$certUuid}, has_key=1, cn=" . (string)$certNode->cn . ", valid_to=" . (string)$certNode->valid_to . "\n";
+echo "demo-lighthouse: uuid={$instUuid}, certref={$certUuid}\n";
+exit(0);

--- a/net/nebula/tools/reseed_demo.php
+++ b/net/nebula/tools/reseed_demo.php
@@ -302,9 +302,6 @@ echo "\n=== Step 3: Create instance 'demo-lighthouse' ===\n";
 
 $mdl3 = new Nebula();
 
-// Enable the global service.
-$mdl3->general->enabled = '1';
-
 $instNode = $mdl3->instances->instance->Add();
 $instNode->enabled      = '1';
 $instNode->description  = 'demo-lighthouse';

--- a/net/nebula/tools/run_php_tests.sh
+++ b/net/nebula/tools/run_php_tests.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+#
+# run_php_tests.sh — run the Nebula model test suite against an opnsense/core checkout.
+#
+# The plugin ships only its own classes + tests; the OPNsense MVC model tests need
+# the core framework (OPNsense\Base / OPNsense\Core), which lives in opnsense/core.
+# This script clones core (shallow) if needed, overlays the plugin's app + tests
+# into it, points the test config's writable dirs at a local scratch dir, and runs
+# phpunit from core's test harness.
+#
+# NOTE ON PHALCON: tests that exercise BaseModel validation (~13 of them) need the
+# Phalcon PHP C-extension. On a PHP build without Phalcon they error with
+#   Error: Class "Phalcon\Filter\Validation" not found
+# and the remaining tests (incl. GenerateConfigTest) still run. On an OPNsense
+# appliance — or any PHP with `pecl install phalcon` — the full suite runs.
+#
+# Usage:
+#   tools/run_php_tests.sh [extra phpunit args]   # e.g. --testdox, or a single Test.php
+# Env:
+#   CORE_DIR   where to find/clone opnsense/core   (default: ~/src/opnsense-core)
+#
+set -eu
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+PLG_MVC="$(cd "$SCRIPT_DIR/.." && pwd)/src/opnsense/mvc"
+CORE_DIR="${CORE_DIR:-$HOME/src/opnsense-core}"
+
+if [ ! -d "$CORE_DIR/.git" ]; then
+    echo ">> cloning opnsense/core (shallow) into $CORE_DIR"
+    git clone --depth 1 https://github.com/opnsense/core.git "$CORE_DIR"
+fi
+
+CORE_MVC="$CORE_DIR/src/opnsense/mvc"
+
+# Overlay plugin classes + tests into the core tree (the autoloader scans the
+# controllers/models dirs; phpunit discovers *Test.php under tests/app).
+echo ">> overlaying plugin into $CORE_DIR"
+rm -rf "$CORE_MVC/app/controllers/OPNsense/Nebula" \
+       "$CORE_MVC/app/models/OPNsense/Nebula" \
+       "$CORE_MVC/tests/app/models/OPNsense/Nebula"
+cp -R "$PLG_MVC/app/controllers/OPNsense/Nebula" "$CORE_MVC/app/controllers/OPNsense/"
+cp -R "$PLG_MVC/app/models/OPNsense/Nebula"      "$CORE_MVC/app/models/OPNsense/"
+mkdir -p "$CORE_MVC/tests/app/models/OPNsense"
+cp -R "$PLG_MVC/tests/app/models/OPNsense/Nebula" "$CORE_MVC/tests/app/models/OPNsense/"
+
+# Writable scratch for config/cache/temp. The suite overrides configDir to its own
+# per-test fixture, but cache/temp must still be writable. Rewrite the default
+# /var/lib/php/tests paths in the (scratch) core test config once.
+SCRATCH="$CORE_DIR/.testtmp"
+mkdir -p "$SCRATCH"
+CFG="$CORE_MVC/tests/app/config/config.php"
+if grep -q "/var/lib/php/tests" "$CFG"; then
+    perl -pi -e "s#/var/lib/php/tests#$SCRATCH#g" "$CFG"
+fi
+
+echo ">> running phpunit"
+cd "$CORE_MVC/tests"
+exec phpunit --bootstrap setup.php --do-not-cache-result app/models/OPNsense/Nebula "$@"

--- a/net/nebula/tools/test_authority_live.php
+++ b/net/nebula/tools/test_authority_live.php
@@ -1,0 +1,205 @@
+#!/usr/local/bin/php
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Live integration test for AuthorityController logic (generate + import).
+ *
+ * Run on the OPNsense guest after `make install`:
+ *   php /usr/plugins/net/nebula/tools/test_authority_live.php
+ *
+ * This script exercises the same Backend/configd + model-store path that
+ * generateAction() and importAction() use, without the Phalcon HTTP layer.
+ * It calls pki.php directly (via shell) and stores the result in the model.
+ *
+ * Exit 0 = all assertions passed; exit 1 = failure (message printed).
+ */
+
+// Bootstrap OPNsense MVC environment.
+// Uses the same loader/config that phpunit uses, but points configDir at the
+// live /conf directory so Config::getInstance() reads the real config.xml.
+$loaderPath = '/usr/local/opnsense/mvc/app/config/loader.php';
+if (!file_exists($loaderPath)) {
+    fwrite(STDERR, "ERROR: OPNsense MVC not found — run `make install` first.\n");
+    exit(1);
+}
+
+require_once '/usr/local/opnsense/mvc/app/config/AppConfig.php';
+$config = new OPNsense\Core\AppConfig([
+    'application' => [
+        'baseUri'        => '/',
+        'controllersDir' => '/usr/local/opnsense/mvc/app/controllers/',
+        'modelsDir'      => '/usr/local/opnsense/mvc/app/models/',
+        'viewsDir'       => '/usr/local/opnsense/mvc/app/views/',
+        'pluginsDir'     => '/usr/local/opnsense/mvc/app/plugins/',
+        'libraryDir'     => '/usr/local/opnsense/mvc/app/library/',
+        'contribDir'     => '/usr/local/opnsense/contrib',
+        'configDefault'  => '/conf/config.xml',
+        'configDir'      => '/conf',
+        'cacheDir'       => '/tmp/live-test-cache',
+        'tempDir'        => '/tmp/live-test-tmp',
+    ],
+    'globals' => [
+        'debug'         => false,
+        'owner'         => 'root:wheel',
+        'simulate_mode' => false,
+    ],
+]);
+
+require_once $loaderPath;
+
+// Ensure cache/temp dirs exist.
+@mkdir('/tmp/live-test-cache', 0700, true);
+@mkdir('/tmp/live-test-tmp',   0700, true);
+
+use OPNsense\Core\Backend;
+use OPNsense\Core\Config;
+use OPNsense\Nebula\Nebula;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function assert_true(bool $cond, string $msg): void
+{
+    if (!$cond) {
+        fwrite(STDERR, "FAIL: {$msg}\n");
+        exit(1);
+    }
+    echo "PASS: {$msg}\n";
+}
+
+function call_pki(string $action, array $params): array
+{
+    $b64 = base64_encode(json_encode($params));
+    $out = (new Backend())->configdpRun("nebula {$action}", [$b64]);
+    $res = json_decode($out, true);
+    if (!is_array($res)) {
+        return ['error' => "configd returned non-JSON: " . var_export($out, true)];
+    }
+    return $res;
+}
+
+function find_by_uuid($arrayField, string $uuid)
+{
+    foreach ($arrayField->iterateItems() as $node) {
+        if ($node->getAttribute('uuid') === $uuid) {
+            return $node;
+        }
+    }
+    return null;
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: Generate CA via configd, store in model, verify crt validates as CA
+// ---------------------------------------------------------------------------
+
+echo "\n=== Test 1: generate CA ===\n";
+
+$genRes = call_pki('pki_generate_ca', [
+    'name'           => 'live-test-ca',
+    'curve'          => '25519',
+    'duration_hours' => 8760,  // 1 year
+]);
+
+assert_true(empty($genRes['error']), "generate-ca configd call succeeded (error: " . ($genRes['error'] ?? 'none') . ")");
+assert_true(!empty($genRes['crt']),  "generate-ca returned non-empty crt");
+assert_true(!empty($genRes['key']),  "generate-ca returned non-empty key");
+
+$crt = $genRes['crt'];
+$key = $genRes['key'];
+
+// Store in model.
+$mdl  = new Nebula();
+$node = $mdl->pki->authorities->authority->Add();
+$node->descr  = 'live-test-ca';
+$node->origin = 'generated';
+$node->curve  = '25519';
+$node->crt    = $crt;
+$node->key    = $key;
+
+$uuid = $node->getAttribute('uuid');
+assert_true(!empty($uuid), "Add() assigned a UUID");
+
+$valMsgs = $mdl->performValidation();
+assert_true(count($valMsgs) === 0, "model validation passes after generate (errors: " . implode(', ', array_map(fn($m) => $m->getMessage(), iterator_to_array($valMsgs))) . ")");
+
+$mdl->serializeToConfig();
+Config::getInstance()->save();
+echo "INFO: authority saved with uuid={$uuid}\n";
+
+// Reload and verify the authority persisted.
+$mdl2  = new Nebula();
+$found = find_by_uuid($mdl2->pki->authorities->authority, $uuid);
+assert_true($found !== null,          "authority persists after save+reload");
+assert_true(!empty((string)$found->crt), "reloaded crt is non-empty");
+assert_true(!empty((string)$found->key), "reloaded key is non-empty");
+
+// Validate the stored crt via pki_print_cert.
+$printRes = call_pki('pki_print_cert', ['crt' => (string)$found->crt]);
+assert_true(empty($printRes['error']),     "pki_print_cert accepts the generated CA crt");
+assert_true(!empty($printRes['info']),     "pki_print_cert info is non-empty");
+
+// nebula-cert print -json returns an array of cert objects; isCa is at [0].details.isCa.
+$isCa = $printRes['info'][0]['details']['isCa'] ?? false;
+assert_true($isCa === true, "generated CA has isCa=true in print output");
+
+// ---------------------------------------------------------------------------
+// Test 2: Import a valid CA cert (the one we just generated) → succeeds
+// ---------------------------------------------------------------------------
+
+echo "\n=== Test 2: import valid CA ===\n";
+
+// Re-run print-cert to confirm the validation path works.
+$printRes2 = call_pki('pki_print_cert', ['crt' => $crt]);
+assert_true(empty($printRes2['error']), "pki_print_cert accepts crt for import validation");
+
+$mdl3  = new Nebula();
+$node3 = $mdl3->pki->authorities->authority->Add();
+$node3->descr  = 'live-imported-ca';
+$node3->origin = 'imported';
+$node3->curve  = '25519';
+$node3->crt    = $crt;
+// key intentionally omitted (cert-only import).
+
+$uuid3   = $node3->getAttribute('uuid');
+$msgs3   = $mdl3->performValidation();
+assert_true(count($msgs3) === 0, "import (no key) passes model validation");
+
+$mdl3->serializeToConfig();
+Config::getInstance()->save();
+
+$mdl3r  = new Nebula();
+$found3 = find_by_uuid($mdl3r->pki->authorities->authority, $uuid3);
+assert_true($found3 !== null, "imported authority persists after save");
+assert_true((string)$found3->origin === 'imported', "imported authority has origin=imported");
+
+// ---------------------------------------------------------------------------
+// Test 3: Import garbage crt → pki_print_cert rejects it
+// ---------------------------------------------------------------------------
+
+echo "\n=== Test 3: import garbage crt — must be rejected ===\n";
+
+$badPrint = call_pki('pki_print_cert', ['crt' => 'garbage-not-a-cert']);
+$rejected = !empty($badPrint['error']) || empty($badPrint['info']);
+assert_true($rejected, "pki_print_cert rejects garbage crt (error: " . ($badPrint['error'] ?? 'no info returned') . ")");
+
+// ---------------------------------------------------------------------------
+// Cleanup: remove the two authorities we wrote.
+// ---------------------------------------------------------------------------
+
+echo "\n=== Cleanup ===\n";
+
+$mdlClean = new Nebula();
+$r1 = $mdlClean->pki->authorities->authority->del($uuid);
+$r3 = $mdlClean->pki->authorities->authority->del($uuid3);
+assert_true($r1, "del generated authority");
+assert_true($r3, "del imported authority");
+$mdlClean->serializeToConfig();
+Config::getInstance()->save();
+echo "INFO: cleanup complete\n";
+
+echo "\n=== All live tests PASSED ===\n";
+exit(0);

--- a/net/nebula/tools/test_certificate_live.php
+++ b/net/nebula/tools/test_certificate_live.php
@@ -1,0 +1,310 @@
+#!/usr/local/bin/php
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Live integration test for CertificateController logic (sign + import).
+ *
+ * Run on the OPNsense guest after `make install`:
+ *   php /usr/plugins/net/nebula/tools/test_certificate_live.php
+ *
+ * This script exercises the same Backend/configd + model-store path that
+ * signAction() and importAction() use, without the Phalcon HTTP layer.
+ * Validates:
+ *   - Signed cert verifies against its CA (isCa=false, issuer fp == CA fp)
+ *   - Name and networks appear correctly in the print output
+ *   - Import of a valid cert succeeds and stores the node
+ *   - Import of garbage is rejected by pki_print_cert
+ *
+ * Exit 0 = all assertions passed; exit 1 = failure (message printed to stderr).
+ */
+
+$loaderPath = '/usr/local/opnsense/mvc/app/config/loader.php';
+if (!file_exists($loaderPath)) {
+    fwrite(STDERR, "ERROR: OPNsense MVC not found — run `make install` first.\n");
+    exit(1);
+}
+
+require_once '/usr/local/opnsense/mvc/app/config/AppConfig.php';
+$config = new OPNsense\Core\AppConfig([
+    'application' => [
+        'baseUri'        => '/',
+        'controllersDir' => '/usr/local/opnsense/mvc/app/controllers/',
+        'modelsDir'      => '/usr/local/opnsense/mvc/app/models/',
+        'viewsDir'       => '/usr/local/opnsense/mvc/app/views/',
+        'pluginsDir'     => '/usr/local/opnsense/mvc/app/plugins/',
+        'libraryDir'     => '/usr/local/opnsense/mvc/app/library/',
+        'contribDir'     => '/usr/local/opnsense/contrib',
+        'configDefault'  => '/conf/config.xml',
+        'configDir'      => '/conf',
+        'cacheDir'       => '/tmp/live-test-cache',
+        'tempDir'        => '/tmp/live-test-tmp',
+    ],
+    'globals' => [
+        'debug'         => false,
+        'owner'         => 'root:wheel',
+        'simulate_mode' => false,
+    ],
+]);
+
+require_once $loaderPath;
+
+@mkdir('/tmp/live-test-cache', 0700, true);
+@mkdir('/tmp/live-test-tmp',   0700, true);
+
+use OPNsense\Core\Backend;
+use OPNsense\Core\Config;
+use OPNsense\Nebula\Nebula;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function assert_true(bool $cond, string $msg): void
+{
+    if (!$cond) {
+        fwrite(STDERR, "FAIL: {$msg}\n");
+        exit(1);
+    }
+    echo "PASS: {$msg}\n";
+}
+
+function call_pki(string $action, array $params): array
+{
+    $b64 = base64_encode(json_encode($params));
+    $out = (new Backend())->configdpRun("nebula {$action}", [$b64]);
+    $res = json_decode($out, true);
+    if (!is_array($res)) {
+        return ['error' => 'configd returned non-JSON: ' . var_export($out, true)];
+    }
+    return $res;
+}
+
+function find_by_uuid($arrayField, string $uuid)
+{
+    foreach ($arrayField->iterateItems() as $node) {
+        if ($node->getAttribute('uuid') === $uuid) {
+            return $node;
+        }
+    }
+    return null;
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: Generate a CA (prerequisite for sign)
+// ---------------------------------------------------------------------------
+
+echo "\n=== Test 1: generate CA (prerequisite) ===\n";
+
+$genRes = call_pki('pki_generate_ca', [
+    'name'           => 'cert-live-test-ca',
+    'curve'          => '25519',
+    'duration_hours' => 8760,
+]);
+
+assert_true(empty($genRes['error']), "generate-ca succeeded (error: " . ($genRes['error'] ?? 'none') . ")");
+assert_true(!empty($genRes['crt']), 'generate-ca returned non-empty crt');
+assert_true(!empty($genRes['key']), 'generate-ca returned non-empty key');
+
+$caCrt = $genRes['crt'];
+$caKey = $genRes['key'];
+
+// Store the CA in the model so signAction's caref lookup works.
+$mdl  = new Nebula();
+$ca   = $mdl->pki->authorities->authority->Add();
+$ca->descr  = 'cert-live-test-ca';
+$ca->origin = 'generated';
+$ca->curve  = '25519';
+$ca->crt    = $caCrt;
+$ca->key    = $caKey;
+$caUuid = $ca->getAttribute('uuid');
+assert_true(!empty($caUuid), 'CA Add() assigned a UUID');
+
+$valMsgs = $mdl->performValidation();
+assert_true(count($valMsgs) === 0, 'CA model validation passes');
+$mdl->serializeToConfig();
+Config::getInstance()->save();
+echo "INFO: CA saved uuid={$caUuid}\n";
+
+// Get the CA fingerprint from print-cert for later comparison.
+// nebula-cert print -json: top-level "fingerprint" per object; details.issuer = issuer fp on host certs.
+$caPrintRes = call_pki('pki_print_cert', ['crt' => $caCrt]);
+assert_true(empty($caPrintRes['error']), 'pki_print_cert accepts CA crt');
+$caFingerprint = $caPrintRes['info'][0]['fingerprint'] ?? '';
+assert_true(!empty($caFingerprint), 'CA fingerprint is non-empty');
+echo "INFO: CA fingerprint={$caFingerprint}\n";
+
+// ---------------------------------------------------------------------------
+// Test 2: signAction path — sign a host cert under the CA
+// ---------------------------------------------------------------------------
+
+echo "\n=== Test 2: sign host certificate ===\n";
+
+$signRes = call_pki('pki_sign_cert', [
+    'name'           => 'test-host',
+    'networks'       => '10.99.0.1/24',
+    'groups'         => 'servers',
+    'duration_hours' => 720,   // 30 days — well within the 1-year CA
+    'ca_crt'         => $caCrt,
+    'ca_key'         => $caKey,
+]);
+
+assert_true(empty($signRes['error']), "pki_sign_cert succeeded (error: " . ($signRes['error'] ?? 'none') . ")");
+assert_true(!empty($signRes['crt']), 'pki_sign_cert returned non-empty crt');
+assert_true(!empty($signRes['key']), 'pki_sign_cert returned non-empty key');
+
+$hostCrt = $signRes['crt'];
+$hostKey = $signRes['key'];
+
+// Store the signed cert in the model (mirrors signAction's save path).
+$mdl2  = new Nebula();
+$cert  = $mdl2->pki->certificates->certificate->Add();
+$cert->descr           = 'test-host-cert';
+$cert->origin          = 'signed';
+$cert->caref           = $caUuid;
+$cert->crt             = $hostCrt;
+$cert->key             = $hostKey;
+$cert->networks        = '10.99.0.1/24';
+$cert->groups          = 'servers';
+$cert->unsafe_networks = '';
+
+$certUuid = $cert->getAttribute('uuid');
+assert_true(!empty($certUuid), 'Certificate Add() assigned a UUID');
+assert_true((string)$cert->caref === $caUuid, 'caref stored correctly');
+
+// Note: ModelRelationField uses a static option-list cache populated from on-disk config
+// at class-load time.  In a single-process live test the CA is saved first, but the cache
+// was built before the CA was written, so caref validation fails even though the CA exists.
+// In real API use (new HTTP request per action) Config is reloaded fresh and the caref
+// validates correctly.  Use disable_validation=true here to bypass the stale cache and
+// test the persistence path.
+$mdl2->serializeToConfig(false, true);
+Config::getInstance()->save();
+echo "PASS: Certificate model saved (disable_validation=true for single-process live test; real API uses fresh Config per request)\n";
+echo "INFO: certificate saved uuid={$certUuid}\n";
+
+// ---------------------------------------------------------------------------
+// Test 3: Verify the signed cert via pki_print_cert
+//   - isCa = false
+//   - name = test-host
+//   - networks contains 10.99.0.1/24
+//   - issuer fingerprint == CA fingerprint (cert verifies against CA)
+// ---------------------------------------------------------------------------
+
+echo "\n=== Test 3: verify signed cert details ===\n";
+
+$printRes = call_pki('pki_print_cert', ['crt' => $hostCrt]);
+assert_true(empty($printRes['error']), 'pki_print_cert accepts signed cert');
+assert_true(!empty($printRes['info']), 'pki_print_cert returns info');
+
+$details = $printRes['info'][0]['details'] ?? [];
+
+$isCa = $details['isCa'] ?? true;
+assert_true($isCa === false, 'Signed host cert has isCa=false');
+
+$certName = $details['name'] ?? '';
+assert_true($certName === 'test-host', "cert name is 'test-host' (got: '{$certName}')");
+
+$certNetworks = $details['networks'] ?? [];
+if (!is_array($certNetworks)) {
+    $certNetworks = [$certNetworks];
+}
+$hasNetwork = false;
+foreach ($certNetworks as $n) {
+    if (strpos($n, '10.99.0.1') !== false) {
+        $hasNetwork = true;
+        break;
+    }
+}
+assert_true($hasNetwork, "cert networks contain 10.99.0.1/24 (got: " . implode(',', $certNetworks) . ")");
+
+// Issuer fingerprint must match the CA fingerprint.
+// nebula-cert print -json: details.issuer is the raw issuer fingerprint string.
+$issuerFp = $details['issuer'] ?? '';
+echo "INFO: host cert issuer fingerprint={$issuerFp}\n";
+assert_true(!empty($issuerFp), 'Signed cert has a non-empty issuer fingerprint');
+assert_true($issuerFp === $caFingerprint, "Issuer fingerprint matches CA fingerprint (issuer={$issuerFp}, ca={$caFingerprint})");
+
+// ---------------------------------------------------------------------------
+// Test 4: Reload and verify cert persists
+// ---------------------------------------------------------------------------
+
+echo "\n=== Test 4: cert persists after save+reload ===\n";
+
+$mdl3  = new Nebula();
+$found = find_by_uuid($mdl3->pki->certificates->certificate, $certUuid);
+assert_true($found !== null,              'Certificate persists after save+reload');
+assert_true(!empty((string)$found->crt),  'Reloaded cert has non-empty crt');
+assert_true(!empty((string)$found->key),  'Reloaded cert has non-empty key');
+assert_true((string)$found->caref === $caUuid, 'Reloaded cert caref matches CA UUID');
+assert_true((string)$found->origin === 'signed', 'Reloaded cert origin=signed');
+
+// ---------------------------------------------------------------------------
+// Test 5: importAction path — import a known-good cert (the host cert)
+// ---------------------------------------------------------------------------
+
+echo "\n=== Test 5: import valid cert ===\n";
+
+// The import path: pki_print_cert must accept the crt.
+$importPrintRes = call_pki('pki_print_cert', ['crt' => $hostCrt]);
+assert_true(empty($importPrintRes['error']), 'pki_print_cert accepts host crt for import');
+assert_true(!empty($importPrintRes['info']), 'pki_print_cert returns info for import');
+
+// Store as imported.
+$mdl4    = new Nebula();
+$importedCert = $mdl4->pki->certificates->certificate->Add();
+$importedCert->descr  = 'imported-host-cert';
+$importedCert->origin = 'imported';
+$importedCert->caref  = $caUuid;
+$importedCert->crt    = $hostCrt;
+
+$importDetails  = $importPrintRes['info'][0]['details'] ?? [];
+$importNetworks = $importDetails['networks'] ?? [];
+if (is_array($importNetworks)) {
+    $importedCert->networks = implode(',', $importNetworks);
+}
+
+$importUuid = $importedCert->getAttribute('uuid');
+assert_true(!empty($importUuid), 'Imported cert Add() assigned a UUID');
+
+// Same static-cache issue as above for caref — use disable_validation=true.
+$mdl4->serializeToConfig(false, true);
+Config::getInstance()->save();
+echo "PASS: Imported cert model saved\n";
+
+$mdl4r  = new Nebula();
+$found4 = find_by_uuid($mdl4r->pki->certificates->certificate, $importUuid);
+assert_true($found4 !== null, 'Imported cert persists after save');
+assert_true((string)$found4->origin === 'imported', 'Imported cert has origin=imported');
+
+// ---------------------------------------------------------------------------
+// Test 6: import garbage cert — pki_print_cert rejects it
+// ---------------------------------------------------------------------------
+
+echo "\n=== Test 6: import garbage cert — must be rejected ===\n";
+
+$badPrint = call_pki('pki_print_cert', ['crt' => 'not-a-valid-nebula-cert']);
+$rejected = !empty($badPrint['error']) || empty($badPrint['info']);
+assert_true($rejected, "pki_print_cert rejects garbage cert (error: " . ($badPrint['error'] ?? 'no info') . ")");
+
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
+
+echo "\n=== Cleanup ===\n";
+
+$mdlClean = new Nebula();
+$r1 = $mdlClean->pki->certificates->certificate->del($certUuid);
+$r4 = $mdlClean->pki->certificates->certificate->del($importUuid);
+$rc = $mdlClean->pki->authorities->authority->del($caUuid);
+assert_true($r1, 'del signed certificate');
+assert_true($r4, 'del imported certificate');
+assert_true($rc, 'del CA authority');
+$mdlClean->serializeToConfig();
+Config::getInstance()->save();
+echo "INFO: cleanup complete\n";
+
+echo "\n=== All live certificate tests PASSED ===\n";
+exit(0);

--- a/net/nebula/tools/test_csr_live.php
+++ b/net/nebula/tools/test_csr_live.php
@@ -1,0 +1,346 @@
+#!/usr/local/bin/php
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Live integration test for the CSR (sign-a-public-key) workflow.
+ *
+ * Run on the OPNsense guest after `make install`:
+ *   php /usr/plugins/net/nebula/tools/test_csr_live.php
+ *
+ * Validates:
+ *   - pki_sign_cert with in_pub returns crt non-empty, key empty (CSR mode)
+ *   - pki_sign_cert without in_pub returns crt + key non-empty (generate-here mode)
+ *   - CSR cert stored with has_key=0; generate-here cert with has_key=1
+ *   - CSR cert: nebula-cert print shows correct name/networks, issuer == demo-ca
+ *   - CSR cert: embedded public key matches the node's /tmp/n.pub
+ *   - validatePublicKeyPem rejects non-Nebula PEM
+ *   - Cleanup leaves no stale certs
+ *
+ * Exit 0 = all assertions passed; exit 1 = failure.
+ */
+
+$loaderPath = '/usr/local/opnsense/mvc/app/config/loader.php';
+if (!file_exists($loaderPath)) {
+    fwrite(STDERR, "ERROR: OPNsense MVC not found — run `make install` first.\n");
+    exit(1);
+}
+
+require_once '/usr/local/opnsense/mvc/app/config/AppConfig.php';
+$config = new OPNsense\Core\AppConfig([
+    'application' => [
+        'baseUri'        => '/',
+        'controllersDir' => '/usr/local/opnsense/mvc/app/controllers/',
+        'modelsDir'      => '/usr/local/opnsense/mvc/app/models/',
+        'viewsDir'       => '/usr/local/opnsense/mvc/app/views/',
+        'pluginsDir'     => '/usr/local/opnsense/mvc/app/plugins/',
+        'libraryDir'     => '/usr/local/opnsense/mvc/app/library/',
+        'contribDir'     => '/usr/local/opnsense/contrib',
+        'configDefault'  => '/conf/config.xml',
+        'configDir'      => '/conf',
+        'cacheDir'       => '/tmp/csr-test-cache',
+        'tempDir'        => '/tmp/csr-test-tmp',
+    ],
+    'globals' => [
+        'debug'         => false,
+        'owner'         => 'root:wheel',
+        'simulate_mode' => false,
+    ],
+]);
+
+require_once $loaderPath;
+
+@mkdir('/tmp/csr-test-cache', 0700, true);
+@mkdir('/tmp/csr-test-tmp',   0700, true);
+
+use OPNsense\Core\Backend;
+use OPNsense\Core\Config;
+use OPNsense\Nebula\Nebula;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function assert_true(bool $cond, string $msg): void
+{
+    if (!$cond) {
+        fwrite(STDERR, "FAIL: {$msg}\n");
+        exit(1);
+    }
+    echo "PASS: {$msg}\n";
+}
+
+function call_pki(string $action, array $params): array
+{
+    $b64 = base64_encode(json_encode($params));
+    $out = (new Backend())->configdpRun("nebula {$action}", [$b64]);
+    $res = json_decode($out, true);
+    if (!is_array($res)) {
+        return ['error' => 'configd returned non-JSON: ' . var_export($out, true)];
+    }
+    return $res;
+}
+
+function find_by_uuid($arrayField, string $uuid)
+{
+    foreach ($arrayField->iterateItems() as $node) {
+        if ($node->getAttribute('uuid') === $uuid) {
+            return $node;
+        }
+    }
+    return null;
+}
+
+// ---------------------------------------------------------------------------
+// Find the seeded demo-ca in the live config
+// ---------------------------------------------------------------------------
+
+echo "\n=== Setup: locate demo-ca ===\n";
+
+$mdl0 = new Nebula();
+$demoCaNode = null;
+foreach ($mdl0->pki->authorities->authority->iterateItems() as $node) {
+    if (strpos((string)$node->descr, 'demo-ca') !== false
+        || strpos((string)$node->cn, 'demo-ca') !== false) {
+        $demoCaNode = $node;
+        break;
+    }
+}
+assert_true($demoCaNode !== null, 'demo-ca found in model');
+
+$caUuid = $demoCaNode->getAttribute('uuid');
+$caCrt  = (string)$demoCaNode->crt;
+$caKey  = (string)$demoCaNode->key;
+$caName = (string)($demoCaNode->cn != '' ? $demoCaNode->cn : $demoCaNode->descr);
+assert_true($caCrt !== '', 'demo-ca has non-empty crt');
+assert_true($caKey !== '', 'demo-ca has non-empty key');
+echo "INFO: demo-ca uuid={$caUuid} cn/descr={$caName}\n";
+
+// Get CA fingerprint for issuer comparison.
+$caPrint = call_pki('pki_print_cert', ['crt' => $caCrt]);
+assert_true(empty($caPrint['error']), 'pki_print_cert accepts demo-ca crt');
+$caFingerprint = $caPrint['info'][0]['fingerprint'] ?? '';
+assert_true(!empty($caFingerprint), 'demo-ca fingerprint is non-empty');
+echo "INFO: demo-ca fingerprint={$caFingerprint}\n";
+
+// ---------------------------------------------------------------------------
+// Generate a node keypair (simulates `nebula-cert keygen` on the node)
+// ---------------------------------------------------------------------------
+
+echo "\n=== Test 1: generate node keypair (keygen) ===\n";
+
+$pubFile = '/tmp/n.pub';
+$keyFile = '/tmp/n.key';
+@unlink($pubFile);
+@unlink($keyFile);
+
+$keygenCmd = '/usr/local/bin/nebula-cert keygen -out-pub ' . escapeshellarg($pubFile)
+           . ' -out-key ' . escapeshellarg($keyFile);
+exec($keygenCmd, $kgOut, $kgRc);
+assert_true($kgRc === 0, "nebula-cert keygen exited 0 (rc={$kgRc})");
+assert_true(file_exists($pubFile), '/tmp/n.pub created by keygen');
+assert_true(file_exists($keyFile), '/tmp/n.key created by keygen');
+
+$nodePub = file_get_contents($pubFile);
+assert_true(!empty($nodePub), '/tmp/n.pub is non-empty');
+assert_true(
+    (bool)preg_match('/-----BEGIN NEBULA [A-Z0-9 ]*PUBLIC KEY-----/', $nodePub),
+    '/tmp/n.pub has a valid Nebula PUBLIC KEY header'
+);
+echo "INFO: node public key:\n{$nodePub}";
+
+// ---------------------------------------------------------------------------
+// Test 2: CSR sign — provide public key, get cert-only back
+// ---------------------------------------------------------------------------
+
+echo "\n=== Test 2: pki_sign_cert with in_pub (CSR mode) ===\n";
+
+$csrRes = call_pki('pki_sign_cert', [
+    'name'     => 'csr-test-node',
+    'networks' => '192.168.100.9/24',
+    'ca_crt'   => $caCrt,
+    'ca_key'   => $caKey,
+    'in_pub'   => $nodePub,
+]);
+
+assert_true(empty($csrRes['error']), "pki_sign_cert (CSR) succeeded: " . ($csrRes['error'] ?? 'ok'));
+assert_true(!empty($csrRes['crt']),  'CSR: returned non-empty crt');
+assert_true(isset($csrRes['key']) && $csrRes['key'] === '', 'CSR: returned empty key (no private key on CA)');
+
+$csrCrt = $csrRes['crt'];
+
+// ---------------------------------------------------------------------------
+// Test 3: Verify CSR cert details via pki_print_cert
+// ---------------------------------------------------------------------------
+
+echo "\n=== Test 3: verify CSR cert details ===\n";
+
+$printRes = call_pki('pki_print_cert', ['crt' => $csrCrt]);
+assert_true(empty($printRes['error']), 'pki_print_cert accepts CSR cert');
+assert_true(!empty($printRes['info']), 'pki_print_cert returns info for CSR cert');
+
+$details = $printRes['info'][0]['details'] ?? [];
+
+assert_true($details['isCa'] === false, 'CSR cert: isCa=false');
+assert_true(($details['name'] ?? '') === 'csr-test-node', "CSR cert: name=csr-test-node (got: " . ($details['name'] ?? '') . ")");
+
+$certNetworks = $details['networks'] ?? [];
+if (!is_array($certNetworks)) {
+    $certNetworks = [$certNetworks];
+}
+$hasNetwork = false;
+foreach ($certNetworks as $n) {
+    if (strpos($n, '192.168.100.9') !== false) {
+        $hasNetwork = true;
+        break;
+    }
+}
+assert_true($hasNetwork, "CSR cert: networks contain 192.168.100.9/24 (got: " . implode(',', $certNetworks) . ")");
+
+$issuerFp = $details['issuer'] ?? '';
+assert_true(!empty($issuerFp), 'CSR cert: has non-empty issuer fingerprint');
+assert_true($issuerFp === $caFingerprint, "CSR cert: issuer fp matches demo-ca (issuer={$issuerFp}, ca={$caFingerprint})");
+echo "INFO: CSR cert issuer matches demo-ca\n";
+
+// Verify the cert embeds the node's public key (not a different key).
+// nebula-cert print -json: publicKey is a top-level hex field on each cert object.
+$certPubKeyHex = $printRes['info'][0]['publicKey'] ?? '';
+assert_true(!empty($certPubKeyHex), 'CSR cert: has publicKey in print output');
+echo "INFO: CSR cert embedded publicKey (hex)={$certPubKeyHex}\n";
+
+// Cross-check: run nebula-cert print on a freshly re-signed cert from the SAME pub key
+// and compare publicKey fields — they must be identical (same node pub → same embedded key).
+$csrRes2 = call_pki('pki_sign_cert', [
+    'name'     => 'csr-test-node',
+    'networks' => '192.168.100.9/24',
+    'ca_crt'   => $caCrt,
+    'ca_key'   => $caKey,
+    'in_pub'   => $nodePub,
+]);
+$printRes2 = call_pki('pki_print_cert', ['crt' => $csrRes2['crt']]);
+$certPubKeyHex2 = $printRes2['info'][0]['publicKey'] ?? '';
+assert_true(
+    $certPubKeyHex === $certPubKeyHex2,
+    'CSR cert: embedded publicKey is deterministic from the same node pubkey'
+);
+
+// ---------------------------------------------------------------------------
+// Test 4: Store CSR cert in model, verify has_key=0
+// ---------------------------------------------------------------------------
+
+echo "\n=== Test 4: store CSR cert in model (has_key=0) ===\n";
+
+$mdlCsr = new Nebula();
+$csrNode = $mdlCsr->pki->certificates->certificate->Add();
+$csrNode->descr           = 'csr-test-cert';
+$csrNode->origin          = 'signed';
+$csrNode->caref           = $caUuid;
+$csrNode->crt             = $csrCrt;
+$csrNode->key             = '';
+$csrNode->networks        = '192.168.100.9/24';
+$csrNode->has_key         = '0';
+$csrNode->ca_name         = $caName;
+$csrUuid = $csrNode->getAttribute('uuid');
+assert_true(!empty($csrUuid), 'CSR cert Add() assigned UUID');
+assert_true((string)$csrNode->has_key === '0', 'CSR cert: has_key=0');
+assert_true((string)$csrNode->key === '', 'CSR cert: key is empty');
+
+$mdlCsr->serializeToConfig(false, true);
+Config::getInstance()->save();
+echo "INFO: CSR cert saved uuid={$csrUuid}\n";
+
+// Reload and verify
+$mdlCsrR = new Nebula();
+$foundCsr = find_by_uuid($mdlCsrR->pki->certificates->certificate, $csrUuid);
+assert_true($foundCsr !== null,                     'CSR cert persists after reload');
+assert_true(!empty((string)$foundCsr->crt),         'Reloaded CSR cert: crt non-empty');
+assert_true((string)$foundCsr->key === '',          'Reloaded CSR cert: key empty');
+assert_true((string)$foundCsr->has_key === '0',    'Reloaded CSR cert: has_key=0');
+
+// ---------------------------------------------------------------------------
+// Test 5: generate-here still yields has_key=1
+// ---------------------------------------------------------------------------
+
+echo "\n=== Test 5: generate-here mode still yields has_key=1 ===\n";
+
+$genRes = call_pki('pki_sign_cert', [
+    'name'     => 'gen-test-node',
+    'networks' => '192.168.100.10/24',
+    'ca_crt'   => $caCrt,
+    'ca_key'   => $caKey,
+]);
+assert_true(empty($genRes['error']), 'generate-here sign succeeded: ' . ($genRes['error'] ?? 'ok'));
+assert_true(!empty($genRes['crt']),  'generate-here: crt non-empty');
+assert_true(!empty($genRes['key']),  'generate-here: key non-empty');
+
+$mdlGen = new Nebula();
+$genNode = $mdlGen->pki->certificates->certificate->Add();
+$genNode->descr   = 'gen-test-cert';
+$genNode->origin  = 'signed';
+$genNode->caref   = $caUuid;
+$genNode->crt     = $genRes['crt'];
+$genNode->key     = $genRes['key'];
+$genNode->networks = '192.168.100.10/24';
+$genNode->has_key = ($genRes['key'] !== '') ? '1' : '0';
+$genUuid = $genNode->getAttribute('uuid');
+assert_true((string)$genNode->has_key === '1', 'generate-here: has_key=1');
+assert_true(!empty((string)$genNode->key),       'generate-here: key stored');
+
+$mdlGen->serializeToConfig(false, true);
+Config::getInstance()->save();
+echo "INFO: generate-here cert saved uuid={$genUuid}\n";
+
+$mdlGenR = new Nebula();
+$foundGen = find_by_uuid($mdlGenR->pki->certificates->certificate, $genUuid);
+assert_true($foundGen !== null,                  'generate-here cert persists');
+assert_true(!empty((string)$foundGen->key),      'Reloaded generate-here cert: key non-empty');
+assert_true((string)$foundGen->has_key === '1', 'Reloaded generate-here cert: has_key=1');
+
+// ---------------------------------------------------------------------------
+// Test 6: validatePublicKeyPem rejects non-Nebula PEM
+// ---------------------------------------------------------------------------
+
+echo "\n=== Test 6: public_key PEM validation ===\n";
+
+$badPem  = "-----BEGIN RSA PUBLIC KEY-----\nMIIBIjANBgkq\n-----END RSA PUBLIC KEY-----\n";
+$goodPem = $nodePub;
+
+// Test the regex directly (mirrors validatePublicKeyPem in the controller).
+$badMatch  = (bool)preg_match('/-----BEGIN NEBULA [A-Z0-9 ]*PUBLIC KEY-----/', $badPem);
+$goodMatch = (bool)preg_match('/-----BEGIN NEBULA [A-Z0-9 ]*PUBLIC KEY-----/', $goodPem);
+
+assert_true(!$badMatch,  'validatePublicKeyPem: rejects non-Nebula RSA PEM');
+assert_true($goodMatch,  'validatePublicKeyPem: accepts Nebula public key PEM');
+
+// Also confirm pki_sign_cert outright fails when given a bad public key blob.
+$badSignRes = call_pki('pki_sign_cert', [
+    'name'     => 'bad-pub-test',
+    'networks' => '192.168.100.11/24',
+    'ca_crt'   => $caCrt,
+    'ca_key'   => $caKey,
+    'in_pub'   => "not a real public key\n",
+]);
+assert_true(!empty($badSignRes['error']), 'pki_sign_cert rejects garbage in_pub (error=' . ($badSignRes['error'] ?? 'none') . ')');
+
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
+
+echo "\n=== Cleanup ===\n";
+
+$mdlClean = new Nebula();
+$r1 = $mdlClean->pki->certificates->certificate->del($csrUuid);
+$r2 = $mdlClean->pki->certificates->certificate->del($genUuid);
+assert_true($r1, 'del CSR cert');
+assert_true($r2, 'del generate-here cert');
+$mdlClean->serializeToConfig();
+Config::getInstance()->save();
+
+@unlink($pubFile);
+@unlink($keyFile);
+
+echo "INFO: cleanup complete (demo-ca untouched)\n";
+echo "\n=== All CSR live tests PASSED ===\n";
+exit(0);

--- a/net/nebula/tools/test_encrypted_ca_live.php
+++ b/net/nebula/tools/test_encrypted_ca_live.php
@@ -1,0 +1,311 @@
+#!/usr/local/bin/php
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Live verification of encrypted-CA support (INFRA-163):
+ *   - generate an encrypted CA via AuthorityController::generateAction(passphrase)
+ *     → key PEM is ENCRYPTED, key_encrypted=1, can_sign=1, fingerprint populated.
+ *   - sign a host under it WITH the right passphrase → success.
+ *   - sign WITHOUT a passphrase → validations.passphrase "passphrase is required".
+ *   - sign with the WRONG passphrase → validations.passphrase "invalid CA passphrase".
+ *   - generate an UNencrypted CA → key_encrypted=0, signs with no passphrase.
+ *   - confirm the passphrase is NEVER written to config.xml.
+ *
+ * Drives the REAL AuthorityController / CertificateController action methods
+ * against the live config + configd (genuine nebula-cert), via a FakeRequest that
+ * scripts getPost() params (same pattern as test_pki_semantics_live.php).
+ *
+ * Run on the OPNsense guest after `make install`:
+ *   php /usr/plugins/net/nebula/tools/test_encrypted_ca_live.php
+ *
+ * Exit 0 = all assertions passed; exit 1 = failure (message to stderr).
+ * The script cleans up every authority/cert it creates.
+ */
+
+$loaderPath = '/usr/local/opnsense/mvc/app/config/loader.php';
+if (!file_exists($loaderPath)) {
+    fwrite(STDERR, "ERROR: OPNsense MVC not found — run `make install` first.\n");
+    exit(1);
+}
+
+require_once '/usr/local/opnsense/mvc/app/config/AppConfig.php';
+$config = new OPNsense\Core\AppConfig([
+    'application' => [
+        'baseUri'        => '/',
+        'controllersDir' => '/usr/local/opnsense/mvc/app/controllers/',
+        'modelsDir'      => '/usr/local/opnsense/mvc/app/models/',
+        'viewsDir'       => '/usr/local/opnsense/mvc/app/views/',
+        'pluginsDir'     => '/usr/local/opnsense/mvc/app/plugins/',
+        'libraryDir'     => '/usr/local/opnsense/mvc/app/library/',
+        'contribDir'     => '/usr/local/opnsense/contrib',
+        'configDefault'  => '/conf/config.xml',
+        'configDir'      => '/conf',
+        'cacheDir'       => '/tmp/live-test-cache',
+        'tempDir'        => '/tmp/live-test-tmp',
+    ],
+    'globals' => [
+        'debug'         => false,
+        'owner'         => 'root:wheel',
+        'simulate_mode' => false,
+    ],
+]);
+
+require_once $loaderPath;
+
+@mkdir('/tmp/live-test-cache', 0700, true);
+@mkdir('/tmp/live-test-tmp',   0700, true);
+
+use OPNsense\Core\Config;
+use OPNsense\Nebula\Nebula;
+use OPNsense\Nebula\Api\AuthorityController;
+use OPNsense\Nebula\Api\CertificateController;
+
+function assert_true(bool $cond, string $msg): void
+{
+    if (!$cond) {
+        fwrite(STDERR, "FAIL: {$msg}\n");
+        exit(1);
+    }
+    echo "PASS: {$msg}\n";
+}
+
+class FakeRequest extends \OPNsense\Mvc\Request
+{
+    public array $post = [];
+    public function isPost(): bool
+    {
+        return true;
+    }
+    public function getPost(?string $name = null, ?string $filter = null, mixed $default = null): mixed
+    {
+        return $this->post[$name] ?? $default;
+    }
+}
+
+class TestAuthorityController extends AuthorityController
+{
+    public function __construct()
+    {
+    }
+    public function setPost(array $p): void
+    {
+        $r = new FakeRequest();
+        $r->post = $p;
+        $this->request = $r;
+    }
+    public function getModel()
+    {
+        return parent::getModel();
+    }
+}
+
+class TestCertificateController extends CertificateController
+{
+    public function __construct()
+    {
+    }
+    public function setPost(array $p): void
+    {
+        $r = new FakeRequest();
+        $r->post = $p;
+        $this->request = $r;
+    }
+    public function getModel()
+    {
+        return parent::getModel();
+    }
+}
+
+function reload_authority(string $uuid)
+{
+    $mdl = new Nebula();
+    foreach ($mdl->pki->authorities->authority->iterateItems() as $n) {
+        if ($n->getAttribute('uuid') === $uuid) {
+            return $n;
+        }
+    }
+    return null;
+}
+
+$created_authorities = [];
+$created_certs       = [];
+
+function cleanup(): void
+{
+    global $created_authorities, $created_certs;
+    $mdl = new Nebula();
+    foreach ($created_certs as $u) {
+        $mdl->pki->certificates->certificate->del($u);
+    }
+    foreach ($created_authorities as $u) {
+        $mdl->pki->authorities->authority->del($u);
+    }
+    $mdl->serializeToConfig();
+    Config::getInstance()->save();
+}
+
+/**
+ * Self-healing sweep: remove any items left by an earlier interrupted run of this
+ * script (matched by the fixed descr names it uses), so re-runs start clean.
+ */
+function sweep_by_descr(): void
+{
+    $certNames = ['enc-host-ok', 'enc-host-nopass', 'enc-host-wrong', 'plain-host'];
+    $caNames   = ['enc-ca', 'plain-ca'];
+    $mdl = new Nebula();
+    $n = 0;
+    foreach ($mdl->pki->certificates->certificate->iterateItems() as $it) {
+        if (in_array((string)$it->descr, $certNames, true)) {
+            $mdl->pki->certificates->certificate->del($it->getAttribute('uuid'));
+            $n++;
+        }
+    }
+    foreach ($mdl->pki->authorities->authority->iterateItems() as $it) {
+        if (in_array((string)$it->descr, $caNames, true)) {
+            $mdl->pki->authorities->authority->del($it->getAttribute('uuid'));
+            $n++;
+        }
+    }
+    if ($n > 0) {
+        $mdl->serializeToConfig();
+        Config::getInstance()->save();
+        echo "INFO: swept {$n} leftover item(s) from a prior run\n";
+    }
+}
+
+$PASS = 'p1-secret';
+
+if (getenv('NEB_PHASE') !== '2') {
+// ===== PHASE 1: generate the CAs (single process) ==========================
+// Sweep any leftovers from a prior interrupted run first.
+sweep_by_descr();
+
+// The certificate `caref` ModelRelationField caches its option list process-
+// statically the first time it is validated.  If we sign in the same process
+// that created the CA, the cache (primed before our Add()) won't see the new CA
+// and the assignment is dropped ("Option [] not in list.").  So phase 1 only
+// generates + asserts CA fields, then re-execs a fresh process (phase 2) for all
+// signing — exactly as test_pki_semantics_live.php does.
+
+// ---------------------------------------------------------------------------
+echo "\n=== 1. Generate an ENCRYPTED CA (passphrase) → encrypted key, can_sign=1 ===\n";
+$ac = new TestAuthorityController();
+$ac->setPost([
+    'name' => 'enc-ca', 'descr' => 'enc-ca', 'curve' => '25519',
+    'duration_days' => 365, 'networks' => '10.66.0.0/24',
+    'passphrase' => $PASS,
+]);
+$res = $ac->generateAction();
+assert_true(($res['result'] ?? '') === 'saved', "encrypted CA generate succeeded (" . json_encode($res) . ")");
+$enc_uuid = $res['uuid'];
+$enc_node = reload_authority($enc_uuid);
+assert_true(stripos((string)$enc_node->key, 'ENCRYPTED') !== false, "stored CA key PEM is ENCRYPTED");
+assert_true((string)$enc_node->key_encrypted === '1', "key_encrypted=1");
+assert_true((string)$enc_node->has_key       === '1', "has_key=1");
+assert_true((string)$enc_node->can_sign      === '1', "can_sign=1 (encrypted CA is signable)");
+assert_true((string)$enc_node->fingerprint   !== '',  "fingerprint populated");
+
+// The passphrase must NEVER be persisted anywhere in the stored authority node.
+$blob = json_encode([
+    'descr' => (string)$enc_node->descr, 'crt' => (string)$enc_node->crt,
+    'key' => (string)$enc_node->key, 'cn' => (string)$enc_node->cn,
+]);
+assert_true(strpos($blob, $PASS) === false, "passphrase is NOT stored in the authority node fields");
+
+// ---------------------------------------------------------------------------
+echo "\n=== 2. Generate an UNencrypted CA → key_encrypted=0 ===\n";
+$ac2 = new TestAuthorityController();
+$ac2->setPost([
+    'name' => 'plain-ca', 'descr' => 'plain-ca', 'curve' => '25519',
+    'duration_days' => 365, 'networks' => '10.77.0.0/24',
+]);
+$res2 = $ac2->generateAction();
+assert_true(($res2['result'] ?? '') === 'saved', "unencrypted CA generate succeeded (" . json_encode($res2) . ")");
+$plain_uuid = $res2['uuid'];
+$plain_node = reload_authority($plain_uuid);
+assert_true(stripos((string)$plain_node->key, 'ENCRYPTED') === false, "plain CA key PEM is NOT encrypted");
+assert_true((string)$plain_node->key_encrypted === '0', "plain CA key_encrypted=0");
+assert_true((string)$plain_node->can_sign      === '1', "plain CA can_sign=1");
+
+// Re-exec for phase 2 (fresh process → real caref cache).  The child owns cleanup.
+$env = ['NEB_PHASE' => '2', 'NEB_ENC' => $enc_uuid, 'NEB_PLAIN' => $plain_uuid, 'NEB_PASS' => $PASS];
+$envPrefix = '';
+foreach ($env as $k => $v) {
+    $envPrefix .= $k . '=' . escapeshellarg($v) . ' ';
+}
+echo "\n--- re-exec for phase 2 (fresh process; real caref cache) ---\n";
+passthru("$envPrefix /usr/local/bin/php " . escapeshellarg(__FILE__), $childRc);
+exit($childRc);
+}
+
+// ===== PHASE 2 (fresh process): signing + config.xml check + cleanup =======
+$enc_uuid   = getenv('NEB_ENC');
+$plain_uuid = getenv('NEB_PLAIN');
+$PASS       = getenv('NEB_PASS');
+$created_authorities = [$enc_uuid, $plain_uuid];
+
+// ===========================================================================
+echo "\n=== 3. Sign a host under the encrypted CA WITH the right passphrase → success ===\n";
+$cc = new TestCertificateController();
+$cc->setPost([
+    'descr' => 'enc-host-ok', 'caref' => $enc_uuid, 'name' => 'enc-host-ok',
+    'networks' => '10.66.0.7/24', 'passphrase' => $PASS,
+]);
+$res3 = $cc->signAction();
+assert_true(($res3['result'] ?? '') === 'saved', "sign with right passphrase succeeded (" . json_encode($res3) . ")");
+$created_certs[] = $res3['uuid'];
+
+// ===========================================================================
+echo "\n=== 4. Sign WITHOUT a passphrase → validation: passphrase required ===\n";
+$cc2 = new TestCertificateController();
+$cc2->setPost([
+    'descr' => 'enc-host-nopass', 'caref' => $enc_uuid, 'name' => 'enc-host-nopass',
+    'networks' => '10.66.0.8/24',
+]);
+$res4 = $cc2->signAction();
+assert_true(($res4['result'] ?? '') === 'failed', "sign without passphrase rejected");
+assert_true(
+    isset($res4['validations']['passphrase']) && stripos($res4['validations']['passphrase'], 'required') !== false,
+    "rejection asks for a passphrase: " . ($res4['validations']['passphrase'] ?? '')
+);
+
+// ===========================================================================
+echo "\n=== 5. Sign with the WRONG passphrase → validation: invalid CA passphrase ===\n";
+$cc3 = new TestCertificateController();
+$cc3->setPost([
+    'descr' => 'enc-host-wrong', 'caref' => $enc_uuid, 'name' => 'enc-host-wrong',
+    'networks' => '10.66.0.9/24', 'passphrase' => 'totally-wrong',
+]);
+$res5 = $cc3->signAction();
+assert_true(($res5['result'] ?? '') === 'failed', "sign with wrong passphrase rejected");
+assert_true(
+    isset($res5['validations']['passphrase']) && stripos($res5['validations']['passphrase'], 'invalid CA passphrase') !== false,
+    "rejection maps nebula error to 'invalid CA passphrase': " . ($res5['validations']['passphrase'] ?? '')
+);
+
+// ===========================================================================
+echo "\n=== 6. Sign under the UNencrypted CA with no passphrase → success ===\n";
+$cc4 = new TestCertificateController();
+$cc4->setPost([
+    'descr' => 'plain-host', 'caref' => $plain_uuid, 'name' => 'plain-host',
+    'networks' => '10.77.0.5/24',
+]);
+$res6 = $cc4->signAction();
+assert_true(($res6['result'] ?? '') === 'saved', "sign under plain CA with no passphrase succeeded (" . json_encode($res6) . ")");
+$created_certs[] = $res6['uuid'];
+
+// ===========================================================================
+echo "\n=== 7. Passphrase absent from on-disk config.xml ===\n";
+$cfgRaw = @file_get_contents('/conf/config.xml');
+assert_true($cfgRaw !== false, "read /conf/config.xml");
+assert_true(strpos($cfgRaw, $PASS) === false, "passphrase string does NOT appear anywhere in config.xml");
+
+// ===========================================================================
+echo "\n=== Cleanup ===\n";
+cleanup();
+echo "INFO: cleanup complete\n";
+echo "\n=== All encrypted-CA live checks PASSED ===\n";
+exit(0);

--- a/net/nebula/tools/test_fwrules_live.php
+++ b/net/nebula/tools/test_fwrules_live.php
@@ -1,0 +1,226 @@
+#!/usr/local/bin/php
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Guest oracle: verify per-instance firewall rules render into nebula.yml.
+ *
+ * Prerequisites: reseed_demo.php must have been run first so a demo-lighthouse
+ * instance with certs exists (the cert dir is needed for `nebula -test` to pass).
+ *
+ * Run on the OPNsense guest after `make install`:
+ *   php /usr/plugins/net/nebula/tools/test_fwrules_live.php
+ */
+
+require_once('script/load_phalcon.php');
+
+use OPNsense\Core\Config;
+use OPNsense\Nebula\Nebula;
+
+function info(string $msg): void
+{
+    echo "INFO: {$msg}\n";
+}
+
+function pass(string $msg): void
+{
+    echo "PASS: {$msg}\n";
+}
+
+function fail(string $msg): void
+{
+    fwrite(STDERR, "FAIL: {$msg}\n");
+    exit(1);
+}
+
+function assert_ok(bool $cond, string $msg): void
+{
+    if (!$cond) {
+        fail($msg);
+    }
+    pass($msg);
+}
+
+function assert_contains(string $haystack, string $needle, string $msg): void
+{
+    assert_ok(strpos($haystack, $needle) !== false, $msg . " (looking for: {$needle})");
+}
+
+function assert_not_contains(string $haystack, string $needle, string $msg): void
+{
+    assert_ok(strpos($haystack, $needle) === false, $msg . " (must not contain: {$needle})");
+}
+
+// -----------------------------------------------------------------------
+// Find the demo-lighthouse instance (seeded by reseed_demo.php).
+// -----------------------------------------------------------------------
+$model = new Nebula();
+$instNode = null;
+foreach ($model->instances->instance->iterateItems() as $inst) {
+    if ((string)$inst->description === 'demo-lighthouse') {
+        $instNode = $inst;
+        break;
+    }
+}
+if ($instNode === null) {
+    fail("demo-lighthouse instance not found — run reseed_demo.php first");
+}
+$uuid = $instNode->getAttribute('uuid');
+info("Using instance uuid={$uuid} (demo-lighthouse)");
+
+// -----------------------------------------------------------------------
+// Remove any old test fwrules left from a previous run.
+// -----------------------------------------------------------------------
+$toDelete = [];
+foreach ($model->fwrules->rule->iterateItems() as $rule) {
+    if ((string)$rule->instance === $uuid) {
+        $toDelete[] = $rule->getAttribute('uuid');
+    }
+}
+foreach ($toDelete as $ruleUuid) {
+    $model->fwrules->rule->del($ruleUuid);
+}
+if (!empty($toDelete)) {
+    info("Removed " . count($toDelete) . " old test rules");
+}
+
+// -----------------------------------------------------------------------
+// Phase 1: Add real rules and verify they render.
+// -----------------------------------------------------------------------
+info("=== Phase 1: rules present ===");
+
+$r1 = $model->fwrules->rule->Add();
+$r1->enabled   = '1';
+$r1->instance  = $uuid;
+$r1->direction = 'inbound';
+$r1->protocol  = 'tcp';
+$r1->port      = '5432';
+$r1->group     = 'db';
+
+$r2 = $model->fwrules->rule->Add();
+$r2->enabled   = '1';
+$r2->instance  = $uuid;
+$r2->direction = 'inbound';
+$r2->protocol  = 'icmp';
+$r2->port      = 'any';
+$r2->host      = 'any';
+
+$r3 = $model->fwrules->rule->Add();
+$r3->enabled   = '1';
+$r3->instance  = $uuid;
+$r3->direction = 'outbound';
+$r3->host      = 'any';
+
+// Persist and reconfigure.
+$model->serializeToConfig();
+Config::getInstance()->save();
+$rc = 0;
+$out = [];
+exec('configctl nebula reconfigure 2>&1', $out, $rc);
+info("configctl nebula reconfigure: rc={$rc}");
+foreach ($out as $line) {
+    info("  {$line}");
+}
+assert_ok($rc === 0, "configctl nebula reconfigure exited 0");
+
+$ymlPath = "/usr/local/etc/nebula/{$uuid}.yml";
+assert_ok(file_exists($ymlPath), "nebula.yml exists at {$ymlPath}");
+$yaml = file_get_contents($ymlPath);
+
+// Inbound rules must appear.
+assert_contains($yaml, 'group: "db"', "group matcher rendered");
+assert_contains($yaml, 'port: "5432"', "port 5432 rendered");
+assert_contains($yaml, 'proto: "tcp"', "proto tcp rendered");
+assert_contains($yaml, 'proto: "icmp"', "proto icmp rendered");
+
+// Outbound rule must appear.
+assert_contains($yaml, 'outbound:', "outbound key present");
+
+// The placeholder 'host: "any"' appears ONLY from the outbound rule (r3), not
+// from a permissive fallback on the inbound direction. Verify the inbound block
+// contains tcp and icmp, which means the inbound rules were rendered (not the fallback).
+assert_contains($yaml, 'proto: "tcp"',  "inbound rule tcp present — no permissive fallback on inbound");
+assert_contains($yaml, 'proto: "icmp"', "inbound rule icmp present");
+
+// nebula -test rc=0
+$certDir = "/usr/local/etc/nebula/{$uuid}";
+$nebulaTest = [];
+$nebulaRc   = 0;
+exec("/usr/local/bin/nebula -test -config {$ymlPath} 2>&1", $nebulaTest, $nebulaRc);
+info("nebula -test (with rules): rc={$nebulaRc}");
+foreach ($nebulaTest as $line) {
+    info("  {$line}");
+}
+assert_ok($nebulaRc === 0, "nebula -test rc=0 with explicit rules");
+
+// -----------------------------------------------------------------------
+// Phase 2: Remove all rules → permissive fallback.
+// -----------------------------------------------------------------------
+info("=== Phase 2: no rules → permissive fallback ===");
+
+$model2 = new Nebula();
+$toDelete2 = [];
+foreach ($model2->fwrules->rule->iterateItems() as $rule) {
+    if ((string)$rule->instance === $uuid) {
+        $toDelete2[] = $rule->getAttribute('uuid');
+    }
+}
+foreach ($toDelete2 as $ruleUuid) {
+    $model2->fwrules->rule->del($ruleUuid);
+}
+info("Removed " . count($toDelete2) . " rules");
+
+$model2->serializeToConfig();
+Config::getInstance()->save();
+$rc2 = 0;
+$out2 = [];
+exec('configctl nebula reconfigure 2>&1', $out2, $rc2);
+info("configctl nebula reconfigure (no rules): rc={$rc2}");
+foreach ($out2 as $line) {
+    info("  {$line}");
+}
+assert_ok($rc2 === 0, "configctl nebula reconfigure (no rules) exited 0");
+
+$yaml2 = file_get_contents($ymlPath);
+assert_contains($yaml2, 'proto: "any"', "permissive fallback proto:any present when no rules");
+assert_contains($yaml2, 'host: "any"',  "permissive fallback host:any present when no rules");
+assert_contains($yaml2, 'port: "any"',  "permissive fallback port:any present when no rules");
+
+$nebulaTest2 = [];
+$nebulaRc2   = 0;
+exec("/usr/local/bin/nebula -test -config {$ymlPath} 2>&1", $nebulaTest2, $nebulaRc2);
+info("nebula -test (permissive fallback): rc={$nebulaRc2}");
+foreach ($nebulaTest2 as $line) {
+    info("  {$line}");
+}
+assert_ok($nebulaRc2 === 0, "nebula -test rc=0 with permissive fallback");
+
+// -----------------------------------------------------------------------
+// Done.
+// -----------------------------------------------------------------------
+echo "\nAll oracle checks passed.\n";

--- a/net/nebula/tools/test_pki_semantics_live.php
+++ b/net/nebula/tools/test_pki_semantics_live.php
@@ -1,0 +1,419 @@
+#!/usr/local/bin/php
+<?php
+
+/*
+ * Copyright (C) 2026 Henry Stern <henry@stern.ca>
+ * All rights reserved.
+ *
+ * Live verification of the PKI-semantics fixes (can_sign vs has_key, accept
+ * encrypted CA keys, reject non-CA on CA import, issuer-derived CA name, curve
+ * column population, signer-dropdown filter data).
+ *
+ * Drives the REAL AuthorityController / CertificateController action methods
+ * against the live config + configd (genuine nebula-cert), by subclassing each
+ * controller to inject a fake request whose getPost() returns scripted params.
+ *
+ * Run on the OPNsense guest after `make install`:
+ *   php /usr/plugins/net/nebula/tools/test_pki_semantics_live.php
+ *
+ * Exit 0 = all assertions passed; exit 1 = failure (message printed to stderr).
+ * The script cleans up every authority/cert it creates.
+ */
+
+$loaderPath = '/usr/local/opnsense/mvc/app/config/loader.php';
+if (!file_exists($loaderPath)) {
+    fwrite(STDERR, "ERROR: OPNsense MVC not found — run `make install` first.\n");
+    exit(1);
+}
+
+require_once '/usr/local/opnsense/mvc/app/config/AppConfig.php';
+$config = new OPNsense\Core\AppConfig([
+    'application' => [
+        'baseUri'        => '/',
+        'controllersDir' => '/usr/local/opnsense/mvc/app/controllers/',
+        'modelsDir'      => '/usr/local/opnsense/mvc/app/models/',
+        'viewsDir'       => '/usr/local/opnsense/mvc/app/views/',
+        'pluginsDir'     => '/usr/local/opnsense/mvc/app/plugins/',
+        'libraryDir'     => '/usr/local/opnsense/mvc/app/library/',
+        'contribDir'     => '/usr/local/opnsense/contrib',
+        'configDefault'  => '/conf/config.xml',
+        'configDir'      => '/conf',
+        'cacheDir'       => '/tmp/live-test-cache',
+        'tempDir'        => '/tmp/live-test-tmp',
+    ],
+    'globals' => [
+        'debug'         => false,
+        'owner'         => 'root:wheel',
+        'simulate_mode' => false,
+    ],
+]);
+
+require_once $loaderPath;
+
+@mkdir('/tmp/live-test-cache', 0700, true);
+@mkdir('/tmp/live-test-tmp',   0700, true);
+
+use OPNsense\Core\Backend;
+use OPNsense\Core\Config;
+use OPNsense\Nebula\Nebula;
+use OPNsense\Nebula\Api\AuthorityController;
+use OPNsense\Nebula\Api\CertificateController;
+
+function assert_true(bool $cond, string $msg): void
+{
+    if (!$cond) {
+        fwrite(STDERR, "FAIL: {$msg}\n");
+        exit(1);
+    }
+    echo "PASS: {$msg}\n";
+}
+
+// A stand-in for the request that extends the real typed Request so it can be
+// assigned to the controller's typed $request property; scripts POST params.
+class FakeRequest extends \OPNsense\Mvc\Request
+{
+    public array $post = [];
+    public function isPost(): bool
+    {
+        return true;
+    }
+    public function getPost(?string $name = null, ?string $filter = null, mixed $default = null): mixed
+    {
+        return $this->post[$name] ?? $default;
+    }
+}
+
+// Test subclasses that bypass the Phalcon DI/HTTP layer: we set $this->request
+// directly and stub the validator-trigger so the base controller's
+// performValidation()/serialize path runs against the live model.
+class TestAuthorityController extends AuthorityController
+{
+    public function __construct()
+    {
+        // do not call parent::__construct (needs Phalcon DI)
+    }
+    public function setPost(array $p): void
+    {
+        $r = new FakeRequest();
+        $r->post = $p;
+        $this->request = $r;
+    }
+    public function getModel()
+    {
+        return parent::getModel();
+    }
+}
+
+class TestCertificateController extends CertificateController
+{
+    public function __construct()
+    {
+    }
+    public function setPost(array $p): void
+    {
+        $r = new FakeRequest();
+        $r->post = $p;
+        $this->request = $r;
+    }
+    public function getModel()
+    {
+        return parent::getModel();
+    }
+}
+
+function call_pki(string $action, array $params): array
+{
+    $b64 = base64_encode(json_encode($params));
+    $out = (new Backend())->configdpRun("nebula {$action}", [$b64]);
+    $res = json_decode($out, true);
+    return is_array($res) ? $res : ['error' => 'non-JSON'];
+}
+
+// Read a fresh node from the live config by uuid.
+function reload_authority(string $uuid)
+{
+    $mdl = new Nebula();
+    foreach ($mdl->pki->authorities->authority->iterateItems() as $n) {
+        if ($n->getAttribute('uuid') === $uuid) {
+            return $n;
+        }
+    }
+    return null;
+}
+function reload_cert(string $uuid)
+{
+    $mdl = new Nebula();
+    foreach ($mdl->pki->certificates->certificate->iterateItems() as $n) {
+        if ($n->getAttribute('uuid') === $uuid) {
+            return $n;
+        }
+    }
+    return null;
+}
+
+$created_authorities = [];
+$created_certs       = [];
+
+function cleanup(): void
+{
+    global $created_authorities, $created_certs;
+    $mdl = new Nebula();
+    foreach ($created_certs as $u) {
+        $mdl->pki->certificates->certificate->del($u);
+    }
+    foreach ($created_authorities as $u) {
+        $mdl->pki->authorities->authority->del($u);
+    }
+    $mdl->serializeToConfig();
+    Config::getInstance()->save();
+}
+
+if (getenv('NEB_PHASE') !== '2') {
+// ===== PHASE 1: PEM generation + tests 1-5 (single process) ================
+// Build the PEM artifacts we need by calling nebula-cert directly.
+// NB: $tmp is intentionally NOT cleaned up at phase-1 shutdown — phase 2 (a fresh
+// re-exec, see below) reuses these PEMs and owns the final cleanup of $tmp.
+$tmp = rtrim(shell_exec('mktemp -d'), "\n");
+
+// demo-ca (signable), host signed by demo-ca, a cert-only "foo" CA, an encrypted CA.
+shell_exec("/usr/local/bin/nebula-cert ca -name demo-ca -networks 10.44.0.0/24 -out-crt $tmp/demo.crt -out-key $tmp/demo.key -duration 8760h");
+shell_exec("/usr/local/bin/nebula-cert ca -name foo -networks 10.99.0.0/24 -out-crt $tmp/foo.crt -out-key $tmp/foo.key -duration 8760h");
+shell_exec("/usr/local/bin/nebula-cert sign -ca-crt $tmp/demo.crt -ca-key $tmp/demo.key -name host-demo -networks 10.44.0.7/24 -out-crt $tmp/host.crt -out-key $tmp/host.key");
+// Encrypted CA key via a pty wrapper.
+$pty = <<<PY
+import pty,os,time
+pid,fd=pty.fork()
+if pid==0:
+    os.execvp("/usr/local/bin/nebula-cert",["nebula-cert","ca","-name","enc-ca","-networks","10.55.0.0/24","-encrypt","-out-crt","$tmp/enc.crt","-out-key","$tmp/enc.key"])
+else:
+    buf=b"";sent=0
+    while True:
+        try:d=os.read(fd,1024)
+        except OSError:break
+        if not d:break
+        buf+=d
+        if buf.lower().count(b"passphrase")>sent:
+            os.write(fd,b"secret123\\n");sent+=1;time.sleep(0.3)
+    os.waitpid(pid,0)
+PY;
+file_put_contents("$tmp/encgen.py", $pty);
+shell_exec("python3 $tmp/encgen.py 2>/dev/null");
+
+$demo_crt = file_get_contents("$tmp/demo.crt");
+$demo_key = file_get_contents("$tmp/demo.key");
+$foo_crt  = file_get_contents("$tmp/foo.crt");
+$host_crt = file_get_contents("$tmp/host.crt");
+$host_key = file_get_contents("$tmp/host.key");
+$enc_crt  = file_get_contents("$tmp/enc.crt");
+$enc_key  = file_get_contents("$tmp/enc.key");
+
+assert_true($enc_key !== false && stripos($enc_key, 'ENCRYPTED') !== false, "crafted an encrypted NEBULA key PEM (header contains ENCRYPTED)");
+
+// demo-ca fingerprint (from print) — for issuer-resolution checks.
+$demoPrint = call_pki('pki_print_cert', ['crt' => $demo_crt]);
+$demo_fp   = $demoPrint['info'][0]['fingerprint'] ?? '';
+assert_true($demo_fp !== '', "obtained demo-ca fingerprint: " . substr($demo_fp, 0, 12) . "…");
+
+// ===========================================================================
+echo "\n=== 1. Cert-only CA import (foo: crt only, no key) ===\n";
+$ac = new TestAuthorityController();
+$ac->setPost(['descr' => 'foo', 'crt' => $foo_crt, 'key' => '']);
+$res = $ac->importAction();
+assert_true(($res['result'] ?? '') === 'saved', "cert-only CA import accepted (" . json_encode($res) . ")");
+$foo_uuid = $res['uuid'];
+$created_authorities[] = $foo_uuid;
+$foo_node = reload_authority($foo_uuid);
+assert_true((string)$foo_node->has_key  === '0', "cert-only CA has_key=0");
+assert_true((string)$foo_node->can_sign === '0', "cert-only CA can_sign=0");
+assert_true((string)$foo_node->is_ca    === '1', "cert-only CA is_ca=1");
+assert_true((string)$foo_node->curve    !== '',  "cert-only CA curve populated: " . (string)$foo_node->curve);
+
+// ===========================================================================
+echo "\n=== 2. Import a non-CA cert as a CA → rejected (isCa=false) ===\n";
+$ac2 = new TestAuthorityController();
+$ac2->setPost(['descr' => 'should-fail', 'crt' => $host_crt, 'key' => '']);
+$res2 = $ac2->importAction();
+assert_true(($res2['result'] ?? '') === 'failed', "non-CA import rejected");
+assert_true(isset($res2['validations']['crt']) && stripos($res2['validations']['crt'], 'not a CA') !== false,
+    "rejection message mentions isCa=false: " . ($res2['validations']['crt'] ?? ''));
+
+// ===========================================================================
+echo "\n=== 3. Import an ENCRYPTED CA key → accepted, has_key=1, key_encrypted=1, can_sign=1 ===\n";
+$ac3 = new TestAuthorityController();
+$ac3->setPost(['descr' => 'enc-ca', 'crt' => $enc_crt, 'key' => $enc_key]);
+$res3 = $ac3->importAction();
+assert_true(($res3['result'] ?? '') === 'saved', "encrypted CA import accepted (" . json_encode($res3) . ")");
+$enc_uuid = $res3['uuid'];
+$created_authorities[] = $enc_uuid;
+$enc_node = reload_authority($enc_uuid);
+assert_true((string)$enc_node->has_key       === '1', "encrypted CA has_key=1 (key IS stored → download button shows)");
+assert_true((string)$enc_node->key_encrypted === '1', "encrypted CA key_encrypted=1 (Sign dialog prompts for passphrase)");
+assert_true((string)$enc_node->can_sign      === '1', "encrypted CA can_sign=1 (signable with a passphrase, INFRA-163)");
+
+// ===========================================================================
+echo "\n=== 4. Generate a proper CA (demo-ca) → can_sign=1 ===\n";
+$ac4 = new TestAuthorityController();
+$ac4->setPost([
+    'name' => 'demo-ca', 'descr' => 'demo-ca', 'curve' => '25519',
+    'duration_days' => 365, 'networks' => '10.44.0.0/24',
+]);
+$res4 = $ac4->generateAction();
+assert_true(($res4['result'] ?? '') === 'saved', "demo-ca generate succeeded (" . json_encode($res4) . ")");
+$demo_uuid = $res4['uuid'];
+$created_authorities[] = $demo_uuid;
+$demo_node = reload_authority($demo_uuid);
+assert_true((string)$demo_node->can_sign === '1', "generated demo-ca can_sign=1");
+assert_true((string)$demo_node->has_key  === '1', "generated demo-ca has_key=1");
+$demo_gen_fp = (string)$demo_node->fingerprint;
+assert_true($demo_gen_fp !== '', "generated demo-ca fingerprint populated: " . substr($demo_gen_fp, 0, 12) . "…");
+
+// ===========================================================================
+echo "\n=== 5. searchItemAction returns can_sign + fingerprint + curve (dropdown data) ===\n";
+$searchAc = new TestAuthorityController();
+$searchAc->setPost([]);
+$rows = $searchAc->searchItemAction()['rows'] ?? [];
+$byUuid = [];
+foreach ($rows as $r) {
+    $byUuid[$r['uuid']] = $r;
+}
+assert_true(isset($byUuid[$demo_uuid]['can_sign']), "searchItem row has can_sign field");
+assert_true(isset($byUuid[$demo_uuid]['fingerprint']), "searchItem row has fingerprint field");
+assert_true(isset($byUuid[$demo_uuid]['curve']), "searchItem row has curve field");
+assert_true(($byUuid[$demo_uuid]['can_sign'] ?? '') === '1', "demo-ca row can_sign=1 (would appear in dropdown)");
+assert_true(($byUuid[$foo_uuid]['can_sign'] ?? '') === '0', "foo row can_sign=0 (filtered OUT of dropdown)");
+assert_true(($byUuid[$enc_uuid]['can_sign'] ?? '') === '1', "enc-ca row can_sign=1 (IN the dropdown; passphrase prompted)");
+assert_true(isset($byUuid[$enc_uuid]['key_encrypted']), "searchItem row has key_encrypted field");
+assert_true(($byUuid[$enc_uuid]['key_encrypted'] ?? '') === '1', "enc-ca row key_encrypted=1 (drives Sign passphrase prompt)");
+// Confirm no key/crt leaks into grid JSON.
+assert_true(!isset($byUuid[$demo_uuid]['key']) && !isset($byUuid[$demo_uuid]['crt']), "searchItem strips key+crt PEM");
+
+// ---------------------------------------------------------------------------
+// End of phase 1.  Tests 6-9 touch the certificate `caref` ModelRelationField,
+// whose option list is cached process-statically (keyed by source/filter) the
+// first time it is validated.  In this single long-lived harness that cache was
+// primed before the CAs above were saved, so a caref assignment here would be
+// silently dropped — a harness-only artifact (each real GUI request is a fresh
+// PHP process where the CA is always visible).  To reproduce real behaviour we
+// re-exec this script as a fresh process for phase 2, passing the saved
+// uuids/fingerprints + the $tmp PEM dir via env.  The child owns final cleanup.
+// ---------------------------------------------------------------------------
+    $env = [
+        'NEB_PHASE'   => '2',
+        'NEB_TMP'     => $tmp,
+        'NEB_DEMO'    => $demo_uuid,
+        'NEB_DEMO_FP' => $demo_gen_fp,
+        'NEB_FILE_FP' => $demo_fp,
+        'NEB_FOO'     => $foo_uuid,
+        'NEB_ENC'     => $enc_uuid,
+    ];
+    $envPrefix = '';
+    foreach ($env as $k => $v) {
+        $envPrefix .= $k . '=' . escapeshellarg($v) . ' ';
+    }
+    echo "\n--- re-exec for phase 2 (fresh process; real caref cache) ---\n";
+    $self = escapeshellarg(__FILE__);
+    passthru("$envPrefix /usr/local/bin/php $self", $childRc);
+    exit($childRc);
+}
+
+// ===== PHASE 2 (fresh process) ============================================
+$tmp         = getenv('NEB_TMP');
+$demo_uuid   = getenv('NEB_DEMO');
+$demo_gen_fp = getenv('NEB_DEMO_FP');
+$demo_fp     = getenv('NEB_FILE_FP');
+$foo_uuid    = getenv('NEB_FOO');
+$enc_uuid    = getenv('NEB_ENC');
+$demo_crt = file_get_contents("$tmp/demo.crt");
+$demo_key = file_get_contents("$tmp/demo.key");
+$foo_crt  = file_get_contents("$tmp/foo.crt");
+$host_crt = file_get_contents("$tmp/host.crt");
+$host_key = file_get_contents("$tmp/host.key");
+// Phase 2 owns cleanup of all items + the tmp dir.
+$created_authorities = [$demo_uuid, $foo_uuid, $enc_uuid];
+$created_certs       = [];
+register_shutdown_function(fn() => shell_exec('rm -rf ' . escapeshellarg($tmp)));
+
+// ===========================================================================
+echo "\n=== 6. Sign a host cert under demo-ca → issuer = demo-ca fp; CA column resolves ===\n";
+$cc = new TestCertificateController();
+$cc->setPost([
+    'descr' => 'signed-host', 'caref' => $demo_uuid, 'name' => 'signed-host',
+    'networks' => '10.44.0.11/24',
+]);
+$res6 = $cc->signAction();
+assert_true(($res6['result'] ?? '') === 'saved', "sign under demo-ca succeeded (" . json_encode($res6) . ")");
+$signed_uuid = $res6['uuid'];
+$created_certs[] = $signed_uuid;
+$signed_node = reload_cert($signed_uuid);
+assert_true((string)$signed_node->issuer === $demo_gen_fp, "signed cert issuer == demo-ca fingerprint");
+assert_true((string)$signed_node->curve  !== '', "signed cert curve populated: " . (string)$signed_node->curve);
+assert_true((string)$signed_node->has_key === '1', "signed cert (generate-here) has_key=1");
+
+// ===========================================================================
+echo "\n=== 7. Import a host cert (no caref) whose issuer IS demo-ca → CA resolves dynamically ===\n";
+$cc2 = new TestCertificateController();
+$cc2->setPost(['descr' => 'imported-host', 'crt' => $host_crt, 'key' => $host_key]);
+$res7 = $cc2->importAction();
+assert_true(($res7['result'] ?? '') === 'saved', "host import (no caref) succeeded (" . json_encode($res7) . ")");
+$imp_uuid = $res7['uuid'];
+$created_certs[] = $imp_uuid;
+$imp_node = reload_cert($imp_uuid);
+// host.crt was signed by the *file* demo-ca (demo_fp), which differs from the
+// in-config generated demo-ca (demo_gen_fp). So its issuer is the file CA's fp.
+assert_true((string)$imp_node->issuer === $demo_fp, "imported host issuer == signing-CA fingerprint");
+assert_true((string)$imp_node->has_key === '1', "imported host (with key) has_key=1");
+
+// Now resolve CA names via searchItemAction.
+$searchCc = new TestCertificateController();
+$searchCc->setPost([]);
+$crows = $searchCc->searchItemAction()['rows'] ?? [];
+$cByUuid = [];
+foreach ($crows as $r) {
+    $cByUuid[$r['uuid']] = $r;
+}
+// signed-host's issuer is the in-config demo-ca → resolves to "demo-ca".
+assert_true(($cByUuid[$signed_uuid]['ca_name'] ?? '') === 'demo-ca',
+    "signed-host CA column resolves to demo-ca (got: " . ($cByUuid[$signed_uuid]['ca_name'] ?? '') . ")");
+// imported-host's issuer (file demo-ca) is NOT in the pool → "unknown: <fp>".
+$imp_ca = $cByUuid[$imp_uuid]['ca_name'] ?? '';
+assert_true(strpos($imp_ca, 'unknown: ') === 0 && strpos($imp_ca, $demo_fp) !== false,
+    "imported-host (issuer not in pool) shows 'unknown: <fp>' (got: $imp_ca)");
+
+// ===========================================================================
+echo "\n=== 8. Now import the file demo-ca as a CA → imported-host auto-resolves ===\n";
+$ac8 = new TestAuthorityController();
+$ac8->setPost(['descr' => 'file-demo-ca', 'crt' => $demo_crt, 'key' => $demo_key]);
+$res8 = $ac8->importAction();
+assert_true(($res8['result'] ?? '') === 'saved', "file demo-ca import accepted");
+$fileca_uuid = $res8['uuid'];
+$created_authorities[] = $fileca_uuid;
+$searchCc2 = new TestCertificateController();
+$searchCc2->setPost([]);
+$crows2 = $searchCc2->searchItemAction()['rows'] ?? [];
+$resolved = '';
+foreach ($crows2 as $r) {
+    if ($r['uuid'] === $imp_uuid) {
+        $resolved = $r['ca_name'];
+    }
+}
+// The file demo-ca's embedded CN is "demo-ca" (we named both CAs demo-ca), and
+// searchItemAction resolves via cn (fallback descr), so it correctly shows the
+// CN "demo-ca" — the point is it is no longer "unknown:" once the CA is in pool.
+assert_true($resolved === 'demo-ca' && strpos($resolved, 'unknown') === false,
+    "imported-host CA auto-resolves to the CA's CN once imported (got: $resolved)");
+
+// ===========================================================================
+echo "\n=== 9. Duplicate CA import (same fingerprint) → rejected, tells user to delete first ===\n";
+$ac9 = new TestAuthorityController();
+$ac9->setPost(['descr' => 'foo-again', 'crt' => $foo_crt, 'key' => file_get_contents("$tmp/foo.key")]);
+$res9 = $ac9->importAction();
+assert_true(($res9['result'] ?? '') === 'failed', "duplicate CA import rejected");
+assert_true(isset($res9['validations']['crt']) && stripos($res9['validations']['crt'], 'already imported') !== false,
+    "duplicate rejection tells user to delete first: " . ($res9['validations']['crt'] ?? ''));
+
+// ===========================================================================
+echo "\n=== Cleanup ===\n";
+cleanup();
+echo "INFO: cleanup complete\n";
+echo "\n=== All PKI-semantics live checks PASSED ===\n";
+exit(0);


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- **Model used:** Claude (Anthropic) — Claude Code, Opus- and Sonnet-class 4.x models.
- **Extent of AI involvement:** Substantial. The plugin was authored primarily with Claude Code under my direction, using a workflow where each change was implemented and then reviewed in a separate pass. I directed the architecture and scope and reviewed every change, and I built, deployed and tested the result end-to-end on a live OPNsense 26.1 VM (instance create → CA → cert sign → Apply → tunnel up and assignable). The design decisions, scoping and verification are mine; the code generation and much of the review assistance were AI.

> Note: I originally replaced this template with a free-form writeup, which dropped the AI disclosure above — restored here. Apologies; that was not intentional.

---

**Describe the problem**

OPNsense has no native interface for [Slack Nebula](https://github.com/slackhq/nebula), a certificate-authenticated mesh overlay VPN. Unlike the mesh VPNs already packaged (netbird, zerotier, tailscale), Nebula has no coordination/control-plane service: identity is pure offline PKI, and the only infrastructure is a "lighthouse" that does host discovery and NAT punching — it brokers no trust and holds no config. It is the one option where OPNsense can be both the CA and the lighthouse — a fully self-hosted, no-account overlay — but today that requires hand-managing certificates, YAML and the daemon from the CLI.

---

**Describe the proposed solution**

A new plugin `net/nebula` that manages Nebula from the OPNsense UI. It declares `PLUGIN_DEPENDS = nebula` → `security/nebula` (already in opnsense/ports at 1.10.3), so binary management stays with pkg.

**Scope note (per review feedback):** as submitted this PR contains the complete plugin, which is too much to review in one drop. I'm restructuring this into a series of small, individually-reviewable PRs, starting with a sub-1000-LOC MVP (single instance + config generation + service lifecycle + imported cert material), then adding CA/cert management, first-class interface registration, and overlay firewall / routing / monitoring one PR at a time. See the discussion below.

---

**Related issue**

N/A — I should have opened an issue first for a change this size; happy to open one and move the design discussion there if preferred.