### PR TITLE
Add nobind check for virtualips

### DIFF
--- a/www/squid/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
+++ b/www/squid/src/opnsense/service/templates/OPNsense/Proxy/squid.conf
@@ -41,7 +41,7 @@
 {# virtual ip's #}
 {%         if helpers.exists('virtualip') %}
 {%             for intf_item in helpers.toList('virtualip.vip') %}
-{%                 if intf_item.interface == interface and intf_item.mode in ['carp', 'ipalias'] %}
+{%                 if intf_item.interface == interface and intf_item.mode in ['carp', 'ipalias'] and intf_item.nobind != '1' %}
 {%                     if intf_item.subnet.find(':') > -1 %}
 {{ listener_config('['+intf_item.subnet+']', OPNsense.proxy.forward.port) }}
 {%                     else %}


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [X] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [X] I opened an issue first for non-trivial changes and linked it below.
- [X] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose: "only human stupidity was used"

---

**Describe the problem**

Squid binds to virtual ips which are set up as nobind.

---

**Describe the proposed solution**

Squid templates now checks for nobind

---

**Related issue**

#5539 
