### PR TITLE
security/acme-client: add support for Hostinger DNS API

### DIFF
--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -675,6 +675,16 @@
         <type>text</type>
     </field>
     <field>
+        <label>hostinger</label>
+        <type>header</type>
+        <style>table_dns table_dns_hostinger</style>
+    </field>
+    <field>
+        <id>validation.dns_hostinger_token</id>
+        <label>Token</label>
+        <type>text</type>
+    </field>
+    <field>
         <label>Hurricane Electric</label>
         <type>header</type>
         <style>table_dns table_dns_he</style>

--- a/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
+++ b/security/acme-client/src/opnsense/mvc/app/controllers/OPNsense/AcmeClient/forms/dialogValidation.xml
@@ -675,7 +675,7 @@
         <type>text</type>
     </field>
     <field>
-        <label>hostinger</label>
+        <label>Hostinger</label>
         <type>header</type>
         <style>table_dns table_dns_hostinger</style>
     </field>

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsHostinger.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsHostinger.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * Copyright (C) 2020-2025 Frank Wall
+ * Copyright (C) 2018 Deciso B.V.
+ * Copyright (C) 2018 Franco Fichtner <franco@opnsense.org>
+ * Copyright (c) 2026 Leandro Scardua
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace OPNsense\AcmeClient\LeValidation;
+
+use OPNsense\AcmeClient\LeValidationInterface;
+use OPNsense\Core\Config;
+
+/**
+ * Hostinger DNS API
+ * @package OPNsense\AcmeClient
+ */
+class DnsHostinger extends Base implements LeValidationInterface
+{
+    public function prepare()
+    {
+        $this->acme_env['HOSTINGER_Token'] = (string)$this->config->dns_hostinger_token;
+    }
+}

--- a/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsHostinger.php
+++ b/security/acme-client/src/opnsense/mvc/app/library/OPNsense/AcmeClient/LeValidation/DnsHostinger.php
@@ -1,9 +1,6 @@
 <?php
 
 /*
- * Copyright (C) 2020-2025 Frank Wall
- * Copyright (C) 2018 Deciso B.V.
- * Copyright (C) 2018 Franco Fichtner <franco@opnsense.org>
  * Copyright (c) 2026 Leandro Scardua
  * All rights reserved.
  *

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -477,6 +477,7 @@
                         <dns_hetznercloud>Hetzner Cloud</dns_hetznercloud>
                         <dns_hexonet>hexonet.com</dns_hexonet>
                         <dns_hostingde>hosting.de</dns_hostingde>
+                        <dns_hostinger>hostinger</dns_hostinger>
                         <dns_he>Hurricane Electric</dns_he>
                         <dns_he_ddns>Hurricane Electric DDNS</dns_he_ddns>
                         <dns_infoblox>Infoblox</dns_infoblox>
@@ -752,6 +753,9 @@
                 <dns_hostingde_apiKey type="TextField">
                     <Required>N</Required>
                 </dns_hostingde_apiKey>
+                <dns_hostinger_token type="TextField">
+                    <Required>N</Required>
+                </dns_hostinger_token>
                 <dns_he_user type="TextField">
                     <Required>N</Required>
                 </dns_he_user>

--- a/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
+++ b/security/acme-client/src/opnsense/mvc/app/models/OPNsense/AcmeClient/AcmeClient.xml
@@ -477,7 +477,7 @@
                         <dns_hetznercloud>Hetzner Cloud</dns_hetznercloud>
                         <dns_hexonet>hexonet.com</dns_hexonet>
                         <dns_hostingde>hosting.de</dns_hostingde>
-                        <dns_hostinger>hostinger</dns_hostinger>
+                        <dns_hostinger>Hostinger</dns_hostinger>
                         <dns_he>Hurricane Electric</dns_he>
                         <dns_he_ddns>Hurricane Electric DDNS</dns_he_ddns>
                         <dns_infoblox>Infoblox</dns_infoblox>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below.
- [ ] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used:
- Extent of AI involvement:

---

**Describe the problem**

Starting from the version [3.1.4](https://github.com/acmesh-official/acme.sh/releases/tag/3.1.4), the hostinger dns_api is available to use and on the OPNsense side the implementation is not yet available
---

**Describe the proposed solution**

Add a capability to acme-client plugin to use the Hostinger DNS API 

---

**Related issue**

https://github.com/acmesh-official/acme.sh/pull/6843
https://github.com/acmesh-official/acme.sh/issues/6831
