### PR TITLE
net/frr: Move implicit BGP address family neighbor configuration to explicit dropdown

### DIFF
--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPNeighbor.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPNeighbor.xml
@@ -46,6 +46,13 @@
     </grid_view>
   </field>
   <field>
+    <id>neighbor.family</id>
+    <label>Address Family</label>
+    <type>dropdown</type>
+    <type>select_multiple</type>
+    <help>Select which address families to activate for this neighbor.</help>
+  </field>
+  <field>
     <id>neighbor.password</id>
     <label>BGP MD5 Password</label>
     <type>text</type>
@@ -121,18 +128,6 @@
     <label>Multi-Hop</label>
     <help>Enables connections to eBGP neighbors across multiple hops; often required for peering over loopback addresses.</help>
     <type>checkbox</type>
-    <grid_view>
-      <type>boolean</type>
-      <formatter>boolean</formatter>
-      <visible>false</visible>
-    </grid_view>
-  </field>
-  <field>
-    <id>neighbor.multiprotocol</id>
-    <label>Multi-Protocol</label>
-    <type>checkbox</type>
-    <advanced>true</advanced>
-    <help>Enables multiprotocol BGP for support of additional address families like IPv6.</help>
     <grid_view>
       <type>boolean</type>
       <formatter>boolean</formatter>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
@@ -1,7 +1,7 @@
 <model>
     <mount>//OPNsense/quagga/bgp</mount>
     <description>BGP Routing configuration</description>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
     <items>
         <enabled type="BooleanField">
             <Default>0</Default>
@@ -68,6 +68,15 @@
                 <address type="NetworkField">
                     <Required>Y</Required>
                 </address>
+                <family type="OptionField">
+                    <Required>Y</Required>
+                    <Default>ipv4</Default>
+                    <Multiple>Y</Multiple>
+                    <OptionValues>
+                        <ipv4>IPv4</ipv4>
+                        <ipv6>IPv6</ipv6>
+                    </OptionValues>
+                </family>
                 <remote_as_mode type="OptionField">
                     <BlankDesc>Use Remote AS Number</BlankDesc>
                     <OptionValues>
@@ -104,7 +113,6 @@
                 <nexthopself type="BooleanField"/>
                 <nexthopselfall type="BooleanField"/>
                 <multihop type="BooleanField"/>
-                <multiprotocol type="BooleanField"/>
                 <rrclient type="BooleanField"/>
                 <soft_reconfiguration_inbound type="BooleanField"/>
                 <bfd type="BooleanField"/>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/Migrations/M1_1_3.php
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/Migrations/M1_1_3.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Deciso B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Quagga\Migrations;
+
+use OPNsense\Base\BaseModelMigration;
+use OPNsense\Core\Config;
+
+class M1_1_3 extends BaseModelMigration
+{
+    public function run($model)
+    {
+        $neighbors = $model->getNodeByReference('neighbors.neighbor');
+
+        if ($neighbors === null) {
+            return;
+        }
+
+        $config = Config::getInstance()->object();
+
+        if (empty($config->OPNsense->quagga->bgp->neighbors->neighbor)) {
+            return;
+        }
+
+        foreach ($neighbors->iterateItems() as $uuid => $neighbor) {
+            $config_neighbor = null;
+            // Could be a lookup table but a migration is one shot anyway
+            foreach ($config->OPNsense->quagga->bgp->neighbors->neighbor as $candidate) {
+                if ((string)$candidate['uuid'] === (string)$uuid) {
+                    $config_neighbor = $candidate;
+                    break;
+                }
+            }
+
+            if ($config_neighbor === null || isset($config_neighbor->family)) {
+                continue;
+            }
+
+            if ((string)$config_neighbor->multiprotocol === '1') {
+                $neighbor->family = 'ipv4,ipv6';
+            } elseif (strpos((string)$config_neighbor->address, ':') !== false) {
+                $neighbor->family = 'ipv6';
+            } else {
+                $neighbor->family = 'ipv4';
+            }
+        }
+    }
+
+    // Model is saved by 'run_migrations.php'
+}

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/Config/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/Config/bgpd.conf
@@ -7,14 +7,11 @@
 
 {%   if helpers.exists('OPNsense.quagga.bgp.neighbors.neighbor') %}
 {%     for neighbor in helpers.toList('OPNsense.quagga.bgp.neighbors.neighbor') %}
-{%       if neighbor.enabled == '1' and neighbor.multiprotocol == '1' %}
-{#         // the .append() method in Jinja2 returns "None", so filter through default() to suppress #}
-{{         neighbors['ipv4'].append(neighbor) | default("", True) }}
-{{         neighbors['ipv6'].append(neighbor) | default("", True) }}
-{%       elif neighbor.enabled == '1' and ':' not in neighbor.address %}
-{{         neighbors['ipv4'].append(neighbor) | default("", True) }}
-{%       elif neighbor.enabled == '1' and ':' in neighbor.address %}
-{{         neighbors['ipv6'].append(neighbor) | default("", True) }}
+{%       if neighbor.enabled == '1' %}
+{%         for family in neighbor.family.split(',') %}
+{#           // the .append() method in Jinja2 returns "None", so filter through default() to suppress #}
+{{           neighbors[family].append(neighbor) | default("", True) }}
+{%         endfor %}
 {%       endif %}
 {%     endfor %}
 {%   endif %}


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: ChatGPT 5.5
- Extent of AI involvement: A bit help with the migration

---

**Describe the problem**

Further cleanup in BGP around the address families concept.

---

**Describe the proposed solution**

Now you can create an ipv4 peer that only peers ipv6 and the other way around.

It also gets rid of "Multiprotocol" toggle which implies its some sort of special BGP option but it isn't.

It's now the same as here: https://github.com/opnsense/plugins/blob/03a4c64ba4a5facff730412eedd3a9e5beda70a6/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml#L397

---

**Related issue**

Fixes: https://github.com/opnsense/plugins/issues/5647
