### PR TITLE
net-mgmt/zabbix-proxy: add StartSNMPPollers option

### DIFF
--- a/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/controllers/OPNsense/Zabbixproxy/forms/general.xml
+++ b/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/controllers/OPNsense/Zabbixproxy/forms/general.xml
@@ -88,6 +88,12 @@
         <help>The number of pre-forked instances of Zabbix agent pollers.</help>
     </field>
     <field>
+        <id>general.startsnmppollers</id>
+        <label>Start SNMP Pollers</label>
+        <type>text</type>
+        <help>The number of pre-forked instances of SNMP pollers.</help>
+    </field>
+    <field>
         <id>general.starttrappers</id>
         <label>Start Trappers</label>
         <type>text</type>

--- a/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/models/OPNsense/Zabbixproxy/General.xml
+++ b/net-mgmt/zabbix-proxy/src/opnsense/mvc/app/models/OPNsense/Zabbixproxy/General.xml
@@ -37,6 +37,10 @@
             <MinimumValue>0</MinimumValue>
             <MaximumValue>1000</MaximumValue>
         </startagentpollers>
+        <startsnmppollers type="IntegerField">
+            <MinimumValue>0</MinimumValue>
+            <MaximumValue>1000</MaximumValue>
+        </startsnmppollers>
         <maxconcurrentchecksperpoller type="IntegerField">
             <MinimumValue>1</MinimumValue>
             <MaximumValue>1000</MaximumValue>

--- a/net-mgmt/zabbix-proxy/src/opnsense/service/templates/OPNsense/Zabbixproxy/zabbix_proxy.conf.in
+++ b/net-mgmt/zabbix-proxy/src/opnsense/service/templates/OPNsense/Zabbixproxy/zabbix_proxy.conf.in
@@ -63,6 +63,9 @@ StartPollersUnreachable={{ OPNsense.zabbixproxy.general.startpollersunreachable 
 {% if helpers.exists('OPNsense.zabbixproxy.general.startagentpollers') and OPNsense.zabbixproxy.general.startagentpollers != '' %}
 StartAgentPollers={{ OPNsense.zabbixproxy.general.startagentpollers }}
 {% endif %}
+{% if helpers.exists('OPNsense.zabbixproxy.general.startsnmppollers') and OPNsense.zabbixproxy.general.startsnmppollers != '' %}
+StartSNMPPollers={{ OPNsense.zabbixproxy.general.startsnmppollers }}
+{% endif %}
 {% if helpers.exists('OPNsense.zabbixproxy.general.maxconcurrentchecksperpoller') and OPNsense.zabbixproxy.general.maxconcurrentchecksperpoller != '' %}
 MaxConcurrentChecksPerPoller={{ OPNsense.zabbixproxy.general.maxconcurrentchecksperpoller }}
 {% endif %}


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: Claude Opus 5 (Anthropic), via Claude Code
- Extent of AI involvement: The model examined the existing `StartAgentPollers` implementation (#5037) and drafted the three changes to match its style, along with the commit message and this description. I defined the scope, reviewed the diff, and carried out all functional testing on OPNsense hardware.

---

**Describe the problem**

`StartSNMPPollers` is not exposed in the Zabbix Proxy settings form, so it always stays at the Zabbix default of 1. The only way to change it is to edit `/usr/local/etc/<variant>/zabbix_proxy.conf` by hand, and the plugin regenerates that file on every settings apply, silently discarding the change. Monitoring a larger number of SNMP hosts commonly needs more than one poller.

---

**Describe the proposed solution**

Expose the parameter as an optional field, following the same pattern used for `StartAgentPollers` in #5037:

- `General.xml` — `startsnmppollers` as an `IntegerField`, range 0-1000
- `forms/general.xml` — "Start SNMP Pollers", next to Start Agent Pollers
- `zabbix_proxy.conf.in` — guarded with `helpers.exists(...) and != ''`

Left empty the field emits nothing, so existing configurations are unaffected.

`StartSNMPPollers` requires Zabbix >= 7.0 and this template is shared by the zabbix6/zabbix7/zabbix74 variants. This matches the existing `StartAgentPollers` and `MaxConcurrentChecksPerPoller` fields, and as the field is empty by default there is no change for zabbix6 users.

Tested on os-zabbix74-proxy 1.17 with zabbix74-proxy 7.4.11:

- empty field: `StartSNMPPollers` absent from the generated config, verified with the element present but empty in `config.xml`, which is the state after any settings save
- `1001` and non-numeric input rejected by model validation
- set to `5`: `StartSNMPPollers=5` generated, proxy starts, five `snmp poller` processes, no configuration warnings in the proxy log

---

**Related issue**

None. This is a small additive change mirroring the existing `StartAgentPollers` field, so I did not open an issue first — happy to do so if you would prefer.
