### PR TITLE
Add FRR BGP Confederation Options/Fields

### DIFF
--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/bgp.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/bgp.xml
@@ -11,6 +11,22 @@
         <type>text</type>
         <help>Your AS Number here.</help>
     </field>
+<field>
+		<id>bgp.confed_asn</id>
+		<label>BGP Confederation ASN</label>
+		<type>text</type>
+		<advanced>true</advanced>
+		<help>Specify the autonomous system number of the local confederation group. (Required if Confederation Peers are set)</help>
+	</field>
+	<field>
+		<id>bgp.confed_peers</id>
+		<label>BGP Confederation Peers</label>
+		<type>select_multiple</type>
+		<style>tokenize</style>
+		<allownew>true</allownew>
+		<advanced>true</advanced>
+		<help>Specify the Peers of the confederation group. (Required if Confederation ASN is set)</help>
+	</field>
     <field>
         <id>bgp.distance</id>
         <label>BGP AD Distance</label>

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/bgp.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/bgp.xml
@@ -11,7 +11,7 @@
         <type>text</type>
         <help>Your AS Number here.</help>
     </field>
-<field>
+	<field>
 		<id>bgp.confed_asn</id>
 		<label>BGP Confederation ASN</label>
 		<type>text</type>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.php
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.php
@@ -3,6 +3,41 @@
 namespace OPNsense\Quagga;
 
 use OPNsense\Base\BaseModel;
+use Phalcon\Messages\Message;
+
+class BGP extends BaseModel
+{
+    public function performValidation($validateFullModel = false)
+    {
+        // Run standard XML field validations first
+        $messages = parent::performValidation($validateFullModel);
+
+        // Fetch values
+        $asn = trim((string)$this->confed_asn);
+        $peers = trim((string)$this->confed_peers);
+
+        $has_asn = !empty($asn);
+        $has_peers = !empty($peers);
+
+        // 1. ASN is set, but Peers are empty
+        if ($has_asn && !$has_peers) {
+            $messages->appendMessage(new Message(
+                "BGP Confederation Peers are required when a Confederation ASN is defined.",
+                "confed_peers"
+            ));
+        }
+
+        // 2. Peers are set, but ASN is empty
+        if (!$has_asn && $has_peers) {
+            $messages->appendMessage(new Message(
+                "BGP Confederation ASN is required when Confederation Peers are defined.",
+                "confed_asn"
+            ));
+        }
+
+        return $messages;
+    }
+}
 
 /*
     Copyright (C) 2017 Fabian Franz
@@ -26,6 +61,3 @@ use OPNsense\Base\BaseModel;
     ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
     POSSIBILITY OF SUCH DAMAGE.
 */
-class BGP extends BaseModel
-{
-}

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
@@ -13,6 +13,17 @@
             <MinimumValue>1</MinimumValue>
             <MaximumValue>4294967295</MaximumValue>
         </asnumber>
+		<confed_asn type="IntegerField">
+			<Required>N</Required>
+			<ValidationMessage>BGP Confederation ASN must be an integer between 1 and 4294967295.</ValidationMessage>
+			<MinimumValue>1</MinimumValue>
+			<MaximumValue>4294967295</MaximumValue>
+		</confed_asn>
+		<confed_peers type="CSVListField">
+			<Required>N</Required>
+			<ValidationMessage>Each Peer ASN must be an integer between 1 and 4294967295.</ValidationMessage>
+			<Mask>/^(([1-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[0-1][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[0-1][0-9]{2}|42949672[0-8][0-9]|429496729[0-5])(,|$))+$/</Mask>
+		</confed_peers>
         <distance type="IntegerField">
             <MinimumValue>1</MinimumValue>
             <MaximumValue>255</MaximumValue>

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/Config/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/Config/bgpd.conf
@@ -29,6 +29,12 @@
 {%   endif %}
 {% if helpers.exists('OPNsense.quagga.bgp.asnumber') and OPNsense.quagga.bgp.asnumber != '' %}
 router bgp {{ OPNsense.quagga.bgp.asnumber }}
+{%   if OPNsense.quagga.bgp.confed_asn|default('') != '' %}
+ bgp confederation identifier {{ OPNsense.quagga.bgp.confed_asn }}
+{%   endif %}
+{%   if OPNsense.quagga.bgp.confed_peers|default('') != '' %}
+ bgp confederation peers {{ OPNsense.quagga.bgp.confed_peers|replace(',', ' ') }}
+{%   endif %}
 {%   if not helpers.empty('OPNsense.quagga.bgp.logneighborchanges') %}
  bgp log-neighbor-changes
 {%   endif %}


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: Gemini
- Extent of AI involvement: Assisted for finding relevant files to modify, guided relevant changes and tweaks during testing.

---

**Describe the problem**

Unable to use FRR in OPNsense with in a BGP Confederations without these options.

---

**Describe the proposed solution**

Add 2 fields and relevant validation and config generation to add the two config lines to the FRR service.

---

**Related issue**

https://github.com/opnsense/plugins/issues/2202

---

I have already made these changes locally, and from my limited testing it works as intended.

The BGP.php was the trickiest, and not sure if that was the best or only way to deal with that.

One other minor thing I noticed with this, when using the Copy then Paste buttons on the Confederation Peers, it's only copying the first. Not sure how to fix that, assuming minor change.