### PR TITLE
www/nginx: fix orphaned sni_hostname_upstream_map_item / ip_acl_item on edit

### DIFF
--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/Api/SettingsController.php
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/Api/SettingsController.php
@@ -30,6 +30,7 @@ namespace OPNsense\Nginx\Api;
 
 use OPNsense\Base\ApiMutableModelControllerBase;
 use OPNsense\Core\Backend;
+use OPNsense\Core\Config;
 
 class SettingsController extends ApiMutableModelControllerBase
 {
@@ -643,7 +644,12 @@ class SettingsController extends ApiMutableModelControllerBase
     public function addsnifwdAction()
     {
         if ($this->request->isPost()) {
-            $this->regenerate_hostname_map(null);
+            $result = $this->regenerate_hostname_map(null);
+
+            if ($result['result'] === 'failed') {
+                return $result;
+            }
+
             return $this->addBase('snihostname', 'sni_hostname_upstream_map');
         }
         return [];
@@ -666,7 +672,12 @@ class SettingsController extends ApiMutableModelControllerBase
     public function setsnifwdAction($uuid)
     {
         if ($this->request->isPost()) {
-            $this->regenerate_hostname_map($uuid);
+            $result = $this->regenerate_hostname_map($uuid);
+
+            if ($result['result'] === 'failed') {
+                return $result;
+            }
+
             return $this->setBase('snihostname', 'sni_hostname_upstream_map', $uuid);
         }
         return [];
@@ -687,9 +698,15 @@ class SettingsController extends ApiMutableModelControllerBase
     public function addipaclAction()
     {
         if ($this->request->isPost()) {
-            $this->regenerate_ipacl(null);
+            $result = $this->regenerate_ipacl(null);
+
+            if ($result['result'] === 'failed') {
+                return $result;
+            }
+
             return $this->addBase('ipacl', 'ip_acl');
         }
+
         return [];
     }
 
@@ -710,9 +727,15 @@ class SettingsController extends ApiMutableModelControllerBase
     public function setipaclAction($uuid)
     {
         if ($this->request->isPost()) {
-            $this->regenerate_ipacl($uuid);
+            $result = $this->regenerate_ipacl($uuid);
+
+            if ($result['result'] === 'failed') {
+                return $result;
+            }
+
             return $this->setBase('ipacl', 'ip_acl', $uuid);
         }
+
         return [];
     }
     /*
@@ -763,25 +786,91 @@ class SettingsController extends ApiMutableModelControllerBase
     private function regenerate_hostname_map($uuid = null)
     {
         $nginx = $this->getModel();
-        if ($this->request->hasPost('snihostname') && is_array($_POST['snihostname']['data'])) {
-            if ($uuid != null) {
-                // for an update, we have to clear it.
-                $this->delete_uuids(
-                    $nginx->find_sni_hostname_upstream_map_entry_uuids($uuid),
-                    'sni_hostname_upstream_map_item'
-                );
-            }
-            $ids = [];
-            $postdata = $_POST['snihostname']['data'];
-            foreach ($postdata as $post_item) {
-                $item = $nginx->sni_hostname_upstream_map_item->Add();
-                $ids[] = $item->getAttributes()['uuid'];
-                $item->hostname = $post_item['hostname'];
-                $item->upstream = $post_item['upstream'];
-            }
-            $nginx->serializeToConfig();
-            $_POST['snihostname']['data'] = implode(',', $ids);
+        if (!$this->request->hasPost('snihostname')
+            || !is_array($_POST['snihostname']['data'])) {
+            return ['result' => 'continue'];
         }
+        $postdata = $_POST['snihostname']['data'];
+        /*
+         * An empty map is invalid. Let the GUI report the validation error
+         * without modifying the existing configuration.
+         */
+        if (empty($postdata)) {
+            return [
+                'result' => 'failed',
+                'validations' => [
+                    'snihostname.data' => gettext('A value is required.')
+                ]
+            ];
+        }
+        /*
+         * Create the new map items in memory.
+         */
+        $ids = [];
+        foreach ($postdata as $post_item) {
+            $item = $nginx->sni_hostname_upstream_map_item->Add();
+            $ids[] = $item->getAttributes()['uuid'];
+            $item->hostname = $post_item['hostname'];
+            $item->upstream = $post_item['upstream'];
+        }
+        /*
+         * Validate the new map items before modifying the existing map.
+         */
+        $validation = $nginx->performValidation(true);
+        $validation_messages = [];
+        foreach ($validation as $msg) {
+            foreach ($ids as $rowIndex => $id) {
+                if (strpos(
+                    $msg->getField(),
+                    'sni_hostname_upstream_map_item.' . $id . '.'
+                ) === 0) {
+                    $msgText = $msg->getMessage();
+                    $rawValue = (string)($postdata[$rowIndex]['hostname'] ?? '');
+                    if ($rawValue !== '' && strpos($msgText, $rawValue) === false) {
+                        $msgText = sprintf('[%s] %s', $rawValue, $msgText);
+                    }
+                    if (!in_array($msgText, $validation_messages)) {
+                        $validation_messages[] = $msgText;
+                    }
+                    break;
+                }
+            }
+        }
+        if (!empty($validation_messages)) {
+            return [
+                'result' => 'failed',
+                'validations' => [
+                    'snihostname.data' => count($validation_messages) === 1
+                        ? $validation_messages[0]
+                        : $validation_messages
+                ]
+            ];
+        }
+        /*
+         * The new items are valid. For an existing map, remove the old
+         * items. The parent's reference must be cleared and saved first,
+         * otherwise safe-delete considers the old items still in use.
+         */
+        if ($uuid != null) {
+            $old_uuids = $nginx->find_sni_hostname_upstream_map_entry_uuids($uuid);
+            $parent = $nginx->getNodeByReference(
+                'sni_hostname_upstream_map.' . $uuid
+            );
+            if ($parent != null) {
+                $parent->data = '';
+                $nginx->serializeToConfig(false, true);
+                Config::getInstance()->save();
+            }
+            $this->delete_uuids(
+                $old_uuids,
+                'sni_hostname_upstream_map_item'
+            );
+        }
+        /*
+         * Pass the new item UUIDs to addBase()/setBase().
+         */
+        $_POST['snihostname']['data'] = implode(',', $ids);
+        return ['result' => 'continue'];
     }
 
     /**
@@ -791,25 +880,94 @@ class SettingsController extends ApiMutableModelControllerBase
     private function regenerate_ipacl($uuid = null)
     {
         $nginx = $this->getModel();
-        if ($this->request->hasPost('ipacl') && is_array($_POST['ipacl']['data'])) {
-            if ($uuid != null) {
-                // for an update, we have to clear it.
-                $this->delete_uuids(
-                    $nginx->find_ip_acl_uuids($uuid),
-                    'ip_acl_item'
-                );
-            }
-            $ids = [];
-            $postdata = $_POST['ipacl']['data'];
-            foreach ($postdata as $post_item) {
-                $item = $nginx->ip_acl_item->Add();
-                $ids[] = $item->getAttributes()['uuid'];
-                $item->network = $post_item['network'];
-                $item->action = $post_item['action'];
-            }
-            $nginx->serializeToConfig();
-            $_POST['ipacl']['data'] = implode(',', $ids);
+        if (!$this->request->hasPost('ipacl')
+            || !is_array($_POST['ipacl']['data'])) {
+            return ['result' => 'continue'];
         }
+        $postdata = $_POST['ipacl']['data'];
+        /*
+         * An empty ACL is invalid. Do not modify the existing configuration
+         * and let the GUI report the validation error
+         */
+        if (empty($postdata)) {
+            return [
+                'result' => 'failed',
+                'validations' => [
+                    'ipacl.data' => gettext('A value is required.')
+                ]
+            ];
+        }
+        /*
+         * Create the new ACL items in memory.
+         */
+        $ids = [];
+        foreach ($postdata as $post_item) {
+            $item = $nginx->ip_acl_item->Add();
+            $ids[] = $item->getAttributes()['uuid'];
+            $item->network = $post_item['network'];
+            $item->action = $post_item['action'];
+        }
+        /*
+         * Validate the new ACL items before modifying the existing ACL.
+         */
+        $validation = $nginx->performValidation(true);
+        $validation_messages = [];
+        foreach ($validation as $msg) {
+            foreach ($ids as $rowIndex => $id) {
+                if (strpos(
+                    $msg->getField(),
+                    'ip_acl_item.' . $id . '.'
+                ) === 0) {
+                    $msgText = $msg->getMessage();
+                    $rawValue = (string)($postdata[$rowIndex]['network'] ?? '');
+                    if ($rawValue !== '' && strpos($msgText, $rawValue) === false) {
+                        $msgText = sprintf('[%s] %s', $rawValue, $msgText);
+                    }
+                    if (!in_array($msgText, $validation_messages)) {
+                        $validation_messages[] = $msgText;
+                    }
+                    break;
+                }
+            }
+        }
+        /*
+         * Validation failed. Leave the existing ACL untouched.
+         */
+        if (!empty($validation_messages)) {
+            return [
+                'result' => 'failed',
+                'validations' => [
+                    'ipacl.data' => count($validation_messages) === 1
+                        ? $validation_messages[0]
+                        : $validation_messages
+                ]
+            ];
+        }
+        /*
+         * The new ACL items are valid.
+         *
+         * For an existing ACL, clear the parent's reference to the old
+         * items and persist that intermediate state. This is required
+         * by safe-delete before removing the old items.
+         */
+        if ($uuid != null) {
+            $old_uuids = $nginx->find_ip_acl_uuids($uuid);
+            $parent = $nginx->getNodeByReference('ip_acl.' . $uuid);
+            if ($parent != null) {
+                $parent->data = '';
+                $nginx->serializeToConfig(false, true);
+                Config::getInstance()->save();
+            }
+            $this->delete_uuids(
+                $old_uuids,
+                'ip_acl_item'
+            );
+        }
+        /*
+         * Pass the new item UUIDs to addBase()/setBase().
+         */
+        $_POST['ipacl']['data'] = implode(',', $ids);
+        return ['result' => 'continue'];
     }
 
     /**

--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/Api/SettingsController.php
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/Api/SettingsController.php
@@ -30,7 +30,6 @@ namespace OPNsense\Nginx\Api;
 
 use OPNsense\Base\ApiMutableModelControllerBase;
 use OPNsense\Core\Backend;
-use OPNsense\Core\Config;
 
 class SettingsController extends ApiMutableModelControllerBase
 {
@@ -785,92 +784,15 @@ class SettingsController extends ApiMutableModelControllerBase
      */
     private function regenerate_hostname_map($uuid = null)
     {
-        $nginx = $this->getModel();
-        if (!$this->request->hasPost('snihostname')
-            || !is_array($_POST['snihostname']['data'])) {
-            return ['result' => 'continue'];
-        }
-        $postdata = $_POST['snihostname']['data'];
-        /*
-         * An empty map is invalid. Let the GUI report the validation error
-         * without modifying the existing configuration.
-         */
-        if (empty($postdata)) {
-            return [
-                'result' => 'failed',
-                'validations' => [
-                    'snihostname.data' => gettext('A value is required.')
-                ]
-            ];
-        }
-        /*
-         * Create the new map items in memory.
-         */
-        $ids = [];
-        foreach ($postdata as $post_item) {
-            $item = $nginx->sni_hostname_upstream_map_item->Add();
-            $ids[] = $item->getAttributes()['uuid'];
-            $item->hostname = $post_item['hostname'];
-            $item->upstream = $post_item['upstream'];
-        }
-        /*
-         * Validate the new map items before modifying the existing map.
-         */
-        $validation = $nginx->performValidation(true);
-        $validation_messages = [];
-        foreach ($validation as $msg) {
-            foreach ($ids as $rowIndex => $id) {
-                if (strpos(
-                    $msg->getField(),
-                    'sni_hostname_upstream_map_item.' . $id . '.'
-                ) === 0) {
-                    $msgText = $msg->getMessage();
-                    $rawValue = (string)($postdata[$rowIndex]['hostname'] ?? '');
-                    if ($rawValue !== '' && strpos($msgText, $rawValue) === false) {
-                        $msgText = sprintf('[%s] %s', $rawValue, $msgText);
-                    }
-                    if (!in_array($msgText, $validation_messages)) {
-                        $validation_messages[] = $msgText;
-                    }
-                    break;
-                }
-            }
-        }
-        if (!empty($validation_messages)) {
-            return [
-                'result' => 'failed',
-                'validations' => [
-                    'snihostname.data' => count($validation_messages) === 1
-                        ? $validation_messages[0]
-                        : $validation_messages
-                ]
-            ];
-        }
-        /*
-         * The new items are valid. For an existing map, remove the old
-         * items. The parent's reference must be cleared and saved first,
-         * otherwise safe-delete considers the old items still in use.
-         */
-        if ($uuid != null) {
-            $old_uuids = $nginx->find_sni_hostname_upstream_map_entry_uuids($uuid);
-            $parent = $nginx->getNodeByReference(
-                'sni_hostname_upstream_map.' . $uuid
-            );
-            if ($parent != null) {
-                $parent->data = '';
-                $nginx->serializeToConfig(false, true);
-                Config::getInstance()->save();
-            }
-            $this->delete_uuids(
-                $old_uuids,
-                'sni_hostname_upstream_map_item'
-            );
-        }
-        /*
-         * Pass the new item UUIDs to addBase()/setBase().
-         */
-        $_POST['snihostname']['data'] = implode(',', $ids);
-        return ['result' => 'continue'];
+        $old_uuids = $uuid != null
+            ? $this->getModel()->find_sni_hostname_upstream_map_entry_uuids($uuid)
+            : null;
+        return $this->regenerate_map_items(
+            'snihostname',
+            'sni_hostname_upstream_map_item',
+            ['hostname', 'upstream'],
+            $old_uuids
+        );
     }
 
     /**
@@ -879,47 +801,74 @@ class SettingsController extends ApiMutableModelControllerBase
      */
     private function regenerate_ipacl($uuid = null)
     {
+        $old_uuids = $uuid != null
+            ? $this->getModel()->find_ip_acl_uuids($uuid)
+            : null;
+        return $this->regenerate_map_items(
+            'ipacl',
+            'ip_acl_item',
+            ['network', 'action'],
+            $old_uuids
+        );
+    }
+
+    /**
+     * Build and validate the rows of a map/ACL-style array field entirely in
+     * memory, and only wire the old items for removal once the new ones are
+     * known to be valid. Nothing is persisted here -- the caller's
+     * addBase()/setBase() performs the single, atomic, validated save.
+     *
+     * @param string $post_field   top-level POST key (e.g. 'snihostname')
+     * @param string $item_path    child ArrayField reference (e.g. 'sni_hostname_upstream_map_item')
+     * @param array  $row_fields   field names to copy from each posted row
+     * @param array|null $old_uuids uuids of the previously saved rows to drop, or null on add
+     * @return array result/validations, or ['result' => 'continue']
+     */
+    private function regenerate_map_items($post_field, $item_path, $row_fields, $old_uuids)
+    {
         $nginx = $this->getModel();
-        if (!$this->request->hasPost('ipacl')
-            || !is_array($_POST['ipacl']['data'])) {
+        if (!$this->request->hasPost($post_field)
+            || !is_array($_POST[$post_field]['data'])) {
             return ['result' => 'continue'];
         }
-        $postdata = $_POST['ipacl']['data'];
+        $postdata = $_POST[$post_field]['data'];
         /*
-         * An empty ACL is invalid. Do not modify the existing configuration
-         * and let the GUI report the validation error
+         * An empty map/ACL is invalid. Let the GUI report the validation
+         * error without modifying the existing configuration.
          */
         if (empty($postdata)) {
             return [
                 'result' => 'failed',
                 'validations' => [
-                    'ipacl.data' => gettext('A value is required.')
+                    $post_field . '.data' => gettext('A value is required.')
                 ]
             ];
         }
         /*
-         * Create the new ACL items in memory.
+         * Build the new rows in memory only.
          */
+        $collection = $nginx->getNodeByReference($item_path);
         $ids = [];
         foreach ($postdata as $post_item) {
-            $item = $nginx->ip_acl_item->Add();
+            $item = $collection->Add();
             $ids[] = $item->getAttributes()['uuid'];
-            $item->network = $post_item['network'];
-            $item->action = $post_item['action'];
+            foreach ($row_fields as $field) {
+                $item->$field = $post_item[$field];
+            }
         }
         /*
-         * Validate the new ACL items before modifying the existing ACL.
+         * Validate the new rows before touching anything else.
          */
         $validation = $nginx->performValidation(true);
         $validation_messages = [];
         foreach ($validation as $msg) {
             foreach ($ids as $rowIndex => $id) {
-                if (strpos(
-                    $msg->getField(),
-                    'ip_acl_item.' . $id . '.'
-                ) === 0) {
+                if (strpos($msg->getField(), $item_path . '.' . $id . '.') === 0) {
                     $msgText = $msg->getMessage();
-                    $rawValue = (string)($postdata[$rowIndex]['network'] ?? '');
+                    $rawValue = (string)($postdata[$rowIndex][$row_fields[0]] ?? '');
+                    // some field types already embed the failing value in
+                    // their message, others don't -- avoid duplicating it
+                    // either way.
                     if ($rawValue !== '' && strpos($msgText, $rawValue) === false) {
                         $msgText = sprintf('[%s] %s', $rawValue, $msgText);
                     }
@@ -930,60 +879,33 @@ class SettingsController extends ApiMutableModelControllerBase
                 }
             }
         }
-        /*
-         * Validation failed. Leave the existing ACL untouched.
-         */
         if (!empty($validation_messages)) {
+            // Nothing was persisted -- the new (invalid) in-memory rows are
+            // simply discarded when this request ends.
             return [
                 'result' => 'failed',
                 'validations' => [
-                    'ipacl.data' => count($validation_messages) === 1
+                    $post_field . '.data' => count($validation_messages) === 1
                         ? $validation_messages[0]
                         : $validation_messages
                 ]
             ];
         }
         /*
-         * The new ACL items are valid.
-         *
-         * For an existing ACL, clear the parent's reference to the old
-         * items and persist that intermediate state. This is required
-         * by safe-delete before removing the old items.
+         * The new rows are valid. Drop the old ones -- purely in memory,
+         * no safe-delete involved, no early disk write. The caller's
+         * addBase()/setBase() persists everything (new rows, removed rows,
+         * and the parent's "data" reference) in a single validated save.
          */
-        if ($uuid != null) {
-            $old_uuids = $nginx->find_ip_acl_uuids($uuid);
-            $parent = $nginx->getNodeByReference('ip_acl.' . $uuid);
-            if ($parent != null) {
-                $parent->data = '';
-                $nginx->serializeToConfig(false, true);
-                Config::getInstance()->save();
+        if ($old_uuids !== null) {
+            foreach ($old_uuids as $old_uuid) {
+                $collection->del($old_uuid);
             }
-            $this->delete_uuids(
-                $old_uuids,
-                'ip_acl_item'
-            );
         }
-        /*
-         * Pass the new item UUIDs to addBase()/setBase().
-         */
-        $_POST['ipacl']['data'] = implode(',', $ids);
+        $_POST[$post_field]['data'] = implode(',', $ids);
         return ['result' => 'continue'];
     }
 
-    /**
-     * @param $uuids array list of UUIDs
-     * @param $path string the model prefix from the element to delete
-     */
-    private function delete_uuids($uuids, $path): void
-    {
-        foreach ($uuids as $item_uuid) {
-            try {
-                $this->delBase($path, $item_uuid);
-            } catch (\Exception $e) {
-                // we don't care about then.
-            }
-        }
-    }
     // SYSLOG targets
     public function searchsyslogTargetAction()
     {

--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Migrations/M1_35_3.php
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Migrations/M1_35_3.php
@@ -58,10 +58,16 @@ class M1_35_3 extends BaseModelMigration
         }
         $items = $model->getNodeByReference($item_path);
         if ($items != null) {
+            // Collect the orphan uuids first -- do not mutate the collection
+            // while iterating it.
+            $orphans = [];
             foreach ($items->iterateItems() as $uuid => $item) {
                 if (!isset($referenced[$uuid])) {
-                    $items->del($uuid);
+                    $orphans[] = $uuid;
                 }
+            }
+            foreach ($orphans as $uuid) {
+                $items->del($uuid);
             }
         }
     }

--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Migrations/M1_35_3.php
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Migrations/M1_35_3.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * Copyright (C) 2026 muchachagrande
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Nginx\Migrations;
+
+use OPNsense\Base\BaseModelMigration;
+
+class M1_35_3 extends BaseModelMigration
+{
+    // Purge sni_hostname_upstream_map_item / ip_acl_item entries left
+    // orphaned by the bug fixed in #5650.
+    public function run($model)
+    {
+        $this->purgeOrphans($model, 'sni_hostname_upstream_map', 'sni_hostname_upstream_map_item');
+        $this->purgeOrphans($model, 'ip_acl', 'ip_acl_item');
+
+        // run default migration actions
+        parent::run($model);
+    }
+
+    private function purgeOrphans($model, $parent_path, $item_path)
+    {
+        $referenced = [];
+        $parents = $model->getNodeByReference($parent_path);
+        if ($parents != null) {
+            foreach ($parents->iterateItems() as $parent) {
+                foreach (explode(',', (string)$parent->data) as $uuid) {
+                    if ($uuid !== '') {
+                        $referenced[$uuid] = true;
+                    }
+                }
+            }
+        }
+        $items = $model->getNodeByReference($item_path);
+        if ($items != null) {
+            foreach ($items->iterateItems() as $uuid => $item) {
+                if (!isset($referenced[$uuid])) {
+                    $items->del($uuid);
+                }
+            }
+        }
+    }
+}

--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/Nginx</mount>
-    <version>1.35.2</version>
+    <version>1.35.3</version>
     <description>nginx web server, reverse proxy and waf</description>
     <items>
         <general>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:  Claude Sonnet 4.5/5 and ChatGPT 5.6 Luna
- Extent of AI involvement: Claude was used to read the plugin source and OPNsense core framework (BaseModel, ApiMutableModelControllerBase, Config) to trace the root cause of the bug, and to draft and iterate on the fix. ChatGPT was used for technical discussion, code review, and assistance in understanding the existing code. The changes were manually tested, and verified by the contributor before submission.

---

**Describe the problem**

`regenerate_hostname_map()` / `regenerate_ipacl()` in `SettingsController.php` deleted the previous child items `sni_hostname_upstream_map_item` / `ip_acl_item`) on every edit, but the parent's `data` field (a comma-separated list of child uuids) still referenced the old uuids at delete time. Because `SettingsController` uses `$internalModelUseSafeDelete = true`, the safe-delete check does a raw text search over the whole config.xml, finds this self-reference, and blocks the delete; the exception is silently caught, so the old items are left as permanent orphans. Editing the same map/ACL repeatedly accumulates orphans, and each orphan still references a real upstream server, which then can no longer be deleted ("in use").

Two related issues surfaced while fixing this:
- Saving a map/ACL with all rows removed threw an unhandled
  `ValidationException` (raw stack trace) instead of a normal validation
  message.
- If a save failed validation after old items had already been
  cleared/deleted, cancelling in the GUI left the configuration
  partially modified, since the failed attempt had already been
  persisted to disk.

---

**Describe the proposed solution**

New items are now built and fully validated in memory before anything is written to disk. If the submitted set is empty, or any row fails validation, the request returns a normal `{result: "failed", validations: {...}}` response without touching the existing configuration. Only once the new items are known valid does the function clear the parent's `data` field, persist that intermediate state to disk (required, since `delBase()`'s `Config::lock()` reloads from disk on its first call in the request and would otherwise discard an in-memory-only change), and then delete the old child items. Same fix applied to `regenerate_ipacl()`.

---

**Related issue**

Fixes #5650
