### PR TITLE
net/vnstat: use OPNsense interface names in vnstat widget

### DIFF
--- a/net/vnstat/Makefile
+++ b/net/vnstat/Makefile
@@ -1,5 +1,6 @@
 PLUGIN_NAME=		vnstat
 PLUGIN_VERSION=		1.4
+PLUGIN_REVISION=	1
 PLUGIN_COMMENT=		Network traffic monitor
 PLUGIN_DEPENDS=		vnstat
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net/vnstat/src/opnsense/mvc/app/controllers/OPNsense/Vnstat/Api/ServiceController.php
+++ b/net/vnstat/src/opnsense/mvc/app/controllers/OPNsense/Vnstat/Api/ServiceController.php
@@ -100,11 +100,23 @@ class ServiceController extends ApiMutableServiceControllerBase
         $vnstatIfaces = array_values(array_filter(array_map('trim', explode("\n", $response))));
 
         $opnsenseIfaces = [];
-        foreach (Config::getInstance()->object()->interfaces->children() as $node) {
-            $opnsenseIfaces[] = (string)$node->if;
+        foreach (Config::getInstance()->object()->interfaces->children() as $key => $node) {
+            $opnsenseIfaces[(string)$node->if] = [
+                'identifier' => (string)$key,
+                'description' => !empty((string)$node->descr) ? (string)$node->descr : strtoupper((string)$key),
+            ];
         }
 
-        $interfaces = array_values(array_intersect($vnstatIfaces, $opnsenseIfaces));
+        $interfaces = [];
+        foreach ($vnstatIfaces as $device) {
+            if (isset($opnsenseIfaces[$device])) {
+                $interfaces[] = [
+                    'device' => $device,
+                    'identifier' => $opnsenseIfaces[$device]['identifier'],
+                    'description' => $opnsenseIfaces[$device]['description'],
+                ];
+            }
+        }
         return ["interfaces" => $interfaces];
     }
 

--- a/net/vnstat/src/opnsense/www/js/widgets/Vnstat.js
+++ b/net/vnstat/src/opnsense/www/js/widgets/Vnstat.js
@@ -42,7 +42,10 @@ export default class Vnstat extends BaseTableWidget {
 
     async getWidgetOptions() {
         const data = await this.ajaxCall(`/api/vnstat/service/${'interface_list'}`);
-        const ifaceOptions = (data?.interfaces ?? []).map(name => ({ value: name, label: name }));
+        const ifaceOptions = (data?.interfaces ?? []).map(iface => ({
+            value: iface.device,
+            label: iface.description
+        }));
 
         return {
             excluded_interfaces: {
@@ -154,22 +157,24 @@ export default class Vnstat extends BaseTableWidget {
         const data = await this.ajaxCall(`/api/vnstat/service/${'interface_list'}`);
         if (!data || !data.interfaces) return;
 
-        const names = data.interfaces.filter(name => !this.excludedInterfaces.includes(name));
+        const interfaces = data.interfaces.filter(iface => !this.excludedInterfaces.includes(iface.device));
 
         const $select = $('#vnstat-interface-select');
         $select.empty();
-        for (const name of names) {
-            $select.append($('<option></option>').val(name).text(name));
+        for (const iface of interfaces) {
+            $select.append($('<option></option>').val(iface.device).text(iface.description));
         }
 
-        if (this.currentInterface && names.includes(this.currentInterface)) {
+        const devices = interfaces.map(iface => iface.device);
+        const wan = interfaces.find(iface => iface.identifier === 'wan');
+        if (this.currentInterface && devices.includes(this.currentInterface)) {
             $select.val(this.currentInterface);
-        } else if (names.includes('WAN')) {
-            $select.val('WAN');
-            this.currentInterface = 'WAN';
-        } else if (names.length > 0) {
-            $select.val(names[0]);
-            this.currentInterface = names[0];
+        } else if (wan) {
+            $select.val(wan.device);
+            this.currentInterface = wan.device;
+        } else if (devices.length > 0) {
+            $select.val(devices[0]);
+            this.currentInterface = devices[0];
         }
     }
 


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: Fable 5
- Extent of AI involvement: Code review

---

**Describe the problem**

https://forum.opnsense.org/index.php?topic=51328.0

User asked to use the OPNsense interface names in the widget dropdown instead of the FreeBSD interface names.

Closes #5699