### PR TITLE
security/acme-client: add support for FreeMyIP DNS API

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -564,6 +564,16 @@
         <type>password</type>
     </field>
     <field>
+        <label>FreeMyIP</label>
+        <type>header</type>
+        <style>table_dns table_dns_freemyip</style>
+    </field>
+    <field>
+        <id>validation.dns_freemyip_token</id>
+        <label>Token</label>
+        <type>password</type>
+    </field>
+    <field>
         <label>Fornex</label>
         <type>header</type>
         <style>table_dns table_dns_fornex</style>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsFreeMyIp.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsFreeMyIp.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Leonardo de macedo Sartorello
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\AcmeClient\LeValidation;
+
+use OPNsense\AcmeClient\LeValidationInterface;
+use OPNsense\Core\Config;
+
+/**
+ * FreeMyIp DNS API
+ * @package OPNsense\AcmeClient
+ */
+class DnsFreeMyIp extends Base implements LeValidationInterface
+{
+    public function prepare()
+    {
+        $this->acme_env['FREEMYIP_Token'] = (string)$this->config->dns_freemyip_token;
+    }
+}

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -468,6 +468,7 @@
                         <dns_exoscale>Exoscale</dns_exoscale>
                         <dns_fornex>Fornex</dns_fornex>
                         <dns_freedns>FreeDNS</dns_freedns>
+                        <dns_freemyip>FreeMyIp</dns_freemyip>
                         <dns_gandi_livedns>Gandi LiveDNS</dns_gandi_livedns>
                         <dns_gd>GoDaddy.com</dns_gd>
                         <dns_gcloud>Google Cloud DNS</dns_gcloud>
@@ -722,6 +723,9 @@
                 <dns_freedns_password type="TextField">
                     <Required>N</Required>
                 </dns_freedns_password>
+                <dns_freemyip_token type="TextField">
+                    <Required>N</Required>
+                </dns_freemyip_token>
                 <dns_fornex_api_key type="TextField">
                     <Required>N</Required>
                 </dns_fornex_api_key>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -468,7 +468,7 @@
                         <dns_exoscale>Exoscale</dns_exoscale>
                         <dns_fornex>Fornex</dns_fornex>
                         <dns_freedns>FreeDNS</dns_freedns>
-                        <dns_freemyip>FreeMyIp</dns_freemyip>
+                        <dns_freemyip>FreeMyIP</dns_freemyip>
                         <dns_gandi_livedns>Gandi LiveDNS</dns_gandi_livedns>
                         <dns_gd>GoDaddy.com</dns_gd>
                         <dns_gcloud>Google Cloud DNS</dns_gcloud>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [X] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

acme.sh supports FreeMyIP as of v3.1.2 but acme-client does not support it yet

---

**Describe the proposed solution**

Add FreeMyIP support to acme plugin

---

**Related issue**

https://github.com/acmesh-official/acme.sh/issues/6247
https://github.com/acmesh-official/acme.sh/pull/6240
