### PR TITLE
www/nginx: add hostnames; and proxy_protocol on; options for SNI upstream mapping

### DIFF
--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/sni_hostname_map.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/sni_hostname_map.xml
@@ -6,6 +6,12 @@
     <help>Enter a short description like a name for this redirect.</help>
   </field>
   <field>
+    <id>snihostname.enable_hostnames</id>
+    <label>Enable hostname wildcards</label>
+    <type>checkbox</type>
+    <help>Indicates that map values are hostnames with prefix or suffix mask instead of regex, e.g. "*.example.com", "www.example.*" or ".example.com".</help>
+  </field>
+  <field>
     <id>snihostname.data</id>
     <style>json-data</style>
     <label>Hostname Upstream Map</label>

--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/sni_hostname_map.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/sni_hostname_map.xml
@@ -9,7 +9,7 @@
     <id>snihostname.enable_hostnames</id>
     <label>Enable hostname wildcards</label>
     <type>checkbox</type>
-    <help>Indicates that map values are hostnames with prefix or suffix mask instead of regex, e.g. "*.example.com", "www.example.*" or ".example.com".</help>
+    <help>Indicates that source values can be hostnames with a prefix or suffix mask, e.g. "*.example.com", "www.example.*" or ".example.com".</help>
   </field>
   <field>
     <id>snihostname.data</id>

--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/streamserver.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/streamserver.xml
@@ -106,6 +106,13 @@
     <help>Select an upstream map to choose the host based on the name given by the client.</help>
   </field>
   <field>
+    <id>streamserver.map_proxy_protocol</id>
+    <label>PROXY Protocol to Backend</label>
+    <type>checkbox</type>
+    <advanced>true</advanced>
+    <help>Enables PROXY Protocol to the upstream server so nginx sends the client's real address to the backend chosen by the SNI map.</help>
+  </field>
+  <field>
     <id>streamserver.ip_acl</id>
     <label>IP ACL</label>
     <type>dropdown</type>

--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
@@ -1060,6 +1060,10 @@
                     </check001>
                 </Constraints>
             </sni_upstream_map>
+            <map_proxy_protocol type="BooleanField">
+                <Default>0</Default>
+                <Required>Y</Required>
+            </map_proxy_protocol>
             <ip_acl type="ModelRelationField">
                 <Model>
                     <template>
@@ -1084,6 +1088,10 @@
             <description type="TextField">
                 <Required>Y</Required>
             </description>
+            <enable_hostnames type="BooleanField">
+                <Default>0</Default>
+                <Required>Y</Required>
+            </enable_hostnames>
             <data type="TextField">
                 <!-- sorry, the model relation field is broken here
           <Model>
@@ -1099,8 +1107,10 @@
             </data>
         </sni_hostname_upstream_map>
         <sni_hostname_upstream_map_item type="ArrayField">
-            <hostname type="HostnameField">
+            <hostname type="TextField">
                 <Required>Y</Required>
+                <Mask>/^(~\*?[^\s;{}]+|"~?\*?[^";{}]*"|'~?\*?[^';{}]*'|\*|(\.)?(\*\.)?[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*(\.\*)?)$/</Mask>
+                <ValidationMessage>Please specify a valid SNI mapping regex or hostname.</ValidationMessage>
             </hostname>
             <upstream type="ModelRelationField">
                 <Model>

--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/streams.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/streams.conf
@@ -30,6 +30,9 @@
     # upstream maps
 {% for upstream_map in helpers.toList('OPNsense.Nginx.sni_hostname_upstream_map') %}
     map $ssl_preread_server_name $hostmap{{ upstream_map['@uuid'].replace('-','') }} {
+{%   if upstream_map.enable_hostnames is defined and upstream_map.enable_hostnames == '1' %}
+        hostnames;
+{%   endif %}
 {%   for map_entry_uuid in upstream_map.data.split(',') %}
 {%     set map_entry = helpers.getUUID(map_entry_uuid) %}
         {{ map_entry.hostname }} upstream{{ map_entry.upstream.replace('-','') }};
@@ -104,6 +107,7 @@
 {%     endif %}
 {%   elif server.route_field == 'sni_upstream_map' %}
         proxy_pass $hostmap{{ server.sni_upstream_map.replace('-','') }};
+        proxy_protocol {% if server.map_proxy_protocol is defined and server.map_proxy_protocol == '1' %}on{% else %}off{% endif %};
 {%   endif %}
 {%   if server.proxy_responses is defined and server.proxy_responses != '' %}
         proxy_responses {{ server.proxy_responses }};


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: Claude Sonnet 4.5/5
- Extent of AI involvement: Used to locate the relevant model/form/template files in the plugin source, and to help design and iterate on the hostname validation mask (nginx map key/regex syntax) and the rendering logic in streams.conf. All changes were reviewed and tested manually before submission.

---

**Describe the problem**

The SNI Upstream Mapping feature generates an nginx `map {}` block and a `proxy_pass $hostmap...;` directive, but two related nginx directives were not exposed in the GUI:

- `hostnames;` inside the generated `map {}` block, required for wildcard
  (`*.example.com`, `www.example.*`) or dot-prefixed (`.example.com`) map
  keys — and for regular expressions (`~...`, `~*...`) — to actually be
  interpreted as patterns instead of literal strings. Without it, entries
  using this syntax are silently accepted by the GUI but never match
  anything at runtime.
- `proxy_protocol on;` inside the server {} block, to forward the client's real
 address to the backend selected via the SNI map. This was already possible
 for a fixed "Upstream", but not when routing dynamically via SNI Upstream
 Mapping.

The `hostname` field on each map entry was also a plain `HostnameField`, which rejects the wildcard/regex/dot-prefixed syntax nginx itself accepts for map keys.

---

**Describe the proposed solution**
- Added `enable_hostnames` (BooleanField) to `sni_hostname_upstream_map`,
  exposed as a checkbox on the map's edit form, rendered as `hostnames;`
  in the generated `map {}` block in `streams.conf`.
- Added `map_proxy_protocol` (BooleanField) to `stream_server`, exposed as
  a checkbox on the stream server form, rendered as `proxy_protocol on|off;`
  right after `proxy_pass $hostmap...;` in `streams.conf` (only applies to the
  `sni_upstream_map` routing mode).
- Widened `sni_hostname_upstream_map_item.hostname` from `HostnameField`
  to a `TextField` with a `Mask` covering nginx's full map key syntax:
  exact hostnames, `*`, `*.example.com`, `www.example.*`, `.example.com`,
  and case-sensitive/insensitive regular expressions (`~...`, `~*...`), quoted
  (single or double) or unquoted. The mask explicitly excludes `;`, `{` and `}` from
  every branch, since the value is written verbatim into the generated `.conf` file.

No controller or JS changes were required for the GUI options themselves; both new checkboxes are plain top-level fields already handled by the existing `addBase()`/`setBase()` flow.

While testing this feature I found and fixed an unrelated pre-existing bug (orphaned map/ACL items on edit, blocking deletion of referenced upstreams) — see #5654, tested together with these changes.

---

**Related issue**

Closes #5596
