### PR TITLE
security/netbird: make the daemon configuration write survivable, and fix a setting that never applied

### DIFF
--- a/security/netbird/Makefile
+++ b/security/netbird/Makefile
@@ -1,6 +1,6 @@
 PLUGIN_NAME=		netbird
 PLUGIN_VERSION=		1.3
-PLUGIN_REVISION=	3
+PLUGIN_REVISION=	4
 PLUGIN_DEPENDS=		netbird
 PLUGIN_COMMENT=		Peer-to-peer VPN that seamlessly connects your devices
 PLUGIN_MAINTAINER=	dev@netbird.io

--- a/security/netbird/pkg-descr
+++ b/security/netbird/pkg-descr
@@ -26,3 +26,4 @@ Plugin Changelog
 * Fix quantum peer state display (contributed by Konstantinos Spartalis)
 * Fix setupKey usage after UpdateOnlyTextField introduction
 * Replace the daemon configuration atomically so a failed write cannot lose the peer identity
+* Write external IP mappings to NATExternalIPs, the key the daemon actually reads

--- a/security/netbird/pkg-descr
+++ b/security/netbird/pkg-descr
@@ -25,3 +25,4 @@ Plugin Changelog
 * Added IP Mapping option and authentication banner (contributed by Konstantinos Spartalis)
 * Fix quantum peer state display (contributed by Konstantinos Spartalis)
 * Fix setupKey usage after UpdateOnlyTextField introduction
+* Replace the daemon configuration atomically so a failed write cannot lose the peer identity

--- a/security/netbird/src/opnsense/mvc/app/models/OPNsense/Netbird/ConfigFile.php
+++ b/security/netbird/src/opnsense/mvc/app/models/OPNsense/Netbird/ConfigFile.php
@@ -1,0 +1,158 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Benny <bxnny@bxnny.de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\Netbird;
+
+/**
+ * Reading and replacing the NetBird daemon's configuration file.
+ *
+ * The file holds the peer's WireGuard private key, so losing it costs an
+ * enrolment rather than a setting. Every replacement therefore goes through a
+ * sibling temporary file and rename(), which POSIX requires to be atomic: a
+ * reader sees the whole old file or the whole new one, never a truncated one.
+ *
+ * Deliberately free of OPNsense classes, so it can be tested without the
+ * framework - the same reason StatusReport is.
+ */
+class ConfigFile
+{
+    /** kept next to the target, holding what was there before the last write */
+    public const BACKUP_SUFFIX = '.bak';
+
+    /** written, flushed and renamed over the target; never left behind */
+    public const TEMP_SUFFIX = '.tmp';
+
+    /** used when the target does not exist yet and has no mode to inherit */
+    public const FALLBACK_MODE = 0600;
+
+    /**
+     * @throws \RuntimeException with a message saying which of the failures it was
+     */
+    public static function read(string $target): array
+    {
+        if (!is_file($target)) {
+            throw new \RuntimeException("there is no configuration at $target yet");
+        }
+
+        $raw = @file_get_contents($target);
+        if ($raw === false) {
+            throw new \RuntimeException("the configuration at $target cannot be read");
+        }
+
+        $config = json_decode($raw, true);
+        if (!is_array($config)) {
+            throw new \RuntimeException("the configuration at $target cannot be decoded: " . json_last_error_msg());
+        }
+
+        return $config;
+    }
+
+    /**
+     * Replace $target with $config, or leave $target exactly as it was.
+     *
+     * @throws \RuntimeException
+     */
+    public static function write(string $target, array $config): void
+    {
+        $encoded = json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        if ($encoded === false) {
+            throw new \RuntimeException('the new configuration cannot be encoded: ' . json_last_error_msg());
+        }
+
+        $mode = self::modeOf($target);
+        $temp = $target . self::TEMP_SUFFIX;
+
+        try {
+            /* the backup goes first: if it cannot be written, nothing has been replaced yet */
+            $previous = is_file($target) ? @file_get_contents($target) : false;
+            if ($previous !== false) {
+                self::put($target . self::BACKUP_SUFFIX, $previous, $mode);
+            }
+
+            self::put($temp, $encoded, $mode);
+
+            if (!@rename($temp, $target)) {
+                throw new \RuntimeException("the new configuration cannot be moved into place at $target");
+            }
+        } finally {
+            if (is_file($temp)) {
+                @unlink($temp);
+            }
+        }
+    }
+
+    /**
+     * The target's own mode, so a private key never widens on the way through.
+     */
+    private static function modeOf(string $target): int
+    {
+        $mode = @fileperms($target);
+
+        return $mode === false ? self::FALLBACK_MODE : ($mode & 0777);
+    }
+
+    /**
+     * Write one file, restrictively from the first byte and flushed to disk.
+     *
+     * The umask matters: a fresh file is created with the process umask, which
+     * on this platform is wide enough to expose the key for as long as the
+     * write takes. chmod() afterwards would close a door that was already open.
+     */
+    private static function put(string $path, string $contents, int $mode): void
+    {
+        $previousUmask = umask(0077);
+
+        try {
+            $handle = @fopen($path, 'wb');
+            if ($handle === false) {
+                throw new \RuntimeException("cannot create $path");
+            }
+
+            try {
+                if (@fwrite($handle, $contents) !== strlen($contents)) {
+                    throw new \RuntimeException("cannot write all of $path");
+                }
+                if (!@fflush($handle)) {
+                    throw new \RuntimeException("cannot flush $path");
+                }
+                /* fsync() exists from PHP 8.1; without it the rename can outrun the data */
+                if (function_exists('fsync') && !@fsync($handle)) {
+                    throw new \RuntimeException("cannot sync $path to disk");
+                }
+            } finally {
+                @fclose($handle);
+            }
+        } finally {
+            umask($previousUmask);
+        }
+
+        if (!@chmod($path, $mode)) {
+            throw new \RuntimeException("cannot set the mode on $path");
+        }
+    }
+}

--- a/security/netbird/src/opnsense/mvc/app/models/OPNsense/Netbird/ConfigFile.php
+++ b/security/netbird/src/opnsense/mvc/app/models/OPNsense/Netbird/ConfigFile.php
@@ -107,6 +107,27 @@ class ConfigFile
     }
 
     /**
+     * A comma-separated field as the daemon's list of strings.
+     *
+     * An empty field is an empty list, not null and not a list holding one
+     * empty string: to a Go []string those are three different things, and
+     * only the first one means "no entries".
+     */
+    public static function listOf(string $value): array
+    {
+        $items = [];
+
+        foreach (explode(',', $value) as $item) {
+            $item = trim($item);
+            if ($item !== '') {
+                $items[] = $item;
+            }
+        }
+
+        return $items;
+    }
+
+    /**
      * The target's own mode, so a private key never widens on the way through.
      */
     private static function modeOf(string $target): int

--- a/security/netbird/src/opnsense/mvc/app/models/OPNsense/Netbird/Settings.php
+++ b/security/netbird/src/opnsense/mvc/app/models/OPNsense/Netbird/Settings.php
@@ -46,7 +46,9 @@ class Settings extends BaseModel
 
         $config["WgPort"] = (int)$this->general->wireguardPort->__toString();
         $config["ServerSSHAllowed"] = $this->ssh->enable->__toString() == 1;
-        $config["IpMapping"] = $this->general->ipmapping->__toString();
+        /* the daemon has never had an IpMapping key; the field this describes is NATExternalIPs */
+        $config["NATExternalIPs"] = ConfigFile::listOf($this->general->ipmapping->__toString());
+        unset($config["IpMapping"]);
         $config["EnableSSHRoot"] = $this->ssh->enableRoot->__toString() == 1;
         $config["EnableSSHSFTP"] = $this->ssh->enableSFTP->__toString() == 1;
         $config["EnableSSHLocalPortForwarding"] = $this->ssh->enableLocalPortForwarding->__toString() == 1;

--- a/security/netbird/src/opnsense/mvc/app/models/OPNsense/Netbird/Settings.php
+++ b/security/netbird/src/opnsense/mvc/app/models/OPNsense/Netbird/Settings.php
@@ -37,10 +37,10 @@ class Settings extends BaseModel
 {
     public function syncConfig($target = '/var/db/netbird/config.json')
     {
-        $config = json_decode(file_get_contents($target), true);
-        if (!is_array($config)) {
-            $jsonError = json_last_error_msg();
-            syslog(LOG_ERR, "netbird: failed to decode configuration: $jsonError");
+        try {
+            $config = ConfigFile::read($target);
+        } catch (\RuntimeException $e) {
+            syslog(LOG_ERR, 'netbird: ' . $e->getMessage() . '; the settings were not applied');
             return;
         }
 
@@ -61,10 +61,10 @@ class Settings extends BaseModel
         $config["RosenpassEnabled"] = $this->postquantum->enableRosenpass->__toString() == 1;
         $config["RosenpassPermissive"] = $this->postquantum->rosenpassPermissive->__toString() == 1;
 
-
-        $result = file_put_contents($target, json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
-        if ($result === false) {
-            syslog(LOG_ERR, "netbird: failed to write updated configuration to $target");
+        try {
+            ConfigFile::write($target, $config);
+        } catch (\RuntimeException $e) {
+            syslog(LOG_ERR, 'netbird: ' . $e->getMessage() . '; the previous configuration is unchanged');
         }
     }
 }


### PR DESCRIPTION
**Important notices**

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- **Model used:** Claude Opus 5, via Claude Code
- **Extent of AI involvement:** the code, the tests, the commit messages and this description were written by the model working under my direction. Every change was reviewed by me and verified on my own production OPNsense 26.7 router before submission, and the commits carry `Co-Authored-By` trailers.

I did not open an issue first and should have — I am happy to do that now, or to split anything here that is too large to review as a single change. Apologies for submitting without this template filled in; that was my mistake, not a deliberate omission.

---

Two defects in the same function, both about `/var/db/netbird/config.json` — the file that holds the peer's WireGuard private key.

### 1. The write was not atomic

`syncConfig()` read the file, changed sixteen keys and wrote it back with `file_put_contents()`, which truncates and then writes. Any interrupted write — a full `/var`, a power cut — leaves the file short, and there is no other copy of that key on the box. The cost is not a wrong setting; it is re-enrolling the firewall by hand from the console.

The new content now goes to a sibling temporary file, is flushed with `fsync()` and renamed over the target. Both the temporary file and the `config.json.bak` it leaves behind are created under `umask 0077` and then given the target's own mode, so the key never widens on the way through — a `chmod()` afterwards would be closing a door that was already open.

The read path also says which failure it hit. A missing configuration and a corrupt one shared one log line; they are different problems and only one of them is recoverable by hand.

### 2. `IpMapping` is not a NetBird configuration key

Settings → General → **Force IP Mapping** validates, saves, survives Apply and lands in `config.json` as `"IpMapping"`. NetBird has no such field — not in `v0.74.4`, not in `v0.60.0`, `v0.45.0` or `v0.30.0` — and a code search over `netbirdio/netbird` matches the substring only inside the function name `parseNATExternalIPMappings`. Go's `encoding/json` drops unknown keys, so the daemon has been reading the file and ignoring that line ever since the setting was added.

Read as names and types only, the key set of a live `config.json` and the persisted fields of NetBird's `Config` struct at `v0.74.4` agree on **36 of 37 names**. `IpMapping` is the one the daemon does not know.

The field the help text describes is `NATExternalIPs`, set on the CLI with `--external-ip-map`. The help text gives its three forms correctly, down to the examples, so the feature was understood — only its destination was not. Two things were wrong: the name **and** the type, since the daemon wants a list of strings rather than a comma-separated one.

**Worth flagging for the changelog:** anyone who has filled that field in has had a setting that did nothing, and after this it does something.

### Testing

Both changes were verified on a live 26.7 router (`os-netbird` built from this branch, daemon 0.74.4):

- Apply leaves a `config.json.bak` byte-for-byte the size of the previous configuration, both `0600`, and `netbird status` afterwards shows management and signal connected — the daemon keeps its identity.
- `jq '{IpMapping, NATExternalIPs}' /var/db/netbird/config.json` → `{"IpMapping": null, "NATExternalIPs": []}`.

`ConfigFile` is deliberately free of OPNsense classes so it can be exercised without the framework, and I have unit tests for it — the atomic replacement, the backup, the mode, the failure paths and the list splitting. They are **not** in this diff, because no plugin in this repository ships a `tests/` directory and there is no CI to run them; I did not want to introduce a convention as a side effect of a bugfix. Happy to add them in whatever shape you would want them, or to leave them out.

Checked against `phpcs --standard=<core>/ruleset.xml`: no new errors or warnings.

