### PR TITLE
udpbroadcastrelay: remove stray semicolon in $internalModelClass

### DIFF
--- a/net/udpbroadcastrelay/src/opnsense/mvc/app/controllers/OPNsense/UDPBroadcastRelay/Api/SettingsController.php
+++ b/net/udpbroadcastrelay/src/opnsense/mvc/app/controllers/OPNsense/UDPBroadcastRelay/Api/SettingsController.php
@@ -40,7 +40,7 @@ use OPNsense\Base\UIModelGrid;
 class SettingsController extends ApiMutableModelControllerBase
 {
     protected static $internalModelName = 'udpbroadcastrelay';
-    protected static $internalModelClass = '\OPNsense\UDPBroadcastRelay\UDPBroadcastRelay;';
+    protected static $internalModelClass = '\OPNsense\UDPBroadcastRelay\UDPBroadcastRelay';
     protected static $internalModelUseSafeDelete = true;
 
 


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: Opus 4.8
- Extent of AI involvement: testing and finding location

---

**Describe the problem**

There is a dangling semicolon in the internal model class so it cannot be resolved properly.

---

**Describe the proposed solution**

Remove the semicolon.

---

**Related issue**

None.
