### PR TITLE
haproxy: add SNI Routes and configurable tunnel timeout

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		haproxy
-PLUGIN_VERSION=		5.1
+PLUGIN_VERSION=		5.2
 PLUGIN_COMMENT=		Reliable, high performance TCP/HTTP load balancer
 PLUGIN_DEPENDS=		haproxy32 py${PLUGIN_PYTHON}-haproxy-cli
 PLUGIN_MAINTAINER=	opnsense@moov.de

--- a/net/haproxy/pkg-descr
+++ b/net/haproxy/pkg-descr
@@ -6,6 +6,12 @@ very high loads while needing persistence or Layer7 processing.
 Plugin Changelog
 ================
 
+5.2
+
+Added:
+* add SNI Routes: manage TLS-passthrough/SNI and Host-based routing (domains -> backend) in one place
+* add configurable Tunnel timeout (timeout tunnel) for WebSocket/tunnel connections
+
 5.1
 
 Added:

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/Api/SettingsController.php
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/Api/SettingsController.php
@@ -470,4 +470,34 @@ class SettingsController extends ApiMutableModelControllerBase
     {
         return $this->searchBase('mailers.mailer', array('enabled', 'name', 'mailservers', 'sender', 'recipient'), 'name');
     }
+
+    public function getSniRouteAction($uuid = null)
+    {
+        return $this->getBase('sniroute', 'sniroutes.sniroute', $uuid);
+    }
+
+    public function setSniRouteAction($uuid)
+    {
+        return $this->setBase('sniroute', 'sniroutes.sniroute', $uuid);
+    }
+
+    public function addSniRouteAction()
+    {
+        return $this->addBase('sniroute', 'sniroutes.sniroute');
+    }
+
+    public function delSniRouteAction($uuid)
+    {
+        return $this->delBase('sniroutes.sniroute', $uuid);
+    }
+
+    public function toggleSniRouteAction($uuid, $enabled = null)
+    {
+        return $this->toggleBase('sniroutes.sniroute', $uuid);
+    }
+
+    public function searchSniRoutesAction()
+    {
+        return $this->searchBase('sniroutes.sniroute', array('enabled', 'name', 'domains', 'matchType'), 'name');
+    }
 }

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/IndexController.php
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/IndexController.php
@@ -45,6 +45,7 @@ class IndexController extends \OPNsense\Base\IndexController
     {
         // include form definitions
         $this->view->formDialogAcl = $this->getForm("dialogAcl");
+        $this->view->formDialogSniRoute = $this->getForm("dialogSniRoute");
         $this->view->formDialogAction = $this->getForm("dialogAction");
         $this->view->formDialogBackend = $this->getForm("dialogBackend");
         $this->view->formDialogCpu = $this->getForm("dialogCpu");

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogBackend.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogBackend.xml
@@ -409,6 +409,13 @@
         <advanced>true</advanced>
     </field>
     <field>
+        <id>backend.tuning_timeoutTunnel</id>
+        <label>Tunnel Timeout</label>
+        <type>text</type>
+        <help><![CDATA[Set the maximum inactivity time for tunnel (and WebSocket) connections to this backend, overriding the client/server timeouts once the tunnel is established. Use this to keep idle WebSockets alive longer than the server timeout. Overrides the global Default Parameters tunnel timeout. Leave empty to inherit. Defaults to milliseconds; unit may be "d", "h", "m", "s", "ms" or "us" (e.g. 24h).]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
         <id>backend.tuning_retries</id>
         <label>Retries</label>
         <type>text</type>

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogFrontend.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogFrontend.xml
@@ -275,6 +275,13 @@
         <advanced>true</advanced>
     </field>
     <field>
+        <id>frontend.tuning_timeoutTunnel</id>
+        <label>Tunnel Timeout</label>
+        <type>text</type>
+        <help><![CDATA[Set the maximum inactivity time for tunnel (and WebSocket) connections on this frontend, overriding the client/server timeouts once the tunnel is established. Use this to keep idle WebSockets alive longer than the client timeout. Overrides the global Default Parameters tunnel timeout. Leave empty to inherit. Defaults to milliseconds; unit may be "d", "h", "m", "s", "ms" or "us" (e.g. 24h).]]></help>
+        <advanced>true</advanced>
+    </field>
+    <field>
         <id>frontend.tuning_timeoutHttpReq</id>
         <label>HTTP Request Timeout</label>
         <type>text</type>

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogSniRoute.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/dialogSniRoute.xml
@@ -1,0 +1,52 @@
+<form>
+    <field>
+        <id>sniroute.enabled</id>
+        <label>Enabled</label>
+        <type>checkbox</type>
+        <help>Enable this SNI route.</help>
+    </field>
+    <field>
+        <id>sniroute.name</id>
+        <label>Name</label>
+        <type>text</type>
+        <help>Name to identify this SNI route.</help>
+    </field>
+    <field>
+        <id>sniroute.description</id>
+        <label>Description</label>
+        <type>text</type>
+        <help>Optional description for this SNI route.</help>
+    </field>
+    <field>
+        <label>TLS Passthrough / SNI routing</label>
+        <type>header</type>
+    </field>
+    <field>
+        <id>sniroute.frontend</id>
+        <label>Frontend</label>
+        <type>dropdown</type>
+        <help><![CDATA[The public frontend that serves these domains. Two modes are supported automatically:<br/>
+<b>TCP / SSL (passthrough)</b> — the raw TLS handshake is forwarded and routing is by SNI (<code>req.ssl_sni</code>); the passthrough boilerplate (<code>tcp-request inspect-delay</code> / accept on <code>ssl_hello_type</code>) is added for you.<br/>
+<b>HTTP (TLS terminated here)</b> — the frontend decrypts and routing is by Host header (<code>hdr(host)</code>). Use this when HAProxy holds the certificate; it avoids the HTTP/2 connection-coalescing misrouting that happens with passthrough + a shared wildcard cert.]]></help>
+    </field>
+    <field>
+        <id>sniroute.domains</id>
+        <label>Domains (SNI)</label>
+        <type>select_multiple</type>
+        <style>tokenize</style>
+        <allownew>true</allownew>
+        <help><![CDATA[One or more domain names to match against the TLS SNI. Type a name and press enter to add it. For <b>Exact host</b> matching enter the full hostname (e.g. <code>www.example.com</code>); for <b>Subdomains</b> matching enter the parent domain (e.g. <code>example.com</code>) to match any <code>*.example.com</code>.]]></help>
+    </field>
+    <field>
+        <id>sniroute.matchType</id>
+        <label>Match type</label>
+        <type>dropdown</type>
+        <help><![CDATA[<b>Exact host</b> matches the SNI verbatim (<code>req.ssl_sni -i</code>). <b>Subdomains</b> matches any host ending in the given domain (<code>req.ssl_sni -m end -i .domain</code>); note it does not match the bare parent domain itself.]]></help>
+    </field>
+    <field>
+        <id>sniroute.backend</id>
+        <label>Target backend</label>
+        <type>dropdown</type>
+        <help><![CDATA[The backend that connections for the matched domains are forwarded to. Create the backend in advance as a <b>TCP</b>-mode pool with the destination server(s); this route only wires the SNI match to it via <code>use_backend</code>.]]></help>
+    </field>
+</form>

--- a/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/generalDefaults.xml
+++ b/net/haproxy/src/opnsense/mvc/app/controllers/OPNsense/HAProxy/forms/generalDefaults.xml
@@ -40,6 +40,12 @@
         <help><![CDATA[Set the maximum inactivity time on the server side. Defaults to milliseconds. Optionally the unit may be specified as either "d", "h", "m", "s", "ms" or "us".]]></help>
     </field>
     <field>
+        <id>haproxy.general.defaults.timeoutTunnel</id>
+        <label>Tunnel Timeout</label>
+        <type>text</type>
+        <help><![CDATA[Set the maximum inactivity time for tunnel (and WebSocket) connections, once established. This overrides the client and server timeouts for tunnels, so idle WebSockets are not closed at the (much shorter) client/server timeout. Leave empty to fall back to the client/server timeouts. Defaults to milliseconds; the unit may be specified as "d", "h", "m", "s", "ms" or "us" (e.g. 24h).]]></help>
+    </field>
+    <field>
         <id>haproxy.general.defaults.retries</id>
         <label>Retries</label>
         <type>text</type>

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/HAProxy.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/HAProxy</mount>
-    <version>5.0.0</version>
+    <version>5.1.0</version>
     <description>the HAProxy load balancer</description>
     <items>
         <general>
@@ -282,6 +282,11 @@
                     <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
                     <Required>N</Required>
                 </timeoutServer>
+                <timeoutTunnel type="TextField">
+                    <Mask>/^([0-9]{1,8}(?:us|ms|s|m|h|d)?)/u</Mask>
+                    <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
+                    <Required>N</Required>
+                </timeoutTunnel>
                 <retries type="IntegerField">
                     <MinimumValue>0</MinimumValue>
                     <MaximumValue>100</MaximumValue>
@@ -696,6 +701,11 @@
                     <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
                     <Required>N</Required>
                 </tuning_timeoutClient>
+                <tuning_timeoutTunnel type="TextField">
+                    <Mask>/^([0-9]{1,8}(?:us|ms|s|m|h|d)?)/u</Mask>
+                    <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
+                    <Required>N</Required>
+                </tuning_timeoutTunnel>
                 <tuning_timeoutHttpReq type="TextField">
                     <Mask>/^([0-9]{1,8}(?:us|ms|s|m|h|d)?)/u</Mask>
                     <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
@@ -1387,6 +1397,11 @@
                     <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
                     <Required>N</Required>
                 </tuning_timeoutServer>
+                <tuning_timeoutTunnel type="TextField">
+                    <Mask>/^([0-9]{1,8}(?:us|ms|s|m|h|d)?)/u</Mask>
+                    <ValidationMessage>Should be a number between 1 and 8 characters, optionally followed by either "d", "h", "m", "s", "ms" or "us".</ValidationMessage>
+                    <Required>N</Required>
+                </tuning_timeoutTunnel>
                 <tuning_retries type="IntegerField">
                     <MinimumValue>0</MinimumValue>
                     <MaximumValue>100</MaximumValue>
@@ -4743,6 +4758,66 @@
                 </hostname>
             </mailer>
         </mailers>
+        <sniroutes>
+            <sniroute type="ArrayField">
+                <id type="UniqueIdField">
+                    <Required>Y</Required>
+                </id>
+                <enabled type="BooleanField">
+                    <Default>1</Default>
+                    <Required>Y</Required>
+                </enabled>
+                <name type="TextField">
+                    <Mask>/^[^\t^,^;^\.^\[^\]^\{^\}]{1,255}$/u</Mask>
+                    <ValidationMessage>Should be a string between 1 and 255 characters.</ValidationMessage>
+                    <Required>Y</Required>
+                </name>
+                <description type="TextField">
+                    <Required>N</Required>
+                    <Mask>/^.{1,255}$/u</Mask>
+                    <ValidationMessage>Should be a string between 1 and 255 characters.</ValidationMessage>
+                </description>
+                <frontend type="ModelRelationField">
+                    <Model>
+                        <template>
+                            <source>OPNsense.HAProxy.HAProxy</source>
+                            <items>frontends.frontend</items>
+                            <display>name</display>
+                        </template>
+                    </Model>
+                    <ValidationMessage>Related frontend item not found. The frontend must be in "SSL / TLS offloading (disabled)" or "TCP" mode for SNI passthrough.</ValidationMessage>
+                    <Required>Y</Required>
+                </frontend>
+                <backend type="ModelRelationField">
+                    <Model>
+                        <template>
+                            <source>OPNsense.HAProxy.HAProxy</source>
+                            <items>backends.backend</items>
+                            <display>name</display>
+                        </template>
+                    </Model>
+                    <ValidationMessage>Related backend item not found. Create a TCP-mode backend first.</ValidationMessage>
+                    <Required>Y</Required>
+                </backend>
+                <domains type="CSVListField">
+                    <Required>Y</Required>
+                    <Sorted>N</Sorted>
+                    <Multiple>Y</Multiple>
+                    <Mask>/^(([0-9a-zA-Z._\-\*]+)([,]){0,1})*$/u</Mask>
+                    <ChangeCase>lower</ChangeCase>
+                    <ValidationMessage>Please provide one or more domain names, e.g. www.example.com.</ValidationMessage>
+                </domains>
+                <matchType type="OptionField">
+                    <Required>Y</Required>
+                    <Default>exact</Default>
+                    <OptionValues>
+                        <exact>Exact host (matches www.example.com only)</exact>
+                        <sub>Subdomains (matches *.example.com)</sub>
+                    </OptionValues>
+                    <ValidationMessage>Please select a match type.</ValidationMessage>
+                </matchType>
+            </sniroute>
+        </sniroutes>
         <maintenance>
             <cronjobs>
                 <syncCerts type="BooleanField">

--- a/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/Menu/Menu.xml
+++ b/net/haproxy/src/opnsense/mvc/app/models/OPNsense/HAProxy/Menu/Menu.xml
@@ -15,6 +15,7 @@
               <HealthChecks VisibleName="Health Checks" url="/ui/haproxy#healthchecks"/>
               <Actions VisibleName="Actions" url="/ui/haproxy#actions"/>
               <Acls VisibleName="ACLs" url="/ui/haproxy#acls"/>
+              <SniRoutes VisibleName="SNI Routes" url="/ui/haproxy#sniroutes"/>
               <Users VisibleName="Users" url="/ui/haproxy#users"/>
               <Groups VisibleName="Groups" url="/ui/haproxy#groups"/>
               <Luas VisibleName="Lua Scripts" url="/ui/haproxy#luas"/>

--- a/net/haproxy/src/opnsense/mvc/app/views/OPNsense/HAProxy/index.volt
+++ b/net/haproxy/src/opnsense/mvc/app/views/OPNsense/HAProxy/index.volt
@@ -119,6 +119,18 @@ POSSIBILITY OF SUCH DAMAGE.
             }
         );
 
+        $("#grid-sniroutes").UIBootgrid(
+            {   search:'/api/haproxy/settings/search_sni_routes',
+                get:'/api/haproxy/settings/get_sni_route/',
+                set:'/api/haproxy/settings/set_sni_route/',
+                add:'/api/haproxy/settings/add_sni_route/',
+                del:'/api/haproxy/settings/del_sni_route/',
+                toggle:'/api/haproxy/settings/toggle_sni_route/',
+                options: {
+                }
+            }
+        );
+
         $("#grid-users").UIBootgrid(
             {   search:'/api/haproxy/settings/search_users',
                 get:'/api/haproxy/settings/get_user/',
@@ -585,6 +597,7 @@ POSSIBILITY OF SUCH DAMAGE.
             <li><a data-toggle="tab" id="healthchecks-tab" href="#healthchecks">{{ lang._('Health Monitors') }}</a></li>
             <li><a data-toggle="tab" href="#acls">{{ lang._('Conditions') }}</a></li>
             <li><a data-toggle="tab" href="#actions">{{ lang._('Rules') }}</a></li>
+            <li><a data-toggle="tab" href="#sniroutes">{{ lang._('SNI Routes') }}</a></li>
         </ul>
     </li>
 
@@ -894,6 +907,32 @@ POSSIBILITY OF SUCH DAMAGE.
                 <th data-column-id="description" data-type="string">{{ lang._('Description') }}</th>
                 <th data-column-id="commands" data-width="7em" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
                 <th data-column-id="uuid" data-type="string" data-identifier="true"  data-visible="false">{{ lang._('ID') }}</th>
+            </tr>
+            </thead>
+            <tbody>
+            </tbody>
+            <tfoot>
+            <tr>
+                <td></td>
+                <td>
+                    <button data-action="add" type="button" class="btn btn-xs btn-default"><span class="fa fa-plus"></span></button>
+                    <button data-action="deleteSelected" type="button" class="btn btn-xs btn-default"><span class="fa fa-trash-o"></span></button>
+                </td>
+            </tr>
+            </tfoot>
+        </table>
+    </div>
+
+    <div id="sniroutes" class="tab-pane fade">
+        <table id="grid-sniroutes" class="table table-condensed table-hover table-striped table-responsive" data-editDialog="DialogSniRoute" data-editAlert="haproxyChangeMessage">
+            <thead>
+            <tr>
+                <th data-column-id="enabled" data-type="string" data-formatter="boolean" data-width="4em">{{ lang._('Enabled') }}</th>
+                <th data-column-id="name" data-type="string">{{ lang._('Name') }}</th>
+                <th data-column-id="domains" data-type="string">{{ lang._('Domains (SNI)') }}</th>
+                <th data-column-id="matchType" data-type="string" data-width="8em">{{ lang._('Match') }}</th>
+                <th data-column-id="commands" data-width="7em" data-formatter="commands" data-sortable="false">{{ lang._('Commands') }}</th>
+                <th data-column-id="uuid" data-type="string" data-identifier="true" data-visible="false">{{ lang._('ID') }}</th>
             </tr>
             </thead>
             <tbody>
@@ -1243,6 +1282,7 @@ POSSIBILITY OF SUCH DAMAGE.
 {{ partial("layout_partials/base_dialog",['fields':formDialogHealthcheck,'id':'DialogHealthcheck','label':lang._('Edit Health Monitor')])}}
 {{ partial("layout_partials/base_dialog",['fields':formDialogAction,'id':'DialogAction','label':lang._('Edit Rule')])}}
 {{ partial("layout_partials/base_dialog",['fields':formDialogAcl,'id':'DialogAcl','label':lang._('Edit Condition')])}}
+{{ partial("layout_partials/base_dialog",['fields':formDialogSniRoute,'id':'DialogSniRoute','label':lang._('Edit SNI Route')])}}
 {{ partial("layout_partials/base_dialog",['fields':formDialogUser,'id':'DialogUser','label':lang._('Edit User')])}}
 {{ partial("layout_partials/base_dialog",['fields':formDialogGroup,'id':'DialogGroup','label':lang._('Edit Group')])}}
 {{ partial("layout_partials/base_dialog",['fields':formDialogLua,'id':'DialogLua','label':lang._('Edit Lua Script')])}}

--- a/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
+++ b/net/haproxy/src/opnsense/service/templates/OPNsense/HAProxy/haproxy.conf
@@ -38,6 +38,64 @@
 {%   endif %}
 {%- endmacro -%}
 
+{#- Macro renders TLS passthrough / SNI routes attached to the given frontend. -#}
+{#- For each enabled SNI Route pointing at this frontend it emits the passthrough  -#}
+{#- boilerplate once, then one ACL per domain and a use_backend rule per route.    -#}
+{%- macro SniRoutes(frontend) -%}
+{%   set matched = [] %}
+{%   if helpers.exists('OPNsense.HAProxy.sniroutes') %}
+{%     for route in helpers.toList('OPNsense.HAProxy.sniroutes.sniroute') %}
+{%       if route.enabled|default('') == '1' and route.frontend|default('') != '' %}
+{%         set route_frontend = helpers.getUUID(route.frontend) %}
+{%         if route_frontend != {} and route_frontend.id == frontend.id %}
+{%           do matched.append(route) %}
+{%         endif %}
+{%       endif %}
+{%     endfor %}
+{%   endif %}
+{%   if matched|length > 0 %}
+{%     set fe_mode = frontend.mode|default('') %}
+{%     if fe_mode != 'tcp' and fe_mode != 'ssl' and fe_mode != 'http' %}
+    # ERROR: SNI routes require this frontend to be in HTTP, TCP or SSL mode.
+{%     else %}
+{%       if fe_mode == 'http' %}
+    # Host-based routing (auto-generated from SNI Routes; TLS terminated on this frontend)
+{%       else %}
+    # TLS passthrough / SNI routing (auto-generated from SNI Routes)
+    tcp-request inspect-delay 5s
+    tcp-request content accept if { req.ssl_hello_type 1 }
+{%       endif %}
+{%       for route in matched %}
+{%         if route.backend|default('') == '' %}
+    # ERROR: SNI route "{{ route.name }}" has no backend configured.
+{%         elif route.domains|default('') == '' %}
+    # ERROR: SNI route "{{ route.name }}" has no domains configured.
+{%         else %}
+{%           set route_backend = helpers.getUUID(route.backend) %}
+{%           if route_backend == {} %}
+    # ERROR: SNI route "{{ route.name }}" references a missing backend.
+{%           else %}
+    # SNI route: {{ route.name }}{% if route.description|default('') != '' %} ({{ route.description }}){% endif %}
+
+{%             set acl_name = 'sni_' ~ route.id %}
+{%             set sni_fetch = 'hdr(host)' if fe_mode == 'http' else 'req.ssl_sni' %}
+{%             for domain in route.domains.split(',') %}
+{%               if domain|trim != '' %}
+{%                 if route.matchType|default('exact') == 'sub' %}
+    acl {{ acl_name }} {{ sni_fetch }} -m end -i .{{ domain|trim }}
+{%                 else %}
+    acl {{ acl_name }} {{ sni_fetch }} -i {{ domain|trim }}
+{%                 endif %}
+{%               endif %}
+{%             endfor %}
+    use_backend {{ route_backend.name }} if {{ acl_name }}
+{%           endif %}
+{%         endif %}
+{%       endfor %}
+{%     endif %}
+{%   endif %}
+{%- endmacro -%}
+
 {#- Macro expects an action item and checks for conditional args. #}
 {%- macro ActionConditionalArgs(action_data,action_name) -%}
 {%   if action_data is defined and action_name is defined %}
@@ -2205,6 +2263,9 @@ defaults
 {%   if OPNsense.HAProxy.general.defaults.timeoutServer|default("") != "" %}
     timeout server {{OPNsense.HAProxy.general.defaults.timeoutServer}}
 {%   endif %}
+{%   if OPNsense.HAProxy.general.defaults.timeoutTunnel|default("") != "" %}
+    timeout tunnel {{OPNsense.HAProxy.general.defaults.timeoutTunnel}}
+{%   endif %}
 {%   if OPNsense.HAProxy.general.defaults.retries|default("") != "" %}
     retries {{OPNsense.HAProxy.general.defaults.retries}}
 {%   endif %}
@@ -2536,6 +2597,9 @@ frontend {{frontend.name}}
 {%       if frontend.tuning_timeoutClient is defined %}
     timeout client {{frontend.tuning_timeoutClient}}
 {%       endif %}
+{%       if frontend.tuning_timeoutTunnel|default("") != "" %}
+    timeout tunnel {{frontend.tuning_timeoutTunnel}}
+{%       endif %}
 {%       if frontend.tuning_timeoutHttpReq|default("") != "" and frontend.mode == 'http' %}
     timeout http-request {{frontend.tuning_timeoutHttpReq}}
 {%       endif %}
@@ -2572,6 +2636,8 @@ frontend {{frontend.name}}
 {#         # call macro to evaluate ACLs and actions #}
 {{         AclsAndActions(frontend.linkedActions) }}
 {%-      endif %}
+{#       # TLS passthrough / SNI routes attached to this frontend #}
+{{         SniRoutes(frontend) }}
 {#       # error files #}
 {%       if frontend.linkedErrorfiles|default("") != "" %}
 {#         # call macro to evaluate error files #}
@@ -2760,6 +2826,9 @@ backend {{backend.name}}
 {%       endif %}
 {%       if backend.tuning_timeoutServer|default("") != "" %}
     timeout server {{backend.tuning_timeoutServer}}
+{%       endif %}
+{%       if backend.tuning_timeoutTunnel|default("") != "" %}
+    timeout tunnel {{backend.tuning_timeoutTunnel}}
 {%       endif %}
 {%       if backend.tuning_retries|default("") != "" %}
     retries {{backend.tuning_retries}}


### PR DESCRIPTION
## HAProxy: SNI Routes + configurable Tunnel timeout

Two additive features for the os-haproxy plugin. Happy to split into two PRs if preferred.

### 1. SNI Routes (`sniroutes`)
A new object under **Rules & Checks → SNI Routes** that collapses the common
"domains → backend" routing pattern into a single item, instead of hand-building an ACL
per domain + a `use_backend` rule + (for passthrough) the inspect-delay boilerplate.

Each route links a **frontend** and an existing **backend**, a list of **domains**, and a
**match type** (exact / subdomain). Rendering adapts to the linked frontend's mode:

- **TCP / SSL (passthrough)** → emits the passthrough boilerplate once, then
  `acl … req.ssl_sni …` per domain + `use_backend`.
- **HTTP (TLS terminated)** → emits `acl … hdr(host) …` per domain + `use_backend`
  (host-based routing; also avoids the HTTP/2 connection-coalescing misrouting that
  passthrough + a shared wildcard cert can cause).

Touches: model (`sniroutes` ArrayField), template macro `SniRoutes(frontend)`, form
`dialogSniRoute.xml`, `SettingsController` CRUD actions, `IndexController`, `index.volt`
(grid + tab + dialog), `Menu.xml`.

### 2. Tunnel timeout (`timeout tunnel`)
Adds a **Tunnel Timeout** field in **Default Parameters** plus per-frontend and
per-backend tuning overrides, rendered as `timeout tunnel <value>`. This governs
tunnel/upgraded (WebSocket) connections independently of the client/server timeouts, so
idle WebSockets are not dropped at the (short) default client/server timeout.

Touches: model (`general.defaults.timeoutTunnel`, `frontend/backend tuning_timeoutTunnel`),
template (defaults/frontend/backend render), forms `generalDefaults.xml` /
`dialogFrontend.xml` / `dialogBackend.xml`.

### Notes
- Model version `5.0.0` → `5.1.0`. Both changes are **additive optional fields**, so no
  migration is required (existing configs load unchanged).
- `PLUGIN_VERSION` `5.1` → `5.2`, changelog added to `pkg-descr`.
- Validated: model loads, `haproxy -c` passes on rendered config, and generated output
  matches hand-written passthrough/host-routing configs on a live OPNsense (HAProxy 3.2).
