### PR TITLE
net/freeradius: simultaneous-use verify query must select by user, not group

### DIFF
--- a/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/queries.conf
+++ b/net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/queries.conf
@@ -157,7 +157,7 @@ simul_verify_query = "\
         SELECT radacctid, acctsessionid, username, nasipaddress, nasportid, framedipaddress, \
                 callingstationid, framedprotocol \
         FROM ${acct_table1} \
-        WHERE username = '%{${group_attribute}}' \
+        WHERE username = '%{SQL-User-Name}' \
         AND acctstoptime IS NULL"
 
 #######################################################################


### PR DESCRIPTION
**Important notices**

Before you submit a pull request, we ask you kindly to acknowledge the following:

- [x] I have read the contributing guidelines at https://github.com/opnsense/plugins/blob/master/CONTRIBUTING.md
- [ ] I opened an issue first for non-trivial changes and linked it below. (One-line fix, no issue opened.)
- [x] AI tools were used to create at least part of the code submitted herewith.

If AI was used, please disclose:

- Model used: Claude Fable 5.1 (Anthropic, via Claude Code)
- Extent of AI involvement: helped diagnose the fault with `radiusd -X`, proposed the one-line change, and drafted this text. The change and every measurement below were reviewed and reproduced by the author.

---

**Describe the problem**

`simul_verify_query` in `net/freeradius/src/opnsense/service/templates/OPNsense/Freeradius/queries.conf` filters `radacct` on `%{${group_attribute}}`, which renders as `%{SQL-Group}`. That attribute is empty on an Access-Request, so the verify step finds no live session and `Simultaneous-Use` never rejects: every extra login is accepted even when the sessions are sitting in `radacct` with no stop time. The count query directly above it already uses `%{SQL-User-Name}`, and so does the stock FreeRADIUS 3.2 sqlite dialect, so the count says N and the verify says 0, and the verify wins.

Measured on OPNsense 26.7.3_11, plugin 1.10.2, the captive portal as the RADIUS client over 127.0.0.1, sqlite store and the session limit both on, a user with `Simultaneous-Use := 2`, two open rows in `radacct`, `radiusd -X` running: the verify query expands to `WHERE username = ''` and the request gets Access-Accept.

---

**Describe the proposed solution**

One line: use `%{SQL-User-Name}` in `simul_verify_query`, as the count query and the stock dialect do. After the change the same request expands to `WHERE username = '<the user>'`, returns both rows, and gets `Multiple logins (max 2)` and Access-Reject. Confirmed end to end through the captive portal from three real devices: the first two sign in, the third is refused before it connects. Template only; no version bump.

---

**Related issue**

None opened; the fix is a single substitution.