### PR TITLE
dns/dnscrypt-proxy: Add OISD wildcard blocklists (big, small, NSFW, NSFW small) to DNSBL selection

### DIFF
--- a/dns/dnscrypt-proxy/Makefile
+++ b/dns/dnscrypt-proxy/Makefile
@@ -1,6 +1,5 @@
 PLUGIN_NAME=		dnscrypt-proxy
 PLUGIN_VERSION=		1.17
-PLUGIN_REVISION=	2
 PLUGIN_COMMENT=		Flexible DNS proxy supporting DNSCrypt and DoH
 PLUGIN_DEPENDS=		dnscrypt-proxy2
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/dns/dnscrypt-proxy/Makefile
+++ b/dns/dnscrypt-proxy/Makefile
@@ -1,6 +1,6 @@
 PLUGIN_NAME=		dnscrypt-proxy
-PLUGIN_VERSION=		1.16
-PLUGIN_REVISION=	2
+PLUGIN_VERSION=		1.17
+PLUGIN_REVISION=	0
 PLUGIN_COMMENT=		Flexible DNS proxy supporting DNSCrypt and DoH
 PLUGIN_DEPENDS=		dnscrypt-proxy2
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/dns/dnscrypt-proxy/Makefile
+++ b/dns/dnscrypt-proxy/Makefile
@@ -1,6 +1,6 @@
 PLUGIN_NAME=		dnscrypt-proxy
 PLUGIN_VERSION=		1.17
-PLUGIN_REVISION=	0
+PLUGIN_REVISION=	2
 PLUGIN_COMMENT=		Flexible DNS proxy supporting DNSCrypt and DoH
 PLUGIN_DEPENDS=		dnscrypt-proxy2
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/dns/dnscrypt-proxy/pkg-descr
+++ b/dns/dnscrypt-proxy/pkg-descr
@@ -4,6 +4,10 @@ such as DNSCrypt v2 and DNS-over-HTTPS.
 Plugin Changelog
 ================
 
+1.17
+
+* Add OISD wildcard blocklists (big, small, NSFW, NSFW small) to DNSBL selection
+
 1.16
 
 * Fix ODoH servers not working (contributed by Pascal Herget)

--- a/dns/dnscrypt-proxy/src/opnsense/mvc/app/models/OPNsense/Dnscryptproxy/Dnsbl.xml
+++ b/dns/dnscrypt-proxy/src/opnsense/mvc/app/models/OPNsense/Dnscryptproxy/Dnsbl.xml
@@ -19,6 +19,10 @@
                 <ep>Easyprivacy List</ep>
                 <nc>NoCoin List</nc>
                 <pt>PornTop1M List</pt>
+                <ob>OISD big (wildcard)</ob>
+                <os>OISD small (wildcard)</os>
+                <on>OISD NSFW (wildcard)</on>
+                <ons>OISD NSFW small (wildcard)</ons>
                 <qf>Q-Feeds (when installed)</qf>
                 <sa>Simple Ad List</sa>
                 <st>Simple Tracker List</st>

--- a/dns/dnscrypt-proxy/src/opnsense/scripts/OPNsense/Dnscryptproxy/dnsbl.sh
+++ b/dns/dnscrypt-proxy/src/opnsense/scripts/OPNsense/Dnscryptproxy/dnsbl.sh
@@ -161,6 +161,34 @@ qfeeds() {
 	fi
 }
 
+oisd_big() {
+	# OISD Big
+	/usr/bin/fetch -qT 30 https://big.oisd.nl/domainswild -o ${WORKDIR}/oisd_big-raw
+	sed "/\.$/d" ${WORKDIR}/oisd_big-raw | sed "/^#/d" | sed "/\_/d" | sed "/^[[:space:]]*$/d" | sed "/\.\./d" | sed "s/^\.//g" > ${WORKDIR}/oisd_big
+	rm ${WORKDIR}/oisd_big-raw
+}
+
+oisd_small() {
+	# OISD Small
+	/usr/bin/fetch -qT 30 https://small.oisd.nl/domainswild -o ${WORKDIR}/oisd_small-raw
+	sed "/\.$/d" ${WORKDIR}/oisd_small-raw | sed "/^#/d" | sed "/\_/d" | sed "/^[[:space:]]*$/d" | sed "/\.\./d" | sed "s/^\.//g" > ${WORKDIR}/oisd_small
+	rm ${WORKDIR}/oisd_small-raw
+}
+
+oisd_nsfw() {
+	# OISD NSFW
+	/usr/bin/fetch -qT 30 https://nsfw.oisd.nl/domainswild -o ${WORKDIR}/oisd_nsfw-raw
+	sed "/\.$/d" ${WORKDIR}/oisd_nsfw-raw | sed "/^#/d" | sed "/\_/d" | sed "/^[[:space:]]*$/d" | sed "/\.\./d" | sed "s/^\.//g" > ${WORKDIR}/oisd_nsfw
+	rm ${WORKDIR}/oisd_nsfw-raw
+}
+
+oisd_nsfwsmall() {
+	# OISD NSFW Small
+	/usr/bin/fetch -qT 30 https://nsfw-small.oisd.nl/domainswild -o ${WORKDIR}/oisd_nsfwsmall-raw
+	sed "/\.$/d" ${WORKDIR}/oisd_nsfwsmall-raw | sed "/^#/d" | sed "/\_/d" | sed "/^[[:space:]]*$/d" | sed "/\.\./d" | sed "s/^\.//g" > ${WORKDIR}/oisd_nsfwsmall
+	rm ${WORKDIR}/oisd_nsfwsmall-raw
+}
+
 install() {
 	# Put all files in correct format
 	for FILE in $(find ${WORKDIR} -type f); do
@@ -228,6 +256,18 @@ for CAT in $(echo ${DNSBL} | tr ',' ' '); do
 		;;
 	yy)
 		yoyo
+		;;
+	ob)
+		oisd_big
+		;;
+	os)
+		oisd_small
+		;;
+	on)
+		oisd_nsfw
+		;;
+	ons)
+		oisd_nsfwsmall
 		;;
 	qf)
 		qfeeds


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: Claude Sonnet 5
- Extent of AI involvement: Research if domain wildcards are usable, since all other DNSBL lists are using the `hosts` format [that is discontinued on OISD](https://oisd.nl/faq#legacysyntaxes).

---

**Describe the problem**

I wanted to add the OISD Blocklists since they are pretty well maintained and available in ubound as well.

---

**Describe the proposed solution**

It adds the OISD Blocklist to DNSBL selection of Dnscrypt.

---

**Related issue**

I didn't create a Issue since this change is trivial
