### PR TITLE
dns/bind: add validate-except config option (#5549)

### DIFF
--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/general.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/general.xml
@@ -133,6 +133,14 @@
         <help>Default is "No". Set to "Auto" to use the static trust anchor configuration by the system.</help>
     </field>
     <field>
+        <id>general.validate_except</id>
+        <label>DNSSEC Validate Except</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <allownew>true</allownew>
+        <help>Specify a list of domain names at and beneath which DNSSEC validation should not be performed (essential for internal split DNS zones in forward zones).</help>
+    </field>
+    <field>
         <id>general.hidehostname</id>
         <label>Hide Hostname</label>
         <type>checkbox</type>

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/General.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/General.xml
@@ -125,6 +125,13 @@
             <Default>no</Default>
             <Required>Y</Required>
         </dnssecvalidation>
+        <validate_except type="HostnameField">
+            <Required>N</Required>
+            <AsList>Y</AsList>
+            <IsDNSName>Y</IsDNSName>
+            <IpAllowed>N</IpAllowed>
+            <ValidationMessage>[%s] is not a valid domain name.</ValidationMessage>
+        </validate_except>
         <hidehostname type="BooleanField">
             <Default>0</Default>
             <Required>Y</Required>

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
@@ -80,6 +80,13 @@ options {
 {% if helpers.exists('OPNsense.bind.general.dnssecvalidation') and OPNsense.bind.general.dnssecvalidation != '' %}
         dnssec-validation    {{ OPNsense.bind.general.dnssecvalidation }};
 {% endif %}
+{% if helpers.exists('OPNsense.bind.general.validate_except') and OPNsense.bind.general.validate_except != '' %}
+        validate-except {
+{% for domain in OPNsense.bind.general.validate_except.split(',') %}
+                "{{ domain }}";
+{% endfor %}
+        };
+{% endif %}
 {% if helpers.exists('OPNsense.bind.general.hidehostname') and OPNsense.bind.general.hidehostname == '1' %}
         hostname none;
 {% endif %}


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

When running a split-horizon DNS setup where the public domain is DNSSEC-signed, internal clients experience `SERVFAIL` errors when querying internal, unsigned forward zones. While BIND implicitly trusts local primary zones and bypasses validation for them, forwarded zones trigger strict recursive checks. BIND attempts to validate the forwarded zone against the public chain of trust and naturally fails.

Currently, the BIND plugin UI does not expose the `validate-except` directive, making it impossible to exclude these internal zones/subdomains from DNSSEC validation without manual backend workarounds that get overwritten by the template engine.

---

**Describe the proposed solution**

Expose the `validate-except` directive in the UI.

---

**Related issue**

#5549 
