### PR TITLE
Add conditional SQL configuration for MySQL support

### DIFF
--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/sites-enabled-default
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/sites-enabled-default
@@ -60,6 +60,9 @@ authorize {
 {% else %}
         -sql
 {% endif %}
+{% if helpers.exists('OPNsense.freeradius.general.mysql') and OPNsense.freeradius.general.mysql == '1' %}
+        sql1
+{% endif %}
 {% if helpers.exists('OPNsense.freeradius.general.ldap_enabled') and OPNsense.freeradius.general.ldap_enabled == '1' %}
         ldap
         if ((ok || updated) && User-Password) {


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [X] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [X] I opened an issue first for non-trivial changes and linked it below.
- [] AI tools were used to create at least part of the code submitted herewith.

---
When Remote MySQL is enabled in the FreeRADIUS plugin, OPNsense correctly generates and initializes the sql1 module. The module successfully connects to the configured MySQL/MariaDB database and can also load RADIUS clients from the nas table when read_clients = yes.

However, sql1 is not called from the authorize section of the default virtual server. As a result, the configured remote SQL tables such as radcheck, radreply, radusergroup, radgroupcheck, and radgroupreply are not consulted during authentication and authorization.

This prevents use cases such as SQL-backed MAC authentication and dynamic VLAN assignment, even though the Remote MySQL connection itself is working.

---
Invoke sql1 in the default virtual server's authorize section when Remote MySQL is enabled.

The change adds:
{% if helpers.exists('OPNsense.freeradius.general.mysql') and OPNsense.freeradius.general.mysql == '1' %}
        sql1
{% endif %}
This was tested with an existing Remote MySQL FreeRADIUS database. After adding sql1, FreeRADIUS successfully:

authenticated a user from radcheck
processed radreply
resolved membership through radusergroup
processed radgroupcheck and radgroupreply
returned dynamic VLAN attributes in the Access-Accept, including Tunnel-Type, Tunnel-Medium-Type, and Tunnel-Private-Group-Id

SQL-backed NAS clients via read_clients = yes continue to work as expected.

This pull request intentionally only addresses authorization. Remote MySQL accounting and post-auth integration are separate concerns.

---

Related issue

Related to #5196, which describes another area where Remote MySQL is configured but not fully integrated into the FreeRADIUS processing flow.

This PR specifically addresses Remote MySQL authorization and does not attempt to change accounting behavior.