### PR TITLE
net/cloudflared: add edge IP version setting, move advanced options behind toggle

### DIFF
--- a/net/cloudflared/Makefile
+++ b/net/cloudflared/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		cloudflared
-PLUGIN_VERSION=		1.0.1
+PLUGIN_VERSION=		1.1
 PLUGIN_COMMENT=		Cloudflare Tunnel integration
 PLUGIN_MAINTAINER=	rick+github@insanityinside.net
 PLUGIN_DEPENDS=		cloudflared

--- a/net/cloudflared/Makefile
+++ b/net/cloudflared/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		cloudflared
-PLUGIN_VERSION=		1.0
+PLUGIN_VERSION=		1.0.1
 PLUGIN_COMMENT=		Cloudflare Tunnel integration
 PLUGIN_MAINTAINER=	rick+github@insanityinside.net
 PLUGIN_DEPENDS=		cloudflared

--- a/net/cloudflared/src/opnsense/mvc/app/controllers/OPNsense/Cloudflared/forms/general.xml
+++ b/net/cloudflared/src/opnsense/mvc/app/controllers/OPNsense/Cloudflared/forms/general.xml
@@ -20,19 +20,29 @@
         <id>cloudflared.general.protocol</id>
         <label>Protocol</label>
         <type>dropdown</type>
+        <advanced>true</advanced>
         <help>Transport protocol. Leave unset unless you have a specific reason to force QUIC or HTTP/2.</help>
     </field>
     <field>
         <id>cloudflared.general.post_quantum</id>
         <label>Post-Quantum Encryption</label>
         <type>checkbox</type>
+        <advanced>true</advanced>
         <help>Enable post-quantum cryptography for the tunnel connection (requires QUIC).</help>
     </field>
     <field>
         <id>cloudflared.general.quic_disable_pmtu_discovery</id>
         <label>Disable QUIC PMTU Discovery</label>
         <type>checkbox</type>
+        <advanced>true</advanced>
         <help>Disable Path MTU Discovery for QUIC connections. May help in environments where ICMP is blocked.</help>
+    </field>
+    <field>
+        <id>cloudflared.general.edge_ip_version</id>
+        <label>Edge IP Version</label>
+        <type>dropdown</type>
+        <advanced>true</advanced>
+        <help>Force the IP version used to connect to Cloudflare's edge. Leave on Auto unless you need to restrict to IPv4 or IPv6.</help>
     </field>
     <field>
         <id>cloudflared.general.log_level</id>

--- a/net/cloudflared/src/opnsense/mvc/app/models/OPNsense/Cloudflared/Cloudflared.xml
+++ b/net/cloudflared/src/opnsense/mvc/app/models/OPNsense/Cloudflared/Cloudflared.xml
@@ -30,6 +30,15 @@
                 <Default>0</Default>
                 <Required>Y</Required>
             </quic_disable_pmtu_discovery>
+            <edge_ip_version type="OptionField">
+                <Default>auto</Default>
+                <Required>Y</Required>
+                <OptionValues>
+                    <auto/>
+                    <ipv4>IPv4</ipv4>
+                    <ipv6>IPv6</ipv6>
+                </OptionValues>
+            </edge_ip_version>
             <log_level type="OptionField">
                 <Default>info</Default>
                 <Required>Y</Required>

--- a/net/cloudflared/src/opnsense/mvc/app/models/OPNsense/Cloudflared/Cloudflared.xml
+++ b/net/cloudflared/src/opnsense/mvc/app/models/OPNsense/Cloudflared/Cloudflared.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/Cloudflared</mount>
-    <version>1.0</version>
+    <version>1.0.0</version>
     <description>Cloudflare Tunnel settings</description>
     <items>
         <general>

--- a/net/cloudflared/src/opnsense/mvc/app/models/OPNsense/Cloudflared/Cloudflared.xml
+++ b/net/cloudflared/src/opnsense/mvc/app/models/OPNsense/Cloudflared/Cloudflared.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/Cloudflared</mount>
-    <version>1.0.1</version>
+    <version>1.0</version>
     <description>Cloudflare Tunnel settings</description>
     <items>
         <general>
@@ -31,12 +31,10 @@
                 <Required>Y</Required>
             </quic_disable_pmtu_discovery>
             <edge_ip_version type="OptionField">
-                <Default>auto</Default>
-                <Required>Y</Required>
+                <BlankDesc>auto</BlankDesc>
                 <OptionValues>
-                    <auto/>
-                    <ipv4>IPv4</ipv4>
-                    <ipv6>IPv6</ipv6>
+                    <ipv4 value="4">IPv4</ipv4>
+                    <ipv6 value="6">IPv6</ipv6>
                 </OptionValues>
             </edge_ip_version>
             <log_level type="OptionField">

--- a/net/cloudflared/src/opnsense/mvc/app/models/OPNsense/Cloudflared/Cloudflared.xml
+++ b/net/cloudflared/src/opnsense/mvc/app/models/OPNsense/Cloudflared/Cloudflared.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/Cloudflared</mount>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <description>Cloudflare Tunnel settings</description>
     <items>
         <general>

--- a/net/cloudflared/src/opnsense/service/templates/OPNsense/Cloudflared/rc.conf.d
+++ b/net/cloudflared/src/opnsense/service/templates/OPNsense/Cloudflared/rc.conf.d
@@ -3,7 +3,7 @@ cloudflared_enable="YES"
 cloudflared_conf="/usr/local/etc/cloudflared/config.yml"
 {% if helpers.exists('OPNsense.Cloudflared.general.token') %}
 {% set ns = namespace(env='TUNNEL_TOKEN=' + OPNsense.Cloudflared.general.token|trim) %}
-{% if helpers.exists('OPNsense.Cloudflared.general.edge_ip_version') and OPNsense.Cloudflared.general.edge_ip_version != 'auto' %}
+{% if helpers.exists('OPNsense.Cloudflared.general.edge_ip_version') %}
 {% set ns.env = ns.env + ' TUNNEL_EDGE_IP_VERSION=' + OPNsense.Cloudflared.general.edge_ip_version %}
 {% endif %}
 cloudflared_env="{{ ns.env }}"

--- a/net/cloudflared/src/opnsense/service/templates/OPNsense/Cloudflared/rc.conf.d
+++ b/net/cloudflared/src/opnsense/service/templates/OPNsense/Cloudflared/rc.conf.d
@@ -2,7 +2,7 @@
 cloudflared_enable="YES"
 cloudflared_conf="/usr/local/etc/cloudflared/config.yml"
 {% if helpers.exists('OPNsense.Cloudflared.general.token') %}
-cloudflared_env="TUNNEL_TOKEN={{ OPNsense.Cloudflared.general.token|trim }}"
+cloudflared_env="TUNNEL_TOKEN={{ OPNsense.Cloudflared.general.token|trim }}{% if helpers.exists('OPNsense.Cloudflared.general.edge_ip_version') and OPNsense.Cloudflared.general.edge_ip_version != 'auto' %} TUNNEL_EDGE_IP_VERSION={{ OPNsense.Cloudflared.general.edge_ip_version | replace('ipv', '') }}{% endif %}"
 {% endif %}
 cloudflared_mode_options="run"
 {% else %}

--- a/net/cloudflared/src/opnsense/service/templates/OPNsense/Cloudflared/rc.conf.d
+++ b/net/cloudflared/src/opnsense/service/templates/OPNsense/Cloudflared/rc.conf.d
@@ -2,7 +2,11 @@
 cloudflared_enable="YES"
 cloudflared_conf="/usr/local/etc/cloudflared/config.yml"
 {% if helpers.exists('OPNsense.Cloudflared.general.token') %}
-cloudflared_env="TUNNEL_TOKEN={{ OPNsense.Cloudflared.general.token|trim }}{% if helpers.exists('OPNsense.Cloudflared.general.edge_ip_version') and OPNsense.Cloudflared.general.edge_ip_version != 'auto' %} TUNNEL_EDGE_IP_VERSION={{ OPNsense.Cloudflared.general.edge_ip_version | replace('ipv', '') }}{% endif %}"
+{% set ns = namespace(env='TUNNEL_TOKEN=' + OPNsense.Cloudflared.general.token|trim) %}
+{% if helpers.exists('OPNsense.Cloudflared.general.edge_ip_version') and OPNsense.Cloudflared.general.edge_ip_version != 'auto' %}
+{% set ns.env = ns.env + ' TUNNEL_EDGE_IP_VERSION=' + (OPNsense.Cloudflared.general.edge_ip_version | replace('ipv', '')) %}
+{% endif %}
+cloudflared_env="{{ ns.env }}"
 {% endif %}
 cloudflared_mode_options="run"
 {% else %}

--- a/net/cloudflared/src/opnsense/service/templates/OPNsense/Cloudflared/rc.conf.d
+++ b/net/cloudflared/src/opnsense/service/templates/OPNsense/Cloudflared/rc.conf.d
@@ -1,9 +1,9 @@
-{% if helpers.exists('OPNsense.Cloudflared.general.enabled') and OPNsense.Cloudflared.general.enabled == '1' %}
+{% if not helpers.empty('OPNsense.Cloudflared.general.enabled') %}
 cloudflared_enable="YES"
 cloudflared_conf="/usr/local/etc/cloudflared/config.yml"
-{% if helpers.exists('OPNsense.Cloudflared.general.token') %}
+{% if not helpers.empty('OPNsense.Cloudflared.general.token') %}
 {% set ns = namespace(env='TUNNEL_TOKEN=' + OPNsense.Cloudflared.general.token|trim) %}
-{% if helpers.exists('OPNsense.Cloudflared.general.edge_ip_version') %}
+{% if not helpers.empty('OPNsense.Cloudflared.general.edge_ip_version') %}
 {% set ns.env = ns.env + ' TUNNEL_EDGE_IP_VERSION=' + OPNsense.Cloudflared.general.edge_ip_version %}
 {% endif %}
 cloudflared_env="{{ ns.env }}"

--- a/net/cloudflared/src/opnsense/service/templates/OPNsense/Cloudflared/rc.conf.d
+++ b/net/cloudflared/src/opnsense/service/templates/OPNsense/Cloudflared/rc.conf.d
@@ -4,7 +4,7 @@ cloudflared_conf="/usr/local/etc/cloudflared/config.yml"
 {% if helpers.exists('OPNsense.Cloudflared.general.token') %}
 {% set ns = namespace(env='TUNNEL_TOKEN=' + OPNsense.Cloudflared.general.token|trim) %}
 {% if helpers.exists('OPNsense.Cloudflared.general.edge_ip_version') and OPNsense.Cloudflared.general.edge_ip_version != 'auto' %}
-{% set ns.env = ns.env + ' TUNNEL_EDGE_IP_VERSION=' + (OPNsense.Cloudflared.general.edge_ip_version | replace('ipv', '')) %}
+{% set ns.env = ns.env + ' TUNNEL_EDGE_IP_VERSION=' + OPNsense.Cloudflared.general.edge_ip_version %}
 {% endif %}
 cloudflared_env="{{ ns.env }}"
 {% endif %}


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [X] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below. (Changes are trivial)
- [X] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: Claude Sonnet 4.6
- Extent of AI involvement: Minimal, used to edit files, no logic work.

---

**Describe the problem**
Niche options visible when advanced mode not enabled, no ability to force IPv4 or IPv6 for connectivity if there's any local routing/connectivity issues.

---

**Describe the proposed solution**

Moved Protocol, Post-Quantum Encryption and Disable QUIC PMTU Discovery options behind Advanced Mode toggle, added Edge IP version to force Cloudflare to use either IPv4 or IPv6 for outbound connections. The Edge IP version is to provide users with an easy method of forcing the IP protocol used for outbound connectivity. Had to use ipv4/ipv6 instead of 4 and 6 in the XML as elements can't start with a digit, trimmed in the template ENV. Bumped plugin version to 1.0.1.