### PR TITLE
[os-intrusion-detection-content-at-antiphishing] Changing dataset extensions and calls for compatibility #5675

### DIFF
--- a/security/intrusion-detection-content-at-antiphishing/src/opnsense/scripts/suricata/metadata/rules/julioliraup-antiphing.xml
+++ b/security/intrusion-detection-content-at-antiphishing/src/opnsense/scripts/suricata/metadata/rules/julioliraup-antiphing.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ruleset documentation_url="https://github.com/julioliraup/Antiphishing">
-  <location url="https://raw.githubusercontent.com/julioliraup/Antiphishing/main/antiphishing.tar.gz"/>
+  <location url="https://github.com/julioliraup/Antiphishing/releases/latest/download/antiphishing-opnsense.tar.gz"/>
   <files>
     <file url="inline::antiphishing.rules" description="julioliraup/Antiphishing">antiphishing.rules</file>
+    <file url="inline::phishing.rules" description="Antiphishing Domains Dataset">phishing.rules</file>
+    <file url="inline::phishing_ips.rules" description="Antiphishing IPs Dataset">phishing_ips.rules</file>
   </files>
 </ruleset>

--- a/security/intrusion-detection-content-at-antiphishing/src/opnsense/scripts/suricata/metadata/rules/julioliraup-antiphing.xml
+++ b/security/intrusion-detection-content-at-antiphishing/src/opnsense/scripts/suricata/metadata/rules/julioliraup-antiphing.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ruleset documentation_url="https://github.com/julioliraup/Antiphishing">
-  <location url="https://raw.githubusercontent.com/julioliraup/Antiphishing/main/antiphishing.tar.gz" prefix="julioliraup/Antiphishing"/>
+  <location url="https://raw.githubusercontent.com/julioliraup/Antiphishing/main/antiphishing.tar.gz"/>
   <files>
     <file url="inline::antiphishing.rules" description="julioliraup/Antiphishing">antiphishing.rules</file>
   </files>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

Datasets dont loads

---

**Describe the proposed solution**

Change dataset extensions for load on path with [.rules](https://github.com/opnsense/core/blob/master/src/opnsense/scripts/suricata/lib/rulecache.py#L55)

---

**Related issue**

[#5675](https://github.com/opnsense/plugins/issues/5675)
