### PR TITLE
sysutils/git-backup: don't accept credentials in the backup url

### DIFF
--- a/sysutils/git-backup/src/opnsense/mvc/app/models/OPNsense/Backup/GitSettings.xml
+++ b/sysutils/git-backup/src/opnsense/mvc/app/models/OPNsense/Backup/GitSettings.xml
@@ -16,8 +16,8 @@
             </Constraints>
         </enabled>
         <url type="TextField">
-            <Mask>/^((https)|(ssh))?:\/\/.*[^\/]$/</Mask>
-            <ValidationMessage>A valid git location must be provided. e.g. ssh://server/project.git, https://server/project.git</ValidationMessage>
+            <Mask>/^((https)|(ssh))?:\/\/[^\/@]*(\/.*)?[^\/]$/</Mask>
+            <ValidationMessage>A valid git location must be provided, without credentials. e.g. ssh://server/project.git, https://server/project.git</ValidationMessage>
             <Constraints>
                 <check001>
                     <ValidationMessage>A backup location (url) is required.</ValidationMessage>


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [x] I opened an issue first for non-trivial changes and linked it below.
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: Claude Opus 5, via Claude Code
- Extent of AI involvement: analysis, the patch and the test scripts. Every result below comes from
  a run through the web form on a real installation, and I reviewed each one before posting.

---

**Describe the problem**

The `url` mask allows a userinfo section, so a url that already carries a user passes validation.
`Git::backup()` then adds the User Name field on top — mandatory once the backup is enabled — and
the remote ends up with the user twice:

```
ssh://git@codeberg.org/user/project.git  +  User Name "git"
   ->  ssh://git@git@codeberg.org/user/project.git
```

The push never authenticates and nothing is backed up. Reported in #5477 and #5606.

---

**Describe the proposed solution**

As you suggested, repair the validation rather than the code: exclude the userinfo part of the
authority from the mask, and say so in the validation message. Credentials have their own User Name
and Password fields, and the field help only ever showed user-less examples. `Git.php` is untouched.
The exclusion covers the authority only, so an `@` stays legal inside the path.

Tested on 26.1.11_10 with os-git-backup 1.1_3, through the form on `diag_backup.php`, against an
ssh remote and an nginx/`git-http-backend` remote. Of nineteen urls, four change — the two from the
reports plus `https://user@host/repo.git` and `https://user:token@host/repo.git`. Ports, an IPv6
literal and an `@` inside the path stay accepted; `git@github.com:user/project.git` stays rejected.
Both intended forms still save and push, over ssh and over https. Credentials in the authority are
the only thing that changes: an empty authority and an empty scheme are still accepted, exactly as
before.

Neither credential-bearing form works today, so nothing that currently backs up becomes invalid:
with such a url stored directly in `config.xml`, the remote comes out as `ssh://git@git@host/...`
and `https://git:pw@git:pw@host/...`, and no commit reaches the server.

One limitation worth stating: this does not reach installations that already stored such a url.
`performValidation()` only validates fields that changed (`BaseModel.php:637`), so re-saving that
page with the url untouched passes the new mask — I ran it, and changing only the branch too; both
report `authentication failure` with nothing pointing at the url. The new message appears only once
that field is edited. No migration, as you said: the model's treatment of the data is unchanged.

`PLUGIN_REVISION` left alone.

---

**Related issue**

Closes #5477
Refs #5606, #5629
