### PR TITLE
security/netbird: fix seven status page display defects

### DIFF
--- a/security/netbird/Makefile
+++ b/security/netbird/Makefile
@@ -1,6 +1,6 @@
 PLUGIN_NAME=		netbird
 PLUGIN_VERSION=		1.3
-PLUGIN_REVISION=	3
+PLUGIN_REVISION=	4
 PLUGIN_DEPENDS=		netbird
 PLUGIN_COMMENT=		Peer-to-peer VPN that seamlessly connects your devices
 PLUGIN_MAINTAINER=	dev@netbird.io

--- a/security/netbird/pkg-descr
+++ b/security/netbird/pkg-descr
@@ -25,3 +25,10 @@ Plugin Changelog
 * Added IP Mapping option and authentication banner (contributed by Konstantinos Spartalis)
 * Fix quantum peer state display (contributed by Konstantinos Spartalis)
 * Fix setupKey usage after UpdateOnlyTextField introduction
+* Fix ICE candidate endpoints being shown as candidate types on the status page
+* Fix elapsed timestamps reading "-" for every peer during January
+* Render status output as text so peer names cannot inject markup
+* Fix the interface type always being reported as userspace
+* Fix idle peers showing a latency of 0.00 ms and empty ICE candidates
+* Report a stopped daemon instead of a status table full of "undefined"
+* Only list installed packages in the status page version table

--- a/security/netbird/src/opnsense/mvc/app/views/OPNsense/Netbird/status.volt
+++ b/security/netbird/src/opnsense/mvc/app/views/OPNsense/Netbird/status.volt
@@ -204,20 +204,20 @@
                 const isConnected = data.management?.connected === true;
                 $peersDetailContainer.toggleClass("hidden", !isConnected);
                 const renderPreTable = (content, maxHeight = null) => {
-                    const style = `padding: 10px;${maxHeight ? ` max-height: ${maxHeight}; overflow-y: auto;` : ''}`;
-                    return `
-                      <table class="table table-hover table-striped table-condensed">
-                        <tbody>
-                          <tr>
-                            <td><pre style="${style}">${content}</pre></td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    `;
+                    // content carries peer names, relay URIs and daemon error
+                    // messages, so it is set as text and never as markup
+                    const $pre = $('<pre/>').css('padding', '10px').text(content);
+                    if (maxHeight) {
+                        $pre.css({'max-height': maxHeight, 'overflow-y': 'auto'});
+                    }
+
+                    return $('<table/>')
+                        .addClass('table table-hover table-striped table-condensed')
+                        .append($('<tbody/>').append($('<tr/>').append($('<td/>').append($pre))));
                 };
 
-                $connStatus.html(renderPreTable(status));
-                $peersDetails.html(renderPreTable(details, '500px'));
+                $connStatus.empty().append(renderPreTable(status));
+                $peersDetails.empty().append(renderPreTable(details, '500px'));
             });
         }
 

--- a/security/netbird/src/opnsense/mvc/app/views/OPNsense/Netbird/status.volt
+++ b/security/netbird/src/opnsense/mvc/app/views/OPNsense/Netbird/status.volt
@@ -106,7 +106,7 @@
             const managementStr = fmtConn(status.management || {});
             const signalStr = fmtConn(status.signal || {});
 
-            const interfaceType = status.kernelInterface ? "Kernel" : status.netbirdIp ? "Userspace" : "N/A";
+            const interfaceType = status.usesKernelInterface ? "Kernel" : status.netbirdIp ? "Userspace" : "N/A";
             const interfaceIp = status.netbirdIp || "N/A";
 
             const relaysStr = fmtList(

--- a/security/netbird/src/opnsense/mvc/app/views/OPNsense/Netbird/status.volt
+++ b/security/netbird/src/opnsense/mvc/app/views/OPNsense/Netbird/status.volt
@@ -91,7 +91,11 @@
         }
 
         function getPeerConnectionStatus(status) {
-            if (!status) return 'No status available.';
+            // the API answers with an empty result when the daemon cannot be
+            // reached at all, which is not the same as a daemon reporting nothing
+            if (!status || Object.keys(status).length === 0) {
+                return 'No status available. The NetBird daemon may not be running.';
+            }
 
             const fmtConn = ({
                     connected,

--- a/security/netbird/src/opnsense/mvc/app/views/OPNsense/Netbird/status.volt
+++ b/security/netbird/src/opnsense/mvc/app/views/OPNsense/Netbird/status.volt
@@ -144,7 +144,8 @@
             const details = status?.peers?.details || [];
 
             return details.map(peer => {
-                const getOrDefault = (val, def = '-') => val ?? def;
+                // the daemon reports unknown values as empty strings, not as null
+                const getOrDefault = (val, def = '-') => (val === null || val === undefined || val === '') ? def : val;
                 const localIce = getOrDefault(peer.iceCandidateType?.local);
                 const remoteIce = getOrDefault(peer.iceCandidateType?.remote);
                 const localIceEndpoint = getOrDefault(peer.iceCandidateEndpoint?.local);
@@ -165,7 +166,9 @@
                 const lastUpdate = new Date(peer.lastStatusUpdate || 0);
                 const handshake = new Date(peer.lastWireguardHandshake || 0);
 
-                const latency = typeof peer.latency === 'number' ?
+                // a peer that was never reached reports a latency of 0, which is
+                // not a measurement and must not be printed as one
+                const latency = typeof peer.latency === 'number' && peer.latency > 0 ?
                     `${(peer.latency / 1_000_000).toFixed(2)} ms` :
                     '-';
 

--- a/security/netbird/src/opnsense/mvc/app/views/OPNsense/Netbird/status.volt
+++ b/security/netbird/src/opnsense/mvc/app/views/OPNsense/Netbird/status.volt
@@ -30,7 +30,9 @@
 <script>
     $(document).ready(() =>{
         function getElapsedTime(date) {
-            if (!(date instanceof Date) || isNaN(date) || date.getMonth() === 0) return "-";
+            // the daemon reports "never" as the zero time (0001-01-01), and missing
+            // values fall back to the epoch below, so both are treated as unknown
+            if (!(date instanceof Date) || isNaN(date) || date.getTime() <= 0) return "-";
 
             const now = new Date();
             const diff = now - date;

--- a/security/netbird/src/opnsense/mvc/app/views/OPNsense/Netbird/status.volt
+++ b/security/netbird/src/opnsense/mvc/app/views/OPNsense/Netbird/status.volt
@@ -232,33 +232,31 @@
             const $packages = $("#packages");
 
             ajaxGet('/api/core/firmware/info', {}, (data) => {
+                // the endpoint reports every known package, remote ones included,
+                // so entries that are merely available have to be filtered out
                 const pkgs = data.package?.filter(pkg =>
-                    pkg.name?.toLowerCase().includes("netbird")
+                    pkg.installed === '1' && pkg.name?.toLowerCase().includes("netbird")
                 ) || [];
 
-                const rows = pkgs.map(pkg => `
-                <tr>
-                    <td>${pkg.name}</td>
-                    <td>${pkg.version}</td>
-                    <td>${pkg.comment}</td>
-                </tr>
-            `).join("");
+                const $head = $('<tr/>');
+                for (const label of ['Name', 'Version', 'Comment']) {
+                    $head.append($('<th/>').text(label));
+                }
 
-                const table = `
-                <table class="table table-hover table-striped table-condensed">
-                    <thead>
-                        <tr>
-                            <th>Name</th>
-                            <th>Version</th>
-                            <th>Comment</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        ${rows}
-                    </tbody>
-                </table>
-            `;
-                $packages.html(table);
+                const $body = $('<tbody/>');
+                for (const pkg of pkgs) {
+                    $body.append($('<tr/>').append(
+                        $('<td/>').text(pkg.name || ''),
+                        $('<td/>').text(pkg.version || ''),
+                        $('<td/>').text(pkg.comment || '')
+                    ));
+                }
+
+                $packages.empty().append(
+                    $('<table/>')
+                        .addClass('table table-hover table-striped table-condensed')
+                        .append($('<thead/>').append($head), $body)
+                );
             });
         }
 

--- a/security/netbird/src/opnsense/mvc/app/views/OPNsense/Netbird/status.volt
+++ b/security/netbird/src/opnsense/mvc/app/views/OPNsense/Netbird/status.volt
@@ -145,6 +145,8 @@
                 const getOrDefault = (val, def = '-') => val ?? def;
                 const localIce = getOrDefault(peer.iceCandidateType?.local);
                 const remoteIce = getOrDefault(peer.iceCandidateType?.remote);
+                const localIceEndpoint = getOrDefault(peer.iceCandidateEndpoint?.local);
+                const remoteIceEndpoint = getOrDefault(peer.iceCandidateEndpoint?.remote);
 
                 const quantumStatus = peer.quantumResistance ?
                     (status.quantumResistance ? 'true' : 'false (connection might not work without a remote permissive mode)') :
@@ -175,7 +177,7 @@
                     indent(`-- detail --`),
                     indent(`Connection type: ${getOrDefault(peer.connectionType)}`),
                     indent(`ICE candidate (Local/Remote): ${localIce}/${remoteIce}`),
-                    indent(`ICE candidate endpoints (Local/Remote): ${localIce}/${remoteIce}`),
+                    indent(`ICE candidate endpoints (Local/Remote): ${localIceEndpoint}/${remoteIceEndpoint}`),
                     indent(`Relay server address: ${getOrDefault(peer.relayAddress)}`),
                     indent(`Last connection update: ${getElapsedTime(lastUpdate)}`),
                     indent(`Last WireGuard handshake: ${getElapsedTime(handshake)}`),


### PR DESCRIPTION
**Important notices**

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- **Model used:** Claude Opus 5, via Claude Code
- **Extent of AI involvement:** the code, the tests, the commit messages and this description were written by the model working under my direction. Every change was reviewed by me and verified on my own production OPNsense 26.7 router before submission, and the commits carry `Co-Authored-By` trailers.

I did not open an issue first and should have — I am happy to do that now, or to split anything here that is too large to review as a single change. Apologies for submitting without this template filled in; that was my mistake, not a deliberate omission.

---

The status page renders `netbird status --json` into two text blocks, with a
package version table below them. Reading that code against real daemon output
from a running 0.74.4 installation turned up seven places where the page states
something that is not true. All are small and independent, so each is its own
commit.

**1. ICE candidate endpoints showed the candidate types.** Both the "ICE candidate"
and the "ICE candidate endpoints" line were built from `iceCandidateType`; the
daemon reports the endpoints separately in `iceCandidateEndpoint`. The endpoint
addresses are what you look at to tell a direct connection from a relayed one, so
this removed the page's only useful P2P debugging output.

**2. Every timestamp read `-` throughout January.** `getElapsedTime()` rejected any
date with `getMonth() === 0` to catch the daemon's zero time (`0001-01-01`), but
January is month 0. Comparing against the epoch catches the zero time (negative)
and the `|| 0` fallback (exactly 0) without discarding a real month.

**3. The interface type was always reported as "Userspace".** The expression read
`status.kernelInterface`; the daemon emits `usesKernelInterface`, so it always
fell through to the `netbirdIp` branch. Confirmed by feeding a capture with
`usesKernelInterface: true` through the renderer - it still printed "Userspace".

**4. Idle peers were shown with a latency of 0.00 ms.** For peers it has not
dialled, the daemon reports `latency: 0` and empty strings for the ICE candidates
and the relay address. `getOrDefault` used `??`, which does not catch an empty
string. With lazy connections enabled most peers are idle, so the list showed
several peers with `ICE candidate (Local/Remote): /`, an empty relay address, and
the best round trip time in the table.

**5. A stopped daemon rendered as a status table full of `undefined`.** With the
service stopped the CLI writes gRPC dial errors and no JSON, so the API controller
returns an empty result. `getPeerConnectionStatus` only guarded against a falsy
value and an empty array is truthy, so the page showed `Daemon version: undefined`,
`CLI version: undefined`, `FQDN: undefined` and `Forwarding rules: undefined`
instead of saying that the daemon is not running.

**6. Peer names and daemon error strings were injected as markup.** The assembled
text went through `.html()`, and it contains peer FQDNs, relay URIs and error
messages originating from the management server. The table is now built as
elements with the payload set through `.text()`.

**7. The version table listed packages that are not installed.**
`/api/core/firmware/info` returns every known package, remote ones included, and
distinguishes them with an `installed` flag. The table filtered on the name only,
so it showed `os-netbird-devel` next to `os-netbird` on a system where `pkg info`
lists only the latter - two plugin versions that cannot coexist at all, since each
declares the other as a conflict.

Tested on OPNsense with netbird 0.74.4 (userspace bind, lazy connections enabled,
four peers): status page with the tunnel up, after `netbird down`, and with
`service netbird stop`. The renderers were additionally exercised against recorded
`netbird status --json` output for each of those states. The version table change
was checked against `pkg info -x netbird` on the same installation, which lists
`netbird` and `os-netbird` only.

