### PR TITLE
security/maltrail: don't override the Check Hostheaders setting

### DIFF
--- a/security/maltrail/src/opnsense/service/templates/OPNsense/Maltrail/maltrail.conf
+++ b/security/maltrail/src/opnsense/service/templates/OPNsense/Maltrail/maltrail.conf
@@ -59,7 +59,6 @@ CHECK_MISSING_HOST false
 {% if helpers.exists('OPNsense.maltrail.general.whitelist') and OPNsense.maltrail.general.whitelist != '' %}
 USER_WHITELIST /usr/local/share/maltrail/misc/user_whitelist.txt
 {% endif %}
-CHECK_HOST_DOMAINS false
 SHOW_DEBUG false
 LOG_DIR /var/log/maltrail
 {% if helpers.exists('OPNsense.maltrail.general.monitorinterface') and OPNsense.maltrail.general.monitorinterface != '' %}


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: Claude Opus 5 (via Claude Code)
- Extent of AI involvement: used to locate the offending line, to check maltrail upstream
  (`core/settings.py`) for the duplicate-key behaviour, and to trace the template history.
  The fix is the one-line deletion proposed by the reporter in #5489. I reviewed and verified
  each of those points before opening this PR.

---

**Describe the problem**

`CHECK_HOST_DOMAINS` is emitted twice in the generated `maltrail.conf`: once from the
`checkhostheader` conditional, and again a few lines below as a hardcoded `false`.

maltrail's `read_config()` walks the file top to bottom and ends each iteration with a plain
`config[name] = value`, with no guard, so the last occurrence wins. The trailing hardcoded line
therefore always overrides the GUI setting and pins `CHECK_HOST_DOMAINS` to `false`.

The hardcoded line dates back to the initial template. The conditional block was later inserted
directly above it in cdf3620 ("security/maltrail: add hostheader checking", #3144) without removing
it, so *Services -> Maltrail -> General -> Check Hostheaders* has had no effect since the option was
introduced.

---

**Describe the proposed solution**

Drop the leftover hardcoded `CHECK_HOST_DOMAINS false` so the emitted value is the one selected in
the GUI. This is the fix suggested by @thwien in the issue.

Users who had the toggle off are unaffected (the conditional still emits `false`); users who had it
on now get the `true` they asked for.

I left `PLUGIN_REVISION` alone, assuming the bump is done on your side as usual - happy to add it if
you prefer.

---

**Related issue**

Closes #5489
