### PR TITLE
net/freeradius: quote password values literally so % is not expanded

### DIFF
--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/users
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/users
@@ -3,7 +3,7 @@
 {%     for user_list in helpers.toList('OPNsense.freeradius.user.users.user') %}
 {%       if user_list.enabled == '1' %}
 
-{{ user_list.username }} {{ user_list.passwordencryption }} := "{{ user_list.password }}"{% if helpers.exists('OPNsense.freeradius.general.sessionlimit') and OPNsense.freeradius.general.sessionlimit == '1' %}{% if user_list.sessionlimit_max_session_limit is defined %}, Max-Daily-Session := {{ user_list.sessionlimit_max_session_limit }}{% endif %}{% endif %}{% if user_list.simuse is defined %}, Simultaneous-Use := "{{ user_list.simuse }}"{% endif %}{% if user_list.logintime is defined %}, Login-Time := "{{ user_list.logintime }}"{% endif %}
+{{ user_list.username }} {{ user_list.passwordencryption }} := '{{ user_list.password }}'{% if helpers.exists('OPNsense.freeradius.general.sessionlimit') and OPNsense.freeradius.general.sessionlimit == '1' %}{% if user_list.sessionlimit_max_session_limit is defined %}, Max-Daily-Session := {{ user_list.sessionlimit_max_session_limit }}{% endif %}{% endif %}{% if user_list.simuse is defined %}, Simultaneous-Use := "{{ user_list.simuse }}"{% endif %}{% if user_list.logintime is defined %}, Login-Time := "{{ user_list.logintime }}"{% endif %}
 
 {%       if user_list.ip is defined %}
        Framed-IP-Address = {{ user_list.ip }},
@@ -25,7 +25,7 @@
 {%         endfor %}
 {%       endif %}
 {%       if user_list.tunnel_password is defined %}
-       Tunnel-Password = {{ user_list.tunnel_password }},
+       Tunnel-Password = '{{ user_list.tunnel_password }}',
 {%       endif %}
 {%       if helpers.exists('OPNsense.freeradius.general.vlanassign') and OPNsense.freeradius.general.vlanassign == '1' %}
 {%         if user_list.vlan is defined %}
@@ -121,7 +121,7 @@ DEFAULT Auth-Type := Accept
        Tunnel-Private-Group-Id = {{ OPNsense.freeradius.general.fallbackvlan_id }},
 {%  endif %}
 {%  if helpers.exists('OPNsense.freeradius.general.fallback_tunnel_password') and OPNsense.freeradius.general.fallback_tunnel_password != '' %}
-       Tunnel-Password = {{ OPNsense.freeradius.general.fallback_tunnel_password }},
+       Tunnel-Password = '{{ OPNsense.freeradius.general.fallback_tunnel_password }}',
 {%  endif %}
        Framed-Protocol = PPP
 {%  endif %}


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.

---

**Describe the problem**

`User.xml` allows `%` in the password field, and the `users` template writes the value in double quotes. Inside a double-quoted string, FreeRADIUS expands `%` followed by one of `c d e l m n t v C D G H I M S T Y`, and it expands `%{...}`. FreeRADIUS then compares the password the client sent against the expanded string, and PAP reports `Cleartext password does not match "known good" password`. The generated file still shows the text that was typed. #5678 lists the result for each character. An unterminated `%{` fails to expand at all. `rlm_files` logs `Failed parsing expanded value for check item, skipping entry`, drops the check items for that entry, and the user is rejected.

The two `Tunnel-Password` values at lines 28 and 124 are written without quotes. An unquoted value stops at the first parser token, and the `tunnel_password` masks allow several of them: `( ) { } = #` and the operators `== := += -= ++ !=`. A tunnel password containing one of these produces `Parse error (reply) ... Expected end of line or comma`. `rlm_files` then fails to load, and the server does not start.

The password has been written in double quotes since the plugin's first commit in 2017.

---

**Describe the proposed solution**

The template now writes all three values in single quotes. FreeRADIUS does not expand single-quoted strings, so `%` and `%{...}` are taken literally, and a parser token no longer ends the value. The only characters that need escaping inside single quotes are `\` and `'`, and none of the three masks allows either, so the template does not escape anything.

The masks are unchanged. Widening them would require escaping `\` and `'` inside the single quotes, and that is not part of this change.

`clients.conf` and `mods-enabled-sql` write their secrets in double quotes, and `proxy.conf` writes its secret without quotes. Those three are covered by #5696 and are not part of this change. Their model fields have no mask, so an admin may already have escaped the secret by hand, as #1655 advised.

**Verification**

I loaded about 500 generated `users` entries into FreeRADIUS 3.2.10, read each value back through a reply attribute, and authenticated with PAP using a client that sends the exact password bytes:

* every character the current masks allow comes back unchanged from a single-quoted value, including `% $ { } ( ) # = : & + !`
* in double quotes, FreeRADIUS expands the 17 single-letter codes and `%{...}` listed above, and an unterminated `%{` gets the user rejected
* without quotes, the file fails to load on a space and on any of `( ) { } = # , ; < > == := += -= ++ != =~ =*`

I rendered the template from master and the patched template against the same stubbed configuration and compared the output. The number of lines is the same, and only the intended lines differ.

On a live OPNsense 26.7.3_8 install with os-freeradius 1.10.2 and FreeRADIUS 3.2.10, I applied the single-quoted template. A 62-character password containing `%c` and `$$` went from Access-Reject to Access-Accept, and a second user whose password was not affected could still log in.

---

**Related issue**

Closes #5678. I opened #5694 for the same problem before finding #5678 and closed it as a duplicate.
