### PR TITLE
dns/bind: add DNS-over-TLS forwarder configuration

### DIFF
--- a/dns/bind/pkg-descr
+++ b/dns/bind/pkg-descr
@@ -7,6 +7,12 @@ necessary for asking and answering name service questions.
 Plugin Changelog
 ================
 
+1.35
+
+* Add per-forwarder destination port for plain DNS forwarders
+* Add DNS-over-TLS (DoT) forwarders with TLS hostname verification
+* Migrate legacy DNS Forwarders list to the new DNS Forwarders tab
+
 1.34
 
 * Add custom configuration include directory /usr/local/etc/namedb/named.conf.d (contributed by Nicholas Card)

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/Api/ForwarderController.php
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/Api/ForwarderController.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ *    Copyright (C) 2026 Bryan Wiegand <inbox@kw-ventures.com>
+ *
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ *    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ *    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+namespace OPNsense\Bind\Api;
+
+use OPNsense\Base\ApiMutableModelControllerBase;
+
+class ForwarderController extends ApiMutableModelControllerBase
+{
+    protected static $internalModelName = 'forwarder';
+    protected static $internalModelClass = '\OPNsense\Bind\Forwarder';
+
+    public function searchDnsForwarderAction()
+    {
+        return $this->searchBase('forwarders.dns', ['enabled', 'ip', 'port']);
+    }
+
+    public function getDnsForwarderAction($uuid = null)
+    {
+        return $this->getBase('dns', 'forwarders.dns', $uuid);
+    }
+
+    public function addDnsForwarderAction()
+    {
+        return $this->addBase('dns', 'forwarders.dns');
+    }
+
+    public function delDnsForwarderAction($uuid)
+    {
+        return $this->delBase('forwarders.dns', $uuid);
+    }
+
+    public function setDnsForwarderAction($uuid)
+    {
+        return $this->setBase('dns', 'forwarders.dns', $uuid);
+    }
+
+    public function toggleDnsForwarderAction($uuid)
+    {
+        return $this->toggleBase('forwarders.dns', $uuid);
+    }
+
+    public function searchDotForwarderAction()
+    {
+        return $this->searchBase('forwarders.dot', ['enabled', 'ip', 'port', 'tlshostname']);
+    }
+
+    public function getDotForwarderAction($uuid = null)
+    {
+        return $this->getBase('dot', 'forwarders.dot', $uuid);
+    }
+
+    public function addDotForwarderAction()
+    {
+        return $this->addBase('dot', 'forwarders.dot');
+    }
+
+    public function delDotForwarderAction($uuid)
+    {
+        return $this->delBase('forwarders.dot', $uuid);
+    }
+
+    public function setDotForwarderAction($uuid)
+    {
+        return $this->setBase('dot', 'forwarders.dot', $uuid);
+    }
+
+    public function toggleDotForwarderAction($uuid)
+    {
+        return $this->toggleBase('forwarders.dot', $uuid);
+    }
+}

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/ForwardingController.php
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/ForwardingController.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Bryan Wiegand <inbox@kw-ventures.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Bind;
+
+class ForwardingController extends \OPNsense\Base\IndexController
+{
+    public function indexAction()
+    {
+        $this->view->formDialogEditBindDnsForwarder = $this->getForm("dialogEditBindDnsForwarder");
+        $this->view->formDialogEditBindDotForwarder = $this->getForm("dialogEditBindDotForwarder");
+        $this->view->pick('OPNsense/Bind/forwarding');
+    }
+}

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindDnsForwarder.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindDnsForwarder.xml
@@ -1,0 +1,46 @@
+<!--
+ Copyright (C) 2026 Bryan Wiegand <inbox@kw-ventures.com>
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+
+<form>
+    <field>
+        <id>dns.enabled</id>
+        <label>Enabled</label>
+        <type>checkbox</type>
+        <help>This will enable or disable this forwarder.</help>
+    </field>
+    <field>
+        <id>dns.ip</id>
+        <label>IP Address</label>
+        <type>text</type>
+        <help>Set the IPv4 or IPv6 address of the upstream DNS server. For a local encryption proxy such as contrld, use 127.0.0.1.</help>
+    </field>
+    <field>
+        <id>dns.port</id>
+        <label>Port</label>
+        <type>text</type>
+        <help>Set the destination port. Defaults to 53; use a custom port for a local proxy (e.g. 5300).</help>
+    </field>
+</form>

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindDotForwarder.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindDotForwarder.xml
@@ -1,0 +1,52 @@
+<!--
+ Copyright (C) 2026 Bryan Wiegand <inbox@kw-ventures.com>
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+
+<form>
+    <field>
+        <id>dot.enabled</id>
+        <label>Enabled</label>
+        <type>checkbox</type>
+        <help>This will enable or disable this DNS-over-TLS forwarder.</help>
+    </field>
+    <field>
+        <id>dot.ip</id>
+        <label>IP Address</label>
+        <type>text</type>
+        <help>Set the IPv4 or IPv6 address of the upstream DoT server (e.g. 1.1.1.1 for Cloudflare).</help>
+    </field>
+    <field>
+        <id>dot.port</id>
+        <label>Port</label>
+        <type>text</type>
+        <help>Set the destination port. Defaults to 853 (the standard DNS-over-TLS port).</help>
+    </field>
+    <field>
+        <id>dot.tlshostname</id>
+        <label>TLS Hostname</label>
+        <type>text</type>
+        <help>Set the TLS hostname for certificate verification (e.g. cloudflare-dns.com). If set, the upstream certificate must match this hostname and is verified against the system CA bundle. If left empty, BIND verifies the certificate against the forwarder's IP address; that IP address must be present in the certificate Subject Alternative Name.</help>
+    </field>
+</form>

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/general.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/general.xml
@@ -62,14 +62,6 @@
         <help>Specify the IPv6 address used as a source for zone transfers.</help>
     </field>
     <field>
-        <id>general.forwarders</id>
-        <label>DNS Forwarders</label>
-        <style>tokenize</style>
-        <type>select_multiple</type>
-        <allownew>true</allownew>
-        <help>Set one or more hosts to send your DNS queries if the request is unknown.</help>
-    </field>
-    <field>
         <id>general.filteraaaav4</id>
         <label>Enable filter-aaaa on IPv4 Clients</label>
         <type>checkbox</type>
@@ -125,6 +117,12 @@
         <label>Allow Query</label>
         <type>select_multiple</type>
         <help>Define the ACLs where you allow which client are allowed to query this server.</help>
+    </field>
+    <field>
+        <id>general.forwarding</id>
+        <label>Forwarding Mode</label>
+        <type>dropdown</type>
+        <help>Set to "Forward Only" to prevent BIND from falling back to its own recursive resolution when forwarders are unreachable. If set to "Forward Only", configure forwarders on the DNS Forwarders tab.</help>
     </field>
     <field>
         <id>general.dnssecvalidation</id>

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Forwarder.php
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Forwarder.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+    Copyright (C) 2026 Bryan Wiegand <inbox@kw-ventures.com>
+    All rights reserved.
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+    AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+
+namespace OPNsense\Bind;
+
+use OPNsense\Base\BaseModel;
+
+class Forwarder extends BaseModel
+{
+}

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Forwarder.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Forwarder.xml
@@ -1,0 +1,78 @@
+<!--
+ Copyright (C) 2026 Bryan Wiegand <inbox@kw-ventures.com>
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+
+<model>
+    <mount>//OPNsense/bind/forwarder</mount>
+    <description>BIND DNS and DNS-over-TLS forwarders</description>
+    <version>1.0.1</version>
+    <items>
+        <forwarders>
+            <dns type="ArrayField">
+                <enabled type="BooleanField">
+                    <Default>1</Default>
+                    <Required>Y</Required>
+                </enabled>
+                <ip type="NetworkField">
+                    <Required>Y</Required>
+                    <NetMaskAllowed>N</NetMaskAllowed>
+                    <Constraints>
+                        <check001>
+                            <ValidationMessage>A plain forwarder with this IP already exists.</ValidationMessage>
+                            <type>UniqueConstraint</type>
+                        </check001>
+                    </Constraints>
+                </ip>
+                <port type="PortField">
+                    <Default>53</Default>
+                    <Required>Y</Required>
+                </port>
+            </dns>
+            <dot type="ArrayField">
+                <enabled type="BooleanField">
+                    <Default>1</Default>
+                    <Required>Y</Required>
+                </enabled>
+                <ip type="NetworkField">
+                    <Required>Y</Required>
+                    <NetMaskAllowed>N</NetMaskAllowed>
+                    <Constraints>
+                        <check001>
+                            <ValidationMessage>A DoT forwarder with this IP already exists.</ValidationMessage>
+                            <type>UniqueConstraint</type>
+                        </check001>
+                    </Constraints>
+                </ip>
+                <port type="PortField">
+                    <Default>853</Default>
+                    <Required>Y</Required>
+                </port>
+                <tlshostname type="HostnameField">
+                    <Required>N</Required>
+                </tlshostname>
+            </dot>
+        </forwarders>
+    </items>
+</model>

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/General.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/General.xml
@@ -45,9 +45,14 @@
             <Default>53530</Default>
             <Required>Y</Required>
         </port>
-        <forwarders type="NetworkField">
-            <AsList>Y</AsList>
-        </forwarders>
+        <forwarding type="OptionField">
+            <Default>first</Default>
+            <Required>Y</Required>
+            <OptionValues>
+                <first>Forward First</first>
+                <only>Forward Only</only>
+            </OptionValues>
+        </forwarding>
         <filteraaaav4 type="BooleanField">
             <Default>0</Default>
             <Required>Y</Required>

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Menu/Menu.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Menu/Menu.xml
@@ -1,8 +1,9 @@
 <menu>
   <Services>
     <BIND cssClass="fa fa-tags">
-      <Configuration url="/ui/bind/general/index"/>
-      <LogFiles VisibleName="Log Files" url="/ui/bind/logs"/>
+      <General VisibleName="General Settings" order="10" url="/ui/bind/general/index"/>
+      <Forwarding VisibleName="Query Forwarding" order="30" url="/ui/bind/forwarding/index"/>
+      <LogFiles VisibleName="Log Files" order="50" url="/ui/bind/logs"/>
     </BIND>
   </Services>
 </menu>

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Migrations/M1_0_1.php
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Migrations/M1_0_1.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Bryan Wiegand <inbox@kw-ventures.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Bind\Migrations;
+
+use OPNsense\Base\BaseModelMigration;
+use OPNsense\Bind\Forwarder;
+use OPNsense\Core\Config;
+
+class M1_0_1 extends BaseModelMigration
+{
+    /**
+     * Migrate the legacy General model forwarders CSV into this model's DNS
+     * forwarder grid.
+     * @param $model
+     */
+    public function run($model)
+    {
+        if (!($model instanceof Forwarder)) {
+            return;
+        }
+
+        $config = Config::getInstance()->object();
+        if (empty($config->OPNsense->bind->general->forwarders)) {
+            return;
+        }
+
+        $legacy = trim((string)$config->OPNsense->bind->general->forwarders);
+        if ($legacy === '') {
+            return;
+        }
+
+        if (count(iterator_to_array($model->forwarders->dns->iterateItems())) > 0) {
+            return;
+        }
+
+        foreach (explode(',', $legacy) as $token) {
+            $token = trim($token);
+            if ($token === '') {
+                continue;
+            }
+
+            $ip = $token;
+            $port = '53';
+
+            if (filter_var($token, FILTER_VALIDATE_IP) === false && strpos($token, ':') !== false) {
+                [$candidateIp, $candidatePort] = explode(':', $token, 2);
+                if (filter_var($candidateIp, FILTER_VALIDATE_IP) !== false &&
+                    ctype_digit($candidatePort) && $candidatePort >= 1 && $candidatePort <= 65535
+                ) {
+                    $ip = $candidateIp;
+                    $port = $candidatePort;
+                } else {
+                    syslog(LOG_WARNING, sprintf('BIND migration: no valid port found in "%s", defaulting to 53.', $token));
+                }
+            }
+
+            $forwarder = $model->forwarders->dns->add();
+            $forwarder->ip = $ip;
+            $forwarder->port = $port;
+        }
+
+        $config->OPNsense->bind->general->forwarders = '';
+    }
+}

--- a/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/forwarding.volt
+++ b/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/forwarding.volt
@@ -1,0 +1,153 @@
+{#
+ # Copyright (C) 2026 Bryan Wiegand <inbox@kw-ventures.com>
+ # All rights reserved.
+ #
+ # Redistribution and use in source and binary forms, with or without
+ # modification, are permitted provided that the following conditions are met:
+ #
+ # 1. Redistributions of source code must retain the above copyright notice,
+ #    this list of conditions and the following disclaimer.
+ #
+ # 2. Redistributions in binary form must reproduce the above copyright notice,
+ #    this list of conditions and the following disclaimer in the documentation
+ #    and/or other materials provided with the distribution.
+ #
+ # THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS AND ANY
+ # EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ # DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE FOR ANY
+ # DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ # (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ # LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ # ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#}
+
+<!-- Navigation bar -->
+<ul class="nav nav-tabs" data-tabs="tabs" id="maintabs">
+    <li class="active"><a data-toggle="tab" href="#forwarders">{{ lang._('DNS Forwarders') }}</a></li>
+</ul>
+
+<div class="tab-content content-box tab-content">
+    <div id="forwarders" class="tab-pane fade in active">
+        <div class="col-md-12">
+            <div class="alert alert-info" role="alert">
+                {{ lang._('If you enter forwarders in both the DNS and DNS over TLS tables, BIND treats them as one combined pool.') }}
+            </div>
+        </div>
+        <div class="col-md-12">
+            <h2>{{ lang._('DNS') }}</h2>
+        </div>
+        <div id="dns-forwarders-area" class="table-responsive">
+            <table id="grid-dns-forwarders" class="table table-condensed table-hover table-striped" data-editAlert="ChangeMessageForwarders" data-editDialog="dialogEditBindDnsForwarder">
+                <thead>
+                    <tr>
+                        <th data-column-id="enabled" data-type="string" data-formatter="rowtoggle">{{ lang._('Enabled') }}</th>
+                        <th data-column-id="ip" data-type="string" data-visible="true">{{ lang._('IP Address') }}</th>
+                        <th data-column-id="port" data-type="string" data-visible="true">{{ lang._('Port') }}</th>
+                        <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
+                        <th data-column-id="commands" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                </tbody>
+                <tfoot>
+                    <tr>
+                        <td colspan="5"></td>
+                        <td>
+                            <button data-action="add" type="button" class="btn btn-xs btn-default"><span class="fa fa-plus"></span></button>
+                            <button data-action="deleteSelected" type="button" class="btn btn-xs btn-default"><span class="fa fa-trash-o"></span></button>
+                        </td>
+                    </tr>
+                </tfoot>
+            </table>
+        </div>
+        <hr/>
+        <div class="col-md-12">
+            <h2>{{ lang._('DNS over TLS') }}</h2>
+        </div>
+        <div id="dot-forwarders-area" class="table-responsive">
+            <table id="grid-dot-forwarders" class="table table-condensed table-hover table-striped" data-editAlert="ChangeMessageForwarders" data-editDialog="dialogEditBindDotForwarder">
+                <thead>
+                    <tr>
+                        <th data-column-id="enabled" data-type="string" data-formatter="rowtoggle">{{ lang._('Enabled') }}</th>
+                        <th data-column-id="ip" data-type="string" data-visible="true">{{ lang._('IP Address') }}</th>
+                        <th data-column-id="port" data-type="string" data-visible="true">{{ lang._('Port') }}</th>
+                        <th data-column-id="tlshostname" data-type="string" data-visible="true">{{ lang._('TLS Hostname') }}</th>
+                        <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
+                        <th data-column-id="commands" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                </tbody>
+                <tfoot>
+                    <tr>
+                        <td colspan="6"></td>
+                        <td>
+                            <button data-action="add" type="button" class="btn btn-xs btn-default"><span class="fa fa-plus"></span></button>
+                            <button data-action="deleteSelected" type="button" class="btn btn-xs btn-default"><span class="fa fa-trash-o"></span></button>
+                        </td>
+                    </tr>
+                </tfoot>
+            </table>
+        </div>
+        <hr/>
+        <div class="col-md-12">
+            <div id="ChangeMessageForwarders" class="alert alert-info" style="display: none" role="alert">
+                {{ lang._('After changing settings, please remember to apply them with the button below') }}
+            </div>
+            <button class="btn btn-primary" id="saveAct_forwarders" type="button"><b>{{ lang._('Save') }}</b> <i id="saveAct_forwarders_progress"></i></button>
+            <br /><br />
+        </div>
+    </div>
+</div>
+
+{{ partial("layout_partials/base_dialog",['fields':formDialogEditBindDnsForwarder,'id':'dialogEditBindDnsForwarder','label':lang._('Edit DNS Forwarder')])}}
+{{ partial("layout_partials/base_dialog",['fields':formDialogEditBindDotForwarder,'id':'dialogEditBindDotForwarder','label':lang._('Edit DNS over TLS Forwarder')])}}
+
+<style>
+    .long-str {
+        word-break: break-word;
+    }
+</style>
+<script>
+$(document).ready(function() {
+    updateServiceControlUI('bind');
+
+    $("#grid-dns-forwarders").UIBootgrid({
+        'search': '/api/bind/forwarder/search_dns_forwarder',
+        'get': '/api/bind/forwarder/get_dns_forwarder/',
+        'set': '/api/bind/forwarder/set_dns_forwarder/',
+        'add': '/api/bind/forwarder/add_dns_forwarder/',
+        'del': '/api/bind/forwarder/del_dns_forwarder/',
+        'toggle': '/api/bind/forwarder/toggle_dns_forwarder/'
+    });
+
+    $("#grid-dot-forwarders").UIBootgrid({
+        'search': '/api/bind/forwarder/search_dot_forwarder',
+        'get': '/api/bind/forwarder/get_dot_forwarder/',
+        'set': '/api/bind/forwarder/set_dot_forwarder/',
+        'add': '/api/bind/forwarder/add_dot_forwarder/',
+        'del': '/api/bind/forwarder/del_dot_forwarder/',
+        'toggle': '/api/bind/forwarder/toggle_dot_forwarder/'
+    });
+
+    $("#saveAct_forwarders").click(function() {
+        $("#saveAct_forwarders_progress").addClass("fa fa-spinner fa-pulse");
+        ajaxCall(url = "/api/bind/service/reconfigure", sendData = {}, callback = function(data, status) {
+            updateServiceControlUI('bind');
+            $("#saveAct_forwarders_progress").removeClass("fa fa-spinner fa-pulse");
+        });
+    });
+
+
+    // update history on tab state and implement navigation
+    if (window.location.hash != "") {
+        $('a[href="' + window.location.hash + '"]').click()
+    }
+    $('.nav-tabs a').on('shown.bs.tab', function(e) {
+        history.pushState(null, null, e.target.hash);
+    });
+});
+</script>

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
@@ -38,9 +38,34 @@ options {
         transfer-source-v6 {{ OPNsense.bind.general.transfersourcev6 }};
 {% endif -%}
 
-{% if helpers.exists('OPNsense.bind.general.forwarders') and OPNsense.bind.general.forwarders != '' %}
-        forwarders    { {{ OPNsense.bind.general.forwarders.replace(',', '; ') }}; };
-{% endif -%}
+{% set forwarder_present = [] %}
+{% if helpers.exists('OPNsense.bind.forwarder.forwarders.dns') %}
+{%   for f in helpers.toList('OPNsense.bind.forwarder.forwarders.dns') %}
+{%     if f.enabled == '1' %}{% do forwarder_present.append(1) %}{% endif %}
+{%   endfor %}
+{% endif %}
+{% if helpers.exists('OPNsense.bind.forwarder.forwarders.dot') %}
+{%   for f in helpers.toList('OPNsense.bind.forwarder.forwarders.dot') %}
+{%     if f.enabled == '1' %}{% do forwarder_present.append(1) %}{% endif %}
+{%   endfor %}
+{% endif %}
+{% if forwarder_present|length > 0 %}
+        forwarders {
+{%   if helpers.exists('OPNsense.bind.forwarder.forwarders.dns') %}
+{%     for f in helpers.toList('OPNsense.bind.forwarder.forwarders.dns') if f.enabled == '1' %}
+                {{ f.ip }} port {{ f.port }};
+{%     endfor %}
+{%   endif %}
+{%   if helpers.exists('OPNsense.bind.forwarder.forwarders.dot') %}
+{%     for f in helpers.toList('OPNsense.bind.forwarder.forwarders.dot') if f.enabled == '1' %}
+                {{ f.ip }} port {{ f.port }} tls "dot-{{ f['@uuid'] }}";
+{%     endfor %}
+{%   endif %}
+        };
+{% if helpers.exists('OPNsense.bind.general.forwarding') %}
+        forward {{ OPNsense.bind.general.forwarding }};
+{% endif %}
+{% endif %}
 
 {% if helpers.exists('OPNsense.bind.dnsbl.enabled') and OPNsense.bind.dnsbl.enabled == '1' %}
         response-policy { {% if helpers.exists('OPNsense.bind.dnsbl.type') and OPNsense.bind.dnsbl.type != '' %}zone "whitelist.localdomain"; zone "blacklist.localdomain";{% endif %}{% if helpers.exists('OPNsense.bind.dnsbl.forcesafegoogle') and OPNsense.bind.dnsbl.forcesafegoogle == '1' %}zone "rpzgoogle";{% endif %}{% if helpers.exists('OPNsense.bind.dnsbl.forcesafeduckduckgo') and OPNsense.bind.dnsbl.forcesafeduckduckgo == '1' %}zone "rpzduckduckgo";{% endif %}{% if helpers.exists('OPNsense.bind.dnsbl.forcesafeyoutube') and OPNsense.bind.dnsbl.forcesafeyoutube == '1' %}zone "rpzyoutube";{% endif %}{% if helpers.exists('OPNsense.bind.dnsbl.forcestrictbing') and OPNsense.bind.dnsbl.forcestrictbing == '1' %}zone "rpzbing";{% endif %} };
@@ -100,6 +125,17 @@ options {
 {%   endif %}
 {% endif %}
 };
+
+{% if helpers.exists('OPNsense.bind.forwarder.forwarders.dot') %}
+{%   for f in helpers.toList('OPNsense.bind.forwarder.forwarders.dot') if f.enabled == '1' %}
+tls "dot-{{ f['@uuid'] }}" {
+{%       if f.tlshostname is defined and f.tlshostname != '' %}
+        remote-hostname "{{ f.tlshostname }}";
+{%       endif %}
+        ca-file "/usr/local/etc/ssl/cert.pem";
+};
+{%   endfor %}
+{% endif %}
 
 {% if helpers.exists('OPNsense.bind.general.rndcalgo') and helpers.exists('OPNsense.bind.general.rndcsecret') %}
 key "rndc-key" {


### PR DESCRIPTION
**Important notices**

- [X] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [X] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Models used: GPT-5.6 Terra
- Extent of AI involvement: I handled design and decisions. It assisted with testing, investigation, code generation, review, commits, commit messages, and PR generation.

---

## Summary

BIND supports native DNS-over-TLS (DoT) forwarders, but the plugin previously exposed only a legacy comma-separated forwarder list. That format cannot represent a destination port or TLS hostname per forwarder.

This PR adds a dedicated **Query Forwarding** page with separate grids for plain DNS and DoT upstreams. Each forwarder has its own address and port; DoT forwarders may also specify a TLS hostname.

## Behaviour

- With a TLS hostname, BIND verifies the upstream certificate against that hostname using the system CA bundle.
- Without a TLS hostname, BIND verifies the certificate against the configured forwarder's IP address; the certificate must include that IP address in its Subject Alternative Name.
- The legacy forwarder CSV is migrated into the plain-DNS grid by the Forwarder model.
- The General page retains the **Forward First** and **Forward Only** policy choice.

## Scope

This PR is intentionally limited to forwarder configuration and DNS-over-TLS support. The unrelated DNSBL, dynamic DNS, reverse-zone, listener-interface, zone-NOTIFY, and UI restructuring work has been split into separate branches for follow-up PRs.

## BIND compatibility

BIND 9.20.24 introduced an upstream regression that breaks DNS-over-TLS forwarders when BIND is configured with **Forward Only**. The fix is upstream in [fb0ae8a5d6b2abb8b6ad3529e205caacbe4e70d1](https://gitlab.isc.org/isc-projects/bind9/-/commit/fb0ae8a5d6b2abb8b6ad3529e205caacbe4e70d1) and was released in BIND 9.20.26.

Users who need DoT with Forward Only should use BIND 9.20.26 or later.

## Validation

- Testing and running all of this on my CARP enabled cluster, on OPNsense 26.1.11_6-amd64.
- PHP syntax checks pass for the BIND plugin.
- Tested on OPNsense with BIND 9.20.26, a configured DoT upstream, and **Forward Only**: queries for `example.com`, `cloudflare.com`, and `openai.com` returned `NOERROR`.

## Related issue

Closes #5546
