### PR TITLE
security/etpro-telemetry: use requests.Session for ET-Telemetry requests

### DIFF
--- a/security/etpro-telemetry/src/opnsense/scripts/etpro_telemetry/send_telemetry.py
+++ b/security/etpro-telemetry/src/opnsense/scripts/etpro_telemetry/send_telemetry.py
@@ -89,6 +89,7 @@ if not telemetry_state.is_running():
                 # the eventcollector loop sets exit_code when issues ocure, no data processed doesn't mean
                 # anything is wrong (it's just not of interest to Proofpoint).
                 exit_code = 0
+                s = requests.Session()
                 for push_data in event_collector:
                     params = {
                         'timeout': 5,
@@ -98,7 +99,7 @@ if not telemetry_state.is_running():
                     if args.insecure:
                         params['verify'] = False
 
-                    r = requests.post(args.endpoint, **params)
+                    r = s.post(args.endpoint, **params)
                     if r.status_code != 201:
                         syslog.syslog(
                             syslog.LOG_ERR,


### PR DESCRIPTION
The current code loops through every telemetry event to submit and makes a standalone POST request, resulting in a DNS lookup for each item.  This results in a ton of DNS requests for the same domain every time this script runs, which is every minute due to the cron job that executes it.  This patch changes the behavior by establishing a requests Session object and then making the POST requests from that, resulting in a single DNS lookup, and as an added benefit, the script completes much faster.

**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [ x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [ n/a] I opened an issue first for non-trivial changes and linked it below.
- [ no] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

The current code loops through every telemetry event to submit and makes a standalone POST request, resulting in a DNS lookup for each item.  This results in a ton of DNS requests for the same domain every time this script runs, which is every minute due to the cron job that executes it. 
---

**Describe the proposed solution**

This patch changes the behavior by establishing a requests Session object and then making the POST requests from that, resulting in a single DNS lookup, and as an added benefit, the script completes much faster.
---

**Related issue**

If this pull request relates to an issue, link it here.
