### PR TITLE
net/frr: Write neighbor remote-as only when set

### DIFF
--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/Config/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/Config/bgpd.conf
@@ -115,10 +115,10 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
 {%   if helpers.exists('OPNsense.quagga.bgp.neighbors.neighbor') %}
 {%     for neighbor in helpers.toList('OPNsense.quagga.bgp.neighbors.neighbor') %}
 {%       if neighbor.enabled == '1' %}
-{%         if 'remoteas' in neighbor and neighbor.remoteas and not neighbor.remote_as_mode %}
- neighbor {{ neighbor.address }} remote-as {{ neighbor.remoteas }}
-{%         else %}
+{%         if 'remote_as_mode' in neighbor and neighbor.remote_as_mode %}
  neighbor {{ neighbor.address }} remote-as {{ neighbor.remote_as_mode }}
+{%         elif 'remoteas' in neighbor and neighbor.remoteas %}
+ neighbor {{ neighbor.address }} remote-as {{ neighbor.remoteas }}
 {%         endif %}
 {%         if 'localas' in neighbor and neighbor.localas != '' %}
  neighbor {{ neighbor.address }} local-as {{ neighbor.localas }}


### PR DESCRIPTION
**Related issue**

Fixes issue #5625
