### PR TITLE
www/nginx: make upstream client-address headers configurable

### DIFF
--- a/www/nginx/Makefile
+++ b/www/nginx/Makefile
@@ -1,6 +1,6 @@
 PLUGIN_NAME=		nginx
 PLUGIN_VERSION=		1.36
-PLUGIN_REVISION=	5
+PLUGIN_REVISION=	6
 PLUGIN_COMMENT=		Nginx HTTP server and reverse proxy
 PLUGIN_DEPENDS=		nginx
 PLUGIN_MAINTAINER=	franz.fabian.94@gmail.com

--- a/www/nginx/pkg-descr
+++ b/www/nginx/pkg-descr
@@ -12,6 +12,7 @@ Plugin Changelog
 
 * Add optional HTTP/3 support with dynamic Alt-Svc (contributed by Jan Chlouba)
 * Fix HTTP/3 reuseport duplicates (contributed by Jan Chlouba)
+* Make upstream client-address headers configurable (X-Forwarded-For, Forwarded, CF-/True-Client-IP)
 
 1.35
 

--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/upstream.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/upstream.xml
@@ -63,7 +63,7 @@
     <style>selectpicker</style>
     <type>dropdown</type>
     <advanced>true</advanced>
-    <help>Controls the X-Forwarded-For header sent to the upstream. Append (default) keeps the existing chain via $proxy_add_x_forwarded_for. Replace sends only the validated client address ($remote_addr after trusted-proxy / real_ip processing). Drop suppresses the header. Use Replace with Forwarded Replace and Suppress CF-/True-Client-IP when nginx should act as a strict client-IP trust boundary.</help>
+    <help>Append (default) keeps the X-Forwarded-For chain via $proxy_add_x_forwarded_for. Replace sends only the validated client address ($remote_addr). Drop suppresses the header.</help>
   </field>
   <field>
     <id>upstream.forwarded_header_mode</id>
@@ -71,12 +71,12 @@
     <style>selectpicker</style>
     <type>dropdown</type>
     <advanced>true</advanced>
-    <help>Controls the RFC 7239 Forwarded header sent to the upstream. Preserve (default) leaves any client-supplied Forwarded header unchanged. Replace overwrites it with a sanitized value derived from $remote_addr and $scheme (IPv6 is quoted per RFC 7239). Drop suppresses the header. Without Replace or Drop, backends that prefer Forwarded over X-Real-IP may accept a spoofed client address.</help>
+    <help>Preserve (default) leaves a client-supplied Forwarded header unchanged. Replace sets a sanitized RFC 7239 value from $remote_addr and $scheme. Drop suppresses the header. Backends that prefer Forwarded may otherwise accept a spoofed address.</help>
   </field>
   <field>
     <id>upstream.suppress_client_headers</id>
     <label>Suppress CF-/True-Client-IP</label>
-    <help>Clear CF-Connecting-IP and True-Client-IP before proxying so provider-specific client identity headers cannot bypass the validated $remote_addr trust boundary.</help>
+    <help>Clear CF-Connecting-IP and True-Client-IP before proxying so they cannot bypass the validated client address.</help>
     <advanced>true</advanced>
     <type>checkbox</type>
   </field>

--- a/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/upstream.xml
+++ b/www/nginx/src/opnsense/mvc/app/controllers/OPNsense/Nginx/forms/upstream.xml
@@ -58,6 +58,29 @@
     <type>checkbox</type>
   </field>
   <field>
+    <id>upstream.xff_header_mode</id>
+    <label>XFF: Mode</label>
+    <style>selectpicker</style>
+    <type>dropdown</type>
+    <advanced>true</advanced>
+    <help>Controls the X-Forwarded-For header sent to the upstream. Append (default) keeps the existing chain via $proxy_add_x_forwarded_for. Replace sends only the validated client address ($remote_addr after trusted-proxy / real_ip processing). Drop suppresses the header. Use Replace with Forwarded Replace and Suppress CF-/True-Client-IP when nginx should act as a strict client-IP trust boundary.</help>
+  </field>
+  <field>
+    <id>upstream.forwarded_header_mode</id>
+    <label>Forwarded: Mode</label>
+    <style>selectpicker</style>
+    <type>dropdown</type>
+    <advanced>true</advanced>
+    <help>Controls the RFC 7239 Forwarded header sent to the upstream. Preserve (default) leaves any client-supplied Forwarded header unchanged. Replace overwrites it with a sanitized value derived from $remote_addr and $scheme (IPv6 is quoted per RFC 7239). Drop suppresses the header. Without Replace or Drop, backends that prefer Forwarded over X-Real-IP may accept a spoofed client address.</help>
+  </field>
+  <field>
+    <id>upstream.suppress_client_headers</id>
+    <label>Suppress CF-/True-Client-IP</label>
+    <help>Clear CF-Connecting-IP and True-Client-IP before proxying so provider-specific client identity headers cannot bypass the validated $remote_addr trust boundary.</help>
+    <advanced>true</advanced>
+    <type>checkbox</type>
+  </field>
+  <field>
     <id>upstream.tls_enable</id>
     <label>Enable TLS (HTTPS)</label>
     <help>Use TLS (HTTPS) to connect to the server.</help>

--- a/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
+++ b/www/nginx/src/opnsense/mvc/app/models/OPNsense/Nginx/Nginx.xml
@@ -1,6 +1,6 @@
 <model>
     <mount>//OPNsense/Nginx</mount>
-    <version>1.35.2</version>
+    <version>1.35.3</version>
     <description>nginx web server, reverse proxy and waf</description>
     <items>
         <general>
@@ -131,6 +131,28 @@
                 <Default>0</Default>
                 <Required>Y</Required>
             </x_forwarded_host_verbatim>
+            <xff_header_mode type="OptionField">
+                <OptionValues>
+                    <append>Append</append>
+                    <replace>Replace</replace>
+                    <drop>Drop</drop>
+                </OptionValues>
+                <Required>Y</Required>
+                <Default>append</Default>
+            </xff_header_mode>
+            <forwarded_header_mode type="OptionField">
+                <OptionValues>
+                    <preserve>Preserve</preserve>
+                    <replace>Replace</replace>
+                    <drop>Drop</drop>
+                </OptionValues>
+                <Required>Y</Required>
+                <Default>preserve</Default>
+            </forwarded_header_mode>
+            <suppress_client_headers type="BooleanField">
+                <Default>0</Default>
+                <Required>Y</Required>
+            </suppress_client_headers>
             <proxy_protocol type="BooleanField">
                 <Default>0</Default>
                 <Required>Y</Required>

--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/http.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/http.conf
@@ -72,6 +72,16 @@ map $ssl_server_name $upstream_sni_name {
     '' $host;
 }
 
+# Maps used in location.conf for RFC 7239 Forwarded header
+map $remote_addr $forwarded_for {
+    ~^[0-9.]+$          "for=$remote_addr";
+    ~^[0-9A-Fa-f:.]+$   "for=\"[$remote_addr]\"";
+    default             "for=unknown";
+}
+map $scheme $proxy_forwarded {
+    default "$forwarded_for;proto=$scheme";
+}
+
 include http_post/*.conf;
 
 # TODO add when core is ready for allowing nginx to serve the web interface

--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/http.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/http.conf
@@ -72,6 +72,13 @@ map $ssl_server_name $upstream_sni_name {
     '' $host;
 }
 
+{% set need_forwarded_map = [] %}
+{% for upstream in helpers.toList('OPNsense.Nginx.upstream') %}
+{%   if upstream.forwarded_header_mode is defined and upstream.forwarded_header_mode == 'replace' %}
+{%     do need_forwarded_map.append(1) %}
+{%   endif %}
+{% endfor %}
+{% if need_forwarded_map %}
 # Maps used in location.conf for RFC 7239 Forwarded header
 map $remote_addr $forwarded_for {
     ~^[0-9.]+$          "for=$remote_addr";
@@ -81,6 +88,7 @@ map $remote_addr $forwarded_for {
 map $scheme $proxy_forwarded {
     default "$forwarded_for;proto=$scheme";
 }
+{% endif %}
 
 include http_post/*.conf;
 

--- a/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/location.conf
+++ b/www/nginx/src/opnsense/service/templates/OPNsense/Nginx/location.conf
@@ -176,10 +176,25 @@ location {{ location.matchtype }} {{ location.urlpattern }} {
     proxy_set_header Early-Data $ssl_early_data;
 {%   endif %}
     proxy_set_header X-Real-IP $remote_addr;
+{%   if upstream.xff_header_mode is defined and upstream.xff_header_mode == 'replace' %}
+    proxy_set_header X-Forwarded-For $remote_addr;
+{%   elif upstream.xff_header_mode is defined and upstream.xff_header_mode == 'drop' %}
+    proxy_set_header X-Forwarded-For "";
+{%   else %}
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+{%   endif %}
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Forwarded-Port $server_port;
     proxy_set_header X-Forwarded-Host {% if upstream.x_forwarded_host_verbatim is defined and upstream.x_forwarded_host_verbatim == '1'%}$http_host{% else %}$host{% endif %};
+{%   if upstream.forwarded_header_mode is defined and upstream.forwarded_header_mode == 'replace' %}
+    proxy_set_header Forwarded $proxy_forwarded;
+{%   elif upstream.forwarded_header_mode is defined and upstream.forwarded_header_mode == 'drop' %}
+    proxy_set_header Forwarded "";
+{%   endif %}
+{%   if upstream.suppress_client_headers is defined and upstream.suppress_client_headers == '1' %}
+    proxy_set_header CF-Connecting-IP "";
+    proxy_set_header True-Client-IP "";
+{%   endif %}
     proxy_set_header X-TLS-Client-Intercepted $tls_intercepted;
 {%   if location.proxy_read_timeout is defined and location.proxy_read_timeout != '' %}
     proxy_read_timeout {{ location.proxy_read_timeout }}s;


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: Cursor Grok 4.5
- Extent of AI involvement: Assisted with implementation planning, model/form/template edits for the new Upstream options, and drafting this pull request text. Changes were reviewed and adjusted by the author.

---

**Describe the problem**

The `www/nginx` plugin hardcodes upstream client-address headers in `location.conf` (`X-Real-IP`, `X-Forwarded-For` via `$proxy_add_x_forwarded_for`, etc.). There is no GUI option to change or disable `X-Forwarded-For`, no control over RFC 7239 `Forwarded`, and provider headers such as `CF-Connecting-IP` / `True-Client-IP` are passed through unchanged.

With trusted proxies and `real_ip_header`, `$remote_addr` is the validated client address, but `$proxy_add_x_forwarded_for` can still preserve a client-supplied chain, and an unsanitized `Forwarded` header can be preferred by backends over `X-Real-IP`. Existing include hooks cannot safely replace these location-level `proxy_set_header` directives without duplicates.

---

**Describe the proposed solution**

Add Upstream advanced options next to the existing `x_forwarded_host_verbatim` setting:

- `XFF: Mode` — Append (default), Replace (`$remote_addr`), or Drop
- `Forwarded: Mode` — Preserve (default), Replace (sanitized RFC 7239 from `$remote_addr` + `$scheme`), or Drop
- `Suppress CF-/True-Client-IP` — clear those headers before proxying

Defaults keep the current behavior. Generated config emits at most one `proxy_set_header` per header name. RFC 7239 maps are only generated when an upstream uses Forwarded Replace.

---

**Related issue**

https://github.com/opnsense/plugins/issues/5684