### PR TITLE
benchmarks/iperf: optionally use default port 5201, if available

### DIFF
--- a/benchmarks/iperf/Makefile
+++ b/benchmarks/iperf/Makefile
@@ -1,6 +1,6 @@
 PLUGIN_NAME=		iperf
 PLUGIN_VERSION=		1.0
-PLUGIN_REVISION=	2
+PLUGIN_REVISION=	3
 PLUGIN_COMMENT=		Connection speed tester
 PLUGIN_DEPENDS=		iperf3 ruby rubygem-rexml
 PLUGIN_MAINTAINER=	franz.fabian.94@gmail.com

--- a/benchmarks/iperf/src/opnsense/mvc/app/controllers/OPNsense/iperf/Api/InstanceController.php
+++ b/benchmarks/iperf/src/opnsense/mvc/app/controllers/OPNsense/iperf/Api/InstanceController.php
@@ -55,9 +55,11 @@ class InstanceController extends ApiMutableModelControllerBase
                     'error' => 'interface parameter is missing');
         }
         $interface_name = $_POST['instance']['interface'];
+        $prefer_port_5201 = isset($_POST['instance']['prefer_port_5201']) &&
+            $_POST['instance']['prefer_port_5201'] === '1';
         if ($interface = $this->get_real_interface_name($interface_name)) {
             // start iperf
-            return $this->send_command("start $interface", $backend);
+            return $this->send_command("start $interface " . ($prefer_port_5201 ? '1' : '0'), $backend);
         } else {
             return array('status' => 'error',
                       'error' => 'interface is unknown');

--- a/benchmarks/iperf/src/opnsense/mvc/app/controllers/OPNsense/iperf/forms/instance_settings.xml
+++ b/benchmarks/iperf/src/opnsense/mvc/app/controllers/OPNsense/iperf/forms/instance_settings.xml
@@ -5,4 +5,10 @@
       <type>dropdown</type>
       <help>Choose the interface on which the port should be opened.</help>
    </field>
+   <field>
+      <id>instance.prefer_port_5201</id>
+      <label>Use port 5201 when available</label>
+      <type>checkbox</type>
+      <help>Use the standard iPerf port 5201 when it is available; otherwise, use a random available port.</help>
+   </field>
 </form>

--- a/benchmarks/iperf/src/opnsense/mvc/app/models/OPNsense/iperf/FakeInstance.xml
+++ b/benchmarks/iperf/src/opnsense/mvc/app/models/OPNsense/iperf/FakeInstance.xml
@@ -7,5 +7,9 @@
             <Required>Y</Required>
             <Multiple>N</Multiple>
         </interface>
+        <prefer_port_5201 type="BooleanField">
+            <Default>1</Default>
+            <Required>N</Required>
+        </prefer_port_5201>
     </items>
 </model>

--- a/benchmarks/iperf/src/opnsense/scripts/iperf/ruby_iperf.rb
+++ b/benchmarks/iperf/src/opnsense/scripts/iperf/ruby_iperf.rb
@@ -39,6 +39,7 @@ SOCKET_FILE = '/var/run/iperf-manager.sock'
 ONE_HOUR = 3600
 KEY_START_TIME = 'start_time'
 KEY_PORT = 'port'
+IPERF_DEFAULT_PORT = 5201
 LF = "\n"
 
 def execute_firewall_port(rule)
@@ -106,8 +107,11 @@ def find_open_ports
   ports
 end
 
-def find_open_port
-  find_open_ports.sample
+def find_open_port(prefer_default_port = false)
+  ports = find_open_ports
+  return IPERF_DEFAULT_PORT if prefer_default_port && ports.include?(IPERF_DEFAULT_PORT)
+
+  ports.sample
 end
 
 def run_iperf3(port)
@@ -123,9 +127,9 @@ def run_iperf3(port)
   output
 end
 
-def run_test(interface = 'any', data)
+def run_test(interface, data, prefer_default_port = false)
   ret = nil
-  data[KEY_PORT] = port = find_open_port
+  data[KEY_PORT] = port = find_open_port(prefer_default_port)
   # regenerate ruleset
   flush_firewall_rules
   gen_firewall_rules
@@ -149,12 +153,12 @@ def run_test(interface = 'any', data)
   ret
 end
 
-def run_test_thread(interface = 'any')
+def run_test_thread(interface = 'any', prefer_default_port = false)
   data = {}
   t = Thread.new do
     data[KEY_START_TIME] = Time.now
     data['interface'] = interface
-    run_test(interface, data)
+    run_test(interface, data, prefer_default_port)
   end
   $instances[t] = data
 end
@@ -190,7 +194,8 @@ begin
               # check if a valid interface was given
               interface = intf if intf =~ /^[a-z0-9_-]+$/
             end
-            data = run_test_thread interface
+            prefer_default_port = command.shift == '1'
+            data = run_test_thread interface, prefer_default_port
             connection.puts '{"status": "queued job"}'
           when 'query'
             connection.puts $instances.values.to_json


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: GPT 5.6
- Extent of AI involvement: Extensive, but I reviewed all changes.

---

**Describe the problem**

iperf3 default port is 5201.  But the plugin always uses a random port.

---

**Describe the proposed solution**

Add an option: Use the standard iperf3 port 5201 when it is available; otherwise, use a random available port.

Might require an iPerf restart after applying this update.

---

**Related issue**

None
