### PR TITLE
Correct opnsense bootgrid.css

### DIFF
--- a/misc/theme-rebellion/Makefile
+++ b/misc/theme-rebellion/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		theme-rebellion
-PLUGIN_VERSION=		1.9.6
+PLUGIN_VERSION=		1.9.7
 PLUGIN_COMMENT=		A suitably dark theme
 PLUGIN_MAINTAINER=	martin@queens-park.com
 PLUGIN_NO_ABI=		yes

--- a/misc/theme-rebellion/src/opnsense/www/themes/rebellion/build/css/opnsense-bootgrid.css
+++ b/misc/theme-rebellion/src/opnsense/www/themes/rebellion/build/css/opnsense-bootgrid.css
@@ -213,7 +213,7 @@
 }
 
 .bootgrid-footer-commands {
-  width: 90px;
+  width: 110px;
   padding-left: 8px;
 }
 


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x ] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md

Buttons are too far to the right in Rebellion theme.