### PR TITLE
Add julioliraup/Antiphishing ruleset #5536

### DIFF
--- a/security/intrusion-detection-content-at-antiphishing/Makefile
+++ b/security/intrusion-detection-content-at-antiphishing/Makefile
@@ -1,0 +1,8 @@
+PLUGIN_NAME=		intrusion-detection-content-julioliraup-antiphishing
+PLUGIN_VERSION=		1.0
+PLUGIN_REVISION=	1
+PLUGIN_COMMENT=		julioliraup/Antiphishing rulesets for protect against phishing attack. 
+PLUGIN_MAINTAINER=	jul10l1r4@disroot.org
+PLUGIN_WWW=		https://julioliraup.github.io/AT/
+
+.include "../../Mk/plugins.mk"

--- a/security/intrusion-detection-content-at-antiphishing/pkg-descr
+++ b/security/intrusion-detection-content-at-antiphishing/pkg-descr
@@ -1,0 +1,11 @@
+Suricata ruleset julioliraup/Antiphishing for protect against
+phishing attack. This rule is built using malicious URLs and
+domains involved in phishing attacks. We utilize some community
+APIs to construct these rules, and with them, we create TLS,
+DNS, and HTTP rules.
+
+Our rule updates frequently and includes SIDs that take other
+rulesets into consideration. Range: 6000000 - 6100000.
+
+LICENSE: https://github.com/julioliraup/Antiphishing?tab=GPL-3.0-1-ov-file
+WWW: https://julioliraup.github.io/AT/

--- a/security/intrusion-detection-content-at-antiphishing/src/opnsense/scripts/suricata/metadata/rules/julioliraup-antiphing.xml
+++ b/security/intrusion-detection-content-at-antiphishing/src/opnsense/scripts/suricata/metadata/rules/julioliraup-antiphing.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ruleset documentation_url="https://github.com/julioliraup/Antiphishing">       
+  <location url="https://julioliraup.github.io/AT/" prefix="julioliraup/Antiphishing"/>                
+  <files>                                                                       
+    <file documentation_url="https://github.com/julioliraup/Antiphishing/README.md"
+        url="https://raw.githubusercontent.com/julioliraup/Antiphishing/refs/heads/main/antiphishing.rules" 
+          description="julioliraup/Antiphishing">antiphishing.rules</file>                                                                     
+  </files>             
+</ruleset>                                                                      


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

---

**Describe the problem**

julioliraup/Antiphishing is available in suricata-update; it is a frequently updated rule designed to protect against phishing attacks

---

**Describe the proposed solution**

Add in list of rulesets

---

**Related issue**

[#5536](https://github.com/opnsense/plugins/issues/5536)
