### PR TITLE
[os-cloudflared] Correct UI token entry text field validation mask

### DIFF
--- a/net/cloudflared/Makefile
+++ b/net/cloudflared/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		cloudflared
-PLUGIN_VERSION=		1.1
+PLUGIN_VERSION=		1.2
 PLUGIN_COMMENT=		Cloudflare Tunnel integration
 PLUGIN_MAINTAINER=	rick+github@insanityinside.net
 PLUGIN_DEPENDS=		cloudflared

--- a/net/cloudflared/Makefile
+++ b/net/cloudflared/Makefile
@@ -1,5 +1,6 @@
 PLUGIN_NAME=		cloudflared
-PLUGIN_VERSION=		1.2
+PLUGIN_VERSION=		1.1
+PLUGIN_REVISION=	1
 PLUGIN_COMMENT=		Cloudflare Tunnel integration
 PLUGIN_MAINTAINER=	rick+github@insanityinside.net
 PLUGIN_DEPENDS=		cloudflared

--- a/net/cloudflared/src/opnsense/mvc/app/models/OPNsense/Cloudflared/Cloudflared.xml
+++ b/net/cloudflared/src/opnsense/mvc/app/models/OPNsense/Cloudflared/Cloudflared.xml
@@ -10,8 +10,8 @@
             </enabled>
             <token type="TextField">
                 <Required>Y</Required>
-                <Mask>/^[a-zA-Z0-9\._\-]+$/</Mask>
-                <ValidationMessage>Token may only contain letters, digits, dots, underscores and hyphens.</ValidationMessage>
+                <Mask>/^[a-zA-Z0-9\._\-=]+$/</Mask>
+                <ValidationMessage>Token may only contain letters, digits, dots, underscores, equal signs, and hyphens.</ValidationMessage>
             </token>
             <protocol type="OptionField">
                 <Default>auto</Default>


### PR DESCRIPTION
### Correct UI token entry text field validation mask to include equal signs which are standardly present in Cloudflare tunnel tokens

**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: N/A
- Extent of AI involvement: none

---

**Describe the problem**

Valid cloudflared tunnel tokens from the dashboard cannot be entered under the current UI text field validation mask.

---

**Describe the proposed solution**

Add the equal sign to the hash as a valid character, allowing valid tokens to be entered. Update validation error message to include the equal sign.

---

**Related issue**

#5597

**Additional notes**
It's worth mentioning I'm not 100% positive this is the correct and complete fix since so it ought to be validated by someone who knows this project better than I do. It looks sufficiently correct to me based on examination of similar files on my own OPNsense system and successful testing of the fix. 
