### PR TITLE
net/frr: Add per-neighbor local-as no-prepend/replace-as options

### DIFF
--- a/net/frr/Makefile
+++ b/net/frr/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		frr
-PLUGIN_VERSION=		1.55
+PLUGIN_VERSION=		1.56
 PLUGIN_COMMENT=		The FRRouting Protocol Suite
 PLUGIN_DEPENDS=		frr10-pythontools
 PLUGIN_MAINTAINER=	ad@opnsense.org

--- a/net/frr/pkg-descr
+++ b/net/frr/pkg-descr
@@ -11,6 +11,10 @@ switching and routing, Internet access routers, and Internet peering.
 Plugin Changelog
 ================
 
+1.56
+
+* BGP: Add per-neighbor local-as no-prepend/replace-as options (contributed by clarkchentw)
+
 1.55
 
 * BGP: Write neighbor remote-as only when set (contributed by juan-ferrer-toribio)

--- a/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPNeighbor.xml
+++ b/net/frr/src/opnsense/mvc/app/controllers/OPNsense/Quagga/forms/dialogEditBGPNeighbor.xml
@@ -46,6 +46,16 @@
     </grid_view>
   </field>
   <field>
+    <id>neighbor.localasoptions</id>
+    <label>Local AS Options</label>
+    <type>dropdown</type>
+    <advanced>true</advanced>
+    <help>Optional modifiers for the neighbor local-as command. "No-Prepend" prevents prepending the Local AS to received AS-Paths. "Replace-AS" causes only the Local AS to be prepended to outbound updates.</help>
+    <grid_view>
+      <visible>false</visible>
+    </grid_view>
+  </field>
+  <field>
     <id>neighbor.password</id>
     <label>BGP MD5 Password</label>
     <type>text</type>

--- a/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
+++ b/net/frr/src/opnsense/mvc/app/models/OPNsense/Quagga/BGP.xml
@@ -82,7 +82,22 @@
                 <localas type="IntegerField">
                     <MinimumValue>1</MinimumValue>
                     <MaximumValue>4294967295</MaximumValue>
+                    <Constraints>
+                        <check001>
+                            <ValidationMessage>A Local AS is required when Local AS Options are set.</ValidationMessage>
+                            <type>DependConstraint</type>
+                            <addFields>
+                                <field1>localasoptions</field1>
+                            </addFields>
+                        </check001>
+                    </Constraints>
                 </localas>
+                <localasoptions type="OptionField">
+                    <OptionValues>
+                        <noprepend value="no-prepend">No-Prepend</noprepend>
+                        <replaceas value="no-prepend replace-as">No-Prepend Replace-AS</replaceas>
+                    </OptionValues>
+                </localasoptions>
                 <password type="TextField"/>
                 <weight type="IntegerField">
                     <MinimumValue>0</MinimumValue>

--- a/net/frr/src/opnsense/service/templates/OPNsense/Quagga/Config/bgpd.conf
+++ b/net/frr/src/opnsense/service/templates/OPNsense/Quagga/Config/bgpd.conf
@@ -121,7 +121,7 @@ router bgp {{ OPNsense.quagga.bgp.asnumber }}
  neighbor {{ neighbor.address }} remote-as {{ neighbor.remoteas }}
 {%         endif %}
 {%         if 'localas' in neighbor and neighbor.localas != '' %}
- neighbor {{ neighbor.address }} local-as {{ neighbor.localas }}
+ neighbor {{ neighbor.address }} local-as {{ neighbor.localas }}{% if neighbor.localasoptions|default('') %} {{ neighbor.localasoptions }}{% endif %}
 {%         endif %}
 {%         if 'description' in neighbor and neighbor.description != '' %}
  neighbor {{ neighbor.address }} description {{ neighbor.description }}


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: grok-4.6 (development), gpt-5.6-sol (review)
- Extent of AI involvement: grok-4.6 assisted with implementing the model/form/template changes, validation constraint, and changelog. gpt-5.6-sol performed an independent code review. Changes were reviewed.

---

**Describe the problem**

Neighbor-level `local-as` was added in #5308, but FRR's `no-prepend` and `replace-as` modifiers are still missing. Without them, the configured Local AS is prepended to received AS-Paths, and the real AS remains in outbound updates. That is often not the desired behavior for ASN migrations or provider peering such as AWS Direct Connect.

---

**Describe the proposed solution**

This pull request adds optional per-neighbor Local AS modifiers:

- Add `localasoptions` to the BGP neighbor model (`no-prepend`, `no-prepend replace-as`)
- Add an advanced `Local AS Options` dropdown next to Local AS
- Require Local AS when Local AS Options are set
- Render `neighbor <address> local-as <asn> [no-prepend [replace-as]]` in `bgpd.conf` when configured

The change is backward compatible: no extra keywords are emitted unless explicitly configured.

---

**Related issue**

Closes #5687
