### PR TITLE
vnstat: Add a Sort Order option

### DIFF
--- a/net/vnstat/Makefile
+++ b/net/vnstat/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		vnstat
-PLUGIN_VERSION=		1.4
+PLUGIN_VERSION=		1.5
 PLUGIN_COMMENT=		Network traffic monitor
 PLUGIN_DEPENDS=		vnstat
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net/vnstat/pkg-descr
+++ b/net/vnstat/pkg-descr
@@ -8,6 +8,10 @@ ensures light use of system resources.
 Plugin Changelog
 ================
 
+1.5
+
+* Add Sort Option to dashboard widget options (contributed by Greg Pfountz)
+
 1.4
 
 * Add Month Rotate option to UI (contributed by Greg Pfountz)

--- a/net/vnstat/src/opnsense/www/js/widgets/Metadata/Vnstat.xml
+++ b/net/vnstat/src/opnsense/www/js/widgets/Metadata/Vnstat.xml
@@ -19,6 +19,9 @@
             <excluded_interfaces>Excluded Interfaces</excluded_interfaces>
             <refresh_interval>Refresh Interval (minutes)</refresh_interval>
             <show_avg_rate>Show Average Rate</show_avg_rate>
+            <sort_order>Sort Order</sort_order>
+            <sort_ascending>Ascending</sort_ascending>
+            <sort_descending>Descending</sort_descending>
         </translations>
     </vnstat>
 </metadata>

--- a/net/vnstat/src/opnsense/www/js/widgets/Vnstat.js
+++ b/net/vnstat/src/opnsense/www/js/widgets/Vnstat.js
@@ -32,6 +32,7 @@ export default class Vnstat extends BaseTableWidget {
         this.configurable = true;
         this.excludedInterfaces = [];
         this.showAvgRate = false;
+        this.sortOrder = 'ascending';
     }
 
     getGridOptions() {
@@ -75,6 +76,16 @@ export default class Vnstat extends BaseTableWidget {
                     { value: 'yes', label: 'Yes' },
                 ],
                 default: 'no'
+            },
+            sort_order: {
+                id: 'vnstat-sort-order',
+                title: this.translations.sort_order,
+                type: 'select',
+                options: [
+                    { value: 'ascending', label: this.translations.sort_ascending },
+                    { value: 'descending', label: this.translations.sort_descending },
+                ],
+                default: 'ascending'
             }
         };
     }
@@ -84,6 +95,7 @@ export default class Vnstat extends BaseTableWidget {
         this.excludedInterfaces = config.excluded_interfaces ?? [];
         this.tickTimeout = Number(config.refresh_interval) || 300;
         this.showAvgRate = config.show_avg_rate === 'yes';
+        this.sortOrder = config.sort_order === 'descending' ? 'descending' : 'ascending';
         await this._populateInterfaceDropdown();
         await this._fetchAndUpdateTable();
     }
@@ -116,6 +128,7 @@ export default class Vnstat extends BaseTableWidget {
         this.excludedInterfaces = config.excluded_interfaces ?? [];
         this.tickTimeout = Number(config.refresh_interval) || 300;
         this.showAvgRate = config.show_avg_rate === 'yes';
+        this.sortOrder = config.sort_order === 'descending' ? 'descending' : 'ascending';
 
         $(document).on('change.vnstat-widget', '#vnstat-period-select', async (e) => {
             this.currentPeriod = e.target.value;
@@ -214,7 +227,9 @@ export default class Vnstat extends BaseTableWidget {
         if (limits[this.currentPeriod]) {
             entries = entries.slice(0, limits[this.currentPeriod]);
         }
-        entries.reverse();
+        if (this.sortOrder === 'ascending') {
+            entries.reverse();
+        }
 
         for (const entry of entries) {
             const totalBytes = entry.rx + entry.tx;


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: Codex 5.6 Terra
- Extent of AI involvement: I reviewed and modified all generated code.

---

**Describe the problem**

The vnstat widget lists the last 14 rows in ascending order. I am using this to monitor my WAN's daily usage, that is 14 rows that need to be displayed in the widget window in order to see the current and previous days. Adding the Sort Order option to the widget option menu allows me to sort the days displayed in descending order, then make the widget window smaller while still showing the most recent days.

---

**Describe the proposed solution**

This pull request will add an option to widget's option menu labeled Sort Order with Ascending and Descending options. Ascending is the default. Making this change in the option menu keeps the actual widget window uncluttered.

<img width="678" height="637" alt="Screenshot 2026-08-14 at 3 39 13 PM" src="https://github.com/user-attachments/assets/e4f0b798-6768-4b6a-977c-838e1bf5ea3b" />

---

**Related issue**

If this pull request relates to an issue, link it here.
