### PR TITLE
security/netbird: say what the buttons that drop the tunnel do

### DIFF
--- a/security/netbird/Makefile
+++ b/security/netbird/Makefile
@@ -1,6 +1,6 @@
 PLUGIN_NAME=		netbird
 PLUGIN_VERSION=		1.3
-PLUGIN_REVISION=	3
+PLUGIN_REVISION=	4
 PLUGIN_DEPENDS=		netbird
 PLUGIN_COMMENT=		Peer-to-peer VPN that seamlessly connects your devices
 PLUGIN_MAINTAINER=	dev@netbird.io

--- a/security/netbird/pkg-descr
+++ b/security/netbird/pkg-descr
@@ -25,3 +25,5 @@ Plugin Changelog
 * Added IP Mapping option and authentication banner (contributed by Konstantinos Spartalis)
 * Fix quantum peer state display (contributed by Konstantinos Spartalis)
 * Fix setupKey usage after UpdateOnlyTextField introduction
+* Say on the settings page that Apply restarts the daemon and drops the tunnel
+* Ask for confirmation before disconnecting NetBird

--- a/security/netbird/src/opnsense/mvc/app/views/OPNsense/Netbird/authentication.volt
+++ b/security/netbird/src/opnsense/mvc/app/views/OPNsense/Netbird/authentication.volt
@@ -42,10 +42,12 @@
                 let message;
                 let type;
                 if (!isEnabled) {
-                    message = "Enable NetBird first";
+                    message = "{{ lang._('Enable NetBird first') }}";
                     type = "warning";
                 } else {
-                    message = isConnected ? "NetBird is connected" : "NetBird is not connected";
+                    message = isConnected
+                        ? "{{ lang._('NetBird is connected') }}"
+                        : "{{ lang._('NetBird is not connected') }}";
                     type = isConnected ? "info" : "warning";
                 }
 
@@ -91,6 +93,45 @@
         });
 
         $("#disconnectBtn").SimpleActionButton({
+            /*
+             * One click here takes the tunnel offline, and an admin who reaches
+             * this firewall through NetBird is on it. SimpleActionButton has no
+             * confirm of its own; it runs the endpoint when this deferred
+             * resolves, so rejecting it is how the action is called off.
+             */
+            onPreAction: () => {
+                const dfObj = new $.Deferred();
+                BootstrapDialog.show({
+                    type: BootstrapDialog.TYPE_WARNING,
+                    title: "{{ lang._('Disconnect NetBird') }}",
+                    message: "{{ lang._('This takes the tunnel offline. If you are reaching this firewall through NetBird, this session ends here and you will need another way in to reconnect it.') }}",
+                    buttons: [
+                        {
+                            label: "{{ lang._('Cancel') }}",
+                            action: (dialog) => {
+                                /* settle before closing: the onhide below fires on the way out */
+                                dfObj.reject();
+                                dialog.close();
+                            }
+                        },
+                        {
+                            label: "{{ lang._('Disconnect') }}",
+                            cssClass: 'btn-warning',
+                            action: (dialog) => {
+                                dfObj.resolve();
+                                dialog.close();
+                            }
+                        }
+                    ],
+                    /* closing any other way - backdrop, escape, the X - is a decision not to
+                       disconnect; a deferred the buttons already settled ignores this */
+                    onhide: () => {
+                        dfObj.reject();
+                    }
+                });
+
+                return dfObj;
+            },
             onAction: () => {
                 updateServiceControlUI('netbird');
                 updateNetBirdStatusUI();

--- a/security/netbird/src/opnsense/mvc/app/views/OPNsense/Netbird/settings.volt
+++ b/security/netbird/src/opnsense/mvc/app/views/OPNsense/Netbird/settings.volt
@@ -53,4 +53,11 @@
 <div class="content-box">
     {{ partial("layout_partials/base_form",['fields':settingsForm,'id':'frmSettings']) }}
 </div>
-{{ partial('layout_partials/base_apply_button', {'data_endpoint': '/api/netbird/service/reconfigure', 'data_service_widget': 'netbird'}) }}
+{{ partial(
+    'layout_partials/base_apply_button',
+    {
+        'data_endpoint': '/api/netbird/service/reconfigure',
+        'data_service_widget': 'netbird',
+        'data_change_message_content': lang._('Apply restarts the NetBird service: the tunnel goes down and comes back up. If you are reaching this firewall through NetBird, you will lose access for a moment, so make sure you have another way in before applying.')
+    }
+) }}


### PR DESCRIPTION
**Important notices**

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- **Model used:** Claude Opus 5, via Claude Code
- **Extent of AI involvement:** the code, the commit messages and this description were written by the model working under my direction. Every change was reviewed by me and verified on my own production OPNsense 26.7 router before submission. Note that the commits on *this* branch are missing the `Co-Authored-By` trailer that my other pull requests carry — an oversight on my part rather than a distinction; I have left them alone rather than force-push over an open pull request, but will rewrite them if you would prefer that.

I did not open an issue first and should have — I am happy to do that now, or to split anything here that is too large to review as a single change. Apologies for submitting without this template filled in; that was my mistake, not a deliberate omission.

---

Two buttons in this plugin take the tunnel down, and neither says so.

The plugin is typically installed on a router, which means the admin using it may well be reaching that router *through* NetBird. Both of these are then a way to cut the connection you are sitting on, with no undo from the far side.

**Apply, on the Settings page.** `ApiMutableServiceControllerBase::reconfigureAction()` runs `netbird stop`, regenerates `/etc/rc.conf.d/netbird` and runs `netbird start` — `reconfigureForceRestart()` returns 1 by default and this plugin does not override it. The tunnel drops and re-establishes. The page showed the stock "After changing settings, please remember to apply them."

This uses `data_change_message_content`, the slot the apply partial already provides, the same way seven other plugin views in this repository explain what their Apply does.

**Disconnect, on the Authentication page.** One click ran `netbird down` with no confirmation. Apply at least requires an unsaved change first; this required nothing.

`SimpleActionButton` has no confirm option, but it only calls the endpoint once `onPreAction`'s deferred resolves, so a dialog that rejects on every exit except the confirm button is the intended shape. Closing by backdrop or escape counts as saying no.

**Also in here:** three status strings on the Authentication page (`"Enable NetBird first"`, `"NetBird is connected"`, `"NetBird is not connected"`) were plain JavaScript literals and stayed English regardless of the GUI language. They go through `lang._()` now.

No behaviour changes beyond the one confirmation dialog. No model, endpoint or configd changes.

**Tested** on an OPNsense 26.7 router running NetBird 0.74.4 against a self-hosted management server: the Apply warning renders and is accurate (the tunnel drops and returns); the Disconnect dialog confirms, cancels cleanly without calling the endpoint, and treats dismissal as cancel; the tunnel and LAN routing are unaffected.

