### PR TITLE
dns/bind: add reverse zone configuration

### DIFF
--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/Api/DomainController.php
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/Api/DomainController.php
@@ -31,6 +31,7 @@ namespace OPNsense\Bind\Api;
 
 use OPNsense\Base\ApiMutableModelControllerBase;
 use OPNsense\Core\Backend;
+use OPNsense\Bind\Domain;
 
 class DomainController extends ApiMutableModelControllerBase
 {
@@ -85,6 +86,22 @@ class DomainController extends ApiMutableModelControllerBase
         );
     }
 
+    public function searchReverseDomainAction()
+    {
+        $result = $this->searchBase(
+            'domains.domain',
+            ['enabled', 'type', 'domainname', 'source_subnet'],
+            'domainname',
+            function ($record) {
+                return $record->type->getNodeData()['reverse']['selected'] === 1;
+            }
+        );
+        foreach ($result['rows'] as &$row) {
+            $row['interface'] = $this->getInterfaceFromSubnet($row['source_subnet'] ?? '');
+        }
+        return $result;
+    }
+
     public function getDomainAction($uuid = null)
     {
         return $this->getBase('domain', 'domains.domain', $uuid);
@@ -105,6 +122,11 @@ class DomainController extends ApiMutableModelControllerBase
         return $this->addBase('domain', 'domains.domain', ['type' => 'forward']);
     }
 
+    public function addReverseDomainAction($uuid = null)
+    {
+        return $this->addBase('domain', 'domains.domain', ['type' => 'reverse']);
+    }
+
     public function delDomainAction($uuid)
     {
         return $this->delBase('domains.domain', $uuid);
@@ -118,5 +140,67 @@ class DomainController extends ApiMutableModelControllerBase
     public function toggleDomainAction($uuid)
     {
         return $this->toggleBase('domains.domain', $uuid);
+    }
+
+    protected function setBaseHook($node)
+    {
+        if ((string)$node->type === 'reverse') {
+            $zoneName = Domain::reverseZoneName((string)$node->source_subnet);
+            if ($zoneName !== null) {
+                $node->domainname = $zoneName;
+            }
+        }
+    }
+
+    private function getInterfaceFromSubnet($subnet)
+    {
+        if (empty($subnet)) {
+            return '';
+        }
+
+        $backend = new Backend();
+        $ifconfig = json_decode($backend->configdRun('interface list ifconfig'), true) ?? [];
+        foreach ($ifconfig as $if => $details) {
+            foreach (['ipv4', 'ipv6'] as $family) {
+                foreach ($details[$family] ?? [] as $addr) {
+                    if (empty($addr['ipaddr']) || !isset($addr['subnetbits'])) {
+                        continue;
+                    }
+                    if ($this->networkAddress($addr['ipaddr'], $addr['subnetbits']) !== $subnet) {
+                        continue;
+                    }
+                    $cfg = \OPNsense\Core\Config::getInstance()->object();
+                    if (isset($cfg->interfaces)) {
+                        foreach ($cfg->interfaces->children() as $key => $node) {
+                            if ((string)$node->if === $if) {
+                                return !empty((string)$node->descr) ? (string)$node->descr : strtoupper($key);
+                            }
+                        }
+                    }
+                    return $if;
+                }
+            }
+        }
+        return '';
+    }
+
+    private function networkAddress($address, $prefix)
+    {
+        if (!is_numeric($prefix) || ($packed = inet_pton($address)) === false) {
+            return null;
+        }
+        $prefix = (int)$prefix;
+        if ($prefix < 0 || $prefix > strlen($packed) * 8) {
+            return null;
+        }
+        $remainingBits = $prefix;
+        $network = '';
+        for ($index = 0; $index < strlen($packed); ++$index) {
+            $bits = min(max($remainingBits, 0), 8);
+            $mask = $bits === 0 ? 0 : (0xff << (8 - $bits)) & 0xff;
+            $network .= chr(ord($packed[$index]) & $mask);
+            $remainingBits -= 8;
+        }
+        return inet_ntop($network) . '/' . $prefix;
     }
 }

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/Api/GeneralController.php
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/Api/GeneralController.php
@@ -59,4 +59,65 @@ class GeneralController extends ApiMutableModelControllerBase
         }
         return $response;
     }
+
+    public function listSubnetsAction()
+    {
+        $result = ['subnets' => []];
+        $seenNetworks = [];
+        $backend = new Backend();
+        $ifconfig = json_decode($backend->configdRun('interface list ifconfig'), true) ?? [];
+        $cfg = \OPNsense\Core\Config::getInstance()->object();
+        $intfmap = [];
+        if (isset($cfg->interfaces)) {
+            foreach ($cfg->interfaces->children() as $key => $node) {
+                $intfmap[(string)$node->if] = !empty((string)$node->descr) ? (string)$node->descr : strtoupper($key);
+            }
+        }
+
+        foreach ($ifconfig as $if => $details) {
+            foreach (['ipv4', 'ipv6'] as $family) {
+                foreach ($details[$family] ?? [] as $addr) {
+                    if (empty($addr['ipaddr']) || !isset($addr['subnetbits'])) {
+                        continue;
+                    }
+                    if (($family === 'ipv4' && strpos($addr['ipaddr'], '127.') === 0) ||
+                        ($family === 'ipv6' && $addr['ipaddr'] === '::1')) {
+                        continue;
+                    }
+                    $network = $this->networkAddress($addr['ipaddr'], $addr['subnetbits']);
+                    if ($network === null || isset($seenNetworks[$network])) {
+                        continue;
+                    }
+                    $seenNetworks[$network] = true;
+                    $result['subnets'][] = [
+                        'label' => ($intfmap[$if] ?? $if) . ' - ' . $network,
+                        'value' => $network,
+                        'family' => $family,
+                        'interface' => $if,
+                    ];
+                }
+            }
+        }
+        return $result;
+    }
+
+    private function networkAddress($address, $prefix)
+    {
+        if (!is_numeric($prefix) || ($packed = inet_pton($address)) === false) {
+            return null;
+        }
+        $prefix = (int)$prefix;
+        if ($prefix < 0 || $prefix > strlen($packed) * 8) {
+            return null;
+        }
+        $remainingBits = $prefix;
+        $network = '';
+        for ($index = 0; $index < strlen($packed); ++$index) {
+            $bits = min(max($remainingBits, 0), 8);
+            $mask = $bits === 0 ? 0 : (0xff << (8 - $bits)) & 0xff;
+            $network .= chr(ord($packed[$index]) & $mask);
+            $remainingBits -= 8;
+        }
+        return inet_ntop($network) . '/' . $prefix;
+    }
 }

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/ReverseZonesController.php
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/ReverseZonesController.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace OPNsense\Bind;
+
+class ReverseZonesController extends \OPNsense\Base\IndexController
+{
+    public function indexAction()
+    {
+        $this->view->formDialogEditBindReverseDomain = $this->getForm('dialogEditBindReverseDomain');
+        $this->view->pick('OPNsense/Bind/reverse_zones');
+    }
+}

--- a/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindReverseDomain.xml
+++ b/dns/bind/src/opnsense/mvc/app/controllers/OPNsense/Bind/forms/dialogEditBindReverseDomain.xml
@@ -1,0 +1,14 @@
+<form>
+    <field>
+        <id>domain.enabled</id>
+        <label>Enabled</label>
+        <type>checkbox</type>
+        <help>Enable this reverse DNS zone.</help>
+    </field>
+    <field>
+        <id>domain.source_subnet</id>
+        <label>Subnet</label>
+        <type>dropdown</type>
+        <help>Select a directly-connected subnet for this reverse zone.</help>
+    </field>
+</form>

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Domain.php
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Domain.php
@@ -25,9 +25,68 @@
 namespace OPNsense\Bind;
 
 use OPNsense\Base\BaseModel;
+use OPNsense\Base\Messages\Message;
 
 class Domain extends BaseModel
 {
+    public function performValidation($validateFullModel = false)
+    {
+        $messages = parent::performValidation($validateFullModel);
+        foreach ($this->domains->domain->iterateItems() as $domain) {
+            if ((string)$domain->type !== 'reverse') {
+                if (trim((string)$domain->domainname) === '') {
+                    $messages->appendMessage(new Message(
+                        gettext('A zone name is required.'),
+                        $domain->domainname->getInternalXMLTagName()
+                    ));
+                }
+                continue;
+            }
+            if (self::reverseZoneName((string)$domain->source_subnet) === null) {
+                $messages->appendMessage(new Message(
+                    gettext('Reverse zones require an IPv4 octet-aligned or IPv6 nibble-aligned source subnet.'),
+                    $domain->source_subnet->getInternalXMLTagName()
+                ));
+            }
+        }
+        return $messages;
+    }
+
+    /**
+     * Return the ARPA zone name for an IPv4 octet-aligned or IPv6 nibble-aligned subnet.
+     *
+     * @param string $subnet CIDR notation
+     * @return string|null reverse zone name or null for invalid input
+     */
+    public static function reverseZoneName($subnet)
+    {
+        $parts = explode('/', $subnet, 2);
+        if (count($parts) !== 2 || !is_numeric($parts[1])) {
+            return null;
+        }
+
+        $packed = inet_pton($parts[0]);
+        if ($packed === false) {
+            return null;
+        }
+
+        $prefix = (int)$parts[1];
+        if (strlen($packed) === 4 && $prefix >= 0 && $prefix <= 32 && $prefix % 8 === 0) {
+            $octets = array_slice(unpack('C*', $packed), 0, $prefix / 8);
+            return empty($octets)
+                ? 'in-addr.arpa'
+                : implode('.', array_reverse($octets)) . '.in-addr.arpa';
+        }
+        if (strlen($packed) === 16 && $prefix >= 0 && $prefix <= 128 && $prefix % 4 === 0) {
+            $hex = substr(bin2hex($packed), 0, $prefix / 4);
+            return empty($hex)
+                ? 'ip6.arpa'
+                : implode('.', str_split(strrev($hex))) . '.ip6.arpa';
+        }
+
+        return null;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Domain.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Domain.xml
@@ -16,6 +16,7 @@
                         <primary>primary</primary>
                         <secondary>secondary</secondary>
                         <forward>forward</forward>
+                        <reverse>reverse</reverse>
                     </OptionValues>
                 </type>
                 <primaryip type="NetworkField">
@@ -40,8 +41,12 @@
                     <AsList>Y</AsList>
                 </allownotifysecondary>
                 <domainname type="TextField">
-                    <Required>Y</Required>
+                    <Required>N</Required>
                 </domainname>
+                <source_subnet type="NetworkField">
+                    <Required>N</Required>
+                    <NetMaskRequired>Y</NetMaskRequired>
+                </source_subnet>
                 <allowtransfer type="ModelRelationField">
                     <Model>
                         <template>

--- a/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Menu/Menu.xml
+++ b/dns/bind/src/opnsense/mvc/app/models/OPNsense/Bind/Menu/Menu.xml
@@ -1,8 +1,9 @@
 <menu>
   <Services>
     <BIND cssClass="fa fa-tags">
-      <Configuration url="/ui/bind/general/index"/>
-      <LogFiles VisibleName="Log Files" url="/ui/bind/logs"/>
+      <General VisibleName="General Settings" order="10" url="/ui/bind/general/index"/>
+      <ReverseDNS VisibleName="Reverse DNS" order="22" cssClass="fa fa-exchange" url="/ui/bind/reverse_zones/index"/>
+      <LogFiles VisibleName="Log Files" order="30" url="/ui/bind/logs"/>
     </BIND>
   </Services>
 </menu>

--- a/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/reverse_zones.volt
+++ b/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/reverse_zones.volt
@@ -30,8 +30,7 @@
                 rowSelect: true,
                 formatters: {
                     commands: function(column, row) {
-                        return '<button type="button" class="btn btn-xs btn-default command-edit" data-row-id="' + row.uuid + '"><span class="fa fa-fw fa-pencil"></span></button> ' +
-                            '<button type="button" class="btn btn-xs btn-default command-delete" data-row-id="' + row.uuid + '"><span class="fa fa-fw fa-trash-o"></span></button> ' +
+                        return '<button type="button" class="btn btn-xs btn-default command-delete" data-row-id="' + row.uuid + '"><span class="fa fa-fw fa-trash-o"></span></button> ' +
                             '<button type="button" class="btn btn-xs btn-default command-toggle" data-row-id="' + row.uuid + '"><span class="fa fa-fw fa-' + (row.enabled == '1' ? 'check-square-o' : 'square-o') + '"></span></button> ' +
                             '<button type="button" class="btn btn-xs btn-default bind-checkzone" data-row-id="' + row.uuid + '"><span class="fa fa-fw fa-stethoscope"></span></button>';
                     }

--- a/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/reverse_zones.volt
+++ b/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/reverse_zones.volt
@@ -1,0 +1,64 @@
+<script>
+    $(document).ready(function() {
+        $('#dialogEditBindReverseDomain').on('shown.bs.modal', function() {
+            ajaxCall('/api/bind/general/listsubnets/', {}, function(data) {
+                if (data && data.subnets) {
+                    var select = $('#domain\\.source_subnet');
+                    var selected = select.val();
+                    select.empty().append('<option value="">Select a subnet...</option>');
+                    data.subnets.forEach(function(subnet) {
+                        select.append($('<option></option>').val(subnet.value).text(subnet.label));
+                    });
+                    if (selected) {
+                        select.val(selected);
+                    }
+                    select.selectpicker('refresh');
+                }
+            });
+        });
+
+        var grid = $('#grid-reverse-domains').UIBootgrid({
+            search: '/api/bind/domain/search_reverse_domain',
+            get: '/api/bind/domain/get_domain/',
+            set: '/api/bind/domain/set_domain/',
+            add: '/api/bind/domain/add_reverse_domain/',
+            del: '/api/bind/domain/del_domain/',
+            toggle: '/api/bind/domain/toggle_domain/',
+            options: {
+                selection: true,
+                multiSelect: false,
+                rowSelect: true,
+                formatters: {
+                    commands: function(column, row) {
+                        return '<button type="button" class="btn btn-xs btn-default command-edit" data-row-id="' + row.uuid + '"><span class="fa fa-fw fa-pencil"></span></button> ' +
+                            '<button type="button" class="btn btn-xs btn-default command-delete" data-row-id="' + row.uuid + '"><span class="fa fa-fw fa-trash-o"></span></button> ' +
+                            '<button type="button" class="btn btn-xs btn-default command-toggle" data-row-id="' + row.uuid + '"><span class="fa fa-fw fa-' + (row.enabled == '1' ? 'check-square-o' : 'square-o') + '"></span></button> ' +
+                            '<button type="button" class="btn btn-xs btn-default bind-checkzone" data-row-id="' + row.uuid + '"><span class="fa fa-fw fa-stethoscope"></span></button>';
+                    }
+                }
+            }
+        });
+        grid.on('click', '.bind-checkzone', function() {
+            var uuid = $(this).data('row-id');
+            ajaxGet('/api/bind/domain/get_domain/' + uuid, {}, function(data) {
+                if (data && data.domain) {
+                    zone_test(data.domain.domainname);
+                }
+            });
+        });
+    });
+</script>
+<div class="content-box"><div class="table-responsive">
+    <table id="grid-reverse-domains" class="table table-striped table-bordered" data-editDialog="dialogEditBindReverseDomain">
+        <thead><tr>
+            <th data-column-id="domainname" data-type="string">{{ lang._('Zone Name') }}</th>
+            <th data-column-id="source_subnet" data-type="string">{{ lang._('Subnet') }}</th>
+            <th data-column-id="interface" data-type="string">{{ lang._('Interface') }}</th>
+            <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
+            <th data-column-id="commands" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
+        </tr></thead><tbody></tbody>
+        <tfoot><tr><td colspan="5"><button type="button" class="btn btn-xs btn-primary" data-action="add" data-target="#dialogEditBindReverseDomain"><span class="fa fa-fw fa-plus"></span> {{ lang._('Add') }}</button></td></tr></tfoot>
+    </table>
+</div></div>
+{{ partial("layout_partials/base_dialog", ['fields': formDialogEditBindReverseDomain, 'id': 'dialogEditBindReverseDomain', 'label': lang._('Edit Reverse Zone')]) }}
+{{ partial("OPNsense/Bind/zone_check") }}

--- a/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/zone_check.volt
+++ b/dns/bind/src/opnsense/mvc/app/views/OPNsense/Bind/zone_check.volt
@@ -1,0 +1,89 @@
+<style>
+    #zone-content { overflow-x: auto; }
+    #zone-table { display: grid; max-height: 400px; overflow-y: auto; white-space: pre-wrap; word-break: break-word; padding-right: 20px; }
+    .l-number { position: relative; width: 1%; min-width: 40px; padding-right: 20px; padding-left: 1px; font-family: ui-monospace,monospace; text-align: right; white-space: nowrap; vertical-align: top; user-select: none; filter: brightness(2.0); filter: contrast(0.3); }
+    .long-str { word-break: break-word; }
+    .copy-button { display: none; }
+</style>
+<script>
+function zone_test(zonename) {
+    let payload = {'zone': zonename};
+    ajaxCall(url = "/api/bind/general/zonetest/", payload, callback = function(data, status) {
+        if (data['response'].indexOf('Zone check completed successfully') == -1) {
+            BootstrapDialog.show({
+                type: BootstrapDialog.TYPE_DANGER,
+                closeByBackdrop: false,
+                title: "{{ lang._('Zone check failed') }}",
+                message: data['response'],
+                buttons: [{
+                    label: "{{ lang._('Show zone content') }}",
+                    action: function(dlg) {
+                        $(this).closest(".modal-dialog").find("div.bootstrap-dialog-body").append('<div id="zone-wait">{{ lang._("Loading zone content..") }}<div>');
+                        zone_show(payload);
+                    },
+                }, {
+                    label: 'Ok', action: function(dlg) { dlg.close(); },
+                }]
+            });
+        } else {
+            BootstrapDialog.show({
+                type: BootstrapDialog.TYPE_INFO,
+                title: "{{ lang._('Zone check completed successfully') }}",
+                message: data['response'],
+                buttons: [{
+                    label: "{{ lang._('Show zone content') }}",
+                    action: function(dlg) {
+                        $(this).closest(".modal-dialog").find("div.bootstrap-dialog-body").append('<div id="zone-wait">{{ lang._("Loading zone content..") }}<div>');
+                        zone_show(payload);
+                    },
+                }, {
+                    label: 'Ok', action: function(dlg) { dlg.close(); },
+                }]
+            });
+        }
+    });
+}
+
+function zone_show(payload) {
+    ajaxCall(url = "/api/bind/general/zoneshow/", payload, callback = function(data, status) {
+        if (data['time'] && data['zone_content']) {
+            $("#zone-wait").remove();
+            let lineNumber = 0;
+            let content = [];
+            content.push('<tr><td class="l-number"></td><td class="conf-line">; zone file dump from ' + data['path'] + '</td></tr>');
+            content.push('<tr><td class="l-number"></td><td class="conf-line">; zone file created at ' + data['time'] + '</td></tr>');
+            $.each(data['zone_content'], function(index, line) {
+                lineNumber += 1;
+                content.push('<tr><td class="l-number">' + lineNumber.toString() + '</td><td class="conf-line">' + line + '</td></tr>');
+            });
+            BootstrapDialog.show({
+                type: BootstrapDialog.TYPE_INFO,
+                title: "{{ lang._('Zone loaded successfully') }}",
+                message: '<div id="zone-content"><table><tbody id="zone-table">' + content.join('') + '</tbody></table></div>',
+                onshown: function(dialogRef) {
+                    if ((typeof navigator.clipboard === 'object') && (typeof navigator.clipboard.writeText === 'function')) {
+                        $(".copy-button").show();
+                    }
+                },
+                buttons: [{
+                    label: '<i id="copy-progress" class="fa fa-spinner fa-pulse" style="display: none"></i> {{ lang._("Copy to clipboard") }}',
+                    cssClass: 'copy-button',
+                    action: function() { zone_copy(); }
+                }, {
+                    label: 'Ok', action: function(dlg) { dlg.close(); }
+                }]
+            });
+        } else {
+            $("#zone-wait").text("{{ lang._('Empty response from the backend. Please check logs.') }}");
+        }
+    });
+}
+
+function zone_copy() {
+    $('#copy-progress').show();
+    let clipboard = [];
+    $('.conf-line').each(function() { clipboard.push($(this).text()); });
+    navigator.clipboard.writeText(clipboard.join('\n'));
+    setTimeout(() => { $("#copy-progress").hide(); }, 1000);
+}
+</script>

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/domain.db
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/domain.db
@@ -2,9 +2,12 @@
 {%   if helpers.exists('OPNsense.bind.domain.domains.domain') %}
 {%     for domaindb in helpers.toList('OPNsense.bind.domain.domains.domain') %}
 {%       if TARGET_FILTERS['OPNsense.bind.domain.domains.domain.' ~ loop.index0] or TARGET_FILTERS['OPNsense.bind.domain.domains.domain'] %}
-{%         if domaindb.enabled == '1' and domaindb.type == 'primary' %}
+{%         if domaindb.enabled == '1' and (domaindb.type == 'primary' or domaindb.type == 'reverse') %}
 $TTL {{ domaindb.ttl }}
 @       IN      SOA    {{ domaindb.dnsserver }}. {{ domaindb.mailadmin|replace('@', '.') }}. ( {{ domaindb.serial|trim }} {{ domaindb.refresh }} {{ domaindb.retry }} {{ domaindb.expire }} {{ domaindb.negative }} )
+{%           if domaindb.type == 'reverse' %}
+@       IN      NS     {{ domaindb.dnsserver }}.
+{%           endif %}
 {%           if helpers.exists('OPNsense.bind.record.records.record') %}
 {%             for record in helpers.sortDictList(OPNsense.bind.record.records.record, 'name', 'type' ) %}
 {%               if record.domain == domaindb['@uuid'] %}

--- a/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
+++ b/dns/bind/src/opnsense/service/templates/OPNsense/Bind/named.conf
@@ -151,11 +151,12 @@ zone "rpzbing" { type primary; file "/usr/local/etc/namedb/primary/bing.db"; not
 {%   set usedkeys = [] %}
 {%   for domain in helpers.toList('OPNsense.bind.domain.domains.domain') %}
 {%     if domain.enabled == '1' %}
+{%       set zone_type = 'primary' if domain.type == 'reverse' else domain.type %}
 zone "{{ domain.domainname }}" {
-        type {{ domain.type }};
-{%       if domain.type == 'forward' %}
+        type {{ zone_type }};
+{%       if zone_type == 'forward' %}
         forwarders { {{ domain.forwardserver.replace(',', '; ') }}; };
-{%       elif domain.type == 'secondary' %}
+{%       elif zone_type == 'secondary' %}
 {%         if domain.transferkey is defined %}
         primaries { {{ domain.primaryip.replace(',', ' key "' ~ domain.transferkeyname ~ '"; ') }} key "{{ domain.transferkeyname }}"; };
 {%         else %}
@@ -165,7 +166,7 @@ zone "{{ domain.domainname }}" {
         allow-notify { {{ domain.allownotifysecondary.replace(',', '; ') }}; };
 {%         endif %}
         file "/usr/local/etc/namedb/secondary/{{ domain.domainname }}.db";
-{%       elif domain.type == 'primary' %}
+{%       elif zone_type == 'primary' %}
         file "/usr/local/etc/namedb/primary/{{ domain.domainname }}.db";
 {%       endif %}
 {%      if domain.allowtransfer is defined or (domain.allowrndctransfer is defined and domain.allowrndctransfer == "1") %}
@@ -189,7 +190,7 @@ zone "{{ domain.domainname }}" {
 {%              endfor %}
         };
 {%      endif %}
-{%      if domain.allowrndcupdate is defined and domain.allowrndcupdate == "1" and domain.type == 'primary' %}
+{%      if domain.allowrndcupdate is defined and domain.allowrndcupdate == "1" and (domain.type == 'primary' or domain.type == 'reverse') %}
         update-policy {
 		grant rndc-key zonesub ANY;
         };


### PR DESCRIPTION
**Important notices**

- [X] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [X] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Models used: GPT-5 (Codex)
- Extent of AI involvement: I handled design and decisions. It assisted with implementation, testing, investigation, review, commits, and PR generation.

---

## Summary

This PR adds standalone IPv4 and IPv6 reverse-DNS primary-zone configuration to the BIND plugin.

The new **Reverse DNS** page lets an administrator select a directly connected subnet. The plugin derives the corresponding `in-addr.arpa` or `ip6.arpa` zone name and generates the BIND zone configuration and database.

## Behaviour

- IPv4 source networks must be octet-aligned; IPv6 source networks must be nibble-aligned.
- The page lists unique, non-loopback networks from the live interface configuration.

## Validation

- Tested on OPNsense 26.1.11_6-amd64 with aligned IPv4 `/24` and IPv6 `/64` reverse zones: `named-checkzone` passed for both, and live SOA/NS queries returned authoritative `NOERROR` responses.

## Related issue

None.

<img width="1141" height="373" alt="{6A29C55A-4646-43FB-B19A-9064C351A1CD}" src="https://github.com/user-attachments/assets/c45bf282-8ce1-4700-afb2-7fcecf8491c6" />
