### PR TITLE
security/acme-client: add support for HostUp DNS API

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -675,6 +675,31 @@
         <type>text</type>
     </field>
     <field>
+        <label>HostUp</label>
+        <type>header</type>
+        <style>table_dns table_dns_hostup</style>
+    </field>
+    <field>
+        <id>validation.dns_hostup_api_key</id>
+        <label>API Key</label>
+        <type>password</type>
+    </field>
+    <field>
+        <id>validation.dns_hostup_api_base</id>
+        <label>API Base</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_hostup_ttl</id>
+        <label>TTL</label>
+        <type>text</type>
+    </field>
+    <field>
+        <id>validation.dns_hostup_zone_id</id>
+        <label>Zone ID</label>
+        <type>text</type>
+    </field>
+    <field>
         <label>Hurricane Electric</label>
         <type>header</type>
         <style>table_dns table_dns_he</style>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsHostup.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsHostup.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Rasmus Leini
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\AcmeClient\LeValidation;
+
+use OPNsense\AcmeClient\LeValidationInterface;
+use OPNsense\Core\Config;
+
+/**
+ * HostUp DNS API
+ * @package OPNsense\AcmeClient
+ */
+class DnsHostup extends Base implements LeValidationInterface
+{
+    public function prepare()
+    {
+        $this->acme_env['HOSTUP_API_KEY'] = (string)$this->config->dns_hostup_api_key;
+        $this->acme_env['HOSTUP_API_BASE'] = (string)$this->config->dns_hostup_api_base;
+        $this->acme_env['HOSTUP_TTL'] = (string)$this->config->dns_hostup_ttl;
+        $this->acme_env['HOSTUP_ZONE_ID'] = (string)$this->config->dns_hostup_zone_id;
+    }
+}

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -477,6 +477,7 @@
                         <dns_hetznercloud>Hetzner Cloud</dns_hetznercloud>
                         <dns_hexonet>hexonet.com</dns_hexonet>
                         <dns_hostingde>hosting.de</dns_hostingde>
+                        <dns_hostup>HostUp</dns_hostup>
                         <dns_he>Hurricane Electric</dns_he>
                         <dns_he_ddns>Hurricane Electric DDNS</dns_he_ddns>
                         <dns_infoblox>Infoblox</dns_infoblox>
@@ -752,6 +753,18 @@
                 <dns_hostingde_apiKey type="TextField">
                     <Required>N</Required>
                 </dns_hostingde_apiKey>
+                <dns_hostup_api_key type="TextField">
+                    <Required>N</Required>
+                </dns_hostup_api_key>
+                <dns_hostup_api_base type="TextField">
+                    <Required>N</Required>
+                </dns_hostup_api_base>
+                <dns_hostup_ttl type="TextField">
+                    <Required>N</Required>
+                </dns_hostup_ttl>
+                <dns_hostup_zone_id type="TextField">
+                    <Required>N</Required>
+                </dns_hostup_zone_id>
                 <dns_he_user type="TextField">
                     <Required>N</Required>
                 </dns_he_user>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [X] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

---

**Describe the problem**

acme.sh supports HostUp as of v3.1.3 but acme-client does not support it yet

---

**Describe the proposed solution**

add HostUp support to acme plugin

---

**Related issue**

https://github.com/acmesh-official/acme.sh/pull/6655