### PR TITLE
net/freeradius: restore EAP-TTLS-GTC support and fix EAP-GTC against directories that do not expose passwords (#2421)

### DIFF
--- a/net/freeradius/Makefile
+++ b/net/freeradius/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_NAME=		freeradius
-PLUGIN_VERSION=		1.10.2
+PLUGIN_VERSION=		1.10.3
 PLUGIN_COMMENT=		RADIUS Authentication, Authorization and Accounting Server
 PLUGIN_DEPENDS=		freeradius3
 PLUGIN_MAINTAINER=	m.muenz@gmail.com

--- a/net/freeradius/pkg-descr
+++ b/net/freeradius/pkg-descr
@@ -9,6 +9,11 @@ security, particularly in the academic community, including eduroam.
 Plugin Changelog
 ================
 
+1.10.3
+
+* Make the EAP method inside the EAP-TTLS tunnel configurable, restoring EAP-TTLS-GTC support (#2421) (contributed by Clanto007)
+* Fix EAP-GTC failing when the LDAP directory does not expose passwords (contributed by Clanto007)
+
 1.10.2
 
 * Add configurable LDAP group membership mode (contributed by Jerzy Kołosowski)

--- a/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/eap.xml
+++ b/net/freeradius/src/opnsense/mvc/app/controllers/OPNsense/Freeradius/forms/eap.xml
@@ -6,6 +6,13 @@
         <help>Set the default EAP type.</help>
     </field>
     <field>
+        <id>eap.default_eap_ttls_type</id>
+        <label>Default EAP Type inside TTLS</label>
+        <type>dropdown</type>
+        <help>EAP method used inside the EAP-TTLS tunnel, applied only when the client starts an EAP conversation inside the tunnel. Non-EAP inner methods such as PAP or MSCHAPv2 are handled by the inner-tunnel virtual server and are not affected by this setting. Choose GTC for EAP-TTLS-GTC against an LDAP backend.</help>
+        <style>ttls_inner</style>
+    </field>
+    <field>
         <id>eap.elliptic_curve</id>
         <label>Elliptic Curve</label>
         <type>dropdown</type>

--- a/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Eap.xml
+++ b/net/freeradius/src/opnsense/mvc/app/models/OPNsense/Freeradius/Eap.xml
@@ -16,6 +16,17 @@
                 <ttls>TTLS</ttls>
             </OptionValues>
         </default_eap_type>
+        <default_eap_ttls_type type="OptionField">
+            <Default>md5</Default>
+            <Required>Y</Required>
+            <Multiple>N</Multiple>
+            <OptionValues>
+                <md5>MD5</md5>
+                <gtc>GTC</gtc>
+                <mschapv2>MSCHAPv2</mschapv2>
+                <tls>TLS</tls>
+            </OptionValues>
+        </default_eap_ttls_type>
         <elliptic_curve type="OptionField">
             <Default>prime256v1</Default>
             <Required>Y</Required>

--- a/net/freeradius/src/opnsense/mvc/app/views/OPNsense/Freeradius/eap.volt
+++ b/net/freeradius/src/opnsense/mvc/app/views/OPNsense/Freeradius/eap.volt
@@ -41,7 +41,18 @@ POSSIBILITY OF SUCH DAMAGE.
         mapDataToFormUI(data_get_map).done(function (data) {
             formatTokenizersUI();
             $('.selectpicker').selectpicker('refresh');
+            toggleTtlsInner();
         });
+
+        // the inner EAP type only applies to TTLS
+        function toggleTtlsInner() {
+            if ($("#eap\\.default_eap_type").val() === 'ttls') {
+                $(".ttls_inner").closest('tr').show();
+            } else {
+                $(".ttls_inner").closest('tr').hide();
+            }
+        }
+        $("#eap\\.default_eap_type").change(toggleTtlsInner);
         updateServiceControlUI('freeradius');
 
         // link save button to API set action

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-eap
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/mods-enabled-eap
@@ -778,11 +778,11 @@ eap {
                 #  EAP conversation, then this configuration entry is
                 #  ignored.
                 #
-                {% if helpers.exists('OPNsense.freeradius.eap.default_eap_type') and OPNsense.freeradius.eap.default_eap_type == 'ttls-gtc' %}
-                default_eap_type = gtc
-                {% else %}
+{% if helpers.exists('OPNsense.freeradius.eap.default_eap_ttls_type') and OPNsense.freeradius.eap.default_eap_ttls_type != '' %}
+                default_eap_type = {{ OPNsense.freeradius.eap.default_eap_ttls_type }}
+{% else %}
                 default_eap_type = md5
-                {% endif %}
+{% endif %}
 
                 #  The tunneled authentication request does not usually
                 #  contain useful attributes like 'Calling-Station-Id',

--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/sites-enabled-inner-tunnel
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/sites-enabled-inner-tunnel
@@ -213,7 +213,19 @@ authenticate {
         #  in the 'authorize' section supplies a password.  The
         #  password can be clear-text, or encrypted.
         Auth-Type PAP {
+{%   if helpers.exists('OPNsense.freeradius.ldap.innertunnel') and OPNsense.freeradius.ldap.innertunnel == '1' %}
+                #  EAP-GTC hands the password to this section. Use pap when a
+                #  known good password was found, otherwise bind against LDAP
+                #  for directories that never reveal passwords.
+                if (&control:Cleartext-Password || &control:Password-With-Header || &control:NT-Password) {
+                        pap
+                }
+                else {
+                        ldap
+                }
+{%   else %}
                 pap
+{%   endif %}
         }
 
         #


### PR DESCRIPTION
**Important notices**
- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

---

**Describe the problem**

Two separate problems, both preventing EAP-TTLS-GTC from working.

1. The EAP method used inside the EAP-TTLS tunnel is hardcoded to `md5`, so GTC cannot be selected. Support was added in 1.9.9 as a `ttls-gtc` value of the outer `default_eap_type`, which is not a valid EAP method: radiusd refused to start with `No dictionary definition for default EAP method 'ttls-gtc'` (#2421). 1.9.20 removed the option from the model instead of correcting the implementation, leaving the template branch that tests for `ttls-gtc` permanently unreachable and the inner method fixed at `md5`.

2. Even with GTC available, authentication fails against any directory that does not reveal password material. `rlm_eap_gtc` puts the password in the request and calls the `Auth-Type` section directly, without re-running `authorize`; that section ran `pap` unconditionally, and `rlm_pap` needs a known good password in the control list. With Google Workspace Secure LDAP, which only supports bind-based authentication, every request ends in `EAP sub-module failed`.

---

**Describe the proposed solution**

Three commits.

1. Add a `default_eap_ttls_type` field holding a real EAP method and use it inside the `ttls` block, replacing the dead branch. Non-EAP inner methods such as PAP and MSCHAPv2 are handled by the inner-tunnel virtual server and are deliberately absent from the option list, since a non-EAP value makes radiusd fail to start — this is what went wrong in 1.9.9. The field defaults to `md5`, so existing configurations render byte-identical output and no model migration is needed, and it is hidden in the GUI unless TTLS is the selected outer type.

2. In the inner tunnel, bind against LDAP when no password is available, keeping `pap` whenever `Cleartext-Password`, `Password-With-Header` or `NT-Password` is present. Local users therefore keep the existing code path and LDAP users gain a working one, so both backends can be used at the same time. Guarded by the existing "LDAP in inner-tunnel" setting, so installations without it are untouched.

3. Version bump and changelog.

Tested on a live instance: EAP-TTLS-GTC from a real access point against Google Workspace Secure LDAP, `Login OK ... via TLS tunnel`, and local users accepted from the same configuration.

---

**Related issue**

#2421