### PR TITLE
dns/bind: add SVCB record type support

### DIFF
--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Record.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Record.xml
@@ -38,6 +38,7 @@
                         <RRSIG>RRSIG</RRSIG>
                         <SRV>SRV</SRV>
                         <SSHFP>SSHFP</SSHFP>
+                        <SVCB>SVCB</SVCB>
                         <TLSA>TLSA</TLSA>
                         <TXT>TXT</TXT>
                     </OptionValues>


### PR DESCRIPTION
Adds `SVCB` to the BIND plugin's record-type options so RFC 9460/9461 SVCB records can be created via the GUI/API.

### Describe the problem
The plugin's record model rejected the `SVCB` type before it reached `named`, so SVCB records (notably `_dns` records for Discovery of Designated Resolvers, RFC 9461) couldn't be created. BIND 9.18+ supports SVCB natively.

### Describe the proposed solution
One-line addition of `SVCB` to the `Record.xml` OptionValues (alphabetically between `SSHFP` and `TLSA`). No template changes needed — `named` renders SVCB rdata directly.

This complements #5425 (HTTPS record type); `HTTPS` is the HTTPS-specific form of SVCB, this adds the general `SVCB` type. Scoped to this single change.