### PR TITLE
Add NAPTR as a bind record type

### DIFF
--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Record.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Record.xml
@@ -33,6 +33,7 @@
                         <DS>DS</DS>
                         <HTTPS>HTTPS</HTTPS>
                         <MX>MX</MX>
+                        <NAPTR>NAPTR</NAPTR>
                         <NS>NS</NS>
                         <PTR>PTR</PTR>
                         <RP>RP</RP>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [X] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [X] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:
No AI, it's one line

---

**Describe the problem**

I want to add a NAPTR record to bind.  Need this listed as a valid record type in the plugin.

---

**Describe the proposed solution**

Add a line listing NAPTR as a valid record type in the bind plugin.

---

**Related issue**

~~I didn't bother opening an issue for this since it's trivial.~~

Correction: I opened issue #5565 for this, to raise visibility a bit.