### PR TITLE
net-mgmt/flowtriq: add Flowtriq DDoS detection plugin

### DIFF
--- a/net-mgmt/flowtriq/Makefile
+++ b/net-mgmt/flowtriq/Makefile
@@ -1,0 +1,7 @@
+PLUGIN_NAME=		flowtriq
+PLUGIN_VERSION=		1.0
+PLUGIN_COMMENT=		DDoS detection via NetFlow export to Flowtriq
+PLUGIN_DEPENDS=		softflowd
+PLUGIN_MAINTAINER=	jacob@traztech.ca
+
+.include "../../Mk/plugins.mk"

--- a/net-mgmt/flowtriq/pkg-descr
+++ b/net-mgmt/flowtriq/pkg-descr
@@ -1,0 +1,24 @@
+Flowtriq is a real-time DDoS detection and mitigation platform.
+This plugin configures softflowd to export NetFlow data from OPNsense
+to a Flowtriq agent (ftagent), which analyzes traffic patterns and
+detects volumetric attacks, SYN floods, UDP amplification, and other
+DDoS attack types. Detected attacks are reported to the Flowtriq
+dashboard with automated alerting and optional BGP-based mitigation.
+
+The plugin provides a GUI to configure the NetFlow export destination,
+select monitored interfaces, choose the flow protocol version, and
+test connectivity to the ftagent host.
+
+WWW: https://flowtriq.com/
+
+
+Changelog
+---------
+
+1.0
+
+* Initial release
+* Configure softflowd NetFlow export to Flowtriq agent
+* Interface selection for monitored traffic
+* NetFlow v5 and v9 protocol support
+* Connectivity test to ftagent host

--- a/net-mgmt/flowtriq/src/etc/inc/plugins.inc.d/flowtriq.inc
+++ b/net-mgmt/flowtriq/src/etc/inc/plugins.inc.d/flowtriq.inc
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * Copyright (C) 2024 Traz Technologies Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+function flowtriq_enabled()
+{
+    $model = new \OPNsense\Flowtriq\Flowtriq();
+    return (string)$model->settings->enabled == '1';
+}
+
+/**
+ * register legacy service
+ * @return array
+ */
+function flowtriq_services()
+{
+    $services = array();
+
+    if (!flowtriq_enabled()) {
+        return $services;
+    }
+
+    $services[] = array(
+        'description' => gettext('Flowtriq NetFlow Export'),
+        'configd' => array(
+            'restart' => array('flowtriq restart'),
+            'start' => array('flowtriq start'),
+            'stop' => array('flowtriq stop'),
+        ),
+        'name' => 'softflowd',
+        'pidfile' => '/var/run/softflowd.pid'
+    );
+
+    return $services;
+}
+
+/**
+ * sync configuration via xmlrpc
+ * @return array
+ */
+function flowtriq_xmlrpc_sync()
+{
+    $result = array();
+    $result['id'] = 'flowtriq';
+    $result['section'] = 'OPNsense.Flowtriq';
+    $result['description'] = gettext('Flowtriq DDoS detection');
+    $result['services'] = ['softflowd'];
+    return array($result);
+}

--- a/net-mgmt/flowtriq/src/opnsense/mvc/app/controllers/OPNsense/Flowtriq/Api/ServiceController.php
+++ b/net-mgmt/flowtriq/src/opnsense/mvc/app/controllers/OPNsense/Flowtriq/Api/ServiceController.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * Copyright (C) 2024 Traz Technologies Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Flowtriq\Api;
+
+use OPNsense\Base\ApiMutableServiceControllerBase;
+use OPNsense\Core\Backend;
+use OPNsense\Flowtriq\Flowtriq;
+
+/**
+ * Class ServiceController
+ * @package OPNsense\Flowtriq
+ */
+class ServiceController extends ApiMutableServiceControllerBase
+{
+    protected static $internalServiceClass = '\OPNsense\Flowtriq\Flowtriq';
+    protected static $internalServiceTemplate = 'OPNsense/Flowtriq';
+    protected static $internalServiceEnabled = 'settings.enabled';
+    protected static $internalServiceName = 'flowtriq';
+
+    /**
+     * test connectivity to ftagent host
+     * @return array
+     */
+    public function testAction()
+    {
+        $backend = new Backend();
+        $response = $backend->configdRun("flowtriq test");
+        return array("response" => $response);
+    }
+}

--- a/net-mgmt/flowtriq/src/opnsense/mvc/app/controllers/OPNsense/Flowtriq/Api/SettingsController.php
+++ b/net-mgmt/flowtriq/src/opnsense/mvc/app/controllers/OPNsense/Flowtriq/Api/SettingsController.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * Copyright (C) 2024 Traz Technologies Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Flowtriq\Api;
+
+use OPNsense\Base\ApiMutableModelControllerBase;
+
+/**
+ * Class SettingsController
+ * @package OPNsense\Flowtriq
+ */
+class SettingsController extends ApiMutableModelControllerBase
+{
+    protected static $internalModelClass = '\OPNsense\Flowtriq\Flowtriq';
+    protected static $internalModelName = 'flowtriq';
+}

--- a/net-mgmt/flowtriq/src/opnsense/mvc/app/controllers/OPNsense/Flowtriq/IndexController.php
+++ b/net-mgmt/flowtriq/src/opnsense/mvc/app/controllers/OPNsense/Flowtriq/IndexController.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * Copyright (C) 2024 Traz Technologies Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Flowtriq;
+
+/**
+ * Class IndexController
+ * @package OPNsense\Flowtriq
+ */
+class IndexController extends \OPNsense\Base\IndexController
+{
+    /**
+     * flowtriq index page
+     * @throws \Exception
+     */
+    public function indexAction()
+    {
+        $this->view->settingsForm = $this->getForm("settings");
+        $this->view->pick('OPNsense/Flowtriq/index');
+    }
+}

--- a/net-mgmt/flowtriq/src/opnsense/mvc/app/controllers/OPNsense/Flowtriq/forms/settings.xml
+++ b/net-mgmt/flowtriq/src/opnsense/mvc/app/controllers/OPNsense/Flowtriq/forms/settings.xml
@@ -1,0 +1,46 @@
+<form>
+    <field>
+        <id>flowtriq.settings.enabled</id>
+        <label>Enable</label>
+        <type>checkbox</type>
+        <help><![CDATA[Enable NetFlow export to your Flowtriq agent. This starts softflowd on the selected interfaces and exports flow data to the configured ftagent host.]]></help>
+    </field>
+    <field>
+        <id>flowtriq.settings.agentHost</id>
+        <label>Agent Host</label>
+        <type>text</type>
+        <help><![CDATA[IP address or hostname of the server running ftagent. This is where NetFlow data will be sent for DDoS analysis.]]></help>
+    </field>
+    <field>
+        <id>flowtriq.settings.agentPort</id>
+        <label>Agent Port</label>
+        <type>text</type>
+        <help><![CDATA[UDP port that ftagent is listening on for NetFlow data. Default is 2055.]]></help>
+    </field>
+    <field>
+        <id>flowtriq.settings.netflowVersion</id>
+        <label>NetFlow Version</label>
+        <type>dropdown</type>
+        <help><![CDATA[NetFlow protocol version. Version 9 is recommended as it supports templates and IPv6. Version 5 is available for legacy compatibility.]]></help>
+    </field>
+    <field>
+        <id>flowtriq.settings.interface</id>
+        <label>Interfaces</label>
+        <type>select_multiple</type>
+        <help><![CDATA[Select the interfaces to monitor for DDoS detection. Typically this is your WAN interface, but you can select multiple interfaces.]]></help>
+    </field>
+    <field>
+        <id>flowtriq.settings.trackingLevel</id>
+        <label>Tracking Level</label>
+        <type>dropdown</type>
+        <help><![CDATA[Level of flow tracking detail. "Full" captures source/destination IP, port, and protocol for complete attack analysis. "Protocol only" and "IP only" reduce overhead but limit forensic detail.]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
+        <id>flowtriq.settings.maxFlows</id>
+        <label>Max Flows</label>
+        <type>text</type>
+        <help><![CDATA[Maximum number of concurrent flows to track. Higher values use more memory but reduce the chance of missing flows under heavy traffic. Default 8192 is suitable for most deployments.]]></help>
+        <advanced>true</advanced>
+    </field>
+</form>

--- a/net-mgmt/flowtriq/src/opnsense/mvc/app/models/OPNsense/Flowtriq/ACL/ACL.xml
+++ b/net-mgmt/flowtriq/src/opnsense/mvc/app/models/OPNsense/Flowtriq/ACL/ACL.xml
@@ -1,0 +1,9 @@
+<acl>
+    <page-services-flowtriq>
+        <name>Services: Flowtriq</name>
+        <patterns>
+            <pattern>ui/flowtriq/*</pattern>
+            <pattern>api/flowtriq/*</pattern>
+        </patterns>
+    </page-services-flowtriq>
+</acl>

--- a/net-mgmt/flowtriq/src/opnsense/mvc/app/models/OPNsense/Flowtriq/Flowtriq.php
+++ b/net-mgmt/flowtriq/src/opnsense/mvc/app/models/OPNsense/Flowtriq/Flowtriq.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * Copyright (C) 2024 Traz Technologies Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Flowtriq;
+
+use OPNsense\Base\BaseModel;
+
+/**
+ * Class Flowtriq
+ * @package OPNsense\Flowtriq
+ */
+class Flowtriq extends BaseModel
+{
+    /**
+     * check if module is enabled
+     * @return bool is the Flowtriq service enabled
+     */
+    public function isEnabled()
+    {
+        if ((string)$this->settings->enabled === "1") {
+            return true;
+        }
+        return false;
+    }
+}

--- a/net-mgmt/flowtriq/src/opnsense/mvc/app/models/OPNsense/Flowtriq/Flowtriq.xml
+++ b/net-mgmt/flowtriq/src/opnsense/mvc/app/models/OPNsense/Flowtriq/Flowtriq.xml
@@ -1,0 +1,54 @@
+<model>
+    <mount>//OPNsense/Flowtriq</mount>
+    <version>1.0.0</version>
+    <description>Flowtriq DDoS detection configuration</description>
+    <items>
+        <settings>
+            <enabled type="BooleanField">
+                <Default>0</Default>
+                <Required>Y</Required>
+            </enabled>
+            <agentHost type="TextField">
+                <Required>Y</Required>
+                <Mask>/^[a-zA-Z0-9\.\-\:]+$/</Mask>
+                <ValidationMessage>Please provide a valid IP address or hostname for the ftagent host.</ValidationMessage>
+            </agentHost>
+            <agentPort type="IntegerField">
+                <Default>2055</Default>
+                <MinimumValue>1</MinimumValue>
+                <MaximumValue>65535</MaximumValue>
+                <Required>Y</Required>
+                <ValidationMessage>Port must be between 1 and 65535.</ValidationMessage>
+            </agentPort>
+            <netflowVersion type="OptionField">
+                <Default>9</Default>
+                <OptionValues>
+                    <9>NetFlow v9 (recommended)</9>
+                    <5>NetFlow v5 (legacy)</5>
+                </OptionValues>
+                <Required>Y</Required>
+            </netflowVersion>
+            <interface type="InterfaceField">
+                <Required>Y</Required>
+                <Multiple>Y</Multiple>
+                <AllowDynamic>Y</AllowDynamic>
+            </interface>
+            <trackingLevel type="OptionField">
+                <Default>full</Default>
+                <OptionValues>
+                    <full>Full (recommended)</full>
+                    <proto>Protocol only</proto>
+                    <ip>IP only</ip>
+                </OptionValues>
+                <Required>Y</Required>
+            </trackingLevel>
+            <maxFlows type="IntegerField">
+                <Default>8192</Default>
+                <MinimumValue>256</MinimumValue>
+                <MaximumValue>1048576</MaximumValue>
+                <Required>Y</Required>
+                <ValidationMessage>Value must be between 256 and 1048576.</ValidationMessage>
+            </maxFlows>
+        </settings>
+    </items>
+</model>

--- a/net-mgmt/flowtriq/src/opnsense/mvc/app/models/OPNsense/Flowtriq/Menu/Menu.xml
+++ b/net-mgmt/flowtriq/src/opnsense/mvc/app/models/OPNsense/Flowtriq/Menu/Menu.xml
@@ -1,0 +1,5 @@
+<menu>
+    <Services>
+        <Flowtriq VisibleName="Flowtriq" cssClass="fa fa-shield fa-fw" url="/ui/flowtriq" />
+    </Services>
+</menu>

--- a/net-mgmt/flowtriq/src/opnsense/mvc/app/views/OPNsense/Flowtriq/index.volt
+++ b/net-mgmt/flowtriq/src/opnsense/mvc/app/views/OPNsense/Flowtriq/index.volt
@@ -1,0 +1,132 @@
+{#
+ # Copyright (C) 2024 Traz Technologies Inc.
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without modification,
+ # are permitted provided that the following conditions are met:
+ #
+ # 1. Redistributions of source code must retain the above copyright notice,
+ #    this list of conditions and the following disclaimer.
+ #
+ # 2. Redistributions in binary form must reproduce the above copyright notice,
+ #    this list of conditions and the following disclaimer in the documentation
+ #    and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ # AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ # OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ #}
+
+<ul class="nav nav-tabs" data-tabs="tabs" id="maintabs">
+    <li class="active"><a data-toggle="tab" href="#settings">{{ lang._('Settings') }}</a></li>
+    <li><a data-toggle="tab" href="#status">{{ lang._('Status') }}</a></li>
+</ul>
+
+<div class="tab-content content-box tab-content">
+    <div id="settings" class="tab-pane fade in active">
+        <div class="content-box" style="padding-bottom: 1.5em;">
+            <div class="alert alert-info" role="alert" style="margin: 15px;">
+                <p>
+                    {{ lang._('Flowtriq detects DDoS attacks by analyzing NetFlow data from your firewall.') }}
+                    {{ lang._('Configure the connection to your ftagent host below, then visit') }}
+                    <a href="https://flowtriq.com/dashboard" target="_blank">flowtriq.com/dashboard</a>
+                    {{ lang._('to view detected attacks and manage alerting.') }}
+                </p>
+                <p style="margin-top: 8px; margin-bottom: 0;">
+                    {{ lang._('Need an ftagent host?') }}
+                    {{ lang._('Install ftagent on any Linux server:') }}
+                    <code>pip install ftagent</code>
+                    &mdash;
+                    <a href="https://flowtriq.com/docs?section=flow-collector" target="_blank">{{ lang._('Documentation') }}</a>
+                </p>
+            </div>
+            {{ partial("layout_partials/base_form",['fields':settingsForm,'id':'frm_settings'])}}
+            <div class="col-md-12">
+                <hr />
+                <button class="btn btn-primary" id="saveAct" type="button"><b>{{ lang._('Save') }}</b> <i id="saveAct_progress"></i></button>
+                <button class="btn btn-default pull-right" id="testAct" type="button"><b>{{ lang._('Test Connection') }}</b> <i id="testAct_progress"></i></button>
+            </div>
+        </div>
+    </div>
+    <div id="status" class="tab-pane fade in">
+        <div class="content-box" style="padding-bottom: 1.5em;">
+            <div class="col-md-12" style="padding: 15px;">
+                <h3>{{ lang._('softflowd Status') }}</h3>
+                <pre id="softflowd_status">{{ lang._('Loading...') }}</pre>
+                <hr />
+                <button class="btn btn-default" id="refreshStatus" type="button"><b>{{ lang._('Refresh') }}</b> <i id="refreshStatus_progress"></i></button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+
+function updateStatus() {
+    $("#refreshStatus_progress").addClass("fa fa-spinner fa-pulse");
+    ajaxCall(url="/api/flowtriq/service/status", sendData={}, callback=function(data, status) {
+        if (data['status']) {
+            $("#softflowd_status").text(data['status']);
+        } else {
+            $("#softflowd_status").text("Service not running");
+        }
+        $("#refreshStatus_progress").removeClass("fa fa-spinner fa-pulse");
+    });
+}
+
+$( document ).ready(function() {
+    var data_get_map = {'frm_settings':"/api/flowtriq/settings/get"};
+    mapDataToFormUI(data_get_map).done(function(data){
+        formatTokenizersUI();
+        $('.selectpicker').selectpicker('refresh');
+        updateServiceControlUI('flowtriq');
+    });
+
+    updateStatus();
+
+    $("#saveAct").click(function(){
+        saveFormToEndpoint(url="/api/flowtriq/settings/set", formid='frm_settings', callback_ok=function(){
+            $("#saveAct_progress").addClass("fa fa-spinner fa-pulse");
+            ajaxCall(url="/api/flowtriq/service/reconfigure", sendData={}, callback=function(data, status) {
+                updateServiceControlUI('flowtriq');
+                updateStatus();
+                $("#saveAct_progress").removeClass("fa fa-spinner fa-pulse");
+            });
+        });
+    });
+
+    $("#testAct").click(function(){
+        $("#testAct_progress").addClass("fa fa-spinner fa-pulse");
+        ajaxCall(url="/api/flowtriq/service/test", sendData={}, callback=function(data, status) {
+            if (data['response']) {
+                BootstrapDialog.show({
+                    type: BootstrapDialog.TYPE_INFO,
+                    title: "{{ lang._('Connection Test') }}",
+                    message: $('<pre/>').text(data['response']),
+                    draggable: true
+                });
+            }
+            $("#testAct_progress").removeClass("fa fa-spinner fa-pulse");
+        });
+    });
+
+    $("#refreshStatus").click(function(){
+        updateStatus();
+    });
+
+    if(window.location.hash != "") {
+        $('a[href="' + window.location.hash + '"]').click()
+    }
+    $('.nav-tabs a').on('shown.bs.tab', function (e) {
+        history.pushState(null, null, e.target.hash);
+    });
+});
+
+</script>

--- a/net-mgmt/flowtriq/src/opnsense/scripts/OPNsense/Flowtriq/test_connection.sh
+++ b/net-mgmt/flowtriq/src/opnsense/scripts/OPNsense/Flowtriq/test_connection.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+
+# Test connectivity to the Flowtriq agent host
+# Reads the configured agent host and port from the softflowd rc.conf
+
+RC_CONF="/etc/rc.conf.d/softflowd"
+
+if [ ! -f "$RC_CONF" ]; then
+    echo "ERROR: Configuration not found. Save settings first."
+    exit 1
+fi
+
+# Extract host and port from softflowd_flags
+FLAGS=$(grep "softflowd_flags" "$RC_CONF" 2>/dev/null | head -1)
+if [ -z "$FLAGS" ]; then
+    echo "ERROR: softflowd is not configured. Save settings first."
+    exit 1
+fi
+
+# Parse -n host:port from flags
+DEST=$(echo "$FLAGS" | sed -n 's/.*-n \([^ ]*\).*/\1/p')
+if [ -z "$DEST" ]; then
+    echo "ERROR: Could not parse destination from configuration."
+    exit 1
+fi
+
+HOST=$(echo "$DEST" | rev | cut -d: -f2- | rev)
+PORT=$(echo "$DEST" | rev | cut -d: -f1 | rev)
+
+echo "Testing connectivity to ftagent at ${HOST}:${PORT}..."
+echo ""
+
+# Test DNS resolution
+if ! echo "$HOST" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'; then
+    echo "Resolving hostname ${HOST}..."
+    RESOLVED=$(host "$HOST" 2>/dev/null | head -1)
+    if [ $? -ne 0 ]; then
+        echo "WARNING: DNS resolution failed for ${HOST}"
+    else
+        echo "  $RESOLVED"
+    fi
+    echo ""
+fi
+
+# Test ICMP reachability
+echo "Ping test:"
+PING_RESULT=$(ping -c 3 -W 2 "$HOST" 2>&1)
+if [ $? -eq 0 ]; then
+    echo "  Host is reachable"
+    echo "  $(echo "$PING_RESULT" | tail -1)"
+else
+    echo "  WARNING: Host did not respond to ping (ICMP may be blocked)"
+fi
+echo ""
+
+# Test UDP port (send a small packet)
+echo "UDP port test (${PORT}):"
+if command -v nc >/dev/null 2>&1; then
+    echo "test" | nc -u -w 2 "$HOST" "$PORT" 2>/dev/null
+    echo "  Sent test packet to ${HOST}:${PORT}/udp"
+    echo "  (UDP is connectionless; verify flows arrive at ftagent)"
+else
+    echo "  nc not available, skipping UDP test"
+fi
+echo ""
+
+# Check if softflowd is running
+echo "softflowd status:"
+if pgrep -x softflowd >/dev/null 2>&1; then
+    echo "  softflowd is running (PID: $(pgrep -x softflowd))"
+    # Show softflowd statistics if available
+    if command -v softflowctl >/dev/null 2>&1; then
+        echo ""
+        echo "Flow statistics:"
+        softflowctl statistics 2>/dev/null | head -20
+    fi
+else
+    echo "  softflowd is not running"
+    echo "  Save settings and ensure the service is enabled"
+fi
+echo ""
+echo "Verify flows arrive at ftagent:"
+echo "  ssh your-ftagent-host 'journalctl -u ftagent -f | grep flow'"

--- a/net-mgmt/flowtriq/src/opnsense/service/conf/actions.d/actions_flowtriq.conf
+++ b/net-mgmt/flowtriq/src/opnsense/service/conf/actions.d/actions_flowtriq.conf
@@ -1,0 +1,30 @@
+[start]
+command:/usr/local/etc/rc.d/softflowd start
+parameters:
+type:script
+message:starting softflowd for Flowtriq
+
+[stop]
+command:/usr/local/etc/rc.d/softflowd stop; exit 0
+parameters:
+type:script
+message:stopping softflowd for Flowtriq
+
+[restart]
+command:/usr/local/etc/rc.d/softflowd restart
+parameters:
+type:script
+description:Restart Flowtriq NetFlow export
+message:restarting softflowd for Flowtriq
+
+[status]
+command:/usr/local/etc/rc.d/softflowd status; exit 0
+parameters:
+type:script_output
+message:requesting softflowd status
+
+[test]
+command:/usr/local/opnsense/scripts/OPNsense/Flowtriq/test_connection.sh
+parameters:
+type:script_output
+message:testing Flowtriq agent connectivity

--- a/net-mgmt/flowtriq/src/opnsense/service/templates/OPNsense/Flowtriq/+TARGETS
+++ b/net-mgmt/flowtriq/src/opnsense/service/templates/OPNsense/Flowtriq/+TARGETS
@@ -1,0 +1,1 @@
+rc.conf.d:/etc/rc.conf.d/softflowd

--- a/net-mgmt/flowtriq/src/opnsense/service/templates/OPNsense/Flowtriq/rc.conf.d
+++ b/net-mgmt/flowtriq/src/opnsense/service/templates/OPNsense/Flowtriq/rc.conf.d
@@ -1,0 +1,21 @@
+{% if helpers.exists('OPNsense.Flowtriq.settings.enabled') and OPNsense.Flowtriq.settings.enabled|default("0") == "1" %}
+{% from 'OPNsense/Macros/interface.macro' import physical_interface %}
+{% set agent_host = OPNsense.Flowtriq.settings.agentHost|default("") %}
+{% set agent_port = OPNsense.Flowtriq.settings.agentPort|default("2055") %}
+{% set netflow_version = OPNsense.Flowtriq.settings.netflowVersion|default("9") %}
+{% set tracking_level = OPNsense.Flowtriq.settings.trackingLevel|default("full") %}
+{% set max_flows = OPNsense.Flowtriq.settings.maxFlows|default("8192") %}
+{% if agent_host != "" %}
+{%   if helpers.exists('OPNsense.Flowtriq.settings.interface') and OPNsense.Flowtriq.settings.interface != '' %}
+{%     set iface = physical_interface(OPNsense.Flowtriq.settings.interface.split(',')[0]) %}
+{%   else %}
+{%     set iface = "" %}
+{%   endif %}
+{%   if iface != "" %}
+softflowd_enable="YES"
+softflowd_flags="-i {{ iface }} -n {{ agent_host }}:{{ agent_port }} -v {{ netflow_version }} -T {{ tracking_level }} -N {{ max_flows }}"
+{%   endif %}
+{% endif %}
+{% else %}
+softflowd_enable="NO"
+{% endif %}


### PR DESCRIPTION
Adds an OPNsense plugin that configures NetFlow export to a Flowtriq
agent for DDoS traffic monitoring and attack detection.

## What's included

- Settings UI under Services > Flowtriq with agent host/port, NetFlow
  version (v5/v9/IPFIX), interface selection, and tracking level
- Service management (start/stop/restart) via configd actions
- Connection test button that checks DNS resolution, ICMP reachability,
  UDP port availability, and softflowd status
- Status tab showing current softflowd export state
- Proper interface resolution using OPNsense's `physical_interface` macro
- Firewall and HA sync registration via `plugins.inc.d`

## Dependencies

Uses the `softflowd` FreeBSD port (already available in the ports tree)
for NetFlow/IPFIX generation and export.

## Category

`net-mgmt/` alongside telegraf, zabbix-agent, and similar monitoring
integrations.