### PR TITLE
:tada: Add OPNsense-specific Antiphishing ruleset with dataset support

### DIFF
--- a/security/intrusion-detection-content-at-antiphishing/src/opnsense/scripts/suricata/metadata/rules/julioliraup-antiphing.xml
+++ b/security/intrusion-detection-content-at-antiphishing/src/opnsense/scripts/suricata/metadata/rules/julioliraup-antiphing.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
+
 <ruleset documentation_url="https://github.com/julioliraup/Antiphishing">
-  <location url="https://raw.githubusercontent.com/julioliraup/Antiphishing/main/antiphishing.tar.gz"/>
+  <location
+    url="https://github.com/julioliraup/Antiphishing/raw/refs/heads/main/antiphishing-opnsense.tar.gz"
+    prefix="julioliraup"/>
   <files>
-    <file url="inline::antiphishing.rules" description="julioliraup/Antiphishing">antiphishing.rules</file>
+    <file url="inline::antiphishing-opnsense.rules" description="antiphishing">antiphishing-opnsense.rules</file>
+    <file url="inline::phishing.lst" required="true">phishing.lst</file>
+    <file url="inline::phishing_ips.lst" required="true">phishing_ips.lst</file>
   </files>
 </ruleset>


### PR DESCRIPTION
**Important notices**

* [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
* [x] I opened an issue first for non-trivial changes and linked it below.
* [ ] AI tools were used to create at least part of the code submitted herewith.

---

**Describe the problem**

The Antiphishing ruleset uses native Suricata external datasets for DNS, TLS, and IPv4 detection.

The current OPNsense IDS content framework does not provide a uniform mechanism for installing external Suricata dataset files alongside the `.rules` file in the final rules directory.

The standard Antiphishing distribution therefore results in dataset loading errors on OPNsense because the `.lst` files are not available from the location where the installed ruleset is loaded.

An alternative approach of renaming the dataset files to `.rules` was tested. This is not suitable because OPNsense processes `.rules` files as Suricata signature files, causing dataset contents to be interpreted as rules and potentially causing the ruleset reload to fail.

Another approach was tested by converting the approximately 241,000-domain dataset into conventional DNS/TLS signatures. This caused Suricata to exhaust the available memory during startup in the OPNsense test environment, and the kernel terminated the Suricata process:

`suricata, was killed: failed to reclaim memory`

Because the native dataset implementation is important to the upstream Antiphishing ruleset, the upstream distribution should not be modified solely to accommodate the current OPNsense integration behavior.

---

**Describe the proposed solution**

This pull request introduces an OPNsense-specific distribution of the Antiphishing ruleset.

The upstream Antiphishing distribution remains unchanged and continues to provide:

* DNS dataset detection;
* TLS dataset detection;
* IPv4 dataset detection;
* HTTP signatures.

The OPNsense distribution contains the same dataset files, but its rules reference the files using the path where the current OPNsense rule updater stages the downloaded auxiliary files:

`/usr/local/etc/suricata/rules/`

The OPNsense tarball therefore contains:

* `antiphishing.rules`;
* `phishing.lst`;
* `phishing_ips.lst`.

The dataset files remain native Suricata dataset files and are not renamed to `.rules` or converted into Suricata signatures.

The OPNsense metadata declares the auxiliary dataset files as required files so they are downloaded together with the ruleset.

This approach was tested successfully on OPNsense: the dataset files are downloaded by the existing content updater and Suricata can load the DNS, TLS, and IPv4 datasets using the OPNsense-specific ruleset.

This is intended as an interim compatibility solution based on the current OPNsense ruleset staging behavior. It does not attempt to introduce a generic dataset mechanism into the OPNsense framework.

The upstream Antiphishing ruleset is intentionally kept independent of this OPNsense-specific path.

A more general solution for external Suricata datasets may be considered separately through the OPNsense content framework.

---

**Related issue**

https://github.com/opnsense/plugins/issues/5675
