### PR TITLE
net/chrony: configuration overrides via `confdir` and `sourcedir`

### DIFF
--- a/net/chrony/src/opnsense/mvc/app/library/OPNsense/System/Status/ChronyOverrideStatus.php
+++ b/net/chrony/src/opnsense/mvc/app/library/OPNsense/System/Status/ChronyOverrideStatus.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * Copyright (C) 2025 Cedrik Pischem
+ * Copyright (C) 2025 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\System\Status;
+
+use OPNsense\System\AbstractStatus;
+use OPNsense\System\SystemStatusCode;
+
+class ChronyOverrideStatus extends AbstractStatus
+{
+    public function __construct()
+    {
+        $this->internalPriority = 2;
+        $this->internalPersistent = true;
+        $this->internalIsBanner = true;
+        $this->internalTitle = gettext('Chrony config override');
+        $this->internalScope = [
+            '/ui/chrony/general/index',
+        ];
+    }
+
+    public function collectStatus()
+    {
+        if (
+            count(glob('/usr/local/etc/chrony/conf.d/*')) ||
+                count(glob('/usr/local/etc/chrony/sources.d/*'))
+        ) {
+            $this->internalMessage = gettext(
+                'The configuration contains manual overwrites, these may interfere with the settings configured here.'
+            );
+            $this->internalStatus = SystemStatusCode::NOTICE;
+        }
+    }
+}

--- a/net/chrony/src/opnsense/mvc/app/library/OPNsense/System/Status/ChronyOverrideStatus.php
+++ b/net/chrony/src/opnsense/mvc/app/library/OPNsense/System/Status/ChronyOverrideStatus.php
@@ -49,7 +49,10 @@ class ChronyOverrideStatus extends AbstractStatus
     {
         if (
             count(glob('/usr/local/etc/chrony/conf.d/*')) ||
-                count(glob('/usr/local/etc/chrony/sources.d/*'))
+            count(glob('/var/run/chrony/conf.d/*')) ||
+            count(glob('/usr/local/etc/chrony/sources.d/*')) ||
+            count(glob('/var/run/chrony/sources.d/*'))
+
         ) {
             $this->internalMessage = gettext(
                 'The configuration contains manual overwrites, these may interfere with the settings configured here.'

--- a/net/chrony/src/opnsense/mvc/app/models/OPNsense/Chrony/General.xml
+++ b/net/chrony/src/opnsense/mvc/app/models/OPNsense/Chrony/General.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/chrony/general</mount>
     <description>Chrony configuration</description>
-    <version>0.0.2</version>
+    <version>0.0.3</version>
     <items>
         <enabled type="BooleanField">
             <Default>0</Default>
@@ -9,7 +9,7 @@
         </enabled>
         <port type="PortField">
             <Default>323</Default>
-            <Required>Y</Required>
+            <Required>N</Required>
         </port>
         <ntsclient type="BooleanField">
             <Default>0</Default>
@@ -21,7 +21,7 @@
         </ntsnocert>
         <peers type="HostnameField">
             <Default>0.opnsense.pool.ntp.org</Default>
-            <Required>Y</Required>
+            <Required>N</Required>
             <FieldSeparator>,</FieldSeparator>
             <AsList>Y</AsList>
         </peers>

--- a/net/chrony/src/opnsense/mvc/app/models/OPNsense/Chrony/General.xml
+++ b/net/chrony/src/opnsense/mvc/app/models/OPNsense/Chrony/General.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/chrony/general</mount>
     <description>Chrony configuration</description>
-    <version>0.0.3</version>
+    <version>0.0.4</version>
     <items>
         <enabled type="BooleanField">
             <Default>0</Default>
@@ -20,7 +20,7 @@
             <Required>Y</Required>
         </ntsnocert>
         <peers type="HostnameField">
-            <Default>0.opnsense.pool.ntp.org</Default>
+            <Default>0.opnsense.pool.ntp.org,1.opnsense.pool.ntp.org,2.opnsense.pool.ntp.org,3.opnsense.pool.ntp.org</Default>
             <Required>N</Required>
             <FieldSeparator>,</FieldSeparator>
             <AsList>Y</AsList>

--- a/net/chrony/src/opnsense/scripts/OPNsense/Chrony/setup.sh
+++ b/net/chrony/src/opnsense/scripts/OPNsense/Chrony/setup.sh
@@ -1,5 +1,13 @@
 #!/bin/sh
 
-mkdir -p /var/db/chrony /var/lib/chrony /var/run/chrony
-chown -R chronyd:chronyd /var/db/chrony /var/lib/chrony /var/run/chrony
-chmod 750 /var/db/chrony /var/lib/chrony /var/run/chrony
+mkdir -p /var/db/chrony /var/lib/chrony /var/run/chrony \
+  /usr/local/etc/chrony/conf.d /var/run/chrony/conf.d \
+  /usr/local/etc/chrony/sources.d /var/run/chrony/sources.d
+
+chown -R chronyd:chronyd /var/db/chrony /var/lib/chrony /var/run/chrony \
+  /usr/local/etc/chrony/conf.d /var/run/chrony/conf.d \
+  /usr/local/etc/chrony/sources.d /var/run/chrony/sources.d
+
+chmod 750 /var/db/chrony /var/lib/chrony /var/run/chrony \
+  /usr/local/etc/chrony/conf.d /var/run/chrony/conf.d \
+  /usr/local/etc/chrony/sources.d /var/run/chrony/sources.d

--- a/net/chrony/src/opnsense/service/templates/OPNsense/Chrony/chrony.conf
+++ b/net/chrony/src/opnsense/service/templates/OPNsense/Chrony/chrony.conf
@@ -34,3 +34,8 @@ allow {{ network }}
 {%   endif %}
 
 {% endif %}
+
+
+confdir /usr/local/etc/chrony/conf.d
+sourcedir /usr/local/etc/chrony/sources.d
+

--- a/net/chrony/src/opnsense/service/templates/OPNsense/Chrony/chrony.conf
+++ b/net/chrony/src/opnsense/service/templates/OPNsense/Chrony/chrony.conf
@@ -37,5 +37,8 @@ allow {{ network }}
 
 
 confdir /usr/local/etc/chrony/conf.d
+confdir /var/run/chrony/conf.d
+
 sourcedir /usr/local/etc/chrony/sources.d
+sourcedir /var/run/chrony/sources.d
 

--- a/net/chrony/src/opnsense/service/templates/OPNsense/Chrony/chrony.conf
+++ b/net/chrony/src/opnsense/service/templates/OPNsense/Chrony/chrony.conf
@@ -1,6 +1,8 @@
 {% if helpers.exists('OPNsense.chrony.general.enabled') and OPNsense.chrony.general.enabled == '1' %}
 
+{%   if not helpers.empty('OPNsense.chrony.general.port') %}
 port {{ OPNsense.chrony.general.port }}
+{%   endif %}
 driftfile /var/db/chrony/drift
 pidfile /var/run/chrony/chronyd.pid
 makestep 1 3


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

there are some options for Chrony not available in the UI

---

**Describe the proposed solution**

this adds both `confdir` and `sourcedir` entries to `chrony.conf` for both `/usr/local/etc/chrony/` and `/var/run/chrony/`.
the reason for both is that the man page for `chrony.conf` gives the sourcedir example `/var/run/chrony-dhcp` which made me think it would be good to have both in case the user wants to make automation that uses volatile storage to avoid potential issues on power loss.

i also added all other pool domains for OPNsense as default peers because only 2.* supports IPv6 and so including all of them has better support for IPv6-only

