### PR TITLE
Add OPNsense-compatible Antiphishing ruleset without DNS/TLS datasets #5675

### DIFF
--- a/security/intrusion-detection-content-at-antiphishing/src/opnsense/scripts/suricata/metadata/rules/julioliraup-antiphing.xml
+++ b/security/intrusion-detection-content-at-antiphishing/src/opnsense/scripts/suricata/metadata/rules/julioliraup-antiphing.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ruleset documentation_url="https://github.com/julioliraup/Antiphishing">
-  <location url="https://raw.githubusercontent.com/julioliraup/Antiphishing/main/antiphishing.tar.gz"/>
+<ruleset documentation_url="https://github.com/julioliraup/Antiphishing/wiki">
+  <location url="https://julioliraup.github.io/AT/"/>
   <files>
-    <file url="inline::antiphishing.rules" description="julioliraup/Antiphishing">antiphishing.rules</file>
+    <file url="https://github.com/julioliraup/Antiphishing/releases/latest/download/antiphishing-opnsense.rules" description="julioliraup/Antiphishing">antiphishing.rules</file>
   </files>
 </ruleset>


### PR DESCRIPTION
**Important notices**

* [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
* [x] I opened an issue first for non-trivial changes and linked it below.
* [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

---

**Describe the problem**

The Antiphishing ruleset uses external Suricata datasets for DNS, TLS, and IPv4 detection.

The current OPNsense IDS content integration does not provide a uniform mechanism for installing and making these external dataset files available to Suricata. As a result, the dataset-based signatures cannot be loaded correctly when the standard `antiphishing.rules` file is used.

An alternative approach of renaming the dataset files to `.rules` was tested, but this is not suitable because OPNsense processes `.rules` files as Suricata signature files rather than as auxiliary dataset files.

Another approach was tested by converting the 241k-domain dataset into conventional DNS/TLS signatures. This caused Suricata to exhaust the available memory during startup on the OPNsense test environment and the kernel terminated the Suricata process:

`suricata, was killed: failed to reclaim memory`

Since IDS stability is more important than forcing the complete external dataset into the current OPNsense content framework, a smaller OPNsense-specific ruleset is proposed as an interim solution.

---

**Describe the proposed solution**

This pull request adds an OPNsense-specific `antiphishing-opnsense.rules` ruleset.

The OPNsense variant:

* preserves the existing HTTP signatures;
* adds IPv4 phishing intelligence directly to the rule without requiring an external `.lst` dataset;
* does not require the external DNS/TLS datasets;
* avoids converting the large DNS/TLS dataset into hundreds of thousands of individual signatures or PCRE patterns;
* keeps the upstream Antiphishing ruleset and its native Suricata dataset implementation unchanged.

The IPv4 indicators are currently compiled into a single destination-IP group, avoiding the need for an external `phishing_ips.lst` file in the OPNsense installation.

DNS/TLS dataset support is intentionally not included in this variant for now. This is an interim compatibility approach while a more appropriate and memory-efficient method for external Suricata datasets on OPNsense is investigated.

The goal is to provide a stable OPNsense-compatible ruleset rather than ship a configuration that can cause Suricata to fail during reload or startup.

---

**Related issue**

https://github.com/opnsense/plugins/issues/5675
